### PR TITLE
Improve compatibility support for games built with older renpy

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -696,7 +696,7 @@ class Init(Node):
 
     def execute(self):
         next_node(self.next)
-        renpy.execution.not_infinite_loop(60)
+        renpy.execution.not_infinite_loop(300)
         statement_name("init")
 
     def restructure(self, callback):
@@ -858,7 +858,7 @@ class EarlyPython(Node):
 
     def execute(self):
         next_node(self.next)
-        renpy.execution.not_infinite_loop(60)
+        renpy.execution.not_infinite_loop(300)
         statement_name("python early")
 
     def early_execute(self):

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -131,7 +131,8 @@ init -1900 python:
         if version <= (6, 99, 10):
             config.new_translate_order = False
             config.old_say_args = True
-            config.window_auto_hide.remove("call screen")
+            if "call screen" in config.window_auto_hide:
+                config.window_auto_hide.remove("call screen")
             config.quit_action = ui.gamemenus("_quit_prompt")
             config.enforce_window_max_size = False
             config.splashscreen_suppress_overlay = False

--- a/renpy/common/_compat/styles.rpym
+++ b/renpy/common/_compat/styles.rpym
@@ -371,13 +371,6 @@ init python:
             self.property_updates = [ ]
 
 
-    style.selected_button = _SelectedCompat('button')
-    style.selected_button_text = _SelectedCompat('button_text')
-    style.gm_nav_selected_button = _SelectedCompat('gm_nav_button')
-    style.gm_nav_selected_button_text = _SelectedCompat('gm_nav_button_text')
-    style.prefs_selected_button = _SelectedCompat('prefs_button')
-    style.prefs_selected_button_text = _SelectedCompat('prefs_button_text')
-
     def _apply_selected_compat():
         for scs in _selected_compat:
             scs.apply()

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -2845,7 +2845,7 @@ class Interface(object):
 
             while rv is None:
 
-                renpy.execution.not_infinite_loop(10)
+                renpy.execution.not_infinite_loop(50)
 
                 # Check for a change in fullscreen preference.
                 if ((self.fullscreen != renpy.game.preferences.fullscreen) or

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -318,7 +318,7 @@ def main():
     game.contexts = [ renpy.execution.Context(False) ]
     game.contexts[0].init_phase = True
 
-    renpy.execution.not_infinite_loop(60)
+    renpy.execution.not_infinite_loop(300)
 
     # Load the script.
     renpy.game.exception_info = 'While loading the script.'


### PR DESCRIPTION
The problem with Katawa Shoujo is quite known it at least two distributions: when people want to use the latest RenPy the game fails to start:
https://bugs.gentoo.org/show_bug.cgi?id=601200
https://aur.archlinux.org/packages/katawa-shoujo/

The second problem with ElvenRelations was found when looping through my local RenPy games collection.

The third change increases hardcoded values for the infinite loop check: on older hardware it triggers on valid games. Better solution will be to depend this values on CPU frequency/number of cores/generation or make it user configurable.

Commit messages describe both problems and solutions with greater detail. RenPy used for testing is the latest official release 6.99.12.4, though it looks like affected code was not changed in git HEAD.
