### PR TITLE
Use built-in set instead of deprecated import

### DIFF
--- a/renpy/warp.py
+++ b/renpy/warp.py
@@ -24,9 +24,10 @@
 # location.
 
 import renpy
-import sets
+
 
 warp_spec = None
+
 
 def warp():
     """
@@ -56,11 +57,11 @@ def warp():
 
     prev = { }
 
-    workset = sets.Set([ n for n in renpy.game.script.namemap.itervalues() if isinstance(n, renpy.ast.Scene) ])
-    seenset = sets.Set(workset)
+    workset = { n for n in renpy.game.script.namemap.itervalues() if isinstance(n, renpy.ast.Scene) }
+    seenset = set(workset)
 
     # This is called to indicate that next can be executed following node.
-    def add(node, next): #@ReservedAssignment
+    def add(node, next):  # @ReservedAssignment
         if next not in seenset:
             seenset.add(next)
             workset.add(next)


### PR DESCRIPTION
In warp.py and python.py, sets.Set was being used. This is deprecated as of python 2.6. I replaced the usage with the built-in set and set comprehension.

There were 3 outright removals in RevertableSet(): The wrappers for **copy**, **deepcopy**, and union_update(), but I don't believe anything in ren'py hinges on that particular implementation. I'm mildly concerned about removing the copies, but none of the other Revertables use them.

The number of changes exploded a bit due to my IDE's linting. I only applied style changes that seemed inoffensive, but any can be reverted if they break overall style.

Tested the following scenarios:

1) On the command line, entered: renpy.exe "my_project" --warp "rpy_script":"line_number"
Result: Game opens at that line, effects occurring earlier are not applied, "return" statement at end of label returns player to the specified line number.

2) Created a set using both x = set([1, 2, 3, 4, 5, 1, 1]) and x = {1, 2, 3, 4, 5, 1, 1}, then verified each contained no duplicates. Verified that both create RevertableSet, not set.
