### PR TITLE
Use proper API for determining if screen is showing in Show().

### DIFF
--- a/renpy/common/00action_control.rpy
+++ b/renpy/common/00action_control.rpy
@@ -110,7 +110,7 @@ init -1500 python:
             renpy.restart_interaction()
 
         def get_selected(self):
-            return renpy.showing(self.screen)
+            return renpy.get_screen(self.screen) is not None
 
     @renpy.pure
     def ShowTransient(screen, *args, **kwargs):


### PR DESCRIPTION
`renpy.showing()` doesn't work as the `screens` layer is not provided, and providing it gives other weird behaviour. Use `renpy.get_screen()` instead, as this works properly.