### PR TITLE
Document the change to the default image init priority

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1801,7 +1801,7 @@ def image_statement(l, loc):
     rv = ast.Image(loc, name, expr, atl)
 
     if not l.init:
-        rv = ast.Init(loc, [ rv ], 500 + l.init_offset)
+        rv = ast.Init(loc, [ rv ], 990 + l.init_offset)
 
     l.advance()
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1801,7 +1801,7 @@ def image_statement(l, loc):
     rv = ast.Image(loc, name, expr, atl)
 
     if not l.init:
-        rv = ast.Init(loc, [ rv ], 990 + l.init_offset)
+        rv = ast.Init(loc, [ rv ], 500 + l.init_offset)
 
     l.advance()
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -10,6 +10,10 @@ possible to apply a priority offset to statements that run at init
 time, including ``init``, ``init python``, ``define``, ``default``,
 ``style``, and ``transform``.
 
+The default init priority of ``image`` statements has been changed from 990
+to 500, so that larger offsets can be used with :ref:`init offset <init-offset-statement>`
+without sending their init priority out of the range -999 to 999.
+
 The `style_group` ui property has been renamed to `style_prefix`, to make
 its function more apparent. (The old name still works, for compatibility with
 older code.) A new `style_suffix` ui property has been added, allowing

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -137,7 +137,7 @@ displayable. For example::
 The image statement must be run at init-time, before game code
 runs. When not contained inside an init block, image statements are
 run at init-time, as if they were placed inside an init block of
-priority 0.
+priority 500.
 
 See also the :ref:`ATL variant of the image statement. <atl-image-statement>`
 


### PR DESCRIPTION
When init offset support was added in commit 679f9e31, the default image init
priority was changed from 500 to 990. This changes it back.