### PR TITLE
prevent _window_auto_callback from interfering voice system

### DIFF
--- a/renpy/common/000window.rpy
+++ b/renpy/common/000window.rpy
@@ -68,11 +68,17 @@ init -1200 python:
         if not store._window_auto:
             return
 
+        #prevent interaction from interfering voice system.
+        _has_voice = config.has_voice
+        config.has_voice = False
+
         if statement in config.window_auto_hide:
             _window_hide()
 
         if statement in config.window_auto_show:
             _window_show()
+
+        config.has_voice = _has_voice
 
     config.statement_callbacks.append(_window_auto_callback)
 


### PR DESCRIPTION
_window_auto_callback causes interactions, and they interfered voice system in some case.
For example.

```
    scene bg
    with dissolve

    voice "test.ogg"
    "test"
```

When "window auto" mode, "test.ogg" is played at the same time as a window begins to be shown. And the say statement stop the voice if preferences.voice_sustain is False.

voice_interact is made not to be called by _window_auto_callback by this pull request.
