### PR TITLE
add gallery Previous,Next,Close,EnablePreview actions

### DIFF
--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -495,15 +495,15 @@ init -1500:
             style_group "gallery"
             align (.98, .98)
 
-            textbutton _("Previous") action gallery.Previous()
-            textbutton _("Next") action gallery.Next()
-            textbutton _("SlideShow") action gallery.ToggleSlideshow()
-            textbutton _("Close") action gallery.Close()
+            textbutton _("prev") action gallery.Previous()
+            textbutton _("next") action gallery.Next()
+            textbutton _("slide show") action gallery.ToggleSlideshow()
+            textbutton _("close") action gallery.Close()
 
     python:
         style.gallery = Style(style.default)
         style.gallery_button.background = None
-        style.gallery_button_text.color = "#fff"
-        style.gallery_button_text.hover_color = "#666"
-        style.gallery_button_text.selected_color = "#ff0"
+        style.gallery_button_text.color = "#666"
+        style.gallery_button_text.hover_color = "#fff"
+        style.gallery_button_text.selected_color = "#fff"
         style.gallery_button_text.outlines = [(1, "#000", 0, 0)]


### PR DESCRIPTION
I tryed to resolve the part of #22
I added below actions

```
    def Close(self):
        """
        :doc: gallery method

        Close the current image.
        """

    def Next(self, diff=False):
        """
        :doc: gallery method

        This is the action to advance to the next unlocked image.
        When the last image is showing, close it.

        `diff`
            If True, advance to the next image in the button, otherwise
            advance to the image in the next button.
        """

    def Previous(self):
        """
        :doc: gallery method

        This is the action to return to the previous unlocked image.
        When the first image is showing, close it.
        """

    def EnablePreview(self, preview_time=10):
        """
        :doc: gallery method

        This is the action to enable preview_mode.

        `preview_time`
            This is a number in second, defaults to 10. advance to the next unlocked image
            when this time is elapsed if preview_mode is enable.
        """
```

And I use "gallery" screen in place of "_gallery" if exist.

By the way, what is the cradle song image gallery meaning?
