### PR TITLE
fix reverted documentation errors

### DIFF
--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -333,7 +333,7 @@ init -1500 python:
             """
             :doc: music_room method
 
-            This action auses the music room to start playing. If `filename` is given, that
+            This action causes the music room to start playing. If `filename` is given, that
             file begins playing. Otherwise, the currently playing file starts
             over (if it's unlocked), or the first file starts playing.
 

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -75,7 +75,7 @@ init -1500 python:
          * Preference("wait for voice", "disable") - Do not wait for the currently playing voice to complete before auto-forwarding.
          * Preference("wait for voice", "toggle")  - Toggle wait voice.
 
-         * Preference("voice sustain", "enable")  - Sustain voice paist the current interaction.
+         * Preference("voice sustain", "enable")  - Sustain voice past the current interaction.
          * Preference("voice sustain", "disable") - Don't sustain voice past the current interaction.
          * Preference("voice sustain", "toggle")  - Toggle voice sustain.
 

--- a/renpy/common/00stylepreferences.rpy
+++ b/renpy/common/00stylepreferences.rpy
@@ -31,7 +31,7 @@ init -1500 python:
         Registers information about an alternative for a style preference.
 
         `preference`
-            A string, the name of the style property.
+            A string, the name of the style preference.
 
         `alternative`
             A string, the name of the alternative.


### PR DESCRIPTION
3fde29f reverted b074038 and 835fe5d because prior commits fixed auto generated files.
This commit fixes original rpy files.
