### PR TITLE
No longer try to reuse existing windows when switching video modes.

### DIFF
--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -746,23 +746,13 @@ class SWDraw(object):
         else:
             fsflag = 0
 
-        # If a window exists of the right size and flags, use it. Otherwise,
-        # make our own window.
-        old_screen = pygame.display.get_surface()
+        # Don't reuse the old screen, because doing so fails to update
+        # properly on Xorg.
 
         scaled_width = int(width * scale_factor)
         scaled_height = int(height * scale_factor)
 
-        if ((old_screen is not None) and
-            (old_screen.get_size() == (scaled_width, scaled_height)) and
-            (old_screen.get_flags() & pygame.FULLSCREEN == fsflag) and
-            not (old_screen.get_flags() & pygame.OPENGL)
-            ):
-
-            self.screen = old_screen
-
-        else:
-            self.screen = pygame.display.set_mode((scaled_width, scaled_height), fsflag, 32)
+        self.screen = pygame.display.set_mode((scaled_width, scaled_height), fsflag, 32)
 
         if scale_factor != 1.0:
             self.window = surface(width, height, True)


### PR DESCRIPTION
This fixes a bug where, if you're using the software renderer on Xorg on Debian Jessie,
switching into fullscreen produces an unusable screen (usually, a fullscreen window with
the current screen contents stuck on it; sometimes the game window scaled to full screen
but refusing to accept graphic updates (though clicks ARE passed through to the underlying
game), sometimes the game window drawn actual size in the upper left corner of the screen
with the rest of the screen occupied by the previous screen contents).  This bug was
seen on two different Jessie machines.

The fix doesn't appear to cause problems on my Win8 test machine; I haven't tested it on anything else.  There doesn't seem to be any real performance benefit from the window reuse on Jessie or Win8.