### PR TITLE
gallery: Just one option to advance trough unlocked images by left-cl…

### DIFF
--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -170,6 +170,10 @@ init -1500 python:
 
             The default idle border used by make_button.
 
+        .. attribute:: unlocked_advance
+
+            If true, the gallery will only advance through unlocked images.
+
         .. attribute:: navigation
 
             If true, the gallery will display navigation and slideshow
@@ -179,18 +183,9 @@ init -1500 python:
             gallery_navigation screen. The default screen is defined in
             common/00gallery.rpy
 
-        .. attribute:: unlocked_navigation
-
-            If true, the gallery will only navigate through unlocked
-            images.
-
         .. attribute:: span_buttons
 
             If true, the gallery will advance between buttons.
-
-        .. attribute:: locked
-
-            If true, the gallery will advance through locked images.
 
         .. attribute:: slideshow_delay
 
@@ -218,11 +213,11 @@ init -1500 python:
 
             self.unlockable = None
 
+            self.unlocked_advance = False
+
             self.navigation = False
-            self.unlocked_navigation = False
 
             self.span_buttons = False
-            self.locked = True
 
             self.slideshow_delay = 5
 
@@ -470,7 +465,7 @@ init -1500 python:
                 # At this point, result is either 'next', "next_unlocked", "previous", or "previous_unlocked"
                 # Go through the common advance code.
 
-                if self.locked and result.endswith("_unlocked"):
+                if self.unlocked_advance:
                     images = unlocked_images
                 else:
                     images = all_images
@@ -585,8 +580,8 @@ init -1500:
             style_group "gallery"
             align (.98, .98)
 
-            textbutton _("prev") action gallery.Previous(unlocked=gallery.unlocked_navigation)
-            textbutton _("next") action gallery.Next(unlocked=gallery.unlocked_navigation)
+            textbutton _("prev") action gallery.Previous(unlocked=gallery.unlocked_advance)
+            textbutton _("next") action gallery.Next(unlocked=gallery.unlocked_advance)
             textbutton _("slideshow") action gallery.ToggleSlideshow()
             textbutton _("return") action gallery.Return()
 


### PR DESCRIPTION
Just one option to control how to advance trough unlocked images, 
by left-clicking or using the navigation screen buttons...
This is my idea how it should work, I know this is not perfect but gives me the functionality I'm looking for.