### PR TITLE
Updated urls linking to renpy.org to use https

### DIFF
--- a/help.html
+++ b/help.html
@@ -124,7 +124,7 @@ H3 {
     <dt>v</dt>
     <dd>
       Toggles self-voicing mode, which reads text to the user using an os-supplied speech synthesizer. For more
-      information, please read the <a href="http://www.renpy.org/doc/html/self_voicing.html">self-voicing</a>
+      information, please read the <a href="https://www.renpy.org/doc/html/self_voicing.html">self-voicing</a>
       documentation.
     </dd>
     <dt>Shift+C</dt>
@@ -171,7 +171,7 @@ H3 {
   <h2>Legal Notice</h2>
   <p>
     This program contains free software licensed under a number of licenses, including the GNU Lesser Public License. A
-    complete list of software is available at <a href="http://www.renpy.org/doc/html/license.html">http://www.renpy.org/doc/html/license.html</a>.
+    complete list of software is available at <a href="https://www.renpy.org/doc/html/license.html">https://www.renpy.org/doc/html/license.html</a>.
   </p>
 
 </body>


### PR DESCRIPTION
Minor change. I just changed URLs to the Renpy website to use https instead of http.

This will make users go directly to the webpages linked, instead of automatically being redirected to the https version by the website. Should be (very slightly) better for user experience! 😊