### PR TITLE
Fix change language of the launcher

### DIFF
--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -214,7 +214,7 @@ screen preferences:
                                 textbutton tlname action Language(tlvalue) style "l_list"
 
 
-    textbutton _("Back") action Jump("front_page") style "l_left_button"
+    textbutton _("Back") action Jump("start") style "l_left_button"
 
 label projects_directory_preference:
     call choose_projects_directory


### PR DESCRIPTION
Changed label on the "back" button from the preferences screen.

Before, when changing the language of the launcher:

![ren py launcher_003](https://cloud.githubusercontent.com/assets/1286535/3455005/e385d906-01d9-11e4-9b36-b54614caef47.png)

I'm not sure if this is the best solution.
