### PR TITLE
Small fix for newline_indent behavior.

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -593,8 +593,9 @@ class Layout(object):
             lines.extend(l)
 
             # Figure out the indent of the next line.
-            first_indent = style.newline_indent
-            if first_indent is None:
+            if style.newline_indent:
+                first_indent = style.first_indent
+            else:
                 first_indent = rest_indent
 
         if style.line_spacing < 0:


### PR DESCRIPTION
Small fix for newline_indent behavior.
Now should work as described in documentation ( http://www.renpy.org/doc/html/style_properties.html#style-property-newline_indent )
Before if newline_indent was set to True newlines started with no indentation.
