### PR TITLE
add local/nested labels support

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1904,7 +1904,7 @@ class Screen(Node):
 class Translate(Node):
     """
     A translation block, produced either by explicit translation statements
-    or implicit translation blocs.
+    or implicit translation blocks.
 
     If language is None, when executed this transfers control to the translate
     statement in the current language, if any, and otherwise runs the block.

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -491,7 +491,7 @@ class Lexer(object):
     sub-lexers to lex sub-blocks.
     """
 
-    def __init__(self, block, init=False, init_offset=0):
+    def __init__(self, block, init=False, init_offset=0, global_label=None):
 
         # Are we underneath an init block?
         self.init = init
@@ -509,6 +509,7 @@ class Lexer(object):
         self.text = ""
         self.number = 0
         self.subblock = [ ]
+        self.global_label = global_label
         self.pos = 0
         self.word_cache_pos = -1
         self.word_cache_newpos = -1
@@ -653,7 +654,7 @@ class Lexer(object):
 
         init = self.init or init
 
-        return Lexer(self.subblock, init=init, init_offset=self.init_offset)
+        return Lexer(self.subblock, init=init, init_offset=self.init_offset, global_label=self.global_label)
 
     def string(self):
         """
@@ -753,6 +754,48 @@ class Lexer(object):
             return None
 
         return rv
+
+    def set_global_label(self, label):
+        """
+        Set current global_label, which is used for label_name calculations.
+        label can be any valid label or None, but this has only effect if label
+        has global part.
+        """
+        if label and label[0] != '.':
+            self.global_label = label.split('.')[0]
+
+    def label_name(self):
+        """
+        Try to parse label name. Returns name in form of "global.local" if local
+        is present, "global" otherwise; or None if it doesn't parse.
+        """
+
+        old_pos = self.pos
+        local_name = None
+        global_name = self.name()
+
+        if not global_name:
+            # .local label
+            if not self.match('\.') or not self.global_label:
+                self.pos = old_pos
+                return None
+            global_name = self.global_label
+            local_name = self.name()
+            if not local_name:
+                self.pos = old_pos
+                return None
+        else:
+            if self.match('\.'):
+                # full global.local name
+                local_name = self.name()
+                if not local_name:
+                    self.pos = old_pos
+                    return None
+
+        if not local_name:
+            return global_name
+
+        return global_name+'.'+local_name
 
     def image_name_component(self):
         """
@@ -1604,7 +1647,8 @@ def pass_statement(l, loc):
 @statement("menu")
 def menu_statement(l, loc):
     l.expect_block('menu statement')
-    label = l.name()
+    label = l.label_name()
+    l.set_global_label(label)
     l.require(':')
     l.expect_eol()
 
@@ -1645,7 +1689,7 @@ def jump_statement(l, loc):
         target = l.require(l.simple_expression)
     else:
         expression = False
-        target = l.require(l.name)
+        target = l.require(l.label_name)
 
     l.expect_eol()
     l.advance()
@@ -1663,7 +1707,7 @@ def call_statement(l, loc):
 
     else:
         expression = False
-        target = l.require(l.name)
+        target = l.require(l.label_name)
 
     # Optional pass, to let someone write:
     # call expression foo pass (bar, baz)
@@ -1674,7 +1718,8 @@ def call_statement(l, loc):
     rv = [ ast.Call(loc, target, expression, arguments) ]
 
     if l.keyword('from'):
-        name = l.require(l.name)
+        name = l.require(l.label_name)
+        l.set_global_label(name)
         rv.append(ast.Label(loc, name, [], None))
     else:
         if expression:
@@ -1949,8 +1994,9 @@ def python_statement(l, loc):
 
 @statement("label")
 def label_statement(l, loc, init=False):
-    name = l.require(l.name)
 
+    name = l.require(l.label_name)
+    l.set_global_label(name)
     parameters = parse_parameters(l)
 
     if l.keyword('hide'):

