### PR TITLE
Let choose to developer if strings need to be empty while generating translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 saves
 tmp
 cache
+env
 
 log.txt
 /errors.txt

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -169,7 +169,7 @@ screen preferences:
                         textbutton _("Hardware rendering") style "l_checkbox" action ToggleField(persistent, "gl_enable")
                         textbutton _("Show templates") style "l_checkbox" action ToggleField(persistent, "show_templates")
                         textbutton _("Large fonts") style "l_checkbox" action [ ToggleField(persistent, "large_print"), renpy.utter_restart ]
-						textbutton _("Generate empty strings for translations") style "l_checkbox" action ToggleField(persistent, "generate_empty_strings")
+                        textbutton _("Generate empty strings for translations") style "l_checkbox" action ToggleField(persistent, "generate_empty_strings")
 
                         if renpy.windows:
                             textbutton _("Console output") style "l_checkbox" action ToggleField(persistent, "windows_console")

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -169,6 +169,7 @@ screen preferences:
                         textbutton _("Hardware rendering") style "l_checkbox" action ToggleField(persistent, "gl_enable")
                         textbutton _("Show templates") style "l_checkbox" action ToggleField(persistent, "show_templates")
                         textbutton _("Large fonts") style "l_checkbox" action [ ToggleField(persistent, "large_print"), renpy.utter_restart ]
+						textbutton _("Generate empty strings for translations") style "l_checkbox" action ToggleField(persistent, "generate_empty_strings")
 
                         if renpy.windows:
                             textbutton _("Console output") style "l_checkbox" action ToggleField(persistent, "windows_console")

--- a/launcher/game/translations.rpy
+++ b/launcher/game/translations.rpy
@@ -41,7 +41,7 @@ label translate:
 
         if language == "rot13":
             args.append("--rot13")
-        else:
+        elif persistent.generate_empty_strings:
             args.append("--empty")
 
         interface.processing(_("Ren'Py is generating translations...."))


### PR DESCRIPTION
I created a specific option in the preference panel to handle this behavior and I subordinated it to the rot13 check.

I think it will be useful to change that check also and to create explicit request to the developer for rot13 option, maybe with just before the export and after the choose of the language name, so it will not be tied to the language name.