### PR TITLE
Update MultipleTransition documentation example

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -108,7 +108,7 @@ class MultipleTransition(Transition):
     scene following it. For example::
 
         define logodissolve = MultipleTransition([
-            False, Dissolve(0.5)
+            False, Dissolve(0.5),
             "logo.jpg", Pause(1.0),
             "logo.jpg", dissolve,
             True])

--- a/sphinx/source/inc/transition
+++ b/sphinx/source/inc/transition
@@ -241,7 +241,7 @@
     scene following it. For example::
     
         define logodissolve = MultipleTransition([
-            False, Dissolve(0.5)
+            False, Dissolve(0.5),
             "logo.jpg", Pause(1.0),
             "logo.jpg", dissolve,
             True])


### PR DESCRIPTION
Current example is missing a comma and will crash the game if used.