### PR TITLE
autosave before load

### DIFF
--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -316,6 +316,7 @@ init -1500 python:
 
             if not main_menu:
                 if self.confirm:
+                    renpy.loadsave.force_autosave()
                     layout.yesno_screen(layout.LOADING, FileLoad(self.name, False, self.page))
                     return
 


### PR DESCRIPTION
Now loading loses unsaved progress, but then autosave isn't done.
Ren'Py will also do autosave before FileLoad.
