### PR TITLE
Use mkdtemp() for creating the temporary directory.

### DIFF
--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -24,6 +24,7 @@ init python in project:
     import json
     import subprocess
     import re
+    import tempfile
     
     class Project(object):
     
@@ -52,7 +53,7 @@ init python in project:
             self.load_data()
 
             # The project's temporary directory.
-            self.tmp = os.path.join(self.path, "tmp")
+            self.tmp = tempfile.mkdtemp()
                 
             # The path to the json dumpfile.
             self.dump_filename = os.path.join(self.tmp, "navigation.json")


### PR DESCRIPTION
This allows launching a project when you have read-only privileges to it.

Common example: the two sample projects might be installed by the package manager to /usr/local/share/renpy or similar; without this diff, you have to be root to launch these projects.
