### PR TITLE
Preferences.voice sustain

### DIFF
--- a/renpy/common/00defaults.rpy
+++ b/renpy/common/00defaults.rpy
@@ -17,6 +17,9 @@ init -1500 python:
     # If not None, the default value of afm_enable
     config.default_afm_enable = None
 
+    # If not None, the default value of voice_sustain
+    config.default_voice_sustain = None
+
 
 init 1500 python:
 
@@ -31,6 +34,9 @@ init 1500 python:
 
         if config.default_afm_time is not None:
             _preferences.afm_time = config.default_afm_time
+
+        if config.default_voice_sustain is not None:
+            _preferences.voice_sustain = config.default_voice_sustain
 
     if config.default_afm_enable is not None:
         _preferences.afm_enable = config.default_afm_enable

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -83,6 +83,10 @@ init -1500 python:
          * Preference("voice mute", "disable") - Un-mute the voice mixer.
          * Preference("voice mute", "toggle") - Toggle voice mute.
 
+         * Preference("voice sustain", "enable")  - Sustain voice through the current interaction.
+         * Preference("voice sustain", "disable") - Don't sustain voice through the current interaction.
+         * Preference("voice sustain", "toggle")  - Toggle sustain voice.
+
          * Preference("music volume", 0.5) - Set the music volume.
          * Preference("sound volume", 0.5) - Set the sound volume.
          * Preference("volice volume", 0.5) - Set the voice volume.
@@ -226,6 +230,15 @@ init -1500 python:
                 return SetDict(_preferences.mute, "voice", False)
             elif value == "toggle":
                 return ToggleDict(_preferences.mute, "voice")
+
+        elif name == "voice sustain":
+
+            if value == "enable":
+                return SetField(_preferences, "voice_sustain", True)
+            elif value == "disable":
+                return SetField(_preferences, "voice_sustain", False)
+            elif value == "toggle":
+                return ToggleField(_preferences, "voice_sustain")
 
         else:
             raise Exception("Preference(%r, %r) is unknown." % (name , value))

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -200,6 +200,9 @@ init -1500 python hide:
 
         _voice.play = None
         _voice.sustain = False
+        
+        if _preferences.voice_sustain:
+            _voice.sustain = True
 
     config.start_interact_callbacks.append(voice_interact)
     config.say_sustain_callbacks.append(voice_sustain)

--- a/renpy/game.py
+++ b/renpy/game.py
@@ -111,6 +111,7 @@ class Preferences(renpy.object.Object):
         self.text_cps = 0
         self.afm_time = 0
         self.afm_enable = True
+        self.voice_sustain = False
 
         # These will be going away soon.
         self.sound = True

--- a/template/game/screens.rpy
+++ b/template/game/screens.rpy
@@ -437,6 +437,7 @@ screen preferences:
                 label _("Voice Volume")
                 bar value Preference("voice volume")
 
+                textbutton "Voice Sustain" action Preference("voice sustain", "toggle")
                 if config.sample_voice:
                     textbutton "Test":
                         action Play("voice", config.sample_voice)

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -446,6 +446,7 @@ screen preferences:
                 label _("Voice Volume")
                 bar value Preference("voice volume")
 
+                textbutton "Voice Sustain" action Preference("voice sustain", "toggle")
                 if config.sample_voice:
                     textbutton "Test":
                         action Play("voice", config.sample_voice)


### PR DESCRIPTION
I allowed a user to determine whether voices were sustained through the current interaction.

I added three actions.
         \* Preference("voice sustain", "enable")  - Sustain voice through the current interaction.
         \* Preference("voice sustain", "disable") - Don't sustain voice through the current interaction.
         \* Preference("voice sustain", "toggle")  - Toggle sustain voice.
And I used all_character_callbacks to implement this future.
Default to False
