### PR TITLE
Support pre-6.11 games that overwrite config.layers.

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -182,6 +182,10 @@ init 1900 python hide::
     if compat(6, 9, 0):
         style.motion.clear()
 
+    if compat(6, 10, 2):
+        if 'screens' not in config.layers:
+            config.layers.append('screens')
+
     if "Fullscreen" in config.translations:
         fs = _("Fullscreen")
         config.translations.setdefault("Fullscreen 4:3", fs + " 4:3")


### PR DESCRIPTION
Some pre-6.11 games overwrite `config.layers` entirely and omit "screens", which makes sense given that the screen system wasn't a thing back then.

However, this breaks on modern Ren'Py which expects the layer to be there (see `renpy.get_screen()` et al.). This fix adds compatibility support for games with such old `script_version`s.