### PR TITLE
Update some strings is Spanish translation / Found some typos in gui/screens.rpy

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -1069,15 +1069,15 @@ screen gamepad_help():
 
     hbox:
         label _("Right Trigger\nA/Bottom Button")
-        text _("Advance dialogue and activates the interface.")
+        text _("Advances dialogue and activates the interface.")
 
     hbox:
         label ("Left Trigger\nLeft Shoulder")
-        text _("Roll back to earlier dialogue.")
+        text _("Rolls back to earlier dialogue.")
 
     hbox:
         label _("Right Shoulder")
-        text _("Roll forward to later dialogue.")
+        text _("Rolls forward to later dialogue.")
 
     hbox:
         label _("D-Pad, Sticks")
@@ -1085,7 +1085,7 @@ screen gamepad_help():
 
     hbox:
         label _("Start, Guide")
-        text _("Access the game menu.")
+        text _("Accesses the game menu.")
 
     hbox:
         label _("Y/Top Button")

--- a/launcher/game/tl/spanish/common.rpy
+++ b/launcher/game/tl/spanish/common.rpy
@@ -167,23 +167,23 @@ translate spanish strings:
 
     # 00gui.rpy:228
     old "Are you sure you want to delete this save?"
-    new "¿Seguro que desea borrar esta partida?"
+    new "¿Seguro que quieres borrar esta partida?"
 
     # 00gui.rpy:229
     old "Are you sure you want to overwrite your save?"
-    new "¿Seguro que desea sobreescribir esta partida?"
+    new "¿Seguro que quieres sobreescribir esta partida?"
 
     # 00gui.rpy:230
     old "Loading will lose unsaved progress.\nAre you sure you want to do this?"
-    new "Al cargar se perderá el progreso no guardado.\n¿Seguro que desea hacer esto?"
+    new "Al cargar se perderá el progreso no guardado.\n¿Seguro que quieres hacer esto?"
 
     # 00gui.rpy:231
     old "Are you sure you want to quit?"
-    new "¿Seguro que desea salir?"
+    new "¿Seguro que quieres salir?"
 
     # 00gui.rpy:232
     old "Are you sure you want to return to the main menu?\nThis will lose unsaved progress."
-    new "¿Seguro que desea volver al menú principal?\nSe perderá el progreso no guardado."
+    new "¿Seguro que quieres volver al menú principal?\nSe perderá el progreso no guardado."
 
     # 00gui.rpy:233
     old "Are you sure you want to end the replay?"
@@ -191,15 +191,15 @@ translate spanish strings:
 
     # 00gui.rpy:234
     old "Are you sure you want to begin skipping?"
-    new "¿Seguro que desea empezar el modo salto?"
+    new "¿Seguro que quieres empezar el modo salto?"
 
     # 00gui.rpy:235
     old "Are you sure you want to skip to the next choice?"
-    new "¿Seguro que desea saltar hasta la próxima elección?"
+    new "¿Seguro que quieres saltar hasta la próxima elección?"
 
     # 00gui.rpy:236
     old "Are you sure you want to skip unseen dialogue to the next choice?"
-    new "Are you sure you want to skip unseen dialogue to the next choice?"
+    new "¿Seguro que quieres saltar el texto no visto hasta la próxima elección?"
 
     # 00keymap.rpy:250
     old "Saved screenshot as %s."
@@ -207,7 +207,7 @@ translate spanish strings:
 
     # 00library.rpy:142
     old "Self-voicing disabled."
-    new "Auto-voz desactivada."
+    new "Voz automática desactivada."
 
     # 00library.rpy:143
     old "Clipboard voicing enabled. "
@@ -215,15 +215,15 @@ translate spanish strings:
 
     # 00library.rpy:144
     old "Self-voicing enabled. "
-    new "Auto-voz activada. "
+    new "Voz automática activada. "
 
     # 00library.rpy:179
     old "Skip Mode"
-    new "Modo Salto"
+    new "Modo salto"
 
     # 00library.rpy:262
     old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
