### PR TITLE
Only consider unique image attributes when determining best match.

### DIFF
--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -403,7 +403,7 @@ class ShownImageInfo(renpy.object.Object):
                 if num_required != len(required):
                     continue
 
-                len_attrs = len(attrs)
+                len_attrs = len(set(attrs))
 
                 if len_attrs < max_len:
                     continue


### PR DESCRIPTION
This fixes cases where `tag attr1 attr2` and `tag attr2 attr2` are given equal precedence and thus cause an ambiguity error.
