### PR TITLE
- Fixes Lint Exception:

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -525,10 +525,14 @@ def check_style(name, s):
 
     for p in s.properties:
         for k, v in p.iteritems():
-
+            
             # Treat font specially.
             if k.endswith("font"):
-                check_file(name, v)
+                if isinstance(v, renpy.text.font.FontGroup):
+                    for f in v.fonts:
+                        check_file(name, f)
+                else:
+                    check_file(name, v)
 
             if isinstance(v, renpy.display.core.Displayable):
                 check_style_property_displayable(name, k, v)

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -531,7 +531,7 @@ Text Style Properties
     ``"greedy"``
         A word is placed on the first line that has room for it.
 
-    ``"nowrap"``
+    ``"nobreak"``
         Do not line-break.
 
 .. style-property:: line_leading int


### PR DESCRIPTION
AttributeError: 'FontGroup' object has no attribute 'lstrip'

where FontGroup is mistaken for font path string.