-    new "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
+    new "Este programa contiene software libre sujeto a diversas licencias que incluyen la licencia MIT y la {i}GNU Lesser General Public License{/i} (Licencia Pública General Reducida de GNU). Puedes encontrar la lista completa de software, con enlaces al código fuente completo, {a=https://www.renpy.org/l/license}aquí (en inglés){/a}."
 
     # 00preferences.rpy:422
     old "Clipboard voicing enabled. Press 'shift+C' to disable."
@@ -231,15 +231,15 @@ translate spanish strings:
 
     # 00preferences.rpy:424
     old "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
-    new "Auto-voz dirà \"[renpy.display.tts.last]\". Pulsa 'alt+shift+V' para desactivar."
+    new "Voz automática dirà \"[renpy.display.tts.last]\". Pulsa 'alt+shift+V' para desactivar."
 
     # 00preferences.rpy:426
     old "Self-voicing enabled. Press 'v' to disable."
-    new "Self-voicing activado. Presiona 'v' para desactivarlo."
+    new "Voz automática activada. Presiona 'v' para desactivarla."
 
     # 00iap.rpy:217
     old "Contacting App Store\nPlease Wait..."
-    new "Contacting App Store\nPlease Wait..."
+    new "Contactando App Store\nPor favor, espera..."
 
     # 00updater.rpy:367
     old "The Ren'Py Updater is not supported on mobile devices."
@@ -287,7 +287,7 @@ translate spanish strings:
 
     # 00updater.rpy:1406
     old "[u.version] is available. Do you want to install it?"
-    new "[u.version] está disponible. ¿Desea instalarla?"
+    new "[u.version] está disponible. ¿Quieres instalarla?"
 
     # 00updater.rpy:1408
     old "Preparing to download the updates."

--- a/launcher/game/tl/spanish/developer.rpy
+++ b/launcher/game/tl/spanish/developer.rpy
@@ -55,7 +55,7 @@ translate spanish strings:
 
     # _developer/developer.rpym:383
     old "Right-click or escape to quit."
-    new "Click-derecho o escape para salir."
+    new "Clic-derecho o escape para salir."
 
     # _developer/developer.rpym:412
     old "Rectangle copied to clipboard."

--- a/launcher/game/tl/spanish/screens.rpy
+++ b/launcher/game/tl/spanish/screens.rpy
@@ -71,7 +71,7 @@ translate spanish strings:
 
     # screens.rpy:262
     old "History"
-    new "History"
+    new "Historial"
 
     # screens.rpy:263
     old "Skip"
@@ -111,11 +111,11 @@ translate spanish strings:
 
     # screens.rpy:308
     old "Start"
-    new "Start"
+    new "Comenzar"
 
     # screens.rpy:316
     old "Load"
-    new "Load"
+    new "Cargar"
 
     # screens.rpy:318
     old "Preferences"
@@ -123,7 +123,7 @@ translate spanish strings:
 
     # screens.rpy:322
     old "End Replay"
-    new "End Replay"
+    new "Fin repetición"
 
     # screens.rpy:326
     old "Main Menu"
@@ -199,7 +199,7 @@ translate spanish strings:
 
     # screens.rpy:561
     old "Version [config.version!t]\n"
-    new "Version [config.version!t]\n"
+    new "Versión [config.version!t]\n"
 
     # screens.rpy:563
     old "## gui.about is usually set in options.rpy."
@@ -207,7 +207,7 @@ translate spanish strings:
 
     # screens.rpy:567
     old "Made with {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
-    new "Made with {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
+    new "Hecho con {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
 
     # screens.rpy:570
     old "## This is redefined in options.rpy to add text to the about screen."
@@ -251,7 +251,7 @@ translate spanish strings:
 
     # screens.rpy:649
     old "empty slot"
-    new "empty slot"
+    new "vacío"
 
     # screens.rpy:657
     old "## Buttons to access other pages."
@@ -267,7 +267,7 @@ translate spanish strings:
 
     # screens.rpy:670
     old "{#quick_page}Q"
-    new "{#quick_page}Q"
+    new "{#quick_page}R"
 
     # screens.rpy:676
     old ">"
@@ -299,7 +299,7 @@ translate spanish strings:
 
     # screens.rpy:744
     old "Rollback Side"
