### PR TITLE
Add a PushMove transition.

### DIFF
--- a/renpy/common/00definitions.rpy
+++ b/renpy/common/00definitions.rpy
@@ -352,6 +352,12 @@ init -1400:
 
     define irisout = CropMove(1.0, "irisout")
     define irisin = CropMove(1.0, "irisin")
+    
+    # Various uses of PushMove.
+    define pushright = PushMove(1.0, "pushright")
+    define pushleft = PushMove(1.0, "pushleft")
+    define pushup = PushMove(1.0, "pushup")
+    define pushdown = PushMove(1.0, "pushdown")
 
     # Zoom-based transitions. Legacy - nowadays, these are probably best done with ATL.
     define zoomin = OldMoveTransition(0.5, enter_factory=ZoomInOut(0.01, 1.0))

--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -167,6 +167,7 @@ Dissolve = renpy.curry.curry(renpy.display.transition.Dissolve)
 ImageDissolve = renpy.curry.curry(renpy.display.transition.ImageDissolve)
 AlphaDissolve = renpy.curry.curry(renpy.display.transition.AlphaDissolve)
 CropMove = renpy.curry.curry(renpy.display.transition.CropMove)
+PushMove = renpy.curry.curry(renpy.display.transition.PushMove)
 Pixellate = renpy.curry.curry(renpy.display.transition.Pixellate)
 
 

--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -59,7 +59,7 @@ pure_functions = {
     "Particles", "SnowBlossom", "Text", "ParameterizedText", "FontGroup",
     "Drag", "Alpha", "AlphaMask", "Position", "Pan", "Move", "Motion", "Revolve", "Zoom",
     "RotoZoom", "FactorZoom", "SizeZoom", "Fade", "Dissolve", "ImageDissolve",
-    "AlphaDissolve", "CropMove", "Pixellate", "OldMoveTransition",
+    "AlphaDissolve", "CropMove", "PushMove", "Pixellate", "OldMoveTransition",
     "MoveTransition", "MoveFactory", "MoveIn", "MoveOut", "ZoomInOut",
     "RevolveInOut", "MultipleTransition", "ComposeTransition", "Pause",
     "SubTransition", "ADVSpeaker", "ADVCharacter", "Speaker", "Character",


### PR DESCRIPTION
This adds a new transition type, which causes the new scene to "push" the old scene off the screen in one of four directions. It's basically just a special case of CropMove--a combination of a slide in and a slide out applied simultaneously. I couldn't think of a nice way to do it with the tools available, so I made it its own transition, which I thought other people might find useful.

As a side note, because this is code I've written for a MangaGamer project, I'd appreciate it if you could credit them alongside me wherever you credit contributors, should you choose to accept this.