### PR TITLE
Fix FTBFS on Big-endian architectures.

### DIFF
--- a/module/IMG_savepng.c
+++ b/module/IMG_savepng.c
@@ -133,7 +133,7 @@ int IMG_SavePNG_RW(SDL_RWops *src, SDL_Surface *surf,int compression){
 	}
 #else
 	if (fmt->Amask) {
-		target_format = SDL_PIXELFORMAT_RGBA8888
+		target_format = SDL_PIXELFORMAT_RGBA8888;
 	} else {
 		target_format = SDL_PIXELFORMAT_RGB888;
 	}


### PR DESCRIPTION
Ren'py fails to build from source on Big-endian architectures due to a missing semicolon in module/IMG_savepng.c. 