### PR TITLE
Fix Nightly's translation

### DIFF
--- a/launcher/game/tl/simplified_chinese/updater.rpy
+++ b/launcher/game/tl/simplified_chinese/updater.rpy
@@ -35,7 +35,7 @@ translate simplified_chinese strings:
 
     # game/updater.rpy:129
     old "Nightly"
-    new "暗黑版"
+    new "每夜版"
 
     # game/updater.rpy:135
     old "The bleeding edge of Ren'Py development. This may have the latest features, or might not run at all."


### PR DESCRIPTION
It should be "每夜版", not "暗黑版".
Old translation means "darkness version", not "nightly".