### PR TITLE
Custom text replacement hook

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -563,6 +563,9 @@ log_to_stdout = False
 # new-style custom text tags.
 custom_text_tags = { }
 
+# A function that given the text from a TEXT token, returns a replacement text.
+replace_text = None
+
 # A function that is called when a label is missing.
 missing_label_callback = None
 

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1854,9 +1854,11 @@ class Text(renpy.display.core.Displayable):
             t = tokens.pop(0)
             kind, text = t
 
-            if kind != TAG:
+            if kind == TEXT and renpy.config.replace_text:
+                rv.append((TEXT, unicode(renpy.config.replace_text(text))))
+
+            elif kind != TAG:
                 rv.append(t)
-                continue
 
             else:
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -612,6 +612,27 @@ Occasionally Used
     a window. The default action prompts the user to see if he wants
     to quit the game.
 
+.. var:: config.replace_text = None
+
+    If not None, a function that is called with a single argument, a text to
+    be displayed to the user. The function can return the same text it was
+    passed, or a replacement text that will be displayed instead.
+
+    The function is called after substitutions have been performed and after
+    the text has been split on tags, so its argument contains nothing but
+    actual text. All displayed text passes through the function: not only
+    dialogue text, but also user interface text.
+
+    This can be used to replace specific ASCII sequences with corresponding
+    Unicode characters, as demonstrated by the following code::
+
+        def replace_text(s):
+            s = s.replace("'", u'\u2019') # apostrophe
+            s = s.replace('--', u'\u2014') # em dash
+            s = s.replace('...', u'\u2026') # ellipsis
+            return s
+        config.replace_text = replace_text
+
 .. var:: config.save_json_callbacks = [ ]
 
     A list of callback functions that are used to create the json object


### PR DESCRIPTION
This allows a custom function to for example replace '--' with em-dash and '...' with an actual ellipsis character. While it is possible to instead put those Unicode characters directly in the .rpy file, it is easier to type them as ASCII sequences.