### PR TITLE
New preference for forcing fallback images on video sprites

### DIFF
--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -70,6 +70,10 @@ init -1500 python:
          * Preference("transitions", "none") - do not show transitions.
          * Preference("transitions", "toggle") - toggle transitions.
 
+         * Preference("video sprites", "show") - show all video sprites.
+         * Preference("video sprites", "hide") - fall back to images where possible.
+         * Preference("video sprites", "toggle") - toggle image fallback behavior. 
+
          * Preference("show empty window", "show") - Allow the "window show" and "window auto" statement to show an empty window outside of the say statement.
          * Preference("show empty window", "hide") - Prevent the above.
          * Preference("show empty window", "toggle") - Toggle the above.
@@ -196,6 +200,15 @@ init -1500 python:
                     return SetField(_preferences, "transitions", 0)
                 elif value == "toggle":
                     return ToggleField(_preferences, "transitions", true_value=2, false_value=0)
+
+            elif name == "video sprites":
+
+                if value == "show":
+                    return SetField(_preferences, "video_image_fallback", False)
+                elif value == "hide":
+                    return SetField(_preferences, "video_image_fallback", True)
+                elif value == "toggle":
+                    return ToggleField(_preferences, "video_image_fallback")
 
             elif name == "show empty window":
 

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -229,7 +229,8 @@ class Movie(renpy.display.core.Displayable):
         An image that is displayed when `play` has been given, but the
         file it refers to does not exist. (For example, this can be used
         to create a slimmed-down mobile version that does not use movie
-        sprites.)
+        sprites.) Users can also choose to fall back to this image as a
+        preference if video is too taxing for their system.
 
     This displayable will be transparent when the movie is not playing.
     """
@@ -278,15 +279,17 @@ class Movie(renpy.display.core.Displayable):
 
     def render(self, width, height, st, at):
 
-        if (self.image is not None) and (self._play is not None) and (not renpy.loader.loadable(self._play)):
-            surf = renpy.display.render.render(self.image, width, height, st, at)
+        if (self.image is not None) and (self._play is not None):
+            # Checks if the given movie is loadable or if the user prefers images only
+            if (not renpy.loader.loadable(self._play)) or (renpy.game.preferences.video_image_fallback is True):
+                surf = renpy.display.render.render(self.image, width, height, st, at)
 
-            w, h = surf.get_size()
+                w, h = surf.get_size()
 
-            rv = renpy.display.render.Render(w, h)
-            rv.blit(surf, (0, 0))
+                rv = renpy.display.render.Render(w, h)
+                rv.blit(surf, (0, 0))
 
-            return rv
+                return rv
 
         if self._play:
             channel_movie[self.channel] = self

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -92,6 +92,7 @@ class Preferences(renpy.object.Object):
             self.init_rollback_side()
         if version < 18:
             self.virtual_size = None
+            self.video_image_fallback = False
 
     def __init__(self):
         self.fullscreen = False
@@ -113,6 +114,9 @@ class Preferences(renpy.object.Object):
         # 1 - Only non-default transitions.
         # 0 - No transitions.
         self.transitions = 2
+
+        # Should video sprites always default to provided displayables if possible?
+        self.video_image_fallback = False
 
         self.skip_after_choices = False
 


### PR DESCRIPTION
Video was too taxing for some of our systems and we wanted to be able to fall back to the already defined backup images for movie sprites without deleting the original file paths.