### PR TITLE
Update screens.rpy

### DIFF
--- a/templates/arabic/game/screens.rpy
+++ b/templates/arabic/game/screens.rpy
@@ -379,7 +379,7 @@ screen preferences:
 
                 label _("Language")
                 textbutton "English" action Language(None)
-                textbutton u"Arabic" text_font "tl/arabic/AdvertisingBold.ttf" action Language("arabic")    
+                textbutton u"Arabic" text_font "tl/None/AdvertisingBold.ttf" action Language("arabic")    
 
             frame:
                 style_group "pref"


### PR DESCRIPTION
fixed the path where Ren'Py had the wrong path for the arabic font AdvertisingBold.ttf which created an error message while trying to access "Options" from the inside the game.
