### PR TITLE
add Gallery get_fraction

### DIFF
--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -303,6 +303,22 @@ init -1500 python:
                 
             return Button(action=action, child=unlocked, insensitive_child=locked, hover_foreground=hover_border, idle_foreground=idle_border, **properties)
 
+        def get_fraction(self, name):
+            """
+            :doc: gallery method
+            
+            This returns the rate of the images seen by the player all images associated with the given button name as a fraction.
+
+            `name`
+                The name of the button that will be analyzed.
+            """            
+            seen_image = 0
+            all_image = len(self.buttons[name].images)
+            for i in range(all_image):
+                if self.buttons[name].images[i].check_unlock(True):
+                    seen_image += 1
+            return "%d/%d" % (seen_image, all_image)
+
 
 init -1500:
 


### PR DESCRIPTION
I add Gallery Class get_fraction func.
This enables the rate of seen_images all_images about the given button to be shown on the screen like below.

```
                        vbox:
                            add g.make_button("test2", "image/thum/stest02.png")
                            text g.get_fraction("test2") xalign 1.0
```

![screenshot0001](https://f.cloud.github.com/assets/1556311/725357/28137198-e05f-11e2-8871-558825d6b42f.png)
