### PR TITLE
Fix creator-defined statement prediction

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1704,7 +1704,7 @@ class UserStatement(Node):
             parsed = renpy.statements.parse(self, self.line, self.block)
             self.parsed = parsed
 
-        renpy.statements.call(method, parsed, *args, **kwargs)
+        return renpy.statements.call(method, parsed, *args, **kwargs)
 
     def get_name(self):
         parsed = self.parsed


### PR DESCRIPTION
Completed the fix for #292: `UserStatement.predict` uses the return value from `UserStatement.call`, but that method did not return anything.