### PR TITLE
add preferences.wait_voice

### DIFF
--- a/renpy/common/00defaults.rpy
+++ b/renpy/common/00defaults.rpy
@@ -16,6 +16,9 @@ init -1500 python:
 
     # If not None, the default value of afm_enable
     config.default_afm_enable = None
+    
+    # If not None, the default value of wait_voice
+    config.default_wait_voice = None
 
 
 init 1500 python:
@@ -31,6 +34,9 @@ init 1500 python:
 
         if config.default_afm_time is not None:
             _preferences.afm_time = config.default_afm_time
+
+        if config.default_wait_voice is not None:
+            _preferences.wait_voice = config.default_wait_voice
 
     if config.default_afm_enable is not None:
         _preferences.afm_enable = config.default_afm_enable

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -71,6 +71,10 @@ init -1500 python:
          * Preference("auto-forward", "disable") - Disable auto-forward mode.
          * Preference("auto-forward", "toggle") - Toggle auto-forward mode.
 
+         * Preference("wait voice", "enable")  - Dnable auto-forwarding when a voice is playing.
+         * Preference("wait voice", "disable") - Eisable auto-forwarding when a voice is playing.
+         * Preference("wait voice", "toggle")  - Toggle auto-forwarding when a voice is playing.
+
          * Preference("music mute", "enable") - Mute the music mixer.
          * Preference("music mute", "disable") - Un-mute the music mixer.
          * Preference("music mute", "toggle") - Toggle music mute.
@@ -178,6 +182,15 @@ init -1500 python:
                 return SetField(_preferences, "afm_enable", False)
             elif value == "toggle":
                 return ToggleField(_preferences, "afm_enable")
+
+        elif name == "wait voice":
+
+            if value == "enable":
+                return SetField(_preferences, "wait_voice", True)
+            elif value == "disable":
+                return SetField(_preferences, "wait_voice", False)
+            elif value == "toggle":
+                return ToggleField(_preferences, "wait_voice")
 
         elif name == "music volume":
 

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -205,7 +205,10 @@ init -1500 python hide:
     config.say_sustain_callbacks.append(voice_sustain)
 
     def voice_afm_callback():
-        return not renpy.sound.is_playing(channel="voice")
+        if _preferences.wait_voice:
+            return not renpy.sound.is_playing(channel="voice")
+        else:
+            return True
 
     config.afm_callback = voice_afm_callback
 

--- a/renpy/game.py
+++ b/renpy/game.py
@@ -111,6 +111,7 @@ class Preferences(renpy.object.Object):
         self.text_cps = 0
         self.afm_time = 0
         self.afm_enable = True
+        self.wait_voice = True
 
         # These will be going away soon.
         self.sound = True

--- a/template/game/screens.rpy
+++ b/template/game/screens.rpy
@@ -410,6 +410,9 @@ screen preferences:
                 label _("Auto-Forward Time")
                 bar value Preference("auto-forward time")
 
+                if config.has_voice:
+                    textbutton _("wait voice") action Preference("wait voice", "toggle")
+
         vbox:
             frame:
                 style_group "pref"

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -419,6 +419,9 @@ screen preferences:
                 label _("Auto-Forward Time")
                 bar value Preference("auto-forward time")
 
+                if config.has_voice:
+                    textbutton _("wait voice") action Preference("wait voice", "toggle")
+
         vbox:
             frame:
                 style_group "pref"


### PR DESCRIPTION
I allowed a user to determine whether wait a voice in auto-foward mode.
I added three actions.
         \* Preference("wait voice", "enable")  - Dnable auto-forwarding when a voice is playing.
         \* Preference("wait voice", "disable") - Eisable auto-forwarding when a voice is playing.
         \* Preference("wait voice", "toggle")  - Toggle auto-forwarding when a voice is playing.

Default to True.
