### PR TITLE
Allow interpolating to any prop-only ATL transform

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -480,12 +480,13 @@ class ATLTransformBase(renpy.object.Object):
 
         block = self.atl.compile(self.context)
 
-        if len(block.statements) == 1 and isinstance(block.statements[0], Interpolation):
-
-            interp = block.statements[0]
-
-            if interp.duration == 0 and interp.properties:
-                self.properties = interp.properties[:]
+        if all(
+            isinstance(statement, Interpolation) and statement.duration == 0
+            for statement in block.statements
+        ):
+            self.properties = []
+            for interp in block.statements:
+                self.properties.extend(interp.properties)
 
         if not constant and renpy.display.predict.predicting:
             self.predict_block = block


### PR DESCRIPTION
It's possible to use an ATL transform as an interpolation target, but only if all the properties are on the same line:

```
transform truecenter:
    xcenter 0.5 ycenter 0.5

transform tocenter:
    linear 1.0 truecenter
```

Now you can do this too:

```
transform truecenter:
    xcenter 0.5
    ycenter 0.5

transform tocenter:
    linear 1.0 truecenter
```