### PR TITLE
Add 'use' keyword to the 'menu' statement

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1439,14 +1439,16 @@ class Menu(Node):
         'items',
         'set',
         'with_',
+        'use_screen',
         ]
 
-    def __init__(self, loc, items, set, with_):  # @ReservedAssignment
+    def __init__(self, loc, items, set, with_, use_screen):  # @ReservedAssignment
         super(Menu, self).__init__(loc)
 
         self.items = items
         self.set = set
         self.with_ = with_
+        self.use_screen = use_screen
 
     def diff_info(self):
         return (Menu,)
@@ -1501,7 +1503,7 @@ class Menu(Node):
             renpy.exports.say(None, "\n".join(narration), interact=False)
 
         say_menu_with(self.with_, renpy.game.interface.set_transition)
-        choice = renpy.exports.menu(choices, self.set)
+        choice = renpy.exports.menu(choices, self.set, self.use_screen)
 
         if choice is not None:
             next_node(self.items[choice][2][0])

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -829,7 +829,7 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
     return rv
 
 
-def menu(items, set_expr):
+def menu(items, set_expr, use_screen):
     """
     :undocumented:
 
@@ -867,7 +867,7 @@ def menu(items, set_expr):
         return None
 
     # Show the menu.
-    rv = renpy.store.menu(items)
+    rv = renpy.store.menu(items, screen=use_screen)
 
     # If we have a set, fill it in with the label of the chosen item.
     if set is not None and rv is not None:

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1369,6 +1369,7 @@ def parse_menu(stmtl, loc):
 
     with_ = None
     set = None  # @ReservedAssignment
+    use_screen = 'choice'
 
     say_who = None
     say_what = None
@@ -1394,6 +1395,11 @@ def parse_menu(stmtl, loc):
             l.expect_noblock('set menuitem')
             l.advance()
 
+            continue
+
+        if l.keyword('use'):
+            use_screen = l.simple_expression()
+            l.advance()
             continue
 
         # Try to parse a say menuitem.
@@ -1470,7 +1476,7 @@ def parse_menu(stmtl, loc):
     if has_say:
         rv.append(ast.Say(loc, say_who, say_what, None, interact=False))
 
-    rv.append(ast.Menu(loc, items, set, with_))
+    rv.append(ast.Menu(loc, items, set, with_, use_screen))
 
     return rv
 


### PR DESCRIPTION
- Allows screens other than 'choice' to be used for menus

Implements #1329 

It seems to work, but I have no idea if this is the best way, or if it causes bugs somewhere else. 