### PR TITLE
Fix some typos in documentation

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -276,7 +276,7 @@ init -1500 python:
 
             Returns an action that is generally used as the hovered property
             of a button. When the button is hovered, the value field of this
-            tooltip is set to `value`. When the buttton loses focus, the
+            tooltip is set to `value`. When the button loses focus, the
             value field of this tooltip reverts to the default.
             """
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -436,9 +436,9 @@ init -1500 python:
         """
          :doc: value
 
-         The value of an adjustment that horizontally scrolls the the viewport with the
-         given id, on the current screen. The viewport must be defined
-         before a bar with this value is.
+         The value of an adjustment that horizontally scrolls the viewport with the
+         given id, on the current screen. The viewport must be defined before a bar
+         with this value is.
          """
 
         equality_fields = [ 'viewport' ]
@@ -460,9 +460,9 @@ init -1500 python:
         """
          :doc: value
 
-         The value of an adjustment that vertically scrolls the the viewport with the
-         given id, on the current screen. The viewport must be defined
-         before a bar with this value is.
+         The value of an adjustment that vertically scrolls the viewport with the
+         given id, on the current screen. The viewport must be defined before a bar
+         with this value is.
          """
 
         equality_fields = [ 'viewport' ]

--- a/renpy/common/00iap.rpy
+++ b/renpy/common/00iap.rpy
@@ -309,7 +309,7 @@ init -1500 python in iap:
         `identifier`
             A string that's used to identify the product internally. Once used
             to represent a product, this must never change. These strings are
-            generall of the form "com.domain.game.product".
+            generally of the form "com.domain.game.product".
 
             If None, defaults to `product`.
 
@@ -428,11 +428,11 @@ init -1500 python in iap:
         :doc: iap_actions
 
         An action that attempts the purchase of `product`. This action is
-        sensitive iff and only if the product is purchasable (a store is
+        sensitive if and only if the product is purchasable (a store is
         enabled, and the product has not already been purchased.)
 
         `success`
-            If not None, this is an action or list of actions that are tun
+            If not None, this is an action or list of actions that are run
             when the purchase succeeds.
         """
 

--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -255,7 +255,7 @@ A layout that lays out its members from top to bottom.
 Grid = _layout_class(renpy.display.layout.Grid, """
 :doc: disp_grid
 
-Lays out displayables in a a grid. The first two positional arguments
+Lays out displayables in a grid. The first two positional arguments
 are the number of columns and rows in the grid. This must be followed
 by `columns * rows` positional arguments giving the displayables that
 fill the grid.

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -88,8 +88,8 @@ class ScreenProfile(renpy.object.Object):
             Displays the variables in the screen that are marked as const and
             not-const.
 
-        All profiling profiling output will be logged to profile_screen.txt in
-        the game directory.
+        All profiling output will be logged to profile_screen.txt in the game
+        directory.
         """
 
         self.predict = predict

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -316,9 +316,9 @@ class Dissolve(Transition):
         The time the dissolve will take.
 
     `alpha`
-        If true, the dissolve will alpha-composite the the result of the
-        transition with the screen. If false, the result of the transition
-        will replace the screen, which is more efficient.
+        If true, the dissolve will alpha-composite the result of the transition
+        with the screen. If false, the result of the transition will replace the
+        screen, which is more efficient.
 
     `time_warp`
         A function that adjusts the timeline. If not None, this should be a
@@ -407,9 +407,9 @@ class ImageDissolve(Transition):
         If true, black pixels will dissolve in before white pixels.
 
     `alpha`
-        If true, the dissolve will alpha-composite the the result of the
-        transition with the screen. If false, the result of the transition
-        will replace the screen, which is more efficient.
+        If true, the dissolve will alpha-composite the result of the transition
+        with the screen. If false, the result of the transition will replace the
+        screen, which is more efficient.
 
     `time_warp`
         A function that adjusts the timeline. If not None, this should be a

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -558,7 +558,7 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
         zorder is preserved if it exists, and is otherwise set to 0.
 
     `tag`
-        A string, used to specify the the image tag of the shown image. The
+        A string, used to specify the image tag of the shown image. The
         equivalent of the ``as`` property.
 
     `behind`
@@ -3230,7 +3230,7 @@ def get_refresh_rate(precision=5):
     number of frames per second.
 
     `precision`
-        The raw data Ren'Py gets is numbe of frames per second, rounded down.
+        The raw data Ren'Py gets is number of frames per second, rounded down.
         This means that a monitor that runs at 59.95 frames per second will
         be reported at 59 fps. The precision argument reduces the precision
         of this reading, such that the only valid readings are multiples of

--- a/renpy/ui.py
+++ b/renpy/ui.py
@@ -236,10 +236,9 @@ def interact(type='misc', roll_forward=None, **kwargs): #@ReservedAssignment
     :args: (roll_forward=None, mouse='default')
 
     Causes an interaction with the user, and returns the result of that
-    interaction. This causes Ren'Py to to redraw the screen and begin
-    processing input events. When a displayable returns a value in
-    response to an event, that value is returned from ui.interact,
-    and the interaction ends.
+    interaction. This causes Ren'Py to redraw the screen and begin processing
+    input events. When a displayable returns a value in response to an event,
+    that value is returned from ui.interact, and the interaction ends.
 
     This function is rarely called directly. It is usually called by other
     parts of Ren'Py, including the say statement, menu statement, with statement,


### PR DESCRIPTION
Fix some typos and edit line lengths (where the changes left the line a
little short).