### PR TITLE
During trans3

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1036,6 +1036,10 @@ class Scene(Node):
 
         next_node(self.next)
 
+        if renpy.store._window == "auto":
+            renpy.store._window = False
+            renpy.store._scene = True
+
         renpy.config.scene(self.layer)
 
         if self.imspec:
@@ -1143,6 +1147,10 @@ class With(Node):
             paired = None
 
         renpy.exports.with_statement(trans, paired)
+
+        if renpy.store._scene:
+            renpy.store._window = "auto"
+            renpy.store._scene = False
 
     def predict(self):
 

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -371,6 +371,9 @@ python early hide:
         store._window = False
         renpy.with_statement(trans)
 
+    def execute_window_auto(p):
+        store._window = "auto"
+
     renpy.register_statement('window show',
                               parse=parse_window,
                               execute=execute_window_show,
@@ -380,6 +383,10 @@ python early hide:
                               parse=parse_window,
                               execute=execute_window_hide,
                               lint=lint_window)
+
+    renpy.register_statement('window auto',
+                              parse=parse_window,
+                              execute=execute_window_auto)
 
     ##########################################################################
     # Pause statement.

--- a/renpy/common/00defaults.rpy
+++ b/renpy/common/00defaults.rpy
@@ -47,6 +47,10 @@ init -1500 python:
     # If not None, the default value of mouse_move.
     config.default_mouse_move = True
 
+    # If not None, the default value of window_during_trans
+    config.default_window_during_trans = False
+
+
 
 init 1500 python:
 
@@ -76,6 +80,9 @@ init 1500 python:
 
         if config.default_afm_enable is not None:
             _preferences.afm_enable = config.default_afm_enable
+
+        if config.default_window_during_trans is not None:
+            _preferences.window_during_trans = config.default_window_during_trans
 
     # Use default_afm_enable to decide if we use the afm_enable
     # preference.
@@ -114,6 +121,9 @@ init -1500 python:
             renpy.call_in_new_context(target)
 
     style.default.hyperlink_functions = (hyperlink_styler, hyperlink_function, None)
+
+init -1500 python:
+    _scene = False
 
 init -1500:
     image text = renpy.ParameterizedText(style="centered_text")

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -68,6 +68,10 @@ init -1500 python:
          * Preference("transitions", "none") - do not show transitions.
          * Preference("transitions", "toggle") - toggle transitions.
 
+         * Preference("window during transitions", "show") - show window during transitions.
+         * Preference("window during transitions", "hide") - hide window during transitions.
+         * Preference("window during transitions", "toggle") - toggle show and hide.
+
          * Preference("text speed", 0) - make text appear instantaneously.
          * Preference("text speed", 142) - set text speed to 142 characters per second.
 
@@ -158,6 +162,15 @@ init -1500 python:
                 return SetField(_preferences, "transitions", 0)
             elif value == "toggle":
                 return ToggleField(_preferences, "transitions", true_value=2, false_value=0)
+
+        elif name == "window during transitions":
+
+            if value == "show":
+                return SetField(_preferences, "window_during_trans", True)
+            elif value == "hide":
+                return SetField(_preferences, "window_during_trans", False)
+            elif value == "toggle":
+                return ToggleField(_preferences, "window_during_trans")
 
         elif name == "text speed":
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1637,6 +1637,10 @@ class Interface(object):
         if not renpy.store._window:
             return
 
+        if (renpy.store._window == "auto" and
+             not renpy.game.preferences.window_during_trans):
+            return
+
         if renpy.game.context().scene_lists.shown_window:
             return
 

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -47,6 +47,7 @@ class Preferences(renpy.object.Object):
             self.mouse_move = False
         if version < 9:
             self.afm_after_click = False
+            self.window_during_trans = False
 
     def __init__(self):
         self.fullscreen = False
@@ -56,6 +57,7 @@ class Preferences(renpy.object.Object):
         self.afm_enable = True
         self.voice_sustain = False
         self.mouse_move = False
+        self.window_during_trans = False
 
         # Should we wait for the voice to stop?
         self.wait_voice = True

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -379,7 +379,9 @@ Hide and Show Window
 The window statement is used to control if a window is shown when a character
 is not speaking. (For example, during transitions and pauses.) The window show
 statement causes the window to be shown, while the window hide statement hides
-the window.
+the window. And the window auto statement decides to show or hide the window by
+the preference. The window is always hidden when the scene statement is used
+even if the window auto statement is used.
 
 If the optional transition is given, it's used to show and hide the window.
 If not given, it defaults to :var:`config.window_show_transition` and


### PR DESCRIPTION
I added window statements the window auto statement.
Showing the window is dependent on _preferences.during_trans If this is used.

If _preferences.during_trans is set to "window" and the window auto statement is used, the window is shown during transitions.
If _preferences.during_trans is set to "string" and the window auto statement is used, text is also shown during transitions.
If _preferences.during_trans is set to False and the window auto statement is used, it is the same that the window hide statement is used.

And the window is hidden automatically when the scene statement is used even if the window auto statement is used.
