### PR TITLE
Port after_checkout.sh to non-Linux Unixes

### DIFF
--- a/after_checkout.sh
+++ b/after_checkout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT="$(dirname $(readlink -f $0))"
+ROOT="$(dirname $(python -c "import os;print(os.path.realpath('$0'))"))"
 
 ln -s "$ROOT/help.html" "$ROOT/tutorial/README.html"
 ln -s "$ROOT/help.html" "$ROOT/the_question/README.html"


### PR DESCRIPTION
`after_checkout.sh` has been using `readlink(1)` to get an absolute path (with
no symlinks) to the renpy root directory.  Unfortunately, `readlink -f` is a
GNU extension, and thus unavailable on the BSDs, including OS X.

[There are](http://stackoverflow.com/q/1055671/120999) a number of options for those systems.  While an exec out to
Python seems like overkill (and is, in fact, a bit slow on my system), the
delay is small enough to not be a problem in a one-time script like this.
Additionally, it seemed silly to include a dozen-line shell function just for
this one usage.  Plus, we know for certain the user has Python, because
otherwise they couldn't run Ren'Py. ;)

I included the parens around `print` just to make sure it works with both
Python 2.x and 3.x.  I doubt this matters, but I figured I might as well.

If we stop caring about resolving symlinks, this entire line [can be replaced](http://stackoverflow.com/a/1371283/120999)
with `$PWD##*`.
