### PR TITLE
add DictValue

### DIFF
--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -110,6 +110,86 @@ init -1500 python:
                 self.old_value = other.value
                 self.start_time = None
 
+    class DictValue(BarValue):
+        """
+         :doc: value
+
+         A value that allows the user to adjust the value of a key
+         in a dict.
+
+         `dict`
+             The dict.
+         `key`
+             The key.
+         `range`
+             The range to adjust over.
+         `max_is_zero`
+             If True, then when the value of a key is zero, the value of the
+             bar will be range, and all other values will be shifted down by 1.
+             This works both ways - when the bar is set to the maximum, the
+             value of a key is set to 0.
+
+         `style`
+             The styles of the bar created.
+         `offset`
+             An offset to add to the value.
+         `step`
+             The amount to change the bar by. If None, defaults to 1/10th of
+             the bar.
+         """
+
+        offset = 0
+
+        def __init__(self, dict, key, range, max_is_zero=False, style="bar", offset=0, step=None):
+            self.dict = dict
+            self.key = key
+            self.range = range
+            self.max_is_zero = max_is_zero
+            self.style = style
+            self.offset = offset
+
+            if step is None:
+                if isinstance(range, float):
+                    step = range / 10.0
+                else:
+                    step = max(range / 10, 1)
+
+            self.step = step
+
+        def changed(self, value):
+
+            if self.max_is_zero:
+                if value == self.range:
+                    value = 0
+                else:
+                    value = value + 1
+
+            value += self.offset
+
+            self.dict[self.key] = value
+            renpy.restart_interaction()
+
+        def get_adjustment(self):
+
+            value = self.dict[self.key]
+
+            value -= self.offset
+
+            if self.max_is_zero:
+                if value == 0:
+                    value = self.range
+                else:
+                    value = value - 1
+
+            return ui.adjustment(
+                range=self.range,
+                value=value,
+                changed=self.changed,
+                step=self.step)
+
+        def get_style(self):
+            return self.style, "v" + self.style
+
     class FieldValue(BarValue):
         """
          :doc: value


### PR DESCRIPTION
Ren'Py doesn't have the BarValue which adjustments a dictionary.
And I added DictValue.

```
    class DictValue(BarValue):
        """
         :doc: value

         A value that allows the user to adjust the value of a key
         in a dict.

         `dict`
             The dict.
         `key`
             The key.
         `range`
             The range to adjust over.
         `max_is_zero`
             If True, then when the value of a key is zero, the value of the
             bar will be range, and all other values will be shifted down by 1.
             This works both ways - when the bar is set to the maximum, the
             value of a key is set to 0.

         `style`
             The styles of the bar created.
         `offset`
             An offset to add to the value.
         `step`
             The amount to change the bar by. If None, defaults to 1/10th of
             the bar.
```
