### PR TITLE
add missing parentheses in setuplib.py and remove old README

### DIFF
--- a/module/README.txt
+++ b/module/README.txt
@@ -1,3 +1,0 @@
-For instructions on compling the module yourself, please read:
-
-http://www.bishoujo.us/renpy/dl/lgpl/README.txt

--- a/module/setuplib.py
+++ b/module/setuplib.py
@@ -43,7 +43,7 @@ cython_command = os.environ.get("RENPY_CYTHON", "cython")
 
 # The install variable is a list of directories that have Ren'Py
 # dependencies installed in them.
-if not android or ios:
+if not (android or ios):
     install = os.environ.get("RENPY_DEPS_INSTALL", "/usr")
     install = install.split("::")
     install = [ os.path.abspath(i) for i in install ]


### PR DESCRIPTION
"if not android or ios:" <- this line has redundant "or ios" part, so either it was meant to be "not (android or ios)" or just "not android".. Not sure if this affects anything, but it's better to keep source clean.

Also removed outdated README in module/ directory.