### PR TITLE
LiveComposite replaced by Composite in tutorial and its translations.

### DIFF
--- a/tutorial/game/indepth_displayables.rpy
+++ b/tutorial/game/indepth_displayables.rpy
@@ -80,15 +80,15 @@ label simple_displayables:
     e "This means that we can apply other displayables, like Transform, to Text in the same way we do to images."
 
     example:
-        image logo livecomposite = LiveComposite((240, 460),
+        image logo composite = Composite((240, 460),
             (0, 0), "logo blink",
             (0, 50), "logo base.png",
             (0, 100), "logo base.png")
 
-    show logo livecomposite at logopos
+    show logo composite at logopos
     with dissolve
 
-    e "The LiveComposite displayable lets us group multiple displayables together into a single one, from bottom to top."
+    e "The Composite displayable lets us group multiple displayables together into a single one, from bottom to top."
 
     hide logo
 
@@ -134,5 +134,3 @@ label simple_displayables:
     e "You can even write custom displayables for minigames, if you're proficient at Python. But for many visual novels, these will be all you'll need."
 
     return
-
-

--- a/tutorial/game/tl/piglatin/indepth_displayables.rpy
+++ b/tutorial/game/tl/piglatin/indepth_displayables.rpy
@@ -62,8 +62,8 @@ translate piglatin simple_displayables_0befbee0:
 # game/indepth_displayables.rpy:91
 translate piglatin simple_displayables_fde549c4:
 
-    # e "The LiveComposite displayable lets us group multiple displayables together into a single one, from bottom to top."
-    e "Hetay Ivecompositelay isplayableday etslay usay oupgray ultiplemay isplayablesday ogethertay intoay aay inglesay oneay, omfray ottombay otay optay."
+    # e "The Composite displayable lets us group multiple displayables together into a single one, from bottom to top."
+    e "Hetay Ompositecay isplayableday etslay usay oupgray ultiplemay isplayablesday ogethertay intoay aay inglesay oneay, omfray ottombay otay optay."
 
 # game/indepth_displayables.rpy:101
 translate piglatin simple_displayables_3dc0050e:
@@ -106,4 +106,3 @@ translate piglatin strings:
     # indepth_displayables.rpy:67
     old "This is a text displayable."
     new "Histay isay aay exttay isplayableday."
-

--- a/tutorial/game/tl/russian/indepth_displayables.rpy
+++ b/tutorial/game/tl/russian/indepth_displayables.rpy
@@ -63,8 +63,8 @@ translate russian simple_displayables_0befbee0:
 # game/indepth_displayables.rpy:91
 translate russian simple_displayables_fde549c4:
 
-    # e "The LiveComposite displayable lets us group multiple displayables together into a single one, from bottom to top."
-    e "Объект LiveComposite позволяет нам группировать разные объекты в один снизу вверх."
+    # e "The Composite displayable lets us group multiple displayables together into a single one, from bottom to top."
+    e "Объект Composite позволяет нам группировать разные объекты в один снизу вверх."
 
 # game/indepth_displayables.rpy:101
 translate russian simple_displayables_3dc0050e:
@@ -107,4 +107,3 @@ translate russian strings:
     # indepth_displayables.rpy:67
     old "This is a text displayable."
     new "Это текстовый объект."
-


### PR DESCRIPTION
In this small pull request, I replaced Live Composite by Composite in tutorial and its translation, according to your [changelog](https://www.renpy.org/doc/html/changelog.html?highlight=changelog#renpy-6-99-14-3) in version 6-99-14-3.

