### PR TITLE
Add application category for OS X

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -613,6 +613,7 @@ init python in distribute:
                 CFBundlePackageType="APPL",
                 CFBundleShortVersionString=version,
                 CFBundleVersion="1.0.{0}".format(int(time.time())),
+                LSApplicationCategoryType="public.app-category.simulation-games",
                 CFBundleDocumentTypes = [
                     {
                         "CFBundleTypeOSTypes" : [ "****", "fold", "disk" ],


### PR DESCRIPTION
The Applications folder in OS X is large and installers tend to expect apps to stay where they were placed (i.e. the root of /Applications). Since Lion, there's been application category metadata for View --> Arrange by Application Category but if the metadata's not in info.plist, the app gets sorted into "Other" at the bottom. 

https://developer.apple.com/library/Mac/releasenotes/General/SubmittingToMacAppStore/#//apple_ref/doc/uid/TP40010572-CH16-SW8 (this applies to all Mac apps, not just those installed through App Store).
