### PR TITLE
add install_headers to pygame_sdl2 build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Then, install pygame_sdl2 by running the following commands::
     pushd pygame_sdl2
     python fix_virtualenv.py $VIRTUAL_ENV
     python setup.py install
+    python setup.py install_headers
     popd
 
 Next, set RENPY_DEPS_INSTALL To a \::-separated list of paths containing the


### PR DESCRIPTION
Apparently distutils & setuptools somewhat differ in what they install with `install` command. `setuptools` version (which is default in pygame_sdl2/setuplib.py) does not install headers and thus renpy `module` build fails unable to find them. Adding `install_headers` step seems to fix the problem and works on both setuptools & distutils.