### PR TITLE
Fixed issue with Directory build option.

### DIFF
--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -262,6 +262,10 @@ init python in distribute:
         def add_file(self, name, path, xbit):
             fn = os.path.join(self.path, name)
 
+            # If this is not a directory, ensure all parent directories
+            # have been created
+            if not os.path.isdir(os.path.dirname(fn)):
+                os.makedirs(os.path.dirname(fn), 0755)
             shutil.copy2(path, fn)
 
             if xbit:


### PR DESCRIPTION
Previously, as the files got added to the 'archive', if adding a file required more than one parent folder to be created then the build would fail.