### PR TITLE
Add {alpha} text tag.

### DIFF
--- a/renpy/color.py
+++ b/renpy/color.py
@@ -488,3 +488,12 @@ class Color(tuple):
         h, _, s = self.hls
         l = lightness
         return Color(hls=(h, l, s), alpha=self.alpha)
+
+    def replace_opacity(self, opacity):
+        """
+        :doc: color method
+
+        Replaces this color's opacity with `opacity`, and returns the result
+        as a new Color.
+        """
+        return Color((self[0], self[1], self[2]), alpha=opacity)

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -987,6 +987,15 @@ class Layout(object):
             elif tag == "color":
                 push().color = renpy.easy.color(value)
 
+            elif tag == "alpha":
+                ts = push()
+                if value[0] in "+-":
+                    value = ts.color.alpha + float(value)
+                else:
+                    value = float(value)
+                value = min(max(value, 0.0), 1.0)
+                ts.color = ts.color.replace_opacity(value)
+
             elif tag == "k":
                 push().kerning = self.scale(float(value))
 

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -184,6 +184,16 @@ Tags that apply to all text are:
             return
 
 
+.. text-tag:: alpha
+
+    The alpha text tag renders the text between itself and its closing
+    tag in the specified opacity. The opacity should be a value between
+    0.0 and 1.0, corresponding to fully invisible and fully opaque,
+    respectively. If the value is prefixed by + or -, the opacity will
+    be changed by that amount instead of completely replaced. ::
+
+        "{alpha=0.1}This text is barely readable!{/alpha}"
+
 .. text-tag:: b
 
     The bold tag renders the text between itself and its closing tag


### PR DESCRIPTION
This text tag can be used to just control the opacity of the affected text.

It takes a value between 0.0 and 1.0, corresponding to invisible to fully opaque, respectively. Values can optionally be prefixed by + or - to indicate a change in opacity, as opposed to a total replacement.