### PR TITLE
add Function Action

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -356,7 +356,6 @@ init -1500 python:
             if _preferences.mouse_move:
                 renpy.set_mouse_pos(self.x, self.y, self.duration)
 
-    @renpy.pure
     class Function(Action, DictEquality):
         """
         :doc: other_action


### PR DESCRIPTION
This Action allows functions that take arguments to be used as Action.

```
class Function(Action):
    """
    :doc: other_action

    This Action calls `callable` with `args` and `kwargs`.

    `callable`
        Callable object.
    `args`
        position arguments to be passed to `callable`.
    `kwargs`
        keyword arguments to be passed to `callable`.
    """
```
