### PR TITLE
Add "arrowkeys" child to Viewport

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -70,11 +70,17 @@ init -1600 python:
         input_enter = [ 'K_RETURN', 'K_KP_ENTER' ],
         input_left = [ 'K_LEFT', 'repeat_K_LEFT' ],
         input_right = [ 'K_RIGHT', 'repeat_K_RIGHT' ],
+        input_up = [ 'K_UP', 'repeat_K_UP' ],
+        input_down = [ 'K_DOWN', 'repeat_K_DOWN' ],
         input_delete = [ 'K_DELETE', 'repeat_K_DELETE' ],
 
         # Viewport.
-        viewport_up = [ 'mousedown_4' ],
-        viewport_down = [ 'mousedown_5' ],
+        viewport_leftarrow = [ 'K_LEFT', 'repeat_K_LEFT' ],
+        viewport_rightarrow = [ 'K_RIGHT', 'repeat_K_RIGHT' ],
+        viewport_uparrow = [ 'K_UP', 'repeat_K_UP' ],
+        viewport_downarrow = [ 'K_DOWN', 'repeat_K_DOWN' ],
+        viewport_wheelup = [ 'mousedown_4' ],
+        viewport_wheeldown = [ 'mousedown_5' ],
         viewport_drag_start = [ 'mousedown_1' ],
         viewport_drag_end = [ 'mouseup_1' ],
 
@@ -105,6 +111,8 @@ init -1600 python:
 
         # Ignored (kept for backwards compatibility).
         toggle_music = [ 'm' ],
+        viewport_up = [ 'mousedown_4' ],
+        viewport_down = [ 'mousedown_5' ],
 
         # Profile commands.
         profile_once = [ 'K_F8' ],

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -237,8 +237,12 @@ init python:
         button_select = [ 'mouseup_1', 'K_RETURN', 'K_KP_ENTER', 'K_SELECT' ],
 
         # Viewport.
-        viewport_up = [ 'mousedown_4' ],
-        viewport_down = [ 'mousedown_5' ],
+        viewport_leftarrow = [ 'K_LEFT', 'repeat_K_LEFT' ],
+        viewport_rightarrow = [ 'K_RIGHT', 'repeat_K_RIGHT' ],
+        viewport_uparrow = [ 'K_UP', 'repeat_K_UP' ],
+        viewport_downarrow = [ 'K_DOWN', 'repeat_K_DOWN' ],
+        viewport_wheelup = [ 'mousedown_4' ],
+        viewport_wheeldown = [ 'mousedown_5' ],
         viewport_drag_start = [ 'mousedown_1' ],
         viewport_drag_end = [ 'mouseup_1' ],
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1348,6 +1348,7 @@ class Viewport(Container):
 
         if version < 5:
             self.focusable = self.draggable
+            self.arrowkeys = False
 
 
     def __init__(self,
@@ -1358,6 +1359,7 @@ class Viewport(Container):
                  yadjustment=None,
                  set_adjustments=True,
                  mousewheel=False,
+                 arrowkeys=False,
                  draggable=False,
                  edgescroll=None,
                  style='viewport',
@@ -1393,6 +1395,7 @@ class Viewport(Container):
         self.child_width, self.child_height = child_size
 
         self.mousewheel = mousewheel
+        self.arrowkeys = arrowkeys
         self.draggable = draggable
 
         # Layout participates in the focus system so drags get migrated.
@@ -1564,14 +1567,44 @@ class Viewport(Container):
 
         if self.mousewheel:
 
-            if renpy.display.behavior.map_event(ev, 'viewport_up'):
+            if renpy.display.behavior.map_event(ev, 'viewport_wheelup'):
                 rv = self.yadjustment.change(self.yadjustment.value - self.yadjustment.step)
                 if rv is not None:
                     return rv
                 else:
                     raise renpy.display.core.IgnoreEvent()
 
-            if renpy.display.behavior.map_event(ev, 'viewport_down'):
+            if renpy.display.behavior.map_event(ev, 'viewport_wheeldown'):
+                rv = self.yadjustment.change(self.yadjustment.value + self.yadjustment.step)
+                if rv is not None:
+                    return rv
+                else:
+                    raise renpy.display.core.IgnoreEvent()
+
+        if self.arrowkeys:
+
+            if renpy.display.behavior.map_event(ev, 'viewport_leftarrow'):
+                rv = self.xadjustment.change(self.xadjustment.value - self.xadjustment.step)
+                if rv is not None:
+                    return rv
+                else:
+                    raise renpy.display.core.IgnoreEvent()
+
+            if renpy.display.behavior.map_event(ev, 'viewport_rightarrow'):
+                rv = self.xadjustment.change(self.xadjustment.value + self.xadjustment.step)
+                if rv is not None:
+                    return rv
+                else:
+                    raise renpy.display.core.IgnoreEvent()
+
+            if renpy.display.behavior.map_event(ev, 'viewport_uparrow'):
+                rv = self.yadjustment.change(self.yadjustment.value - self.yadjustment.step)
+                if rv is not None:
+                    return rv
+                else:
+                    raise renpy.display.core.IgnoreEvent()
+
+            if renpy.display.behavior.map_event(ev, 'viewport_downarrow'):
                 rv = self.yadjustment.change(self.yadjustment.value + self.yadjustment.step)
                 if rv is not None:
                     return rv

--- a/renpy/screenlang.py
+++ b/renpy/screenlang.py
@@ -802,6 +802,7 @@ for name in [ "bar", "vbar" ]:
 FunctionStatementParser("viewport", "ui.viewport", 1)
 Keyword("child_size")
 Keyword("mousewheel")
+Keyword("arrowkeys")
 Keyword("draggable")
 Keyword("edgescroll")
 Keyword("xadjustment")

--- a/renpy/sl2/sldisplayables.py
+++ b/renpy/sl2/sldisplayables.py
@@ -296,6 +296,7 @@ def sl2viewport(**kwargs):
 DisplayableParser("viewport", sl2viewport, "viewport", 1, replaces=True)
 Keyword("child_size")
 Keyword("mousewheel")
+Keyword("arrowkeys")
 Keyword("draggable")
 Keyword("edgescroll")
 Keyword("xadjustment")


### PR DESCRIPTION
I figure if "mousewheel" is a child, it might be nice to be able to have "arrowkeys" as a child... but I'm not entirely certain as to the correctness of the script changes.

It works on my end, but it may not be stylistically correct.