-    new "Rollback Side"
+    new "Lado de retroceso"
 
     # screens.rpy:745
     old "Disable"
@@ -307,15 +307,15 @@ translate spanish strings:
 
     # screens.rpy:746
     old "Left"
-    new "Left"
+    new "Izquierda"
 
     # screens.rpy:747
     old "Right"
-    new "Right"
+    new "Derecha"
 
     # screens.rpy:752
     old "Unseen Text"
-    new "Unseen Text"
+    new "Texto no visto"
 
     # screens.rpy:753
     old "After Choices"
@@ -355,7 +355,7 @@ translate spanish strings:
 
     # screens.rpy:806
     old "Mute All"
-    new "Mute All"
+    new "Silencia todo"
 
     # screens.rpy:882
     old "## History screen"
@@ -383,7 +383,7 @@ translate spanish strings:
 
     # screens.rpy:921
     old "The dialogue history is empty."
-    new "The dialogue history is empty."
+    new "El historial está vacío."
 
     # screens.rpy:965
     old "## Help screen"
@@ -395,11 +395,11 @@ translate spanish strings:
 
     # screens.rpy:986
     old "Keyboard"
-    new "Keyboard"
+    new "Teclado"
 
     # screens.rpy:987
     old "Mouse"
-    new "Mouse"
+    new "Ratón"
 
     # screens.rpy:990
     old "Gamepad"
@@ -411,23 +411,23 @@ translate spanish strings:
 
     # screens.rpy:1004
     old "Advances dialogue and activates the interface."
-    new "Advances dialogue and activates the interface."
+    new "Avanza el diálogo y activa la interfaz."
 
     # screens.rpy:1007
     old "Space"
-    new "Space"
+    new "Espacio"
 
     # screens.rpy:1008
     old "Advances dialogue without selecting choices."
-    new "Advances dialogue without selecting choices."
+    new "Avanza el dilogo sin seleccionar opciones."
 
     # screens.rpy:1011
     old "Arrow Keys"
-    new "Arrow Keys"
+    new "Teclas de flecha"
 
     # screens.rpy:1012
     old "Navigate the interface."
-    new "Navigate the interface."
+    new "Navega la interfaz."
 
     # screens.rpy:1015
     old "Escape"
@@ -435,7 +435,7 @@ translate spanish strings:
 
     # screens.rpy:1016
     old "Accesses the game menu."
-    new "Accesses the game menu."
+    new "Accede al menú del juego."
 
     # screens.rpy:1019
     old "Ctrl"
@@ -443,83 +443,71 @@ translate spanish strings:
 
     # screens.rpy:1020
     old "Skips dialogue while held down."
-    new "Skips dialogue while held down."
+    new "Salta el diálogo mientras se presiona."
 
     # screens.rpy:1023
     old "Tab"
-    new "Tab"
+    new "Tabulador"
 
     # screens.rpy:1024
     old "Toggles dialogue skipping."
-    new "Toggles dialogue skipping."
+    new "Activa/desactiva el salto de diálogo."
 
     # screens.rpy:1027
     old "Page Up"
-    new "Page Up"
+    new "Av. pág."
 
     # screens.rpy:1028
     old "Rolls back to earlier dialogue."
-    new "Rolls back to earlier dialogue."
+    new "Retrocede al diálogo anterior."
 
     # screens.rpy:1031
     old "Page Down"
-    new "Page Down"
+    new "Re. pág."
 
     # screens.rpy:1032
     old "Rolls forward to later dialogue."
-    new "Rolls forward to later dialogue."
+    new "Avanza hacia el diálogo siguiente."
 
     # screens.rpy:1036
     old "Hides the user interface."
-    new "Hides the user interface."
+    new "Oculta la interfaz."
 
     # screens.rpy:1040
     old "Takes a screenshot."
-    new "Takes a screenshot."
+    new "Captura la pantalla."
 
     # screens.rpy:1044
     old "Toggles assistive {a=https://www.renpy.org/l/voicing}self-voicing{/a}."
-    new "Toggles assistive {a=https://www.renpy.org/l/voicing}self-voicing{/a}."
+    new "Activa/desactiva la asistencia por {a=https://www.renpy.org/l/voicing}voz-automática{/a}."
 
     # screens.rpy:1050
     old "Left Click"
