### PR TITLE
Fix crashing Renpy, when inputed string contain '[' character.

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -395,7 +395,7 @@ def watch(expression, style='default', **properties):
 
     renpy.config.overlay_functions.append(overlay_func)
 
-def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=None): #@ReservedAssignment
+def input(prompt, default='', allow=None, exclude='{}[]', length=None, with_none=None): #@ReservedAssignment
     """
     This pops up a window requesting that the user enter in some text.
     It returns the entered text.


### PR DESCRIPTION
Steps to reproduce:
1. Run tutorial
2. Go to 'User Interaction' chapter
3. Go to question 'What is your name?'
4. Enter the name, that contains '[' character, for example 'qwe[rty'
5. Renpy is crashing and printing exception:

**Traceback:**

``` ﻿
I'm sorry, but an uncaught exception occurred.

While running game code:
  File "game/script.rpy", line 113, in script call
  File "game/demo_ui.rpy", line 245, in script
Exception: String u'qwe[rty' ends with an open format operation.

-- Full Traceback ------------------------------------------------------------

Full traceback:
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/execution.py", line 288, in run
    node.execute()
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/ast.py", line 453, in execute
    renpy.exports.say(who, what, interact=self.interact)
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/exports.py", line 752, in say
    who(what, interact=interact)
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/character.py", line 772, in __call__
    who = who_pattern.replace("[who]", sub(who))
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/substitutions.py", line 223, in substitute
    s = formatter.vformat(s, (), kwargs)
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-deps-master/install/lib/python2.7/string.py", line 549, in vformat
    result = self._vformat(format_string, args, kwargs, used_args, 2)
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-deps-master/install/lib/python2.7/string.py", line 558, in _vformat
    self.parse(format_string):
  File "/home/likewise-open/DALSTRAZH/markelovaa/sources/renpy-master/renpy/substitutions.py", line 157, in parse
    raise Exception("String {0!r} ends with an open format operation.".format(s))
Exception: String u'qwe[rty' ends with an open format operation.

Linux-3.2.0-38-generic-pae-i686-with-debian-wheezy-sid
Ren'Py 6.15.0.0
Ren'Py Tutorial 6.15 "Foreign Policy"
```

![square_bracket_bug_1](https://f.cloud.github.com/assets/1083576/220024/cf01e1f2-8555-11e2-99a6-650cae3ce658.jpg)

![square_bracket_bug_2](https://f.cloud.github.com/assets/1083576/220026/d682f092-8555-11e2-8929-7b82670bae38.jpg)
