### PR TITLE
enable translate about screenshot

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -165,7 +165,7 @@ init -1600 python:
             config.screenshot_callback(fn)
 
     def _screenshot_callback(fn):
-        renpy.notify(_("Saved screenshot as %s.") % fn)
+        renpy.notify(__("Saved screenshot as %s.") % fn)
 
     config.screenshot_callback = _screenshot_callback
 


### PR DESCRIPTION
_() can't be used with format texts, so I replaced it by __()