-    new "Left Click"
+    new "Clic izquierdo"
 
     # screens.rpy:1054
     old "Middle Click"
-    new "Middle Click"
+    new "Clic medio"
 
     # screens.rpy:1058
     old "Right Click"
-    new "Right Click"
+    new "Clic derecho"
 
     # screens.rpy:1062
     old "Mouse Wheel Up\nClick Rollback Side"
-    new "Mouse Wheel Up\nClick Rollback Side"
+    new "Rueda del ratón arriba\nClic en lado de retroceso"
 
     # screens.rpy:1066
     old "Mouse Wheel Down"
-    new "Mouse Wheel Down"
+    new "Rueda del ratón abajo"
 
     # screens.rpy:1073
     old "Right Trigger\nA/Bottom Button"
     new "Right Trigger\nA/Bottom Button"
 
-    # screens.rpy:1074
-    old "Advance dialogue and activates the interface."
-    new "Advance dialogue and activates the interface."
-
-    # screens.rpy:1078
-    old "Roll back to earlier dialogue."
-    new "Roll back to earlier dialogue."
-
     # screens.rpy:1081
     old "Right Shoulder"
     new "Right Shoulder"
-
-    # screens.rpy:1082
-    old "Roll forward to later dialogue."
-    new "Roll forward to later dialogue."
 
     # screens.rpy:1085
     old "D-Pad, Sticks"
@@ -527,11 +515,7 @@ translate spanish strings:
 
     # screens.rpy:1089
     old "Start, Guide"
-    new "Start, Guide"
-
-    # screens.rpy:1090
-    old "Access the game menu."
-    new "Access the game menu."
+    new "Comenzar, Guía"
 
     # screens.rpy:1093
     old "Y/Top Button"
@@ -587,7 +571,7 @@ translate spanish strings:
 
     # screens.rpy:1208
     old "Skipping"
-    new "Skipping"
+    new "Saltando"
 
     # screens.rpy:1215
     old "## This transform is used to blink the arrows one after another."
@@ -639,5 +623,6 @@ translate spanish strings:
 
     # screens.rpy:1429
     old "Menu"
-    new "Menu"
+    new "Menú"
+
 

--- a/launcher/game/tl/spanish/script.rpym
+++ b/launcher/game/tl/spanish/script.rpym
@@ -1,23 +1,30 @@
-﻿# You can place the script of your game in this file.
-# - Puedes colocar el 'script' de tu juego en este archivo.
+﻿# Coloca el código de tu juego en este archivo.
 
-# Declare images below this line, using the image statement.
-# - Declara imágenes bajo esta línea, usando 'image' como
-#   en el ejemplo.
-# eg. image eileen happy = "eileen_happy.png"
+# Declara los personajes usados en el juego como en el ejemplo:
 
-# Declare characters used by this game.
-# - Declara los personajes usados en el juego como en el
-#   ejemplo.
-define e = Character('Eileen', color="#c8ffc8")
+define e = Character("Eileen")
 
 
-# The game starts here.
-# - El juego comienza aquí.
+# El juego comienza aquí.
+
 label start:
+
+    # Muestra una imagen de fondo:
+
+    scene bg room
+
+    # Muestra un personaje:
+
+    show eileen happy
+
+    # Presenta las líneas del diálogo.
+
+    "¡Hola, mundo!"
 
     e "Has creado un nuevo juego Ren'Py."
 
     e "Añade una historia, imágenes y música, ¡y puedes presentarlo al mundo!"
+
+    # Finaliza el juego:
 
     return


### PR DESCRIPTION
### Update Spanish translation
- Some missing words and strings have been translated (mostly those that the final player will see, not the developer).

### Some typos in gui/screens.rpy
(This affects the translation files too)
Some sentences in the gamepad help screen have small typos:
"Advance dialogue and activates the interface."  -> Advances
"Roll back to earlier dialogue."    -> Rolls
"Roll forward to later dialogue."  -> Rolls
"Access the game menu."  -> Accesses

These sentences are the same in the keyboard help screen, but should be translated only once. They are duplicated in the translation files because of the typo.