### PR TITLE
Fix cut off sentence in changelog

### DIFF
--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -169,7 +169,7 @@ have run), or when the language changes, the following steps occur.
 
 Ren'Py can be made to return to the old behavior (in which only ``translate``
 `language` ``style``, ``translate`` `language` ``python``, and callbacks
-are executed) by setti
+are executed) by setting :var:`config.new_translate_order` to False.
 
 Local Labels
 ------------


### PR DESCRIPTION
In the changelog there was a sentence that ended abruptly:
> Ren'Py can be made to return to the old behavior (in which only translate language style, translate language python, and callbacks are executed) by setti

I changed it back to how it was before 4b06e96d28e30234251271cc405573981c684fd9, where it got cut off for some reason.