### PR TITLE
close screen "yesno_prompt" by rclick

### DIFF
--- a/renpy/common/00gamemenu.rpy
+++ b/renpy/common/00gamemenu.rpy
@@ -92,7 +92,11 @@ init -1700 python:
             renpy.scene(layer=i)
 
     def _invoke_game_menu():
-        if renpy.context()._menu:
+        if renpy.get_screen("yesno_prompt"):
+            renpy.hide_screen("yesno_prompt")
+            renpy.transition(config.exit_yesno_transition)
+            renpy.restart_interaction()
+        elif renpy.context()._menu:
             if renpy.context()._main_menu:
                 return
             else:


### PR DESCRIPTION
When the screen "yesno_prompt" is shown by quickmenu,  a rclick can't close it but open the game menu.
So I fixed this.

Issue: no_action isn't done if screen is closed by the rclick.
