### PR TITLE
Remove old .rpyc files on "Force Recompile"

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -265,6 +265,18 @@ def main():
     renpy.style.build_styles() # @UndefinedVariable
     renpy.display.screen.prepare_screens()
 
+    # If recompiling everything, remove old .rpyc files.
+    # Otherwise, may fail in case there some orphaned (without .rpy) .rpyc
+    # with same labels as in other scripts (usually happens on script rename).
+    if renpy.game.args.command == 'compile':
+        for (fn, dir) in renpy.game.script.script_files:
+            try:
+                os.unlink(os.path.join(dir, fn+".rpyc"))
+            except OSError:
+                pass
+        # Update script files list, so that it doesn't contain removed .rpyc's
+        renpy.game.script.scan_script_files()
+
     # Load all .rpy files.
     renpy.game.script.load_script() # sets renpy.game.script.
 

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -272,7 +272,8 @@ def main():
         for (fn, dir) in renpy.game.script.script_files:
             if not os.path.isfile(os.path.join(dir, fn+".rpy")):
                 try:
-                    os.unlink(os.path.join(dir, fn+".rpyc"))
+                    name = os.path.join(dir, fn+".rpyc")
+                    os.rename(name, name+".bak")
                 except OSError:
                     # This perhaps shouldn't happen since either .rpy or .rpyc should exist
                     pass

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -265,15 +265,17 @@ def main():
     renpy.style.build_styles() # @UndefinedVariable
     renpy.display.screen.prepare_screens()
 
-    # If recompiling everything, remove old .rpyc files.
-    # Otherwise, may fail in case there some orphaned (without .rpy) .rpyc
-    # with same labels as in other scripts (usually happens on script rename).
+    # If recompiling everything, remove orphan .rpyc files.
+    # Otherwise, will fail in case orphan .rpyc have same
+    # labels as in other scripts (usually happens on script rename).
     if renpy.game.args.command == 'compile':
         for (fn, dir) in renpy.game.script.script_files:
-            try:
-                os.unlink(os.path.join(dir, fn+".rpyc"))
-            except OSError:
-                pass
+            if not os.path.isfile(os.path.join(dir, fn+".rpy")):
+                try:
+                    os.unlink(os.path.join(dir, fn+".rpyc"))
+                except OSError:
+                    # This perhaps shouldn't happen since either .rpy or .rpyc should exist
+                    pass
         # Update script files list, so that it doesn't contain removed .rpyc's
         renpy.game.script.scan_script_files()
 


### PR DESCRIPTION
Otherwise, compiling may fail in case there some orphaned (without .rpy) .rpyc with same labels as in other scripts (usually happens on script rename).

The only problem with this i can see is that it may affect .rpyc files in renpy/common. Not sure if that is a real problem and whether or not those files are touched without this change.