### PR TITLE
Use dill for saving

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -23,6 +23,7 @@
 
 import pickle
 import cPickle
+import dill
 
 from cStringIO import StringIO
 


### PR DESCRIPTION
This allows to save things which are impossible with regular pickle/cPickle, including cases which are pickled fine in py3, but can't be pickled by py2 pickle. [Dill](https://pypi.python.org/pypi/dill) seems to have no effect with cPickle, but as long as there's long-term plan to migrate to py3 this shouldn't be a problem.

I don't know what is correct way to add dependency (i just installed dill using 'pip install dill' in virtual env, but perhaps there's a way to automatize this?), but if you're going to accept this, i can either put that into README or do proper dependency if you tell me where to look.