### PR TITLE
call_screen() shouldn't pass along _with_none

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2647,6 +2647,11 @@ def call_screen(_screen_name, *args, **kwargs):
 
     renpy.exports.mode('screen')
 
+    with_none = renpy.config.implicit_with_none
+
+    if "_with_none" in kwargs:
+        with_none = kwargs.pop("_with_none")
+
     show_screen(_screen_name, _transient=True, *args, **kwargs)
 
     roll_forward = renpy.exports.roll_forward_info()
@@ -2657,11 +2662,6 @@ def call_screen(_screen_name, *args, **kwargs):
         rv = e
 
     renpy.exports.checkpoint(rv)
-
-    with_none = renpy.config.implicit_with_none
-
-    if "_with_none" in kwargs:
-        with_none = kwargs.pop("_with_none")
 
     if with_none:
         renpy.game.interface.do_with(None, None)


### PR DESCRIPTION
Previously, `_with_none` was still in `kwargs` when the screen was shown, so the call would explode unless your screen also happened to have a `_with_none` argument.

Incidentally, [the documentation suggests](https://www.renpy.org/doc/html/screens.html#call-screen) that a `with` after a `call screen` should _just work_, but it doesn't if `config.implicit_with_none` is true — which it is by default!  Not sure if the docs ought to point this out, or if it's planned for `_with_none` to be added to the call automatically someday...?