### PR TITLE
Add {alpha} to text_tags dict

### DIFF
--- a/renpy/text/extras.py
+++ b/renpy/text/extras.py
@@ -30,6 +30,7 @@ import renpy.text.textsupport as textsupport
 # A list of text tags, mapping from the text tag prefix to if it
 # requires a closing tag.
 text_tags = dict(
+    alpha=True,
     image=False,
     p=False,
     w=False,


### PR DESCRIPTION
Prevents {alpha} from being incorrectly identified as an invalid text tag during Lint scans.