### PR TITLE
Copy target files of symbolic links

### DIFF
--- a/launcher/game/new_project.rpy
+++ b/launcher/game/new_project.rpy
@@ -98,7 +98,7 @@ label new_project:
         template_path = template.path
 
         with interface.error_handling("creating a new project"):
-            shutil.copytree(template_path, project_dir)
+            shutil.copytree(template_path, project_dir, symlinks=False)
 
             # Delete the tmp directory, if it exists.
             if os.path.isdir(os.path.join(project_dir, "tmp")):


### PR DESCRIPTION
This change copies target files of symlinks in the template.

Package maintainers in UN*X OS may want to use files which are contained in distribution's packages to shrink the package.
For example in debian, Ren'Py has MTLc3m.ttf in Japanese template, but it also contained in fonts-motoya-l-cedar package. However, if they replace it using symlink, the launcher will create the symlink instead of the real font.
