### PR TITLE
change link to old wiki

### DIFF
--- a/sphinx/source/quickstart.rst
+++ b/sphinx/source/quickstart.rst
@@ -16,7 +16,7 @@ learn how the Ren'Py launcher works. The launcher lets you create,
 manage, edit, and run Ren'Py projects.
 
 **Getting Started.** To get started you'll want to
-`download Ren'Py <http://www.renpy.org/wiki/renpy/Download_Ren'Py>`_.
+`download Ren'Py <https://www.renpy.org/latest.html>`_.
 
 Once you've downloaded Ren'Py, you'll want to extract it. This can
 generally be done by right-clicking on the package file, and picking


### PR DESCRIPTION
The Quickstart had a link to the download page of the old wiki.
(Please check, I'm not sure if this is the correct place to change this.)