### PR TITLE
disable Skip if skip_unseen is false and in unseen

### DIFF
--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -197,7 +197,7 @@ init -1500 python:
             return config.skipping
 
         def get_sensitive(self):
-            return config.allow_skipping and (not renpy.context()._main_menu)
+            return ( config.allow_skipping and (not renpy.context()._main_menu) ) and ( renpy.game.preferences.skip_unseen or renpy.game.context().seen_current(True) )
 
 
     class Help(Action):


### PR DESCRIPTION
Now the Skip action is sensitive even if a user is in unseen and renpy.game.preferences.skip_unseen is false.
So I want to change it.
