### PR TITLE
Fixing mistakes on the Language Basics doc page

### DIFF
--- a/sphinx/source/language_basics.rst
+++ b/sphinx/source/language_basics.rst
@@ -298,7 +298,7 @@ Here's a synopsis of python expressions.
     Tuples begin with a left-parenthesis ``(``, consist of zero or
     more comma-separated python expressions, and end with a
     right-parenthesis ``)``. As a special case, the one-item tuple
-    must have a parenthesis following the item. For example::
+    must have a comma following the item. For example::
 
         ()
         (1,)


### PR DESCRIPTION
I was reading through the docs and found some mistakes in the Language Basics page. There was a trailing incomplete sentence fragment in the `True, False, None` section and a mistake in the `Tuple` section.