--- a/renpy/translation.py
+++ b/renpy/translation.py
@@ -161,6 +161,7 @@ class ScriptTranslator(object):
 
     def lookup_translate(self, identifier):
 
+        identifier = identifier.replace('.', '_')
         language = renpy.game.preferences.language
 
         if language is not None:
@@ -214,7 +215,7 @@ class Restructurer(object):
             md5.update(code.encode("utf-8") + "\r\n")
 
         if self.label:
-            base = self.label + "_" + md5.hexdigest()[:8]
+            base = self.label.replace('.', '_') + "_" + md5.hexdigest()[:8]
         else:
             base = md5.hexdigest()[:8]
 
@@ -781,7 +782,7 @@ class TranslateFile(object):
                 label = ""
 
             self.f.write(u"# {}:{}\n".format(t.filename, t.linenumber))
-            self.f.write(u"translate {} {}:\n".format(self.language, t.identifier))
+            self.f.write(u"translate {} {}:\n".format(self.language, t.identifier.replace('.', '_')))
             self.f.write(u"\n")
 
             for n in t.block:

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -19,6 +19,25 @@ A label statement may have a block associated with it. In that case, control
 enters the block whenever the label statement is reached, and proceeds with the
 statement after the label statement whenever the end of the block is reached.
 
+There are two kinds of labels: *global* and *local* labels. Global labels live
+in one global scope shared across all project files and thus should have unique
+names per game. Local labels logically reside inside scope of the global label
+they are declared in. To declare a local label, prefix its name with `.`. For
+example: ::
+
+    label global_label:
+        "Inside a global label.."
+    label .local_name:
+        "..resides a local one."
+        jump .local_name
+
+Local labels can be referenced directly inside the same global label they are
+declared in or by their full name, consisting of global and local name parts: ::
+
+    label another_global:
+        "Now lets jump inside local label located somewhere else."
+        jump global_label.local_name
+
 The label statement may take an optional list of parameters. These parameters
 are processed as described in PEP 3102, with two exceptions:
 
@@ -77,7 +96,7 @@ stacks can return to the proper place when loaded on a changed script. ::
 
     label subroutine(count=1):
 
-        e "I camed here [count] time(s)."
+        e "I came here [count] time(s)."
         e "Next, we will return from the subroutine."
 
         return


### PR DESCRIPTION
Originally proposed here: https://lemmasoft.renai.us/forums/viewtopic.php?f=32&t=38122

> When the script is heavy-choice, amount of labels can soon get unmanageable. I think the usual way to avoid name collisions is to use something like "chapter1_episode1_choice1", but it is ugly, verbose and still doesn't guarantee avoidance of collisions, especially when using third-party code.
> 
> To resolve this problem i propose introducing 'local' labels, which can have identical names inside different 'global' labels. Here's how it works:
> 
> ```renpy
> label global_label:             # normal label, nothing changed for its behaviour
>   "..."
> label .a:                       # local label fully identified as global_label.a
>   "..."
>   jump .a                       # local jump, resolved to global_label.a
> 
> label another_global_label:
>   "..."
> label .a:                       # another_global_label.a
>   jump global_label.a
> ```
> 
> Syntax-wise, it's fully backwards compatible since currently label names cannot contain dot and thus all existing labels are considered global with this change.
> 
> It is also possible to expand this idea to have no nesting limit (i.e. making possible to have label a.b.c.d and jump to it inside a.b.c scope by simply "jump ...d")
> 
> I also found out that it is currently possible to 'nest' labels using indentation, but it doesn't protect from name collisions. It is possible to implement the same mechanism with such nested labels, but since it uses old syntax, it can cause problems with existing code. Also, it is more visual which can sometimes be good, but can also be bad when you prefer all statements to be on same indentation level.

While waiting for comments, i finished implementing it anyway and so making this pr for more specific discussion. If this is going to be accepted, i'll mention this in docs as well.