### PR TITLE
remove doc-ja info in Japanese documentation

### DIFF
--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -D language=$(LANGUAGE)
+SPHINXOPTS    = -D language=$(LANGUAGE) -t language_$(LANGUAGE)
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
@@ -139,7 +139,7 @@ gettext:
 	     source/credit_items/translators.txt \
 	     source/credit_items/footer.txt \
 	         > source/credits.rst
-	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	$(SPHINXBUILD) -b gettext -t gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@ls $(BUILDDIR)/locale
 	@for p in `find $(BUILDDIR)/locale -name *.pot`; do \
 		echo locale/`basename $$p` | sed s/\.pot//g | xargs mkdir -p; \

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -12,9 +12,11 @@ in the Ren'Py Wiki:
 
     http://www.renpy.org/wiki/
 
-日本語のドキュメントは以下にあります:
+.. only:: not language_ja and not gettext
 
-    http://ja.renpy.org/doc/html/
+    日本語のドキュメントは以下にあります:
+
+        http://ja.renpy.org/doc/html/
 
 
 Getting Started


### PR DESCRIPTION
Japanese doc information shouldn't be shown in Japanese, and it should be untranslatable text.
This commit adds two tags: language_LANGUAGE and gettext to support it.

If it's built with "LANGUAGE=ja make html" or "make gettext", this information will be hidden.
