### PR TITLE
fix unlimited save slots count

### DIFF
--- a/renpy/common/_layout/classic_load_save.rpym
+++ b/renpy/common/_layout/classic_load_save.rpym
@@ -289,7 +289,7 @@ init python:
                     tb(True, name, ui.returns(("fppset", i)), fpp == i)
 
                 # Next
-                tb(True, u'Next', ui.returns(("fppdelta", +1)), False)
+                tb(fpp < config.file_quick_access_pages, u'Next', ui.returns(("fppdelta", +1)), False)
 
                 ui.close()
 


### PR DESCRIPTION
By default, user can scroll to the right and see a lot of pages for save/load screen. Some users report this like a bug in game.

Otherwise, I think is may be configurable by another value - like config.max_save_pages or some, for split number of visible pages from all pages count.