### PR TITLE
Changes audio.py to work around an indefinite lockup that occurs if you try to quit while PulseAudio is locked.

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -41,7 +41,18 @@ if 'pss' not in disable:
     try:
         import pysdlsound as pss
         pss.check_version(4)  # @UndefinedVariable
-        atexit.register(pss.quit)  # @UndefinedVariable
+        import platform
+        if platform.system()=='Linux':
+            def audio_atexit():
+                import signal
+                handler = signal.signal(signal.SIGALRM,signal.SIG_DFL)
+                alrm = signal.alarm(10)
+                pss.quit()
+                signal.signal(signal.SIGALRM,handler)
+                signal.alarm(alrm)
+            atexit.register(audio_atexit)
+        else:
+            atexit.register(pss.quit)
     except:
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
To replicate the lockup:

startx as two different users.
Do something that locks the sound card as user1 (say, playing a pile of mp3s
through mpg321)
As the other user, start and then quit a Ren'Py game.

Result: strace will show the Ren'Py game sitting there waiting indefinitely
for a futex until such time as mpg321 releases the sound card.