### PR TITLE
Allow accent in the PATH of Ren'Py directory

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -519,7 +519,7 @@ class RenpyImporter(object):
 
     def translate(self, fullname, prefix=""):
 
-        fn = prefix + fullname.replace(".", "/")
+        fn = (prefix + fullname.replace(".", "/")).decode("utf8")
 
         if loadable(fn + ".py"):
             return fn + ".py"


### PR DESCRIPTION
Before the change, you get an uncaught exception when there is an accent in the Path. With that change, it works.
