### PR TITLE
vpgrid docs: some typo and formatting fixes, plus some rephrasing of grid terminology

### DIFF
--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -1138,17 +1138,18 @@ Vpgrid
 ------
 
 A vpgrid (viewport grid) combines a viewport and grid into a single
-displayable. The vpgrid takes multiple children, like a grid, and
-rendering of those children is optimized so that only children
-being displayed within the viewport are rendered.
+displayable. The vpgrid takes multiple children (like a grid) and is
+optimized so that only the children being displayed within the viewport
+are rendered.
 
-A vpgrid assumes all the cells are the same size, and the size of
-the first child. If a vpgrid appears to be rendering incorrectly,
-please check that all children have of the same side.
+A vpgrid assumes that all children are the same size, the size being taken
+from the dimensions of the first child. If a vpgrid appears to be rendering
+incorrectly, please ensure that all children are of the same size.
 
-A vpgrid must be given at least one of the `cols` and `rows` properties,
-but may be given both. If one is omitted or None, it is automatically
-determind from the other and the number of children.
+A vpgrid must be given at least one of the `cols` and `rows` properties.
+If one is omitted or None, the other is automatically determined from the
+size, spacing, and number of children. If there are not enough children to
+fill all cells, any empty cells will not be rendered.
 
 Vpgrids take the the following properties:
 
@@ -1160,16 +1161,13 @@ Vpgrids take the the following properties:
 
 `transpose`
     If true, columns are filled before rows. The default of this depends
-    on the `cols` ans `rows` properties. If `cols` is given, columns
+    on the `cols` and `rows` properties. If `cols` is given, columns
     are filled before rows, otherwise rows are filled before columns.
 
 `spacing`
-
-    The spacing between columns in pixels.
+    The spacing between cells, measured in pixels.
 
 In addition, a vpgrid takes all properties a :ref:`viewport <sl-viewport>` can.
-It takes multiple children, up to the size of the grid. If there are not
-enough children to fill all cells, some cells are not rendered.
 
 ::
 


### PR DESCRIPTION
Some typo and formatting fixes, plus some rephrasing of grid terminology (it seemed to confuse cells vs. columns because spacing looks to be applied both vertically and horizontally).