### PR TITLE
Added argument to QuickLoad() to control confirm prompt

### DIFF
--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -673,7 +673,7 @@ init -1500 python:
         Performs a quick load.
         
         `confirm`
-            If true, prompt for confirmation before loading the file.
+            If true and not at the main menu, prompt for confirmation before loading the file.
         """
 
         rv = FileLoad(1, page="quick", confirm=confirm, newest=False)

--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -305,7 +305,7 @@ init -1500 python:
              the file will not be loadable.
 
          `confirm`
-             If true, prompt if loading the file will end the game.
+             If true and not at the main menu, prompt for confirmation before loading the file.
 
          `page`
              The page that the file will be loaded from. If None, the
@@ -666,14 +666,17 @@ init -1500 python:
         return rv
 
     @renpy.pure
-    def QuickLoad(showprompt=True):
+    def QuickLoad(confirm=True):
         """
         :doc: file_action
-
+        
         Performs a quick load.
+        
+        `confirm`
+            If true, prompt for confirmation before loading the file.
         """
 
-        rv = FileLoad(1, page="quick", confirm=showprompt, newest=False)
+        rv = FileLoad(1, page="quick", confirm=confirm, newest=False)
         rv.alt = "Quick load."
         return rv
 

--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -666,14 +666,14 @@ init -1500 python:
         return rv
 
     @renpy.pure
-    def QuickLoad():
+    def QuickLoad(showprompt=True):
         """
         :doc: file_action
 
         Performs a quick load.
         """
 
-        rv = FileLoad(1, page="quick", confirm=True, newest=False)
+        rv = FileLoad(1, page="quick", confirm=showprompt, newest=False)
         rv.alt = "Quick load."
         return rv
 


### PR DESCRIPTION
So that you can quickload a file without having the load confirm prompt show up. I intend to make all prompts optional for my next game so this was a necessary change for me, and it's a convenient option for other devs who might want to do the same.