### PR TITLE
Add renpy.reset_physical_size()

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2608,6 +2608,21 @@ def set_physical_size(size):
         renpy.display.draw.quit()
         renpy.display.interface.set_mode(size)
 
+def reset_physical_size():
+    """
+    :doc: other
+
+    Attempts to set the size of the physical window to the specified values 
+    in renpy.config. (That is, screen_width and screen_height.) This has the
+    side effect of taking the screen out of fullscreen mode.
+    """
+
+    renpy.game.preferences.fullscreen = False
+
+    if get_renderer_info()["resizable"]:
+        renpy.display.draw.quit()
+        renpy.display.interface.set_mode((renpy.config.screen_width, renpy.config.screen_height))
+
 
 @renpy_pure
 def fsencode(s):


### PR DESCRIPTION
While this is trivial code, it just makes sense to me that Ren'Py has this (at least, as opposed to not having it). As a complement to renpy.set_physical_size(), anyhow.