### PR TITLE
Fix delete the tmp directory

### DIFF
--- a/launcher/game/new_project.rpy
+++ b/launcher/game/new_project.rpy
@@ -81,7 +81,7 @@ label new_project:
 
             # Delete the tmp directory, if it exists.
             if os.path.isdir(os.path.join(project_dir, "tmp")):
-                os.path.rmtree(os.path.join(project_dir, "tmp"))
+                shutil.rmtree(os.path.join(project_dir, "tmp"))
 
             # Delete project.json, which must exist.
             os.unlink(os.path.join(project_dir, "project.json"))


### PR DESCRIPTION
Replaced: os.path.rmtree() --> shutil.rmtree()

It's also valid for 6.16.x.
