### PR TITLE
fix doc that doesn't contain needed line break

### DIFF
--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -188,6 +188,7 @@ them can be a problem.
      Extend is aware of NVL-mode, and treats it correctly. 
 
 For example::
+
     # Show the first line of dialogue, wait for a click, change expression, and show
     # the rest.
 


### PR DESCRIPTION
Line breakings are needed before example codes.
