### PR TITLE
Add translation function _() in Update 00updater.rpy error messages

### DIFF
--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -359,7 +359,7 @@ init -1500 python in updater:
             """
 
             if renpy.mobile:
-                raise UpdateError("The Ren'Py Updater is not supported on mobile devices.")
+                raise UpdateError(_("The Ren'Py Updater is not supported on mobile devices."))
 
             self.load_state()
             self.test_write()
@@ -475,7 +475,7 @@ init -1500 python in updater:
                 raise UpdateCancelled()
 
             if self.simulate == "error":
-                raise UpdateError("An error is being simulated.")
+                raise UpdateError(_("An error is being simulated."))
 
             if self.simulate == "not_available":
                 self.can_cancel = False
@@ -651,7 +651,7 @@ init -1500 python in updater:
             fn = os.path.join(self.updatedir, "current.json")
 
             if not os.path.exists(fn):
-                raise UpdateError("Either this project does not support updating, or the update status file was deleted.")
+                raise UpdateError(_("Either this project does not support updating, or the update status file was deleted."))
 
             with open(fn, "rb") as f:
                 self.current_state = json.load(f)
@@ -665,10 +665,10 @@ init -1500 python in updater:
 
                 os.unlink(fn)
             except:
-                raise UpdateError("This account does not have permission to perform an update.")
+                raise UpdateError(_("This account does not have permission to perform an update."))
 
             if not self.log:
-                raise UpdateError("This account does not have permission to write the update log.")
+                raise UpdateError(_("This account does not have permission to write the update log."))
 
         def check_updates(self):
             """
@@ -693,7 +693,7 @@ init -1500 python in updater:
                 try:
                     rsa.verify(updates_json, signature, self.public_key)
                 except:
-                    raise UpdateError("Could not verify update signature.")
+                    raise UpdateError(_("Could not verify update signature."))
 
                 if "monkeypatch" in self.updates:
                     exec self.updates["monkeypatch"] in globals(), globals()
@@ -953,7 +953,7 @@ init -1500 python in updater:
                 if os.path.exists(new_fn + ".part"):
                     os.rename(new_fn + ".part", new_fn)
                 else:
-                    raise UpdateError("The update file was not downloaded.")
+                    raise UpdateError(_("The update file was not downloaded."))
 
             # Check that the downloaded file has the right digest.
             import hashlib
@@ -971,7 +971,7 @@ init -1500 python in updater:
                 digest = hash.hexdigest()
 
             if digest != self.updates[module]["digest"]:
-                raise UpdateError("The update file does not have the correct digest - it may have been corrupted.")
+                raise UpdateError(_("The update file does not have the correct digest - it may have been corrupted."))
 
             if os.path.exists(new_fn + ".part.old"):
                 os.unlink(new_fn + ".part.old")


### PR DESCRIPTION
Add the translation function _() to `raise UpdateError` strings because they are showed to the end user.

Don't know how this can be done in line 1030: `raise UpdateError("While unpacking {}, unknown type {}.".format(info.name, info.type))`