### PR TITLE
Fixed the implementation of `config.game_main_transition`

### DIFF
--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -168,7 +168,7 @@ init -1500 python:
 
                 layout.yesno_screen(layout.MAIN_MENU, MainMenu(False))
             else:
-                renpy.full_restart()
+                renpy.full_restart(config.game_main_transition)
 
         def get_sensitive(self):
             return not renpy.context()._main_menu

--- a/renpy/common/00gamemenu.rpy
+++ b/renpy/common/00gamemenu.rpy
@@ -218,13 +218,7 @@ label _noisy_return:
 
 # Return to the game.
 label _return:
-
-    if main_menu:
-        $ renpy.transition(config.game_main_transition)
-        jump _main_menu_screen
-
     $ renpy.transition(config.exit_transition)
-
     return
 
 label _confirm_quit:


### PR DESCRIPTION
Hello Ren'Py maintainers,

I'm not very familiar with the inner workings of Ren'Py, but I think there might be a bug in the implementation of the `config.game_main_transition` variable, that I was trying to use earlier.

# Bug Details
[In the documentation](https://www.renpy.org/doc/html/config.html#var-config.game_main_transition), `config.game_main_transition` is described as follows:
> The transition that is used **to display the main menu after leaving the game menu**. This is used when the load and preferences screens are invoked from the main menu, and **it's also used when the user picks "Main Menu" from the game menu**.   

The intended effect of the bolded sentences does not seem to work. **The transition from the game menu to the main menu triggers no transition** after assigning a transition to the variable.

The problem appears both with the current stable version (6.99.13.2919) and with the latest nightly build  (nightly-2018-01-01-85cbb149).

# Reproducing the Bug
Create an empty project with the Ren'Py launcher, and just add a line to define a transition for this config variable in `options.rpy`: 
> `define config.game_main_transition = dissolve`

Then start the story, and open the game menu to get back to the main menu. No transition will occur:
![2018-01-03_23-01-03](https://user-images.githubusercontent.com/720624/34541816-08531c2e-f0da-11e7-8bf7-75d06bbb07cb.gif)

# Bug Fix
The fix must be applied inside the MainMenu action, in `00action_menu.rpy`.  
The config variable must be passed to `renpy.full_restart()`, so that a transition is triggered upon restarting the game.

As far as I can see, the _return label from lines 222 to 225 in `00gamemenu.rpy` is already supposed to trigger the transition. That's why I think I'm just missing something, ahaha. But I don't see how the `if main_menu` condition could ever be True while in the game menu.

Sorry if this was actually no bug! I just couldn't figure it out.





