### PR TITLE
Add SetCharacterVolume

### DIFF
--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -153,6 +153,27 @@ init -1500 python:
             renpy.restart_interaction()
 
     @renpy.pure
+    def SetCharacterVolume(voice_tag, volume=None):
+        """
+        :doc: voice_action
+
+        This allows the volume of each characters to be adjusted.
+        If `volume` is None, this returns the value of volume of `voice_tag`.
+        Otherwise, this set it to `volume`.
+        
+        `volume` is a number between 0.0 and 1.0, and is interpreted as a
+        fraction of the mixer volume for `voice` channel.
+        """
+
+        if voice_tag not in persistent._character_volume:
+            persistent._character_volume[voice_tag] = 1.0
+
+        if volume is None:
+            return DictValue(persistent._character_volume, voice_tag, 1.0)
+        else:
+            return SetDict(persistent._character_volume, voice_tag, volume)
+
+    @renpy.pure
     class ToggleVoiceMute(Action, DictEquality):
         """
         :doc: voice_action
@@ -207,6 +228,10 @@ init -1500 python hide:
     if persistent._voice_mute is None:
         persistent._voice_mute = set()
 
+    # The dictionary of the volume of each voice tags.
+    if persistent._character_volume is None:
+        persistent._character_volume = dict()
+
     # This is called on each interaction, to ensure that the
     # appropriate voice file is played for the user.
     def voice_interact():
@@ -250,6 +275,7 @@ init -1500 python hide:
                         c.context.pre_secondary_volume = c.context.secondary_volume
                         c.set_secondary_volume(config.volume_in_voice, config.reduce_volume_time)
 
+            renpy.music.get_channel("voice").set_volume(persistent._character_volume.get(_voice.tag, 1.0))
             renpy.sound.play(_voice.play, channel="voice")
             store._last_voice_play = _voice.play
         elif not _voice.sustain:


### PR DESCRIPTION
This pull request allows the volume of each characters to be adjusted.

I added persistent._character_volume and SetCharacterVolume.

```
    def SetCharacterVolume(voice_tag, volume=None):
        """
        :doc: voice_action

        This allows the volume of each characters to be adjustment.
        If `volume` is None, this returns the value of volume of `voice_tag`.
        Otherwise, this set it to `volume`.

        `volume` is a number between 0.0 and 1.0, and is interpreted as a
        fraction of the mixer volume for `voice` channel.
        """
```
