### PR TITLE
reduce bgm volume during voice playing

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -120,6 +120,9 @@ class MusicContext(renpy.python.RevertableObject):
         # The secondary volume.
         self.secondary_volume = 1.0
 
+        # This is used to reduce volumes during playing a voice
+        self.pre_secondary_volume = None
+
         # The time the channel was ordered last changed.
         self.last_changed = 0
 
@@ -297,6 +300,11 @@ class Channel(object):
 
         # Should we do the callback?
         do_callback = False
+
+        # return secondary_volume to pre_secondary_volume after finishing voices
+        if self.context.pre_secondary_volume and not renpy.audio.music.get_playing("voice") and self.mixer != "voice":
+            self.set_secondary_volume(self.context.pre_secondary_volume, renpy.config.reduce_volume_time)
+            self.context.pre_secondary_volume = None
 
         # This has been modified so we only queue a single sound file
         # per call, to prevent memory leaks with really short sound

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -166,3 +166,6 @@ init 1900 python hide::
         config.has_quicksave = False
         config.quit_action = ui.gamemenus("_confirm_quit")
         config.default_afm_enable = None
+
+    if compat(6, 17, 6):
+        config.reduce_volume_in_voice = False

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -244,6 +244,12 @@ init -1500 python hide:
             renpy.sound.stop(channel="voice")
             store._last_voice_play = _voice.play
         elif _voice.play and not config.skipping:
+            if config.reduce_volume_in_voice:
+                for c in renpy.audio.audio.all_channels:
+                    if c.mixer != "voice" and config.volume_in_voice < c.context.secondary_volume:
+                        c.context.pre_secondary_volume = c.context.secondary_volume
+                        c.set_secondary_volume(config.volume_in_voice, config.reduce_volume_time)
+
             renpy.sound.play(_voice.play, channel="voice")
             store._last_voice_play = _voice.play
         elif not _voice.sustain:

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -477,6 +477,17 @@ key_repeat = (.3, .03)
 # A callback that is called with the character's voice_tag.
 voice_tag_callback = None
 
+# If True, reduce the volumes of all the channels other than the "voice" channel
+# during voice playing.
+reduce_volume_in_voice = True
+
+# If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+# than "voice" mixer during voice playing.
+volume_in_voice = .5
+
+# It takes this seconds to reduce and return the volume when voice is played.
+reduce_volume_time = .5
+
 # A list of callbacks that can be used to add JSON to save files.
 save_json_callbacks = [ ]
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -294,6 +294,20 @@ Occasionally Used
 
     See :ref:`Automatic Voice <automatic-voice>` for more details.
 
+.. var:: config.reduce_volume_in_voice = True
+
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+
+.. var:: config.volume_in_voice = .5
+
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+
+.. var:: config.reduce_volume_time = .5
+
+    # It takes this seconds to reduce and return the volume when voice is played.
+
 .. var:: config.automatic_images = None
 
     If not None, this causes Ren'Py to automatically define

--- a/templates/arabic/game/options.rpy
+++ b/templates/arabic/game/options.rpy
@@ -170,6 +170,17 @@ init -1 python hide:
 
     config.has_voice = True
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
 
     # style.button.activate_sound = "click.wav"

--- a/templates/english/game/options.rpy
+++ b/templates/english/game/options.rpy
@@ -169,6 +169,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
 
     # style.button.activate_sound = "click.wav"

--- a/templates/french/game/options.rpy
+++ b/templates/french/game/options.rpy
@@ -163,6 +163,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sons utilisés lorsque les boutons et les imagemaps sont cliqués
 
     # style.button.activate_sound = "click.wav"

--- a/templates/japanese/game/options.rpy
+++ b/templates/japanese/game/options.rpy
@@ -319,6 +319,22 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    # True ならボイス再生中は "voice" チャンネル以外のすべてのチャンネル
+    # の音量を減らします。
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    # reduce_volume_in_voice が True なら、ボイス再生中の "voice" チャンネル以外のチャンネル
+    # の音量の割合です。
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    # この秒数をかけて音量を変更します。
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
     ## ボタンやイメージボタンをクリックした時に鳴らす効果音。
 

--- a/templates/korean/game/options.rpy
+++ b/templates/korean/game/options.rpy
@@ -170,6 +170,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## 버튼이나 이미지맵이 클릭될 때 재생하는 효과음.
 
     # style.button.activate_sound = "click.wav"

--- a/templates/russian/game/options.rpy
+++ b/templates/russian/game/options.rpy
@@ -171,6 +171,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Звуки при нажатии на кнопки и imagemap-ы.
 
     # style.button.activate_sound = "click.wav"

--- a/templates/spanish/game/options.rpy
+++ b/templates/spanish/game/options.rpy
@@ -241,6 +241,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
     ## - Sonidos utilizados cuando se hace clic en un botón.
 

--- a/testcases/game/options.rpy
+++ b/testcases/game/options.rpy
@@ -170,6 +170,17 @@ init -1 python hide:
 
     config.has_voice = True
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
 
     # style.button.activate_sound = "click.wav"

--- a/the_question/game/options.rpy
+++ b/the_question/game/options.rpy
@@ -181,6 +181,17 @@ init -1 python hide:
 
     config.has_voice = True
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
 
     # style.button.activate_sound = "click.wav"

--- a/tutorial/game/options.rpy
+++ b/tutorial/game/options.rpy
@@ -179,6 +179,17 @@ init -1 python hide:
 
     config.has_voice = False
 
+    # If True, reduce the volumes of all the channels other than the "voice" channel
+    # during voice playing.
+    config.reduce_volume_in_voice = True
+    
+    # If reduce_volume_in_voice is True, fraction of the volumes of the mixers other
+    # than "voice" mixer during voice playing.
+    config.volume_in_voice = .5
+    
+    # It takes this seconds to reduce and return the volume when voice is played.
+    config.reduce_volume_time = .5
+
     ## Sounds that are used when button and imagemaps are clicked.
 
     style.button.activate_sound = "click.wav"


### PR DESCRIPTION
I added three config variables.

If config.reduce_volume_in_voice is True, the volumes of all the channels other than the "voice" channel are reduced to config.volume_in_voice in config.reduce_volume_time seconds during voice playing.

This gets voices to be easier to hear.
