### PR TITLE
Please set "cython" to RENPY_CYTHON

### DIFF
--- a/module/setuplib.py
+++ b/module/setuplib.py
@@ -11,7 +11,7 @@ import distutils.core
 android = "RENPY_ANDROID" in os.environ
 
 # The cython command.
-cython_command = os.environ.get("RENPY_CYTHON", None)
+cython_command = os.environ.get("RENPY_CYTHON", "cython")
 
 # Note that the android build sets up CFLAGS for us, and ensures
 # that necessary libraries are present. So autoconfiguration is


### PR DESCRIPTION
Currently, None is set as default variable, so we have to set RENPY_CYTHON manually regardless of our environment.
I think "cython" is most typical variable of RENPY_CYTHON. Please set it.
