### PR TITLE
Added feature to renpy launcher allowing you to specify additional di…

### DIFF
--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -435,17 +435,15 @@ init python in project:
 
             if self.projects_directory is not None:
                 self.scan_directory(self.projects_directory)
-                
-                # If a file called "projectPaths.txt" exists in the main project directory,
-                # also scan any directories listed there
-                extraPathsFName = os.path.join(self.projects_directory,"projectPaths.txt")
-                if os.path.isfile(extraPathsFName):
-                    extraPathsF = open(extraPathsFName,"r")
-                    for path in extraPathsF:
+
+                # If a file called "projects.txt" exists in the main project directory,
+                # include any projects listed in it.
+                extra_projects_fn = os.path.join(self.projects_directory,"projects.txt")
+                with open(extra_projects_fn,"r") as f:
+                    for path in f:
                         path = path.strip()
-                        if len(path) > 0 and os.path.isdir(path):
-                            self.scan_directory(path)
-                    extraPathsF.close()
+                        if len(path) > 0:
+                            self.scan_directory_direct(path)
 
             self.scan_directory(config.renpy_base)
             self.scan_directory(os.path.join(config.renpy_base, "templates"))
@@ -506,40 +504,48 @@ init python in project:
             for pdir in util.listdir(d):
 
                 ppath = os.path.join(d, pdir)
+                self.scan_directory_direct(ppath,pdir)
 
-                # A project must be a directory.
-                if not os.path.isdir(ppath):
-                    continue
-
-                try:
-                    ppath = self.find_basedir(ppath)
-                except:
-                    continue
-
-                if ppath is None:
-                    continue
-
-                if ppath in self.scanned:
-                    continue
-
-                self.scanned.add(ppath)
-
-                # We have a project directory, so create a Project.
-                p = Project(ppath, pdir)
-
-                if project_filter and (p.name not in project_filter):
-                    continue
-
-                project_type = p.data.get("type", "normal")
-
-                if project_type == "hidden":
-                    pass
-                elif project_type == "template":
-                    self.templates.append(p)
-                else:
-                    self.projects.append(p)
-
-                self.all_projects.append(p)
+        def scan_directory_direct(self, ppath, name=None):
+            """
+            Checks if there is a project in `ppath` and creates a project
+            object with the name `name` if so.
+            """
+            
+            # A project must be a directory.
+            if not os.path.isdir(ppath):
+                return
+            
+            try:
+                ppath = self.find_basedir(ppath)
+            except:
+                return
+            
+            if ppath is None:
+                return
+            
+            if ppath in self.scanned:
+                return
+            
+            self.scanned.add(ppath)
+            
+            # We have a project directory, so create a Project.
+            p = Project(ppath, name)
+            
+            if project_filter and (p.name not in project_filter):
+                return
+            
+            project_type = p.data.get("type", "normal")
+            
+            if project_type == "hidden":
+                pass
+            elif project_type == "template":
+                self.templates.append(p)
+            else:
+                self.projects.append(p)
+            
+            self.all_projects.append(p)
+            
 
         def get(self, name):
             """

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -435,6 +435,17 @@ init python in project:
 
             if self.projects_directory is not None:
                 self.scan_directory(self.projects_directory)
+                
+                # If a file called "projectPaths.txt" exists in the main project directory,
+                # also scan any directories listed there
+                extraPathsFName = os.path.join(self.projects_directory,"projectPaths.txt")
+                if os.path.isfile(extraPathsFName):
+                    extraPathsF = open(extraPathsFName,"r")
+                    for path in extraPathsF:
+                        path = path.strip()
+                        if len(path) > 0 and os.path.isdir(path):
+                            self.scan_directory(path)
+                    extraPathsF.close()
 
             self.scan_directory(config.renpy_base)
             self.scan_directory(os.path.join(config.renpy_base, "templates"))


### PR DESCRIPTION
…rectories that Renpy should scan for projects.

These directories are specified in a file called "projectsPaths.txt" that is placed in the main projects directory.
---------

The need for this feature came up when I tried working with Renpy projects hosted in a google drive.
Getting the google-drive system to only share a specific renpy project folder is awkward. It's much easier to just point Renpy at the project folder you want it to scan.