### PR TITLE
don't take_screenshot menu

### DIFF
--- a/renpy/common/00gamemenu.rpy
+++ b/renpy/common/00gamemenu.rpy
@@ -69,7 +69,8 @@ init -1700 python:
         config.skipping = None
 
         renpy.movie_stop(only_fullscreen=True)
-        renpy.take_screenshot((config.thumbnail_width, config.thumbnail_height))
+        if not renpy.context()._menu:
+            renpy.take_screenshot((config.thumbnail_width, config.thumbnail_height))
 
         for i in config.menu_clear_layers:
             renpy.scene(layer=i)


### PR DESCRIPTION
Now, Ren'Py takes screenshot of the game menu when I open the game menu and click the close buttton.
So I fixed this problem.
