### PR TITLE
Fix typo in "renpy.get_attributes" doc

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -491,7 +491,7 @@ def get_attributes(tag, layer=None):
     :doc: image_func
 
     Return a tuple giving the image attributes for the image with `tag`. If
-    the image is now showing, returns None.
+    the image is not showing, returns None.
 
     `layer`
         The layer to check. If None, uses the default layer for `tag`.


### PR DESCRIPTION
Saying that this returns "None" when an image is showing instead of when it isn't makes this function incredibly confusing at first sight.