### PR TITLE
Clarify error when unable to find platform files.

### DIFF
--- a/renpy.sh
+++ b/renpy.sh
@@ -52,9 +52,16 @@ fi
 
 for BASE in "$ROOT" "$ROOT1" "$ROOT2"; do
     LIB="$BASE/lib/$RENPY_PLATFORM"
-		if test -d "$LIB"; then
-		    break
-		fi
+    if test -d "$LIB"; then
+        break
+    fi
 done
+
+if ! test -d "$LIB"; then
+    echo "Ren'Py platform files not found in any of $ROOT, $ROOT1 or $ROOT2!"
+    echo "Please compile the platform files using the instructions in README.md"
+    echo "or point them to an existing installation using ./after_checkout.sh <path>."
+    exit 1
+fi
 
 exec $RENPY_GDB "$LIB/$BASEFILE" $RENPY_PYARGS -EO "$BASE/$BASEFILE.py" "$@"


### PR DESCRIPTION
This make it easier for people to figure out why their fresh git checkout won't run.