### PR TITLE
add toggle to show/hide "Edit File" section

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2015 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2015 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -197,8 +197,9 @@ screen front_page_project:
                     textbutton _("base") action OpenDirectory(".")
                     # textbutton _("images") action OpenDirectory("game/images") style "l_list"
                     # textbutton _("save") action None style "l_list"
-
+                
             vbox:
+              if persistent.show_edit_funcs:
 
                 label _("Edit File") style "l_label_small"
 
@@ -209,6 +210,8 @@ screen front_page_project:
                     textbutton "options.rpy" action editor.Edit("game/options.rpy", check=True)
                     textbutton "screens.rpy" action editor.Edit("game/screens.rpy", check=True)
                     textbutton _("All script files") action editor.EditAll()
+              else:
+                pass
 
         add SPACER
         add SEPARATOR

--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -199,19 +199,17 @@ screen front_page_project:
                     # textbutton _("save") action None style "l_list"
                 
             vbox:
-              if persistent.show_edit_funcs:
+                if persistent.show_edit_funcs:
 
-                label _("Edit File") style "l_label_small"
+                    label _("Edit File") style "l_label_small"
 
-                frame style "l_indent":
-                    has vbox
+                    frame style "l_indent":
+                        has vbox
 
-                    textbutton "script.rpy" action editor.Edit("game/script.rpy", check=True)
-                    textbutton "options.rpy" action editor.Edit("game/options.rpy", check=True)
-                    textbutton "screens.rpy" action editor.Edit("game/screens.rpy", check=True)
-                    textbutton _("All script files") action editor.EditAll()
-              else:
-                pass
+                        textbutton "script.rpy" action editor.Edit("game/script.rpy", check=True)
+                        textbutton "options.rpy" action editor.Edit("game/options.rpy", check=True)
+                        textbutton "screens.rpy" action editor.Edit("game/screens.rpy", check=True)
+                        textbutton _("All script files") action editor.EditAll()
 
         add SPACER
         add SEPARATOR

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2015 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2015 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -24,6 +24,9 @@ init python:
         persistent.gl_enable = True
 
     config.gl_enable = persistent.gl_enable
+
+    if persistent.show_edit_funcs is None:
+        persistent.show_edit_funcs = True
 
     if persistent.windows_console is None:
         persistent.windows_console = False
@@ -168,6 +171,7 @@ screen preferences:
 
                         textbutton _("Hardware rendering") style "l_checkbox" action ToggleField(persistent, "gl_enable")
                         textbutton _("Show templates") style "l_checkbox" action ToggleField(persistent, "show_templates")
+                        textbutton _("Show edit functions") style "l_checkbox" action ToggleField(persistent, "show_edit_funcs")
                         textbutton _("Large fonts") style "l_checkbox" action [ ToggleField(persistent, "large_print"), renpy.utter_restart ]
 
                         if renpy.windows:

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -171,7 +171,7 @@ screen preferences:
 
                         textbutton _("Hardware rendering") style "l_checkbox" action ToggleField(persistent, "gl_enable")
                         textbutton _("Show templates") style "l_checkbox" action ToggleField(persistent, "show_templates")
-                        textbutton _("Show edit functions") style "l_checkbox" action ToggleField(persistent, "show_edit_funcs")
+                        textbutton _("Show edit buttons") style "l_checkbox" action ToggleField(persistent, "show_edit_funcs")
                         textbutton _("Large fonts") style "l_checkbox" action [ ToggleField(persistent, "large_print"), renpy.utter_restart ]
 
                         if renpy.windows:


### PR DESCRIPTION
Many power users have no need for the edit shortcuts in the launcher,
and in projects with a large number of script files hitting "edit all
script files" by accident can be annoying