### PR TITLE
Backward compatibility: latest renpy-modules doesn`t work with renpy prior to 6.13.

### DIFF
--- a/renpy/gl/gldraw.pyx
+++ b/renpy/gl/gldraw.pyx
@@ -215,7 +215,7 @@ cdef class GLDraw:
             opengl = 0            
             # EGL automatically handles vsync for us.
         
-        if renpy.config.gl_resize:
+        if getattr(renpy.config, "gl_resize", False):
             resizable = pygame.RESIZABLE
         else:
             resizable = 0


### PR DESCRIPTION
When you trying to run a game written for renpy <6.14 and use latest
modules there is an error:

  File "gldraw.pyx", line 218, in renpy.gl.gldraw.GLDraw.set_mode
  (gen/renpy.gl.gldraw.c:3048)
  AttributeError: 'module' object has no attribute 'gl_resize'
