### PR TITLE
Typofix on docstring

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2327,7 +2327,7 @@ def call_screen(_screen_name, *args, **kwargs):
     """
     :doc: screens
 
-    The programmatic equivalent of the show screen statement.
+    The programmatic equivalent of the call screen statement.
 
     This shows `_screen_name` as a screen, then causes an interaction
     to occur. The screen is hidden at the end of the interaction, and


### PR DESCRIPTION
"The programmatic equivalent of the show screen statement." became "The programmatic equivalent of the call screen statement." for def call_screen