### PR TITLE
Additional documentation corrections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,14 @@ on feature branches.
 Getting Started
 ===============
 
-Ren'Py depends on a number of python modules written in Cython and C. For
-changes to Ren'Py that only involve python modules, you can use the modules
+Ren'Py depends on a number of Python modules written in Cython and C. For
+changes to Ren'Py that only involve Python modules, you can use the modules
 found in the latest nightly build. Otherwise, you'll have to compile the
 modules yourself.
 
 The development scripts assume a POSIX-like platform. The scripts should run
-on Linux or Mac OS X, and can be made to run on Windows using an environment
-like Msys.
+on Linux or macOS, and can be made to run on Windows using an environment
+like MSYS.
 
 Nightly Build
 -------------

--- a/renpy/character.py
+++ b/renpy/character.py
@@ -398,7 +398,7 @@ def display_say(
         advance=True,
         multiple=None):
 
-    # Final is true if this statement should perform an interaction.
+    # Final is True if this statement should perform an interaction.
 
     if multiple is None:
         final = interact
@@ -1148,17 +1148,17 @@ def Character(name=NotSet, kind=None, **properties):
 
     `name`
         If a string, the name of the character for dialogue. When
-        `name` is ``None``, display of the name is omitted, as for
+        ``name`` is None, display of the name is omitted, as for
         narration.
 
     `kind`
         The Character to base this Character off of. When used, the
         default value of any argument not supplied to this Character
-        is the value of that argument supplied to `kind`. This can
+        is the value of that argument supplied to ``kind``. This can
         be used to define a template character, and then copy that
         character with changes.
 
-    **Linked Image**
+    **Linked Image.**
     An image tag may be associated with a Character. This allows a
     say statement involving this character to display an image with
     the tag, and also allows Ren'Py to automatically select a side
@@ -1168,7 +1168,7 @@ def Character(name=NotSet, kind=None, **properties):
          A string giving the image tag that is linked with this
          character.
 
-    **Voice Tag**
+    **Voice Tag.**
     If a voice tag is assign to a Character, the voice files that are
     associated with it, can be muted or played in the preference
     screen.
@@ -1202,7 +1202,7 @@ def Character(name=NotSet, kind=None, **properties):
     These options help to control the display of the name.
 
     `dynamic`
-        If true, then `name` should be a string containing a python
+        If True, then ``name`` should be a string containing a python
         expression. That string will be evaluated before each line
         of dialogue, and the result used as the name of the character.
 
@@ -1212,12 +1212,12 @@ def Character(name=NotSet, kind=None, **properties):
 
     `condition`
         If given, this should be a string containing a python
-        expression. If the expression is false, the dialogue
+        expression. If the expression is False, the dialogue
         does not occur, as if the say statement did not happen.
 
     `interact`
-        If true, the default, an interaction occurs whenever the
-        dialogue is shown. If false, an interaction will not occur,
+        If True, the default, an interaction occurs whenever the
+        dialogue is shown. If False, an interaction will not occur,
         and additional elements can be added to the screen.
 
     `advance`
@@ -1241,18 +1241,18 @@ def Character(name=NotSet, kind=None, **properties):
     finished displaying, to prompt the user to advance.
 
     `ctc`
-        A Displayable to use as the click-to-continue indicator, unless
+        A displayable to use as the click-to-continue indicator, unless
         a more specific indicator is used.
 
     `ctc_pause`
-        A Displayable to use a the click-to-continue indicator when the
+        A displayable to use a the click-to-continue indicator when the
         display of text is paused by the {p} or {w} text tags.
 
     `ctc_timedpause`
-        A Displayable to use a the click-to-continue indicator when the
+        A displayable to use a the click-to-continue indicator when the
         display of text is paused by the {p=} or {w=} text tags. When
         None, this takes its default from ctc_pause, use ``Null()``
-        when you want a ctc_pause but no ctc_timedpause.
+        when you want a ``ctc_pause`` but no ``ctc_timedpause``.
 
     `ctc_position`
         Controls the location of the click-to-continue indicator. If
@@ -1272,18 +1272,18 @@ def Character(name=NotSet, kind=None, **properties):
     Keyword arguments beginning with ``show_`` have the prefix
     stripped off, and are passed to the screen as arguments. For
     example, the value of ``show_myflag`` will become the value of
-    the ``myflag`` variable in the screen. (The myflag variable isn't
+    the ``myflag`` variable in the screen. (The ``myflag`` variable isn't
     used by default, but can be used by a custom say screen.)
 
     One show variable is, for historical reasons, handled by Ren'Py itself:
 
     `show_layer`
         If given, this should be a string giving the name of the layer
-        to show the "say" screen on.
+        to show the say screen on.
 
     **Styling Text and Windows.**
     Keyword arguments beginning with ``who_``, ``what_``, and
-    `window_`` have their prefix stripped, and are used to :ref:`style
+    ``window_`` have their prefix stripped, and are used to :ref:`style
     <styles>` the character name, the spoken text, and the window
     containing both, respectively.
 
@@ -1294,8 +1294,8 @@ def Character(name=NotSet, kind=None, **properties):
     dialogue.
 
     The style applied to the character name, spoken text, and window
-    can also be set this way, using the `who_style`, `what_style`, and
-    `window_style` arguments, respectively.
+    can also be set this way, using the ``who_style``, ``what_style``, and
+    ``window_style`` arguments, respectively.
 
     Setting :var:`config.character_id_prefixes` makes it possible to style
     other displayables as well. For example, when the default GUI is used,

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -52,7 +52,7 @@ init -1500 python:
     _voice.info = None
     _voice.last_playing = 0.0
 
-    # If true, the voice system ignores the interaction.
+    # If True, the voice system ignores the interaction.
     _voice.ignore_interaction = False
 
     # The voice filename format. This may contain the voice tag
@@ -126,12 +126,12 @@ init -1500 python:
         if _last_voice_play is not None:
             renpy.sound.play(_last_voice_play, channel="voice")
 
-    # Returns true if we can replay the voice.
+    # Returns True if we can replay the voice.
     def voice_can_replay():
         """
         :doc: voice
 
-        Returns true if it's possible to replay the current voice.
+        Returns True if it's possible to replay the current voice.
         """
 
         return _last_voice_play is not None
@@ -141,8 +141,8 @@ init -1500 python:
         """
         :doc: voice_action
 
-        If `mute` is true, mutes voices that are played with the given
-        `voice_tag`. If `mute` is false, unmutes voices that are played
+        If `mute` is True, mutes voices that are played with the given
+        `voice_tag`. If `mute` is False, unmutes voices that are played
         with `voice_tag`.
         """
 
@@ -197,7 +197,7 @@ init -1500 python:
             The full path to a sound file. No voice-related handling
             of this file is done.
 
-         selected`
+        `selected`
             If True, buttons using this action will be marked as selected
             while the sample is playing.
         """
@@ -251,7 +251,7 @@ init -1500 python:
         :doc: voice_action
 
         Toggles the muting of `voice_tag`. This is selected if
-        the given voice tag is muted, unless `invert` is true,
+        the given voice tag is muted, unless `invert` is True,
         in which case it's selected if the voice is unmuted.
         """
 

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -400,7 +400,7 @@ class ImageDissolve(Transition):
         completed one step of dissolving in.
 
     `reverse`
-        If true, black pixels will dissolve in before white pixels.
+        If True, black pixels will dissolve in before white pixels.
 
     `alpha`
         Ignored.
@@ -536,7 +536,7 @@ class AlphaDissolve(Transition):
         Ignored.
 
     `reverse`
-        If true, the alpha channel is reversed. Opaque areas are taken
+        If True, the alpha channel is reversed. Opaque areas are taken
         from the old image, while transparent areas are taken from the
         new image.
      """
@@ -659,8 +659,8 @@ class CropMove(Transition):
         to the screen at, a 2-element tuple containing x and y.
 
     `topnew`
-        If true, the scene that is cropped and moved (and is on top of
-        the other scene) is the new scene. If false, it is the old scene.
+        If True, the scene that is cropped and moved (and is on top of
+        the other scene) is the new scene. If False, it is the old scene.
 
     ::
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2474,7 +2474,6 @@ def get_placement(d):
 
     This returns an object with the following fields, each corresponding to a style
     property:
-
         * xpos
         * xanchor
         * xoffset

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -221,7 +221,7 @@ def in_rollback():
     """
     :doc: rollback
 
-    Returns true if the game has been rolled back.
+    Returns True if the game has been rolled back.
     """
 
     return renpy.game.log.in_rollback()
@@ -231,7 +231,7 @@ def can_rollback():
     """
     :doc: rollback
 
-    Returns true if we can rollback.
+    Returns True if we can rollback.
     """
 
     if not renpy.config.rollback_enabled:
@@ -244,7 +244,7 @@ def in_fixed_rollback():
     """
     :doc: blockrollback
 
-    Returns true if rollback is currently occurring and the current
+    Returns True if rollback is currently occurring and the current
     context is before an executed renpy.fix_rollback() statement.
     """
 
@@ -291,7 +291,7 @@ def suspend_rollback(flag):
     suspended.
 
     `flag`:
-        When `flag` is true, rollback is suspended. When false,
+        When `flag` is True, rollback is suspended. When False,
         rollback is resumed.
     """
 
@@ -460,7 +460,7 @@ def showing(name, layer='master'):
     """
     :doc: image_func
 
-    Returns true if an image with the same tag as `name` is showing on
+    Returns True if an image with the same tag as `name` is showing on
     `layer`
 
     `image`
@@ -486,7 +486,7 @@ def get_showing_tags(layer='master', sort=False):
     :doc: image_func
 
     Returns the set of image tags that are currently being shown on `layer`. If
-    sort is true, returns a list of the tags from back to front.
+    sort is True, returns a list of the tags from back to front.
     """
 
     if sort:
@@ -867,7 +867,7 @@ def menu(items, set_expr):
             return s
 
     # Filter the list of items to only include ones for which the
-    # condition is true.
+    # condition is True.
     items = [ (substitute(label), value)
               for label, condition, value in items
               if renpy.python.py_eval(condition) ]
@@ -980,7 +980,7 @@ def display_menu(items,
     Except for `items`, all arguments should be given as keyword arguments.
 
     `interact`
-        If false, the menu is displayed, but no interaction is performed.
+        If False, the menu is displayed, but no interaction is performed.
 
     `screen`
         The name of the screen used to display the menu.
@@ -1170,8 +1170,8 @@ def say(who, what, *args, **kwargs):
         in this string.
 
     `interact`
-        If true, Ren'Py waits for player input when displaying the dialogue. If
-        false, Ren'Py shows the dialogue, but does not perform an interaction.
+        If True, Ren'Py waits for player input when displaying the dialogue. If
+        False, Ren'Py shows the dialogue, but does not perform an interaction.
         (This is passed in as a keyword argument.)
 
     This function is rarely necessary, as the following three lines are
@@ -1267,8 +1267,8 @@ def pause(delay=None, music=None, with_none=None, hard=False, checkpoint=None):
     """
     :doc: other
 
-    Causes Ren'Py to pause. Returns true if the user clicked to end the pause,
-    or false if the pause timed out or was skipped.
+    Causes Ren'Py to pause. Returns True if the user clicked to end the pause,
+    or False if the pause timed out or was skipped.
 
     `delay`
         If given, the number of seconds Ren'Py should pause for.
@@ -1280,12 +1280,12 @@ def pause(delay=None, music=None, with_none=None, hard=False, checkpoint=None):
         Determines if a with None clause is executed at the end of the pause.
 
     `hard`
-        If true, a click will not interrupt the pause. Use this sparingly,
+        If True, a click will not interrupt the pause. Use this sparingly,
         as it's hard to distinguish a hard pause from a crashing game.
 
     `checkpoint`
-        If true, a checkpoint will be set, and players will be able to roll
-        back to this statement. If false, no checkpoint will be set. If None,
+        If True, a checkpoint will be set, and players will be able to roll
+        back to this statement. If False, no checkpoint will be set. If None,
         a checkpoint will only be set if delay is set.
     """
 
@@ -1413,8 +1413,8 @@ def with_statement(trans, always=False, paired=None, clear=True):
         If True, the transition will always occur, even if the user has
         disabled transitions.
 
-    This function returns true if the user chose to interrupt the transition,
-    and false otherwise.
+    This function returns True if the user chose to interrupt the transition,
+    and False otherwise.
     """
 
     if renpy.game.context().init_phase:
@@ -1462,7 +1462,7 @@ def rollback(force=False, checkpoints=1, defer=False, greedy=True, label=None, a
     Rolls the state of the game back to the last checkpoint.
 
     `force`
-        If true, the rollback will occur in all circumstances. Otherwise,
+        If True, the rollback will occur in all circumstances. Otherwise,
         the rollback will only occur if rollback is enabled in the store,
         context, and config.
 
@@ -1471,18 +1471,18 @@ def rollback(force=False, checkpoints=1, defer=False, greedy=True, label=None, a
         will roll back as far as it can, subject to this condition.
 
     `defer`
-        If true, the call will be deferred until control returns to the main
+        If True, the call will be deferred until control returns to the main
         context.
 
     `greedy`
-        If true, rollback will finish just after the previous checkpoint.
-        If false, rollback finish just before the current checkpoint.
+        If True, rollback will finish just after the previous checkpoint.
+        If False, rollback finish just before the current checkpoint.
 
     `label`
         If not None, a label that is called when rollback completes.
 
     `abnormal`
-        If true, the default, script executed after the transition is run in
+        If True, the default, script executed after the transition is run in
         an abnormal mode that skips transitions that would have otherwise
         occured. Abnormal mode ends when an interaction begins.
     """
@@ -1528,7 +1528,7 @@ def has_label(name):
     """
     :doc: label
 
-    Returns true if `name` is a valid label the program, or false otherwise.
+    Returns True if `name` is a valid label the program, or False otherwise.
 
     `name`
         Should be a string to check for the existence of a label. It can
@@ -1633,7 +1633,7 @@ def quit(relaunch=False, status=0):  # @ReservedAssignment
     This causes Ren'Py to exit entirely.
 
     `relaunch`
-        If true, Ren'Py will run a second copy of itself before quitting.
+        If True, Ren'Py will run a second copy of itself before quitting.
 
     `status`
         The status code Ren'Py will return to the operating system.
@@ -1674,7 +1674,7 @@ def call(label, *args, **kwargs):
     to the statement following the current statement.
 
     `from_current`
-        If true, control will return to the current statement, rather than
+        If True, control will return to the current statement, rather than
         the statement following the current statement. (This will lead to
         the current statement being run twice. This must be passed as a
         keyword argument.)
@@ -1712,10 +1712,10 @@ def version(tuple=False):  # @ReservedAssignment
     """
     :doc: renpy_version
 
-    If `tuple` is false, returns a string containing "Ren'Py ", followed by
+    If `tuple` is False, returns a string containing "Ren'Py ", followed by
     the current version of Ren'Py.
 
-    If `tuple` is true, returns a tuple giving each component of the
+    If `tuple` is True, returns a tuple giving each component of the
     version as an integer.
     """
 
@@ -1755,7 +1755,7 @@ def transition(trans, layer=None, always=False, force=False):
         applies to the entire scene.
 
     `always`
-        If false, this respects the transition preference. If true, the
+        If False, this respects the transition preference. If True, the
         transition is always run.
     """
 
@@ -1825,7 +1825,7 @@ def exists(filename):
     """
     :doc: file_rare
 
-    Returns true if the given filename can be found in the
+    Returns True if the given filename can be found in the
     searchpath. This only works if a physical file exists on disk. It
     won't find the file if it's inside of an archive.
 
@@ -2039,8 +2039,8 @@ def seen_label(label):
     """
     :doc: label
 
-    Returns true if the named label has executed at least once on the current user's
-    system, and false otherwise. This can be used to unlock scene galleries, for
+    Returns True if the named label has executed at least once on the current user's
+    system, and False otherwise. This can be used to unlock scene galleries, for
     example.
     """
     return label in renpy.game.persistent._seen_ever  # @UndefinedVariable
@@ -2152,8 +2152,8 @@ def show_layer_at(at_list, layer='master', reset=True):
     statement.
 
     `reset`
-        If true, the transform state is reset to the start when it is shown.
-        If false, the transform state is persisted, allowing the new transform
+        If True, the transform state is reset to the start when it is shown.
+        If False, the transform state is persisted, allowing the new transform
         to update that state.
     """
 
@@ -2276,12 +2276,12 @@ def scry():
 
     Returns the scry object for the current statement.
 
-    The scry object tells Ren'Py about things that must be true in the
+    The scry object tells Ren'Py about things that must be True in the
     future of the current statement. Right now, the scry object has one
     field:
 
     ``nvl_clear``
-        Is true if an ``nvl clear`` statement will execute before the
+        Is True if an ``nvl clear`` statement will execute before the
         next interaction.
     """
 
@@ -2688,7 +2688,7 @@ def call_screen(_screen_name, *args, **kwargs):
     Keyword arguments not beginning with _ are passed to the scope of
     the screen.
 
-    If the keyword argument `_with_none` is false, "with None" is not
+    If the keyword argument `_with_none` is False, "with None" is not
     run at the end of end of the interaction.
     """
 
@@ -2728,7 +2728,7 @@ def list_files(common=False):
     a list of files, with / as the directory separator.
 
     `common`
-        If true, files in the common directory are included in the
+        If True, files in the common directory are included in the
         listing.
     """
 
@@ -2853,7 +2853,7 @@ def variant(name):
     """
     :doc: screens
 
-    Returns true if a `name` is a screen variant that can be chosen
+    Returns True if a `name` is a screen variant that can be chosen
     by Ren'Py. See :ref:`screen-variants` for more details. This function
     can be used as the condition in a python if statement to set up the
     appropriate styles for the selected screen variant.
@@ -3028,7 +3028,7 @@ def get_image_load_log(age=None):
 
     * The time the image was loaded (in seconds since the epoch).
     * The filename of the image that was loaded.
-    * A boolean that is true if the image was preloaded, and false if the
+    * A boolean that is True if the image was preloaded, and False if the
       game stalled to load it.
 
     The entries are ordered from newest to oldest.
@@ -3078,10 +3078,10 @@ def is_seen(ever=True):
     """
     :doc: other
 
-    Returns true if the current line has been seen by the player.
+    Returns True if the current line has been seen by the player.
 
-    If `ever` is true, we check to see if the line has ever been seen by the
-    player. If false, we check if the line has been seen in the current
+    If `ever` is True, we check to see if the line has ever been seen by the
+    player. If False, we check if the line has been seen in the current
     play-through.
     """
 
@@ -3300,7 +3300,7 @@ def predicting():
     """
     :doc: screens
 
-    Returns true if Ren'Py is currently predicting the screen.
+    Returns True if Ren'Py is currently predicting the screen.
     """
 
     return renpy.display.predict.predicting
@@ -3348,7 +3348,7 @@ def add_layer(layer, above=None, below=None, menu_clear=True):
         be placed below.
 
     `menu_clear`
-        If true, this layer will be cleared when entering the game menu
+        If True, this layer will be cleared when entering the game menu
         context, and restored when leaving the
     """
 
@@ -3402,7 +3402,7 @@ def is_start_interact():
     """
     :doc: other
 
-    Returns true if restart_interaction has not been called during the current
+    Returns True if restart_interaction has not been called during the current
     interaction. This can be used to determine if the interaction is just being
     started, or has been restarted.
     """
@@ -3432,8 +3432,8 @@ def get_editable_input_value():
     """
     :undocumented:
 
-    Returns the current input value, and a flag that is true if it is editable.
-    and false otherwise.
+    Returns the current input value, and a flag that is True if it is editable.
+    and False otherwise.
     """
 
     return renpy.display.behavior.current_input_value, renpy.display.behavior.input_value_active
@@ -3515,8 +3515,8 @@ def get_skipping():
     """
     :doc: other
 
-    Returns true if the Ren'Py is skipping, "fast" if Ren'Py is fast skipping,
-    and false if it is not skipping.
+    Returns True if the Ren'Py is skipping, "fast" if Ren'Py is fast skipping,
+    and False if it is not skipping.
     """
 
     return renpy.config.skipping

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -362,7 +362,7 @@ class Script(object):
             A list we append init statements to.
 
         `check_names`
-            If true, produce duplicate name errors.
+            If True, produce duplicate name errors.
 
         `filename`
             If given, a filename that overrides the filename found inside the
@@ -876,7 +876,7 @@ class Script(object):
 
     def has_label(self, label):
         """
-        Returns true if the label exists, or false otherwise.
+        Returns True if the label exists, or False otherwise.
         """
 
         label = renpy.config.label_overrides.get(label, label)

--- a/renpy/text/font.py
+++ b/renpy/text/font.py
@@ -443,7 +443,8 @@ def register_sfont(name=None, size=None, bold=False, italics=False, underline=Fa
         A map from two-character strings to the kern that should be used between
         those characters.
 
-    `charset` - The character set of the font. A string containing characters in
+    `charset`
+        The character set of the font. A string containing characters in
         the order in which they are found in the image. The default character
         set for a SFont is::
 

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -34,7 +34,7 @@ init block, then it is automatically placed inside an init block with a
 priority of 0. The transform may have a list of parameters, which must be
 supplied when it is called.
 
-`Name` must be a python identifier. The transform created by the ATL block is
+`Name` must be a Python identifier. The transform created by the ATL block is
 bound to this name.::
 
    transform left_to_right:
@@ -99,7 +99,7 @@ There are two kinds of ATL statements: simple and complex. Simple statements
 do not take an ATL block. A single logical line may contain one or more ATL
 statements, separated by commas. A complex statement contains a block, must
 be on its own line. The first line of a complex statement always ends with a
-colon (":").
+colon ``:``.
 
 By default, statements in a block are executed in the order in which they
 appear, starting with the first statement in the block. Execution terminates
@@ -195,7 +195,7 @@ Some sample interpolations are::
 An important special case is that the pause warper, followed by a time and
 nothing else, causes ATL execution to pause for that amount of time.
 
-Some properties can have values of multiple types. For example, the xpos
+Some properties can have values of multiple types. For example, the :propref:`xpos`
 property can be an int, float, or absolute. The behavior is undefined when an
 interpolation has old and new property values of different types.
 
@@ -203,7 +203,7 @@ Time Statement
 --------------
 
 The time statement is a simple control statement. It contains a single
-simple_expression, which is evaluated to give a time, expressed as seconds
+``simple_expression``, which is evaluated to give a time, expressed as seconds
 from the start of execution of the containing block.
 
 .. productionlist:: atl
@@ -287,7 +287,7 @@ Repeat Statement
 The repeat statement is a simple statement that causes the block containing it
 to resume execution from the beginning. If the expression is present, then it
 is evaluated to give an integer number of times the block will execute. (So a
-block ending with "repeat 2" will execute at most twice.)
+block ending with ``repeat 2`` will execute at most twice.)
 
 .. productionlist:: atl
     atl_repeat : "repeat" (`simple_expression`)?
@@ -335,7 +335,7 @@ the last choice in the choice set.
               :     `atl_block`
 
 Choice statements are greedily grouped into a choice set when more than one
-choice statement appears consecutively in a block. If the `simple_expression`
+choice statement appears consecutively in a block. If the ``simple_expression``
 is supplied, it is a floating-point weight given to that block, otherwise 1.0
 is assumed.
 
@@ -520,7 +520,6 @@ The functions have the same signature as those used with :func:`Transform`:
 
 ::
 
-    init python:
         def slide_function(trans, st, at):
             if st > 1.0:
                 trans.xalign = 1.0
@@ -572,8 +571,8 @@ http://www.easings.net/.
 
 .. include:: inc/easings
 
-New warpers can be defined using the renpy.atl_warper decorator, in a python
-early block. It should be placed in a file that is parsed before any file
+New warpers can be defined using the renpy.atl_warper decorator, in a ``python
+early`` block. It should be placed in a file that is parsed before any file
 that uses the warper. This looks like::
 
     python early hide:
@@ -589,11 +588,11 @@ List of Transform Properties
 
 The following transform properties exist.
 
-When the type is given as position, it may be an int, renpy.absolute, or
+When the type is given as position, it may be an int, ``renpy.absolute``, or
 float. If it's a float, it's interpreted as a fraction of the size of the
-containing area (for pos) or displayable (for anchor).
+containing area (for :propref:`pos`) or displayable (for :propref:`anchor`).
 
-Note that not all properties are independent. For example, xalign and xpos
+Note that not all properties are independent. For example, :propref:`xalign` and :propref:`xpos`
 both update some of the same underlying data. In a parallel statement, only
 one block should adjust horizontal position, and one should adjust vertical
 positions. (These may be the same block.) The angle and radius properties set
@@ -763,7 +762,7 @@ both horizontal and vertical positions.
     :type: boolean
     :default: None
 
-    If true, the displayable and its children are drawn using nearest-neighbor
+    If True, the displayable and its children are drawn using nearest-neighbor
     filtering. If False, the displayable and its children are drawn using
     bilinear filtering. If None, this is inherited from the parent, or
     :var:`config.nearest_neighbor`, which defaults to False.
@@ -999,7 +998,7 @@ The following events can be triggered automatically:
 
 ``hide``
     Triggered when the transform is hidden using the hide statement or its
-    python equivalent.
+    Python equivalent.
 
     Note that this isn't triggered when the transform is eliminated via
     the scene statement or exiting the context it exists in, such as when

--- a/sphinx/source/audio.rst
+++ b/sphinx/source/audio.rst
@@ -4,23 +4,23 @@ Audio
 Ren'Py supports playing music and sound effects in the background,
 using the following audio file formats
 
-* OPUS
-* OGG Vorbis
+* Opus
+* Ogg Vorbis
 * MP3
 * WAV (uncompressed PCM only)
 
 Ren'Py supports an arbitrary number of audio channels. There are three
 normal channels defined by default:
 
-* music - A channel for music playback.
-* sound - A channel for sound effects.
-* voice - A channel for voice.
+* ``music`` - A channel for music playback.
+* ``sound`` - A channel for sound effects.
+* ``voice`` - A channel for voice.
 
 Normal channels support playing and queueing audio, but only play back
 one audio file at a time. New normal channels can be registered with
 :func:`renpy.music.register_channel`.
 
-The 'Music Volume', 'Sound Volume', and 'Voice Volume' settings
+The Music Volume, Sound Volume, and Voice Volume settings
 of the in-game preferences menu are used to set individual
 volumes for these channels.
 
@@ -42,11 +42,11 @@ the three music/sound statements.
 Play Statement
 ------------------
 
-The play statement is used to play sound and music. If a file is
+The ``play`` statement is used to play sound and music. If a file is
 currently playing on a normal channel, it is interrupted and replaced with
 the new file.
 
-The name of a channel is expected following keyword ``play``,
+The name of a channel is expected following the keyword ``play``.
 (Usually, this is either "sound", "music", "voice", or "audio"). This is
 followed by audiofile(s), where audiofile(s) can be one file or list of files.
 When the list is given, the item of it is played in order.
@@ -54,11 +54,11 @@ When the list is given, the item of it is played in order.
 
 The ``fadein`` and ``fadeout`` clauses are optional. Fadeout gives the fadeout
 time for currently playing music, in seconds, while fadein gives the time
-it takes to fade in the new music. If fadeout is not given, config.fade_music
+it takes to fade in the new music. If fadeout is not given, :var:`config.fade_music`
 is used.
 
 The ``loop`` and ``noloop`` clauses are also optional. The loop clause causes
-the music to loop, while noloop causes it to play only once. If both of them isn't
+the music to loop, while noloop causes it to play only once. If neither of them are
 given, the default of the channel is used. ::
 
         play music "mozart.ogg"
@@ -78,7 +78,7 @@ time::
 Stop Statement
 --------------
 
-The stop statement begin with keyword ``stop``, followed by the the name of a
+The ``stop`` statement begins with the keyword ``stop``, followed by the the name of a
 channel to stop sound on. It may optionally have a ``fadeout``
 clause. ::
 
@@ -89,10 +89,10 @@ clause. ::
 Queue Statement
 ---------------
 
-The queue statement is used to queue up audio files. They will be played when
+The ``queue`` statement is used to queue up audio files. They will be played when
 the channel finishes playing the currently playing file.
 
-The queue statement begin with keyword ``queue``, followed by the the name of a
+The queue statement begins with keyword ``queue``, followed by the the name of a
 channel to play sound on. It optionally takes the ``loop`` and ``noloop`` clauses. ::
 
         queue sound "woof.ogg"
@@ -100,8 +100,8 @@ channel to play sound on. It optionally takes the ``loop`` and ``noloop`` clause
 
 The advantage of using these statements is that your program will be checked for
 missing sound and music files when lint is run. The functions below exist to allow
-access to allow music and sound to be controlled from python, and to expose
-advanced (rarely-used) features.
+access to allow music and sound to be controlled from Python, and to expose
+advanced (rarely used) features.
 
 
 .. _partial-playback:
@@ -134,11 +134,11 @@ For example::
 
         play music "<from 5 to 15.5>waves.opus"
 
-Will play 10.5 seconds of waves.opus, starting at the 5 second mark. The statement::
+will play 10.5 seconds of waves.opus, starting at the 5 second mark. The statement::
 
         play music "<loop 6.333>song.opus"
 
-Will play song.opus all the way through once, then loop back to the 6.333
+will play song.opus all the way through once, then loop back to the 6.333
 second mark before playing it again all the way through to the end.
 
 .. _silence:
@@ -182,6 +182,6 @@ Functions
 Sound Functions
 ---------------
 
-Most renpy.music functions have aliases in renpy.sound. These functions are similar,
+Most ``renpy.music`` functions have aliases in ``renpy.sound``. These functions are similar,
 except they default to the sound channel rather than the music channel, and default
 to not looping.

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -9,7 +9,7 @@ Full Changelog
 
 Ren'Py 7.0 marks the completion of over a decade of development since
 Ren'Py 6 that brought features like ATL, Screen Language, OpenGL and DirectX
-acceleration,  support for the Android and iOS platforms, Translation,
+acceleration, support for the Android and iOS platforms, Translation,
 Accessibility, and so much more.
 
 For releases between 6.0 and 7.0, see the other entries in this changelog,
@@ -25,7 +25,7 @@ created in Photoshop or some other program as a a series of layers.
 The layered image system can use the attributes the image was displayed
 with and Python conditions to determine what layers to display.
 
-Layered images are intended to be a replacement for the use of (Live):func:`composite`
+Layered images are intended to be a replacement for the use of :func:`Composite`
 and :func:`ConditionSwitch` to define layered images. It includes a language
 that makes defining such images simpler, and Ren'Py can generate portions
 of the definitions from appropriately named files. It also integrates better
@@ -38,14 +38,14 @@ Dict Transitions
 :ref:`Dict Transitions <dict-transitions>` makes it
 possible to use the with statement and certain other functions to apply
 transitions to one or more layers. Ren'Py will not pause for these
-transitions to occur. Dict transitions make it possible - and even
-convenient - to have a transition apply to the sprites alone while dialogue is
+transitions to occur. Dict transitions make it possible—and even
+convenient—to have a transition apply to the sprites alone while dialogue is
 being displayed.
 
 Changes
 -------
 
-The old tutorial and old templates are no longer includes with Ren'Py.
+The old tutorial and old templates are no longer included with Ren'Py.
 They can still be used with new version of Ren'Py if copied into
 this or later versions.
 
@@ -54,7 +54,7 @@ change the position of a viewport or the value of a bar.
 
 The :func:`Dissolve`, :func:`ImageDissolve`, and :func:`AlphaDissolve`
 transitions now respect the alpha channels of their source displayables, as
-if given the alpha=True argument. As omitting the alpha channel is no
+if given the ``alpha=True`` argument. As omitting the alpha channel is no
 longer an optimization, this change allows the same transitions to be
 used in more places.
 
@@ -74,7 +74,7 @@ When provided, it should return a unique value that can map information like
 button and transform state to the object it originates from.
 
 There is now alternate ruby text, allowing two kinds of ruby text
-to be displayed at once. (Such as a translation and pronunciation guide.)
+to be displayed at once (such as a translation and pronunciation guide).
 
 The new :ref:`displayable prefix <displayable-prefix>` system make it possible to define your
 own displayables that can be accessed using strings, the same way that

--- a/sphinx/source/chromeos.rst
+++ b/sphinx/source/chromeos.rst
@@ -7,14 +7,14 @@ Android apps under the Android Runtime for Chrome (ARC).
 
 To port a Ren'Py Android app to Chrome, the following steps are required:
 
-1. Install the ARC Welder app from the chrome web store:
+1. Install the ARC Welder app from the Chrome Web Store:
    https://chrome.google.com/webstore/detail/arc-welder/emfinbmielocnlhgmfkkmkngdoccbadn
 
-2. Package the game for android, as described in the :ref:`android documentation <android>`.
+2. Package the game for Android, as described in the :ref:`Android documentation <android>`.
 
-3. Launch ARC Welder from the apps menu inside chrome.
+3. Launch ARC Welder from the apps menu inside Chrome.
 
-4. Find the path to the .apk file containin your app.
+4. Find the path to the .apk file containing your app.
 
 5. Choose the following options:
 
@@ -28,5 +28,5 @@ To port a Ren'Py Android app to Chrome, the following steps are required:
 
 6. Choose "Test". The game will load and run in the Chrome web browser.
 
-7. Choose "Download Zip". Chrome will generate a Zip file suitable for
-   uploading to the chrome web store.
+7. Choose "Download Zip". Chrome will generate a .zip file suitable for
+   uploading to the Chrome Web Store.

--- a/sphinx/source/conditional.rst
+++ b/sphinx/source/conditional.rst
@@ -15,18 +15,18 @@ and for statements, but can't embed Ren'Py script statements.
 If Statement
 ------------
 
-The if statement conditionally executes a block of statements if a python
+The ``if`` statement conditionally executes a block of statements if a python
 expression is true. It consists of an ``if`` clause, zero or more ``elif``
-clauses, and an optional``else`` clause.
+clauses, and an optional ``else`` clause.
 
 Each clause should be on its own logical line, followed by a block of
 statements. The ``if`` and ``elif`` clauses are followed by an expression,
-while all clauses end with a colon. (:)
+while all clauses end with a colon ``:``.
 
 Examples are::
 
     if flag:
-        e "You're set the flag!"
+        e "You've set the flag!"
 
 ::
 
@@ -40,12 +40,12 @@ Examples are::
         jump worst_ending
 
 The expressions in the if statement are evaluated in order, from
-first to last. When an expression evaluates to true, the block
+first to last. When an expression evaluates to True, the block
 corresponding to that statement is executed. When control reaches the
 end of the block, it proceeds to the statement following the if
 statement.
 
-If all expressions evaluate to false, the block associated with
+If all expressions evaluate to False, the block associated with
 the ``else`` clause is executed, if the ``else`` clause is present.
 
 
@@ -54,8 +54,8 @@ the ``else`` clause is executed, if the ``else`` clause is present.
 While Statement
 ---------------
 
-The while statement executes a block of statements while an expression
-evaluates true. For example::
+The ``while`` statement executes a block of statements while an expression
+evaluates True. For example::
 
     $ count = 10
 
@@ -76,7 +76,7 @@ evaluates true. For example::
 
 The expression is evaluated when while statement is first reached, and
 then each time control reaches the end of the block. When the expression
-return a false value, the statement after the while statement is executed.
+return a False value, the statement after the while statement is executed.
 
 Ren'Py does not have continue, break, or for statements. Continue and break
 statements can be replaced by jumps to labels placed before or after the
@@ -89,7 +89,7 @@ how a while loop can replace a for statement.
 Pass Statement
 --------------
 
-The pass statement can be used when a block is required, but no
+The ``pass`` statement can be used when a block is required, but no
 statement is suitable. It does nothing.
 
 For example::
@@ -103,7 +103,7 @@ For example::
 
 ::
 
-    # event.step() is a function that returns true while there are
+    # event.step() is a function that returns True while there are
     # still events that need to be executed.
 
     while event.step():

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -12,7 +12,7 @@ initialized, configuration variables will not change. Changing configuration
 variables outside of init blocks can lead to undefined behavior.
 Configuration variables are not part of the save data.
 
-Configuration variables are often changed in init python blocks::
+Configuration variables are often changed in ``init python`` blocks::
 
     init python:
 
@@ -306,7 +306,7 @@ Occasionally Used
 
 .. var:: config.debug_text_overflow = False
 
-    When true, Ren'Py will log text overflows to text_overflow.txt. A text
+    When True, Ren'Py will log text overflows to text_overflow.txt. A text
     overflow occurs when a :class:`Text` displayable renders to a size
     larger than that allocated to it. By setting this to True and setting
     the :propref:`xmaximum` and :propref:`ymaximum` style properties of the dialogue
@@ -327,7 +327,7 @@ Occasionally Used
 
 .. var:: config.defer_styles = False
 
-    When true, the execution of style statements is deferred until after
+    When True, the execution of style statements is deferred until after
     all "translate python" blocks have executed. This lets a translate
     python block update variables that are then used in style (not
     translate style) statements.
@@ -446,7 +446,7 @@ Occasionally Used
 
 .. var:: config.has_autosave = True
 
-    If true, the game will autosave. If false, no autosaving will
+    If True, the game will autosave. If False, no autosaving will
     occur.
 
 .. var:: config.history_callbacks = [ ... ]
@@ -466,9 +466,9 @@ Occasionally Used
 
 .. var:: config.hw_video = False
 
-    If true, hardware video playback will be used on mobile platforms. This
+    If True, hardware video playback will be used on mobile platforms. This
     is faster, but only some formats are supported and only fullscreen video
-    is available. If false, software playback will be used, but it may be
+    is available. If False, software playback will be used, but it may be
     too slow to be useful.
 
 .. var:: config.hyperlink_handlers = { ... }
@@ -588,7 +588,7 @@ Occasionally Used
 
 .. var:: config.narrator_menu = False
 
-    (This is set to True by the default screens.rpy file.) If true,
+    (This is set to True by the default screens.rpy file.) If True,
     then narration inside a menu is displayed using the narrator
     character. Otherwise, narration is displayed as captions
     within the menu itself.
@@ -879,11 +879,11 @@ Rarely or Internally Used
 
 .. var:: config.autoreload = True
 
-    If true, shift+R will toggle automatic reloading. When automatic
+    If True, Shift+R will toggle automatic reloading. When automatic
     reloading is enabled, Ren'Py will reload the game whenever a used
     file is modified.
 
-    If false, Ren'Py will reload the game once per press of shift+R.
+    If False, Ren'Py will reload the game once per press of Shift+R.
 
 .. var:: config.autosave_frequency = 200
 
@@ -893,12 +893,12 @@ Rarely or Internally Used
 
 .. var:: config.autosave_on_choice = True
 
-    If true, Ren'Py will autosave upon encountering an in-game choice.
+    If True, Ren'Py will autosave upon encountering an in-game choice.
     (When :func:`renpy.choice_for_skipping` is called.)
 
 .. var:: config.autosave_on_quit = True
 
-    If true, Ren'Py will attempt to autosave when the user attempts to quit,
+    If True, Ren'Py will attempt to autosave when the user attempts to quit,
     return to the main menu, or load a game over the existing game. (To
     save time, the autosave occurs while the user is being prompted to confirm
     his or her decision.)
@@ -998,9 +998,9 @@ Rarely or Internally Used
 
 .. var:: config.imagemap_cache = True
 
-    If true, imagemap hotspots will be cached to PNG files,
+    If True, imagemap hotspots will be cached to PNG files,
     reducing time and memory usage, but increasing the size of
-    the game on disk. Set this to false to disable this behavior.
+    the game on disk. Set this to False to disable this behavior.
 
 .. var:: config.implicit_with_none = True
 
@@ -1016,9 +1016,9 @@ Rarely or Internally Used
 
 .. var:: config.keep_running_transform = True
 
-    If true, showing an image without supplying a transform or ATL
+    If True, showing an image without supplying a transform or ATL
     block will cause the image to continue the previous transform
-    an image with that tag was using, if any. If false, the transform
+    an image with that tag was using, if any. If False, the transform
     is stopped.
 
 .. var:: config.keymap = dict(...)
@@ -1031,8 +1031,8 @@ Rarely or Internally Used
 
     If not None, this is a function that is called whenever a label is
     reached. It is called with two parameters. The first is the name
-    of the label. The second is true if the label was reached through
-    jumping, calling, or creating a new context, and false
+    of the label. The second is True if the label was reached through
+    jumping, calling, or creating a new context, and False
     otherwise.
 
 .. var:: config.label_overrides = { }
@@ -1065,7 +1065,7 @@ Rarely or Internally Used
     This is a list of functions that are called, with no arguments,
     when lint is run. The functions are expected to check the script
     data for errors, and print any they find to standard output (using
-    the python print statement is fine in this case).
+    the Python ``print`` statement is fine in this case).
 
 .. var:: config.load_before_transition = True
 
@@ -1142,12 +1142,12 @@ Rarely or Internally Used
 
 .. var:: config.new_substitutions = True
 
-    If true, Ren'Py will apply new-style (square-bracket)
+    If True, Ren'Py will apply new-style (square-bracket)
     substitutions to all text displayed.
 
 .. var:: config.old_substitutions = False
 
-    If true, Ren'Py will apply old-style (percent) substitutions to
+    If True, Ren'Py will apply old-style (percent) substitutions to
     text displayed by the :ref:`say <say-statement>` and :ref:`menu
     <menu-statement>` statements.
 
@@ -1196,7 +1196,7 @@ Rarely or Internally Used
 
 .. var:: config.quit_on_mobile_background = False
 
-    If true, the mobile app will quit when it loses focus.
+    If True, the mobile app will quit when it loses focus.
 
 .. var:: config.rollback_enabled = True
 
@@ -1223,7 +1223,7 @@ Rarely or Internally Used
 
     If not None, this should be a function. The function is called
     with no arguments when the user attempts to dismiss a :ref:`say
-    statement <say-statement>`. If this function returns true, the
+    statement <say-statement>`. If this function returns True, the
     dismissal is allowed, otherwise it is ignored.
 
 .. var:: config.say_layer = "screens"
@@ -1245,7 +1245,7 @@ Rarely or Internally Used
 
 .. var:: config.save_dump = False
 
-   If set to true, Ren'Py will create the file save_dump.txt whenever it
+   If set to True, Ren'Py will create the file save_dump.txt whenever it
    saves a game. This file contains information about the objects contained
    in the save file. Each line consists of a relative size estimate, the path
    to the object, information about if the object is an alias, and a
@@ -1253,21 +1253,21 @@ Rarely or Internally Used
 
 .. var:: config.save_on_mobile_background = True
 
-    If true, the mobile app will save its state when it loses focus. The state
+    If True, the mobile app will save its state when it loses focus. The state
     is saved in a way that allows it to be automatically loaded (and the game
     to resume its place) when the app starts again.
 
 .. var:: config.save_physical_size = True
 
-    If true, the physical size of the window will be saved in the
+    If True, the physical size of the window will be saved in the
     preferences, and restored when the game resumes.
 
 .. var:: config.savedir = ...
 
     The complete path to the directory in which the game is
-    saved. This should only be set in a python early block. See also
+    saved. This should only be set in a ``python early`` block. See also
     config.save_directory, which generates the default value for this
-    if it is not set during a python early block.
+    if it is not set during a ``python early`` block.
 
 .. var:: config.scene = renpy.scene
 
@@ -1291,7 +1291,7 @@ Rarely or Internally Used
 .. var:: config.screenshot_pattern = "screenshot%04d.png"
 
     The pattern used to create screenshot files. This pattern is applied (using
-    python's %-formatting rules) to the natural numbers to generate a sequence
+    Python's %-formatting rules) to the natural numbers to generate a sequence
     of filenames. The filenames may be absolute, or relative to
     config.renpy_base. The first filename that does not exist is used as the
     name of the screenshot.
@@ -1383,7 +1383,7 @@ Rarely or Internally Used
 
 .. var:: config.transition_screens = True
 
-    If true, screens will participate in transitions, dissolving from the
+    If True, screens will participate in transitions, dissolving from the
     old state of the screen to the new state of the screen. If False, only
     the latest state of the screen will be shown.
 

--- a/sphinx/source/custom_text_tags.rst
+++ b/sphinx/source/custom_text_tags.rst
@@ -35,23 +35,19 @@ is used to replace the text tag and its contents.
 
 Content tuples consist of two components. The first component is one of the
 the constants in the following list. The second component varies based on
-the first component, as describe below.
+the first component, as described below.
 
 renpy.TEXT_TEXT
-
     The second component is text that is intended for display to the user.
 
 renpy.TEXT_TAG
-
     The second component is the contents of a text tag, without the
     enclosing braces.
 
 renpy.TEXT_DISPLAYABLE
-
     The second component is a displayable to be embedded into the text.
 
 renpy.TEXT_PARAGRAPH
-
     This represents a break between paragraphs, and the second component
     is undefined (but must be present).
 

--- a/sphinx/source/developer_tools.rst
+++ b/sphinx/source/developer_tools.rst
@@ -16,14 +16,14 @@ The console can be used to:
 
 * Jump to a label.
 * Interactively try out Ren'Py script statements.
-* Evaluate a python expression or statement to see the result.
-* Trace python expressions as the game progresses.
+* Evaluate a Python expression or statement to see the result.
+* Trace Python expressions as the game progresses.
 
 Shift+E Editor Support
 ----------------------
 
 The :var:`config.editor` variable allows a developer to specify an editor
-command that is run when the launch_editor keypress (by default, "shift-E")
+command that is run when the launch_editor keypress (by default, Shift+E)
 occurs.
 
 please see :ref:`Text Editor Integration <text-editor-integration>`
@@ -31,15 +31,15 @@ please see :ref:`Text Editor Integration <text-editor-integration>`
 Shift+D Developer Menu
 ----------------------
 
-When :var:`config.developer` is true, hitting "shift+D" will display a developer
+When :var:`config.developer` is True, hitting Shift+D will display a developer
 menu that provides easy access to some of the features given below.
 
 Shift+R Reloading
 -----------------
 
-When :var:`config.developer` is true, hitting "shift+R" will save the current
+When :var:`config.developer` is True, hitting Shift+R will save the current
 game, reload the game script, and reload the game. This will often place you at
-the last unchanged statement encountered before "shift+R" was pressed.
+the last unchanged statement encountered before Shift+R was pressed.
 
 This allows the developer to make script changes with an external editor, and
 not have to exit and restart Ren'Py to see the effect of the changes.
@@ -52,7 +52,7 @@ new effect.
 Shift+I Style Inspecting
 ------------------------
 
-When :var:`config.developer` is true, pressing "shift+I" will cause style
+When :var:`config.developer` is True, pressing Shift+I will cause style
 inspection to occur. This will display a list of displayables underneath the
 mouse. For each displayable, it will display the type, the style used, and the
 size it is being rendered at.
@@ -61,7 +61,7 @@ Shift+Y Style Dumping
 ---------------------
 
 When :var:`config.developer` is True, pressing the dump_styles key (by default,
-"shift-Y"), will write a description of every style Ren'Py knows about to the
+Shift+Y), will write a description of every style Ren'Py knows about to the
 file "styles.txt". This description includes every property that is part of the
 style, the value of that property, and the style the property is inherited
 from.
@@ -70,7 +70,7 @@ from.
 ---------------
 
 When :var:`config.developer` or :var:`config.fast_skipping` is True, pressing
-the fast_skip key (by default, ">") causes the the game to immediately skip to
+the ``fast_skip`` key (by default, ">") causes the the game to immediately skip to
 the next important interaction.  For this purpose, an important interaction is
 one that is not caused by a say statement, transition, or pause command.
 Usually, this means skipping to the next menu, but it will also stop when

--- a/sphinx/source/developer_tools.rst
+++ b/sphinx/source/developer_tools.rst
@@ -10,7 +10,7 @@ Shift+O Console
 The debug console makes it possible to interactively run Ren'Py script and
 Python statements, and immediately see the results. The console is available in
 developer mode or when :var:`config.console` is True, and can be accessed by
-pressing "shift+O".
+pressing Shift+O.
 
 The console can be used to:
 

--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -237,7 +237,7 @@ non-dialogue interactions.
 
 The ``window auto`` statement uses :var:`config.window_show_transition`
 and :var:`config.window_hide_transition` to show and hide the window,
-respectively. ``window auto`` is cancelled by ``window show`` or ``window hide``.
+respectively. ``window auto`` is cancelled by ``window show`` and ``window hide``.
 
 For example::
 
@@ -273,7 +273,7 @@ in parenthesis after the say statement. For example, one can write::
 
     e "Hello, world." (what_color="#8c8")
 
-Arguments to the Say statement are first processed by var:`config.say_arguments_callback`,
+Arguments to the say statement are first processed by var:`config.say_arguments_callback`,
 if it is not None. If any remain, they are then passed to the character,
 which treats them as if they were present when the character was defined.
 So, the example above displays the dialogue in green.
@@ -324,7 +324,7 @@ When e is a Character, this is further equivalent to::
     Character(kind=e, what_size=32)("Hello, world.", interact=True)
 
 But it's possible to use var:`config.say_arguments_callback` or
-have `e` wrap a character to do things differently.
+have ``e`` wrap a character to do things differently.
 
 
 

--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -216,27 +216,24 @@ these statements control the presence or absence of the window during
 non-dialogue interactions.
 
 ``window show``
-
-The window show statement causes the window to be shown.
-It takes as an argument an optional transition, which is used to show the
-window. If the transition is omitted, :var:`config.window_show_transition`
-is used.
+    The window show statement causes the window to be shown.
+    It takes as an argument an optional transition, which is used to show the
+    window. If the transition is omitted, :var:`config.window_show_transition`
+    is used.
 
 ``window hide``
-
-The window hide statement causes the window to be hidden. It takes as an
-argument an optional transition, which is used to hide the window. If
-the transition is omitted,  :var:`config.window_hide_transition` is
-used.
+    The window hide statement causes the window to be hidden. It takes as an
+    argument an optional transition, which is used to hide the window. If
+    the transition is omitted,  :var:`config.window_hide_transition` is
+    used.
 
 ``window auto``
-
-This enables automatic management of the window. The window is shown
-before statements listed in :var:`config.window_auto_show` - by default,
-say statements. The window is hidden before statements listed in
-:var:`config.window_auto_hide` - by default, ``scene`` and ``call screen``
-statements. (Only statements are considered, not statement equivalent
-functions.)
+    This enables automatic management of the window. The window is shown
+    before statements listed in :var:`config.window_auto_show` - by default,
+    say statements. The window is hidden before statements listed in
+    :var:`config.window_auto_hide` - by default, ``scene`` and ``call screen``
+    statements. (Only statements are considered, not statement equivalent
+    functions.)
 
 The ``window auto`` statement uses :var:`config.window_show_transition`
 and :var:`config.window_hide_transition` to show and hide the window,

--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -61,7 +61,6 @@ the ``[`` character begins a substitution. To use them in dialogue,
 double them. It may also be necessary to precede a quote with a
 backslash to prevent it from closing the string. For example::
 
-   ###
        "I walked past a sign saying, \"Let's give it 100%!\""
 
 
@@ -79,10 +78,9 @@ assign a Character to a variable. For example::
 
 Once this is done, the character can be used in a say statement::
 
-    ###
         e "Hello, world."
 
-Character is a python function, that takes a large number of keyword
+Character is a Python function that takes a large number of keyword
 arguments. These keyword arguments control the behavior of the
 character.
 

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -45,7 +45,7 @@ and ``happy``.
 A displayable is something that can be shown on the screen. The most
 common thing to show is a static image, which can be specified by
 giving the filename of the image, as a string. In the example above,
-we might use ``"mary_beach_night_happy.png"`` as the filename.
+we might use "mary_beach_night_happy.png" as the filename.
 However, an image may refer to :ref:`any displayable Ren'Py supports
 <displayables>`, not just static images. Thus, the same statements
 that are used to display images can also be used for animations, solid
@@ -105,10 +105,10 @@ Images Directory
 The image directory is named "images", and is placed under the game directory.
 When a file with the .jpg or .png extension is placed underneath this directory,
 the extension is stripped, the rest of the filename is forced to lower case,
-and the resulting filename is use as the image name if an image with that
+and the resulting filename is used as the image name if an image with that
 name has not been previously defined.
 
-This process place in all directories underneath the image directory. For
+This process takes place in all directories underneath the image directory. For
 example, all of these files will define the image ``eileen happy``::
 
     game/images/eileen happy.png
@@ -153,7 +153,7 @@ See also the :ref:`ATL variant of the image statement. <atl-image-statement>`
 Show Statement
 ==============
 
-The show statement is used to display an image on a layer. A show
+The ``show`` statement is used to display an image on a layer. A show
 statement consists of a single logical line beginning with the
 keyword ``show``, followed by an image name, followed by zero or
 more properties.
@@ -172,7 +172,7 @@ If a unique image cannot be found, an exception occurs.
 If an image with the same image tag is already showing on the layer,
 the new image replaces it. Otherwise, the image is placed above all
 other images in the layer. (That is, closest to the user.) This order
-may be modified by the zorder and behind properties.
+may be modified by the ``zorder`` and ``behind`` properties.
 
 The show statement does not cause an interaction to occur. For the
 image to actually be displayed to the user, a statement that causes an
@@ -182,12 +182,12 @@ run.
 The show statement takes the following properties:
 
 ``as``
-    The as property takes a name. This name is used in place of the
+    The ``as`` property takes a name. This name is used in place of the
     image tag when the image is shown. This allows the same image
     to be on the screen twice.
 
 ``at``
-    The at property takes one or more comma-separated
+    The ``at`` property takes one or more comma-separated
     simple expressions. Each expression must evaluate to a
     transform. The transforms are applied to the image in
     left-to-right order.
@@ -271,7 +271,7 @@ To stop applying transforms to the layer, use::
 Scene Statement
 ===============
 
-The scene statement removes all displayables from a layer, and then
+The ``scene`` statement removes all displayables from a layer, and then
 shows an image on that layer. It consists of the keyword ``scene``,
 followed by an image name, followed by zero or more properties. The
 image is shown in the same way as in the show statement, and the scene
@@ -296,7 +296,7 @@ displayable.
 Hide Statement
 ==============
 
-The hide statement removes an image from a layer. It consists of the
+The ``hide`` statement removes an image from a layer. It consists of the
 keyword ``hide``, followed by an image name, followed by an optional
 property. The hide statement takes the image tag from the image name,
 and then hides any image on the layer with that tag.
@@ -333,7 +333,7 @@ Instead, just write::
 With Statement
 ==============
 
-The with statement is used to apply a transition effect when the scene
+The ``with`` statement is used to apply a transition effect when the scene
 is changed, making showing and hiding images less abrupt. The with
 statement consists of the keyword ``with``, followed by a simple
 expression that evaluates either to a transition object or the special
@@ -402,7 +402,7 @@ scene consisting of all three images.
 With Clause of Scene, Show, and Hide Statements
 -----------------------------------------------
 
-The show, scene, and hide statements can take an optional with clause,
+The show, scene, and hide statements can take an optional ``with`` clause,
 which allows a transition to be combined with showing or hiding an
 image. This clause follows the statements at the end of the same
 logical line. It begins with the keyword ``with``, followed by a
@@ -428,9 +428,9 @@ is equivalent to::
 Hide and Show Window
 ====================
 
-The window statement is used to control if a window is shown when a character
-is not speaking. (For example, during transitions and pauses.) The window show
-statement causes the window to be shown, while the window hide statement hides
+The ``window`` statement is used to control if a window is shown when a character
+is not speaking (for example, during transitions and pauses). The ``window show``
+statement causes the window to be shown, while the ``window hide`` statement hides
 the window.
 
 If the optional transition is given, it's used to show and hide the window.
@@ -441,7 +441,6 @@ it from occurring.
 The window itself is displayed by calling :var:`config.empty_window`. It defaults to
 having the narrator say an empty string.::
 
-    ###
         show bg washington
         show eileen happy
         with dissolve

--- a/sphinx/source/iap.rst
+++ b/sphinx/source/iap.rst
@@ -4,7 +4,7 @@ In-App Purchasing
 
 Ren'Py includes a high-level in-app purchasing framework. This framework
 currently only supports unlock-style purchases from the Apple App Store,
-Google Play, and the Amazon App Store.
+Google Play, and the Amazon Appstore.
 
 Using this framework is fairly simple, and consists of the following
 functions.
@@ -27,12 +27,12 @@ Apple App Store
     special configuration.
 
 Google Play
-    Before Google Play can be used, you must add the google play key and
+    Before Google Play can be used, you must add the Google Play key and
     a salt to your project. See the :ref:`Expansion APK <expansion-apk>`
     section for information on how to do this.
 
-Amazon App Store
-    The Amazon app store is based on the package name, and does not
+Amazon Appstore
+    The Amazon Appstore is based on the package name, and does not
     require special configuration.
 
 

--- a/sphinx/source/input.rst
+++ b/sphinx/source/input.rst
@@ -3,12 +3,12 @@ Text Input
 ==========
 
 With some limitations, Ren'Py can prompt the user to input a small
-amount of text. This prompting is done by the renpy.input function,
+amount of text. This prompting is done by the :func:`renpy.input` function,
 which returns the entered text, allowing it to be saved in a variable
 or otherwise processed.
 
 On Linux, text input is limited to languages that do not require
-input method (IME) support. Most western languages should work, but
+input method (IME) support. Most Western languages should work, but
 Chinese, Japanese, and Korean probably won't.
 
 The renpy.input function is defined as:
@@ -16,7 +16,7 @@ The renpy.input function is defined as:
 .. include:: inc/input
 
 Games that use renpy.input will often want to process the result
-further, using standard python string manipulation functions. For
+further, using standard Python string manipulation functions. For
 example, the following will ask the player for his or her
 name and remove leading or trailing whitespace. If the name is
 empty, it will be replaced by a default name. Finally, it is

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -21,9 +21,9 @@ statement after the label statement whenever the end of the block is reached.
 
 There are two kinds of labels: *global* and *local* labels. Global labels live
 in one global scope shared across all project files and thus should have unique
-names per game. Local labels logically reside inside scope of the global label
-they are declared in. To declare a local label, prefix its name with `.`. For
-example: ::
+names per game. Local labels logically reside inside the scope of the global label
+they are declared in. To declare a local label, prefix its name with a period ``.``.
+For example::
 
     label global_label:
         "Inside a global label.."
@@ -101,8 +101,7 @@ stacks can return to the proper place when loaded on a changed script. ::
 
         return
 
-The call statement may take arguments, which are processed as described in PEP
-3102.
+The call statement may take arguments, which are processed as described in :pep:`3102`.
 
 When using a call expression with an arguments list, the ``pass`` keyword must
 be inserted between the expression and the arguments list. Otherwise, the
@@ -114,12 +113,12 @@ call.
 Return Statement
 ----------------
 
-The return statement pops the top statement off of the call stack, and transfers
+The ``return`` statement pops the top statement off of the call stack, and transfers
 control to it. If the call stack is empty, the return statement restarts
 Ren'Py, returning control to the main menu.
 
 If the optional expression is given to return, it is evaluated, and it's result
-is stored in the _return variable. This variable is dynamically scoped to each
+is stored in the ``_return`` variable. This variable is dynamically scoped to each
 context.
 
 Special Labels
@@ -158,7 +157,7 @@ The following labels are used by Ren'Py:
 
 ``after_warp``
     If it is existed, this label is called after a warp but before the warped-to
-    statement executes. please see :ref:`Warping to a line <warping_to_a_line>`
+    statement executes. Please see :ref:`Warping to a line <warping_to_a_line>`.
 
 Labels & Control Flow Functions
 -------------------------------

--- a/sphinx/source/menus.rst
+++ b/sphinx/source/menus.rst
@@ -6,10 +6,10 @@ In-Game Menus
 =============
 
 In many visual novels, the player is asked to make choices that
-control the outcome of the story. The Ren'Py language contains a menus
+control the outcome of the story. The Ren'Py language contains a ``menu``
 statement that makes it easy to present choices to the user.
 
-Here's an example of a menu statement::
+Here's an example of a ``menu`` statement::
 
     menu:
          "What should I do?"
@@ -29,7 +29,7 @@ Here's an example of a menu statement::
 
          "After having my drink, I got on with my morning."
 
-The menu statement begins with the keyword menu. This may be followed
+The ``menu`` statement begins with the keyword ``menu``. This may be followed
 by a label name, in which case it's equivalent to preceding the menu
 with that label. For example::
 
@@ -52,7 +52,7 @@ When the choice is selected, the block of statements is run. If execution
 reaches the end of the block, it continues with the statement
 after the end of the menu statement.
 
-An if-clause consists of the keyword ``if``, followed by a python
+An if-clause consists of the keyword ``if``, followed by a Python
 expression. The menu choice is only displayed if the expression is
 true. In the following menu::
 
@@ -64,5 +64,5 @@ true. In the following menu::
         "Fly above." if drank_tea:
             ...
 
-The third choice will only be presented if the drank_tea variable is
+The third choice will only be presented if the ``drank_tea`` variable is
 true.

--- a/sphinx/source/movie.rst
+++ b/sphinx/source/movie.rst
@@ -26,7 +26,7 @@ inside the following container formats:
 * WebM
 * Matroska
 * Ogg
-* Avi
+* AVI
 * Various kinds of MPEG stream.
 
 (Note that using some of these formats may require patent licenses.

--- a/sphinx/source/movie.rst
+++ b/sphinx/source/movie.rst
@@ -9,13 +9,13 @@ video codecs:
 * VP9
 * VP8
 * Theora
-* MPEG 4 part 2 (including Xvid and DivX)
-* MPEG 2
-* MPEG 1
+* MPEG-4 part 2 (including Xvid and DivX)
+* MPEG-2
+* MPEG-1
 
 and the following audio codecs:
 
-* OPUS
+* Opus
 * Vorbis
 * MP3
 * MP2
@@ -31,17 +31,17 @@ inside the following container formats:
 
 (Note that using some of these formats may require patent licenses.
 When in doubt, and especially for commercial games, we recommend using
-VP9, VP8, or Theora, Opus or Vorbis, and WebM, Matroska, or Ogg.)
+VP9, VP8, or Theora; Opus or Vorbis; and WebM, Matroska, or Ogg.)
 
-Movies can be displayed fullscreen, or in a displayable. Fullscreen movies
-are the more efficient.
+Movies can be displayed fullscreen or in a displayable. Fullscreen movies
+are more efficient.
 
 
 Fullscreen Movies
 -----------------
 
 The easiest and most efficient way to display a movie fullscreen is
-to use the renpy.movie_cutscene function. This function displays the
+to use the :func:`renpy.movie_cutscene` function. This function displays the
 movie fullscreen until it either ends, or the player clicks to dismiss
 it. ::
 

--- a/sphinx/source/problems.rst
+++ b/sphinx/source/problems.rst
@@ -9,9 +9,9 @@ Windows Encoding Problems
 
 Ren'Py will fail to start on Windows if it's placed in a directory with a
 full path that isn't representable in the current system language. For example,
-if Ren'Py is in the directory:
+if Ren'Py is in the directory::
 
-    C:\ビジュアルノベル\renpy-6.16.0-sdk\
+  C:\ビジュアルノベル\renpy-6.16.0-sdk\
 
 and the system is set to use the English language, Ren'Py will be unable to
 start. To fix this problem, start the control panel, select "Region and Language

--- a/sphinx/source/python.rst
+++ b/sphinx/source/python.rst
@@ -15,7 +15,7 @@ directly invoke Python, through the various python statements.
 Python
 ------
 
-The python statement takes a block of Python, and runs the block
+The ``python`` statement takes a block of Python, and runs the block
 when control reaches the statement. A basic python statement can be
 very simple::
 
@@ -33,7 +33,6 @@ There are two modifiers to the python statement that change its
 behavior:
 
 ``hide``
-
     If given the hide modifier, the python statement will run the
     block of Python in an anonymous scope. The scope will be lost when the
     python block terminates.
@@ -43,7 +42,6 @@ behavior:
     on the store object, rather than directly.
 
 ``in``
-
    The ``in`` modifier takes a name. Instead of executing in the
    default store, the Python will execute in the store with that
    name.
@@ -57,7 +55,7 @@ default store. For example, a Python one-liner can be used to
 initialize or update a flag. To make writing Python one-liners
 more convenient, there is the one-line python statement.
 
-The one-line python statement begins with the dollar-sign ($)
+The one-line Python statement begins with the dollar-sign ($)
 character, and contains everything else on that line. Here
 are some example of python one-liners::
 
@@ -122,7 +120,7 @@ variables should not be changed after init is over.
 Define Statement
 ----------------
 
-The define statement sets a single variable to a value at init time.
+The ``define`` statement sets a single variable to a value at init time.
 For example::
 
     define e = Character("Eileen")
@@ -151,7 +149,7 @@ when this is not the case.)
 Default Statement
 -----------------
 
-The default statement sets a single variable to a value if that variable
+The ``default`` statement sets a single variable to a value if that variable
 is not defined when the game starts, or after a new game is loaded. For
 example::
 
@@ -179,9 +177,9 @@ prepending it to the variable name with a dot. For example::
 Init Offset Statement
 ---------------------
 
-The init offset statement sets a priority offset for all statements
-that run at init time. (init, init python, define, default, screen,
-transform, style, and more.) The offset applies to all following
+The ``init offset`` statement sets a priority offset for all statements
+that run at init time (init, init python, define, default, screen,
+transform, style, and more). The offset applies to all following
 statements in the current block and chold blocks, up to the next
 init priority statement. The statement::
 
@@ -225,7 +223,7 @@ The following faulty script::
         $ e += 1
         e "You scored a point!"
 
-will not work, because the variable `e` is being used as both a
+will not work, because the variable ``e`` is being used as both a
 character and a flag. Other things that are usually placed into
 the store are transitions and transforms.
 
@@ -243,8 +241,8 @@ conflicts.
 Named stores can be accessed by supplying the ``in`` clause to
 ``python`` or ``init python``, all of which run Python in a named
 store. Each store corresponds to a Python module. The default store is
-``store``, while a named store is accessed as ``store``.`name`. These
-python modules can be imported using the Python import statement,
+``store``, while a named store is accessed as ``store.name``. These
+Python modules can be imported using the Python ``import`` statement,
 while names in the modules can be imported using the Python from
 statement.
 
@@ -274,11 +272,11 @@ define names in a named store.
 
 .. _python-modules:
 
-First and Third Party Python Modules and Packages
+First and Third-Party Python Modules and Packages
 -------------------------------------------------
 
 Ren'Py can import pure-python modules and packages. First-party modules
-and packages - ones  written for the game - can be placed directly
+and packages—ones written for the game—can be placed directly
 into the game directory. Third party packages can be placed into the
 game/python-packages directory.
 

--- a/sphinx/source/raspi.rst
+++ b/sphinx/source/raspi.rst
@@ -6,13 +6,13 @@ demonstrated to run on the Raspberry Pi 3B, but may run on other models.
 
 It's important to realize that the Raspberry Pi is a very limited system,
 even compared to iOS and Android smartphones. As a result, not every Ren'Py
-game will run well - or at all - on a Raspberry Pi. What's more, it's possible
+game will run well—or at all—on a Raspberry Pi. What's more, it's possible
 to crash Ren'Py by allowing a game to use more RAM than the system has available
 to it.
 
 When the Raspberry Pi is configured correctly, Ren'Py should run using the
 device's hardware OpenGL ES. This means that it has the same limitations as
-the Android and iOS platforms, with respect to focus_mast not working.
+the Android and iOS platforms, with respect to ``focus_mast`` not working.
 
 
 Configuring the Raspberry Pi
@@ -22,7 +22,7 @@ Before Ren'Py is used, the Raspberry Pi should be reconfigured, using the
 raspi-config tool. These settings are under advanced options.
 
 * Memory Split: 256 MB
-* Resolution: 1280x720 or smaller.
+* Resolution: 1280x720 or smaller
 * GL Driver: GL (Fake KMS)
 
 After changing the settings, reboot the Raspberry Pi.
@@ -35,13 +35,13 @@ download two files. The first is the Linux version of the SDK, and the
 second is the Raspberry Pi support files.
 
 Untar the Linux version of the SDK, change into it, then untar the Raspberry
-Pi support files. When done correctly, the sdk will have a lib/linux-armv7l
+Pi support files. When done correctly, the SDK will have a lib/linux-armv7l
 directory alongside lib/linux-i686 and lib/linux-x86_64.
 
 Running a Game
 --------------
 
-As the Raspberry Pi is a resource-limited platform, we reccomend avoiding
+As the Raspberry Pi is a resource-limited platform, we recommend avoiding
 the Ren'Py launcher. Instead, we suggest using renpy.sh directly to launch
 the project, using a command like::
 

--- a/sphinx/source/screen_optimization.rst
+++ b/sphinx/source/screen_optimization.rst
@@ -88,7 +88,7 @@ selectedness.
 
 All actions provided with Ren'Py conform to this definition. When defining
 your own actions, it makes sense to provide them with this notion of
-equality. This can be done by supplying an appropriate __eq__ method.
+equality. This can be done by supplying an appropriate ``__eq__`` method.
 For example::
 
     class TargetShip(Action):
@@ -105,7 +105,7 @@ For example::
             global target
             target = self.ship
 
-It's important to define the __eq__ function carefully, making sure it
+It's important to define the ``__eq__`` function carefully, making sure it
 compares all fields, and uses equality (==) and identity (is) comparison
 as appropriate.
 

--- a/sphinx/source/screen_special.rst
+++ b/sphinx/source/screen_special.rst
@@ -97,12 +97,12 @@ with the menu statement. It is given the following parameter:
     .. attribute:: action
 
         An action that should be invoked when the menu choice is
-        chosen. This many be None if this is a menu cation, and
-        :var:`config.narrator_menu` is false.
+        chosen. This may be None if this is a menu caption, and
+        :var:`config.narrator_menu` is False.
 
     .. attribute:: chosen
 
-        This is true if this choice has been chosen at least once
+        This is True if this choice has been chosen at least once
         in any playthrough of the game.
 
 ::

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -106,7 +106,7 @@ in a block may be one of two things:
 Screen Statement
 ----------------
 
-The `screen` statement is a Ren'Py script language statement that is
+The ``screen`` statement is a Ren'Py script language statement that is
 used to declare a new screen. It is parsed using the screen language
 common syntax.
 
@@ -217,7 +217,7 @@ All user interface statements take the following common properties:
     this displayable and its children.
 
 `style_group`
-    An alias for `style_prefix`, used in older version of Ren'Py.
+    An alias for `style_prefix`, used in older versions of Ren'Py.
 
 `style_suffix`
     Specifies the suffix that is combined with the `style_prefix` to
@@ -247,7 +247,7 @@ All user interface statements take the following common properties:
 Many user interface statements take classes of style properties, or
 transform properties. These properties can have a style prefix
 associated with them, that determines when they apply. For example, if
-text is given the hover_size property, it sets the text size when the
+text is given the ``hover_size`` property, it sets the text size when the
 text is hovered.
 
 
@@ -258,7 +258,7 @@ Add
 
 Adds an image or other displayable to the screen. This optionally
 takes :ref:`transform properties <transform-properties>`. If at least
-one transform property is given, a Transform is created to wrap the
+one transform property is given, a :class:`Transform` is created to wrap the
 image, and the properties are given to the transform.
 
 If the displayable is None, nothing is added to the screen.
@@ -291,7 +291,7 @@ data. It takes the following properties:
     A :func:`ui.adjustment` object that this bar adjusts.
 
 `changed`
-    If given, this should be a python function. The function is called
+    If given, this should be a Python function. The function is called
     with the value of the adjustment when the adjustment is changed.
 
 `hovered`
@@ -639,7 +639,7 @@ The input statement takes no parameters, and the following properties:
     An immutable string to append to what the user has typed.
 
 `changed`
-    A python function that is called with what the user has typed,
+    A Python function that is called with what the user has typed,
     when the string changes.
 
 
@@ -728,36 +728,6 @@ It does not take children.
             textbutton "Window" action Preference("display", "window")
 
 
-.. _sl-null:
-
-Null
-----
-
-The null statement inserts an empty area on the screen. This can be
-used to space things out. The null statement takes no parameters, and
-the following properties:
-
-`width`
-    The width of the empty area, in pixels.
-
-`height`
-    The height of the empty area, in pixels.
-
-It also takes:
-
-* :ref:`Common Properties <common-properties>`
-* :ref:`position-style-properties`
-
-It does not take children.
-
-::
-
-    screen text_box():
-        vbox:
-             text "The title."
-             null height 20
-             text "This body text."
-
 .. _mousearea:
 .. _sl-mousearea:
 
@@ -817,6 +787,38 @@ take up the entire screen, a less useful behavior.
     label start:
         show screen button_overlay
 
+
+.. _sl-null:
+
+Null
+----
+
+The null statement inserts an empty area on the screen. This can be
+used to space things out. The null statement takes no parameters, and
+the following properties:
+
+`width`
+    The width of the empty area, in pixels.
+
+`height`
+    The height of the empty area, in pixels.
+
+It also takes:
+
+* :ref:`Common Properties <common-properties>`
+* :ref:`position-style-properties`
+
+It does not take children.
+
+::
+
+    screen text_box():
+        vbox:
+             text "The title."
+             null height 20
+             text "This body text."
+
+
 .. _sl-side:
 
 Side
@@ -826,7 +828,6 @@ This positions displayables in the corners or center of a grid. It
 takes a single parameter, string containing a space-separated list of
 places to place its children. Each component of this list should be
 one of:
-
     'c', 't', 'b', 'l', 'r', 'tl', 'tr', 'bl', 'br'
 
 'c' means center, 't' top, 'tl' top left, 'br' bottom right, and so on.
@@ -1243,7 +1244,7 @@ Imagemap Statements
 ===================
 
 A convenient way of creating a screen, especially for those who think
-visually is to create an imagemap. When creating an imagemap, the
+visually, is to create an imagemap. When creating an imagemap, the
 imagemap statement is used to specify up to six images. The hotspot
 and hotbar images are used to carve rectangular areas out of the
 image, and apply actions and values to those areas.
@@ -1504,10 +1505,7 @@ events occur, and executing arbitrary Python.
 Default
 -------
 
-The default statement sets the default value of a variable when the
-screen is first one. :func:`SetScreenVariable`
-
-The default statement sets the default value of a variable, if it is not
+The ``default`` statement sets the default value of a variable, if it is not
 passed as an argument to the screen, or inherited from a screen that calls
 us using the use statement.
 
@@ -1529,8 +1527,8 @@ us using the use statement.
 For
 ---
 
-The for statement is similar to the Python for statement, except that
-it does not support the else clause. It supports assignment to
+The ``for`` statement is similar to the Python ``for`` statement, except that
+it does not support the ``else`` clause. It supports assignment to
 (optionally nested) tuple patterns, as well as variables.
 
 ::
@@ -1551,7 +1549,7 @@ The for statement takes an index clause::
             for i, numeral index numeral in enumerate(numerals):
                 textbutton numeral action Return(i + 1)
 
-If given, the index clause should consist of an expression that returns
+If given, the ``index`` clause should consist of an expression that returns
 a hashable and comparable value that is unique for each row in the list.
 Ren'Py uses this value to make sure that transforms and other state wind
 up associated with the correct iteration. If you're seeing weird behavior
@@ -1564,8 +1562,8 @@ you might want to use an index clause.
 If
 --
 
-The screen language if statement is the same as the Python/Ren'Py if
-statement. It supports the if, elif, and else clauses.
+The screen language ``if`` statement is the same as the Python/Ren'Py ``if``
+statement. It supports the ``if``, ``elif``, and ``else`` clauses.
 
 ::
 
@@ -1580,7 +1578,7 @@ statement. It supports the if, elif, and else clauses.
 On
 --
 
-The on statement allows the screen to execute an action when an event
+The ``on`` statement allows the screen to execute an action when an event
 occurs. It takes one parameter, a string giving the name of an
 event. This should be one of:
 
@@ -1611,7 +1609,7 @@ occurs.
 Use
 ---
 
-The use statement allows a screen to include another. The use
+The ``use`` statement allows a screen to include another. The use
 statement takes the name of the screen to use. This can optionally be
 followed by an argument list, in parenthesis.
 
@@ -1713,7 +1711,7 @@ The use and transclude constructs form the basis of
 Python
 ------
 
-The screen language also includes single-line and multiple-line python
+The screen language also includes single-line and multiple-line ``python``
 statements, which can execute Python. The Python runs in the scope
 of the screen.
 
@@ -1741,7 +1739,7 @@ has side effects, those side effects may occur at unpredictable times.
 Showif Statement
 ================
 
-The showif statement takes a condition. It shows its children when the
+The ``showif`` statement takes a condition. It shows its children when the
 condition is true, and hides the children when the condition is false.
 When showif's children have transforms, it will supply them with ATL
 events to manage the show and hide process, so that Ren'Py can animate
@@ -1809,19 +1807,19 @@ Screen Statements
 In addition to the screen statement, there are three Ren'Py script
 language statements that involve screens.
 
-Two of these statements take a keyword argument list. This is a python
-argument list, in parenthesis, consisting of only keyword
+Two of these statements take a keyword argument list. This is a Python
+argument list, in parentheses, consisting of only keyword
 arguments. Positional arguments, extra positional arguments (*), and
 extra keyword arguments (**) are not allowed.
 
 Show Screen
 -----------
 
-The show screen statement causes a screen to be shown. It takes an
+The ``show screen`` statement causes a screen to be shown. It takes an
 screen name, and an optional argument list. If present, the arguments
 are used to initialize the scope of the screen.
 
-The show screen statement takes an optional nopredict keyword, that
+The show screen statement takes an optional ``nopredict`` keyword, that
 prevents screen prediction from occurring. During screen prediction,
 arguments to the screen are evaluated. Please ensure that evaluating
 the screen arguments does not cause unexpected side-effects to occur.
@@ -1846,7 +1844,7 @@ hidden. This allows them to be used for overlay purposes.
 Hide Screen
 -----------
 
-The hide screen statement is used to hide a screen that is currently
+The ``hide screen`` statement is used to hide a screen that is currently
 being shown. If the screen is not being shown, nothing happens.
 
 ::
@@ -1858,12 +1856,12 @@ being shown. If the screen is not being shown, nothing happens.
 Call Screen
 -----------
 
-The call screen statement shows a screen, and then hides it again at
+The ``call screen`` statement shows a screen, and then hides it again at
 the end of the current interaction. If the screen returns a value,
-then the value is placed in `_return`.
+then the value is placed in ``_return``.
 
 This can be used to display an imagemap. The imagemap can place a
-value into the `_return` variable using the :func:`Return` action,
+value into the ``_return`` variable using the :func:`Return` action,
 or can jump to a label using the :func:`Jump` action.
 
 The call screen statement takes an optional ``nopredict`` keyword, that

--- a/sphinx/source/self_voicing.rst
+++ b/sphinx/source/self_voicing.rst
@@ -28,7 +28,7 @@ adjust your platform's speech settings.
 
 Windows
     On Windows, Ren'Py uses the Microsoft Speech API. Speech synthesis
-    settings can  be changed on the "Text to Speech" tab of the "Speech
+    settings can be changed on the "Text to Speech" tab of the "Speech
     Recognition" control panel.
 
 Mac OS X
@@ -82,7 +82,7 @@ Alternative text
     available as the "[text]" string substitution. No other string
     substitutions are allowed.
 
-    Supplying the `who_alt` and `what_alt` parameters to Character
+    Supplying the ``who_alt`` and ``what_alt`` parameters to Character
     sets the alt style property for the character name and body text,
     respectively. As an example, we define a Character that uses italics
     to indicate thoughts normally, but explicitly indicates thoughts
@@ -93,13 +93,13 @@ Alternative text
 Descriptive Text
     Descriptive text is text that is displayed (and spoken) by the narrator if
     self-voicing is enabled. The text is not displayed if self-voicing is
-    disabled. Self voicing text uses the `sv` variable, which is defined to
+    disabled. Self-voicing text uses the :var:`sv` variable, which is defined to
     be similar to a character.
 
     .. var:: sv = ...
 
         A character-like object that uses the narrator to speak text if
-        self-vocing is enabled.
+        self-voicing is enabled.
 
     For example::
 
@@ -111,6 +111,6 @@ Descriptive Text
         show event sun_exploding
         pause 10
 
-A self-voicing debug mode can be enabled by typing shift+alt+V. This will
+A self-voicing debug mode can be enabled by typing Shift+Alt+V. This will
 display the text that would be voiced on the screen for development
 purposes.

--- a/sphinx/source/side_image.rst
+++ b/sphinx/source/side_image.rst
@@ -20,7 +20,7 @@ current image attributes that are associated with that tag.
 To determine the side image associated with a tag, Ren'Py tries to find
 an image with the tag "side", and the largest number of attributes from
 the pool. If no image can be found, or more than one image has the same
-number of attributes, an :class:`Null` is shown instead.
+number of attributes, a :class:`Null` is shown instead.
 
 For example, say we have the following script::
 
@@ -98,7 +98,7 @@ using config variables.
 
 .. var:: config.side_image_only_not_showing = False
 
-    When set to true, the side image will only show if an image with that tag
+    When set to True, the side image will only show if an image with that tag
     is not already being shown on the screen.
 
 .. var:: config.side_image_prefix_tag = 'side'
@@ -109,7 +109,7 @@ using config variables.
 
     The Null displayable to use when not displaying a side image. This
     be changed, but only to other Null objects. One reason for doing so
-    would be to set the side of the Null (eg. Null(width=200, height=150))
+    would be to set the side of the Null (eg. ``Null(width=200, height=150)``)
     to prevent dissolves from being cut off.
 
 .. var:: config.side_image_same_transform = None
@@ -152,7 +152,7 @@ associated with that image changes::
 
 This is used to dissolve between old and new side images when the
 character remains the same. (For example, when the character changes
-emotion.) For the Dissolve to work correctly, both side images must
+emotion.) For the :class:`Dissolve` to work correctly, both side images must
 be the same size. ::
 
     transform same_transform(old, new):
@@ -178,7 +178,7 @@ or ``nvl`` screens. Both include the line::
 
     add SideImage() xalign 0.0 yalign 1.0
 
-By changing the xalign and yalign properties, you can control the positioning
+By changing the :propref:`xalign` and :propref:`yalign` properties, you can control the positioning
 of the side image on the screen.
 
 Finally, the :func:`SideImage` function returns, as a displayable, the

--- a/sphinx/source/statement_equivalents.rst
+++ b/sphinx/source/statement_equivalents.rst
@@ -4,7 +4,7 @@
 Statement Equivalents
 =====================
 
-To allow Ren'Py to be scripted in python, each Ren'Py statement has
+To allow Ren'Py to be scripted in Python, each Ren'Py statement has
 a Python equivalent. This usually consists of a Python function,
 but may also consist of a pattern of Python calls that perform an action
 equivalent to the statement.
@@ -22,12 +22,12 @@ as a function. The following displays the same line twice::
 
 Displaying narration can be done the same way, by using the
 ``narrator`` character. When calling a character, it's possible to
-supply the keyword argument `interact`. When interact is false,
+supply the keyword argument ``interact``. When ``interact`` is False,
 Ren'Py will display the character dialogue box, and will then
 return before performing an interaction.
 
 This equivalence of characters and function objects works in the other
-direction as well. It is possible to declare a python function, and
+direction as well. It is possible to declare a Python function, and
 then use that function in the place of a character object. For
 example, the following function uses a variable to choose between
 two characters. ::
@@ -72,14 +72,14 @@ Displaying Images
 =================
 
 The image, scene, show, and hide statements each have an equivalent
-python function.
+Python function.
 
 .. include:: inc/se_images
 
 Transitions
 ===========
 
-The equivalent of the with statement is the renpy.with_statement
+The equivalent of the with statement is the :func:`renpy.with_statement`
 function.
 
 .. include:: inc/se_with
@@ -87,13 +87,13 @@ function.
 Jump
 ====
 
-The equivalent of the jump statement is the renpy.jump function.
+The equivalent of the jump statement is the :func:`renpy.jump` function.
 
 .. include:: inc/se_jump
 
 Call
 ====
 
-The equivalent of the call statement is the renpy.call function.
+The equivalent of the call statement is the :func:`renpy.call` function.
 
 .. include:: inc/se_call

--- a/sphinx/source/store_variables.rst
+++ b/sphinx/source/store_variables.rst
@@ -33,7 +33,7 @@ and rolled-back when rollback occurs.
 
 .. var:: _history = True
 
-    If true, Ren'Py will record dialogue history when a line is shown. (Note
+    If True, Ren'Py will record dialogue history when a line is shown. (Note
     that :var:`config.history_list_length` must be set as well.)
 
 .. var:: _history_list = [ ]
@@ -67,7 +67,7 @@ and rolled-back when rollback occurs.
 
 .. var:: mouse_visible = True
 
-    Controls if the mouse is visible. This is automatically set to true when
+    Controls if the mouse is visible. This is automatically set to True when
     entering the standard game menus.
 
 .. var:: name_only = Character(...)
@@ -82,7 +82,7 @@ and rolled-back when rollback occurs.
         $ temp_char = Character("Eileen", kind=name_only)
         temp_char "Hello, world."
 
-    except that the temp_char variable is not used.
+    except that the ``temp_char`` variable is not used.
 
 .. var:: narrator = Character(...)
 
@@ -103,11 +103,11 @@ and rolled-back when rollback occurs.
 
     A function that is called by Ren'Py to display dialogue. This is called
     with three arguments. The first argument (`who`) is the character saying the
-    dialogue (or None for the narrator). The second argument(`what`) is what dialogue
+    dialogue (or None for the narrator). The second argument (`what`) is what dialogue
     is being said.
 
     The third argument must be a keyword argument named `interact` and defaulting
-    to True. If true, the say function will wait for a click. If false, it will
+    to True. If True, the say function will wait for a click. If False, it will
     immediately return with the dialogue displayed on the screen.
 
     It's rare to call this function directly, as one can simply call a character
@@ -125,13 +125,13 @@ and rolled-back when rollback occurs.
 .. var:: _window = False
 
     This set by the ``window show`` and ``window hide`` statements, and indirectly
-    by ``window auto``. If true, the dialogue window is shown during non-dialogue
+    by ``window auto``. If True, the dialogue window is shown during non-dialogue
     statements.
 
 .. var:: _window_auto = False
 
-    This is set to true by ``window auto`` and to false by ``window show`` and
-    ``window hide``. If true, the window auto behavior occurs.
+    This is set to True by ``window auto`` and to False by ``window show`` and
+    ``window hide``. If True, the window auto behavior occurs.
 
 .. var:: _window_subtitle = ''
 

--- a/sphinx/source/style.rst
+++ b/sphinx/source/style.rst
@@ -83,7 +83,7 @@ When :var:`config.developer` is true, the style inspector can be used to
 see which styles are being used by a displayable.
 
 To activate the style inspector, place the mouse over a displayable, and
-press shift+I. Ren'Py will display a list of displayables that include
+press Shift+I. Ren'Py will display a list of displayables that include
 the mouse position, in the order they are drawn to the screen. (That is,
 the last displayable is the one on top of the others.)
 
@@ -202,25 +202,26 @@ Styles. ::
         style object.
 
 
-..
+.. _indexed-styles:
 
-    Indexed Styles
+Indexed Styles
+--------------
 
-    Indexed styles are lightweight styles that can be used to customize the look
-    of a displayable based on the data supplied to that displayable. An index
-    style is created by indexing a style object with a string or integer. If an
-    indexed style does not exist, indexing creates it.::
+Indexed styles are lightweight styles that can be used to customize the look
+of a displayable based on the data supplied to that displayable. An index
+style is created by indexing a style object with a string or integer. If an
+indexed style does not exist, indexing creates it. ::
 
-        init python:
-            style.button['Foo'].background = "#f00"
-            style.button['Bar'].background = "#00f"
+    init python:
+        style.button['Foo'].background = "#f00"
+        style.button['Bar'].background = "#00f"
 
-    An index style is used by supplying the indexed style to a displayable.::
+An index style is used by supplying the indexed style to a displayable.::
 
-        screen indexed_style_test:
-            vbox:
-                textbutton "Foo" style style.button["Foo"]
-                textbutton "Bar" style style.button["Bar"]
+    screen indexed_style_test:
+        vbox:
+            textbutton "Foo" style style.button["Foo"]
+            textbutton "Bar" style style.button["Bar"]
 
 
 .. _style-preferences:

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -99,7 +99,7 @@ Style Property Values
 =====================
 
 Each style property expects a specific kind of data. Many of these are
-standard python types, but a few are novel. Here are descriptions of the
+standard Python types, but a few are novel. Here are descriptions of the
 novel kinds of value a style property can expect.
 
 `position`
@@ -121,7 +121,7 @@ novel kinds of value a style property can expect.
         sides of the containing area, while 1.0 is on the right or bottom
         side.
     renpy.absolute (like renpy.absolute(100.25))
-        A renpy.absolute number is interpreted as the number of pixels
+        A ``renpy.absolute`` number is interpreted as the number of pixels
         from the left or top side of the screen, when using subpixel-precise
         rendering.
 
@@ -365,30 +365,31 @@ or on the screen when not inside a layout.
 
 .. style-property:: xfill boolean
 
-    If true, the displayable will expand to fill all available
-    horizontal space. If not true, it will only be large enough to
+    If True, the displayable will expand to fill all available
+    horizontal space. If not True, it will only be large enough to
     contain its children.
 
     This only works for displayables that can change size.
 
 .. style-property:: yfill boolean
 
-    If true, the displayable will expand to fill all available
-    vertical space. If not true, it will only be large enough to
+    If True, the displayable will expand to fill all available
+    vertical space. If not True, it will only be large enough to
     contain its children.
 
     This only works for displayables that can change size.
 
 .. style-property:: area tuple of (int, int, int, int)
 
-    The tuple is interpreted as (`xpos`, `ypos`, `width`,
-    `height`). Attempts to position the displayable such that it's
+    The tuple is interpreted as (``xpos``, ``ypos``, ``width``,
+    ``height``). Attempts to position the displayable such that it's
     upper-left corner is at `xpos` and `ypos`, and its size is `width`
     and `height`.
 
-    It does this by setting the xpos, ypos, xanchor, yanchor,
-    xmaximum, ymaximum, xminimum, yminimum, xfill, and yfill
-    properties to appropriate values.
+    It does this by setting the :propref:`xpos`, :propref:`ypos`, 
+    :propref:`xanchor`, :propref:`yanchor`, :propref:`xmaximum`, 
+    :propref:`ymaximum`, :propref:`xminimum`, :propref:`yminimum`, 
+    :propref:`xfill`, and :propref:`yfill` properties to appropriate values.
 
     This will not work with all displayables and all layouts.
 
@@ -400,7 +401,7 @@ Text Style Properties
 
 .. style-property:: antialias boolean
 
-    If True, the default, truetype font text will be rendered
+    If True, the default, TrueType font text will be rendered
     anti-aliased.
 
 .. style-property:: adjust_spacing boolean
@@ -424,11 +425,11 @@ Text Style Properties
 .. style-property:: black_color color
 
     When rendering an image-based font, black will be mapped to this
-    color. This has no effect for truetype fonts.
+    color. This has no effect for TrueType fonts.
 
 .. style-property:: bold boolean
 
-    If True, render the font in a bold style. For a truetype font,
+    If True, render the font in a bold style. For a TrueType font,
     this usually involves synthetically increasing the font weight. It
     can also cause the font to be remapped, using
     :var:`config.font_replacement_map`.
@@ -441,7 +442,7 @@ Text Style Properties
 
 .. style-property:: color color
 
-    The color the text is rendered in. When using a truetype font,
+    The color the text is rendered in. When using a TrueType font,
     the font is rendered in this color. When using an image-based
     font, white is mapped to this color.
 
@@ -454,7 +455,7 @@ Text Style Properties
 
     A string giving the name of the font used to render text.
 
-    For a truetype font file, this is usually the name of the file
+    For a TrueType font file, this is usually the name of the file
     containing the font (like ``"DejaVuSans.ttf"``). To select a second
     font in a collection, this can be prefixed with a number and
     at sign (like ``"0@font.ttc"`` or ``"1@font.ttc"``). For an
@@ -469,14 +470,14 @@ Text Style Properties
 
 .. style-property:: italic boolean
 
-    If true, the text will be rendered in italics. For a truetype font,
+    If True, the text will be rendered in italics. For a TrueType font,
     this usually involves synthetically increasing the font slant. It
     can also cause the font to be remapped, using
     :var:`config.font_replacement_map`.
 
 .. style-property:: justify boolean
 
-    If true, additional whitespace is inserted between words so that
+    If True, additional whitespace is inserted between words so that
     the left and right margins of each line are even. This is not
     performed on the last line of a paragraph.
 
@@ -560,7 +561,7 @@ Text Style Properties
 
 .. style-property:: newline_indent boolean
 
-    If true, the :propref:`first_indent` indentation is used after
+    If True, the :propref:`first_indent` indentation is used after
     each newline in a string. Otherwise, the :propref:`rest_indent`
     indentation is used.
 
@@ -570,15 +571,15 @@ Text Style Properties
     tuple specifies an outline, and outlines are drawn from back to
     front.
 
-    The list contains (`size`, `color`, `xoffset`, `yoffset`)
-    tuples. `Size` is the amount the font is expanded by, in
-    pixels. `Color` is the color of the outline. `xoffset` and
-    `yoffset` are the amount the outline is shifted by, in pixels.
+    The list contains (``size``, ``color``, ``xoffset``, ``yoffset``)
+    tuples. ``size`` is the amount the font is expanded by, in
+    pixels. ``color`` is the color of the outline. ``xoffset`` and
+    ``yoffset`` are the amount the outline is shifted by, in pixels.
 
     The outline functionality can also be used to give drop-shadows to
     fonts, by specifying a size of 0 and non-zero offsets.
 
-    By default, `size`, `xoffset` and `yoffset` are scaled with the text.
+    By default, ``size``, ``xoffset`` and ``yoffset`` are scaled with the text.
     When given as the absolute type, they are not scaled. For example::
 
         style default:
@@ -586,7 +587,7 @@ Text Style Properties
 
     will always produce a 1 pixel-wide border.
 
-    Outlines only work with truetype fonts.
+    Outlines only work with TrueType fonts.
 
 .. style-property:: rest_indent int
 
@@ -632,7 +633,7 @@ Text Style Properties
 
 .. style-property:: underline boolean
 
-    If true, an underline will be added to the text.
+    If True, an underline will be added to the text.
 
 .. style-property:: hyperlink_functions tuple of (function, function, function)
 
@@ -654,7 +655,7 @@ Text Style Properties
 
 .. style-property:: vertical boolean
 
-    If true, the text will be rendered vertically.
+    If True, the text will be rendered vertically.
 
 .. style-property:: hinting str
 
@@ -807,27 +808,27 @@ Button Style Properties
         focused).
     callable
         If a non-displayable callable (like a function, method, or object
-        with a __call__ method) is given, the function is called with two
+        with a ``__call__`` method) is given, the function is called with two
         arguments, the x and y offset from the top-left corner of the
-        displayable. If the function returns true, the displayable is
+        displayable. If the function returns True, the displayable is
         focused.
     None
         If none is given, the entire button can be focused.
 
 .. style-property:: keyboard_focus boolean
 
-   If true, the default, this button can be focused using the keyboard focus
-   mechanism, if it can be focused at all. If false, the keyboard focus
+   If True, the default, this button can be focused using the keyboard focus
+   mechanism, if it can be focused at all. If False, the keyboard focus
    mechanism will skip this button. (The keyboard focus mechanism is used
    by keyboards and keyboard-like devices, such as joypads.)
 
 .. style-property:: key_events boolean
 
-    If true, keyboard-generated events are passed to the children of this
-    button. If false, those events are not propagated. In this default style,
-    this is set to true while the button is hovered, and false otherwise.
+    If True, keyboard-generated events are passed to the children of this
+    button. If False, those events are not propagated. In this default style,
+    this is set to True while the button is hovered, and False otherwise.
 
-    Setting this to true can be used to propagate keyboard events to an input
+    Setting this to True can be used to propagate keyboard events to an input
     inside a button, even when the button isn't focused.
 
 
@@ -852,17 +853,17 @@ left and right sides are used.
 
 .. style-property:: bar_vertical boolean
 
-    If true, the bar has a vertical orientation. If false, it has a
+    If True, the bar has a vertical orientation. If False, it has a
     horizontal orientation.
 
 .. style-property:: bar_invert boolean
 
-    If true, the value of the bar is represented on the right/top
+    If True, the value of the bar is represented on the right/top
     side of the bar, rather than the left/bottom side.
 
 .. style-property:: bar_resizing boolean
 
-    If true, we resize the sides of the bar. If false, we render the
+    If True, we resize the sides of the bar. If False, we render the
     sides of the bar at full size, and then crop them.
 
 .. style-property:: left_gutter int
@@ -943,8 +944,8 @@ left and right sides are used.
 
 .. style-property:: keyboard_focus boolean
 
-   If true, the default, this button can be focused using the keyboard focus
-   mechanism, if it can be focused at all. If false, the keyboard focus
+   If True, the default, this button can be focused using the keyboard focus
+   mechanism, if it can be focused at all. If False, the keyboard focus
    mechanism will skip this button. (The keyboard focus mechanism is used
    by keyboards and keyboard-like devices, such as joypads.)
 
@@ -967,14 +968,14 @@ These are used for the horizontal and vertical box layouts.
 
 .. style-property:: box_reverse boolean
 
-    If true, the placement of the items in the box will be reversed. When
-    this is true, a hbox will be filled right-to-left, and a vbox will
-    be filled bottom-to-top. This defaults to false.
+    If True, the placement of the items in the box will be reversed. When
+    this is True, a hbox will be filled right-to-left, and a vbox will
+    be filled bottom-to-top. This defaults to False.
 
 .. style-property:: box_wrap boolean
 
-    If true, then boxes will wrap when they reach the end of a line or column.
-    If false (the default), they will extend past the end of the line.
+    If True, then boxes will wrap when they reach the end of a line or column.
+    If False (the default), they will extend past the end of the line.
 
 
 
@@ -1009,24 +1010,24 @@ These are used with the fixed layout.
 
 .. style-property:: fit_first boolean or "width" or "height"
 
-    If true, then the size of the fixed layout is shrunk to be equal with
+    If True, then the size of the fixed layout is shrunk to be equal with
     the size of the first item in the layout. If "width", only the width is changed
     (the fixed will fill the screen vertically). Similarly, "height" only changes
     the height.
 
 .. style-property:: xfit boolean
 
-    If true, the size of the fixed layout is shrunk horizontally to match the
+    If True, the size of the fixed layout is shrunk horizontally to match the
     right side of the rightmost child of the fixed.
 
 .. style-property:: yfit boolean
 
-    If true, the size of the fixed layout is shrunk vertically to match the
+    If True, the size of the fixed layout is shrunk vertically to match the
     bottom side of the bottommost child of the fixed.
 
 .. style-property:: order_reverse boolean
 
-    If false, the default, the items in the box will be draw first-to-last,
-    with the first item in the box being below the second, and so on. If true,
+    If False, the default, the items in the box will be draw first-to-last,
+    with the first item in the box being below the second, and so on. If True,
     this order will be reversed, and the first item in the box will be above
     all other items in the box.

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -5,7 +5,7 @@ Text
 ====
 
 Ren'Py contains several ways of displaying text. The :ref:`say <say-statement>`
-and :ref:`menu <menu-statement>` are primarily concerned with the
+and :ref:`menu <menu-statement>` statements are primarily concerned with the
 display of text to the user. The user interface often contains text,
 displayed using the :ref:`text <sl-text>`, :ref:`textbutton <sl-textbutton>`,
 and :ref:`label <sl-label>` screen language statements. These
@@ -96,7 +96,7 @@ formatting syntax. Ren'Py uses [ to introduce string formatting
 because { was taken by text tags.
 
 Along with the !s and !r conversion flags supported by Python, Ren'Py
-supports !q and !t conversion flag. The !q conversion flag ensures that
+supports !q and !t conversion flags. The !q conversion flag ensures that
 text tags are properly quoted, so that displaying a string will not
 introduce unwanted formatting constructs. For example::
 
@@ -125,9 +125,9 @@ styling a portion of text block, or a small fraction of the text
 blocks in the program. If you find yourself applying the same text
 tags to every line of text, consider using a style instead.
 
-There are two text tags. Some text tags are self-closing, while others
+There are two types of text tags. Some text tags are self-closing, while others
 require a closing tag. When multiple closing tags are used, they
-should be closed last open, first closed order - Ren'Py will reject
+should be closed last open, first closed order—Ren'Py will reject
 incorrect nesting. For example::
 
     # This line is correct.
@@ -155,12 +155,12 @@ Tags that apply to all text are:
     :propref:`hyperlink_functions` style property, the default handler
     has the following behavior.
 
-    * When the argument begins with jump:, the rest of the argument is a label to jump to.
+    * When the argument begins with ``jump:``, the rest of the argument is a label to jump to.
 
-    * When the argument begins with call:, the rest of the argument is a label
+    * When the argument begins with ``call:``, the rest of the argument is a label
       to call. As usual, a call ends the current Ren'Py statement.
 
-    * When the argument begins with call_in_new_context:, the rest of the argument
+    * When the argument begins with ``call_in_new_context:``, the rest of the argument
       is a label to call in a new context (using :func:`renpy.call_in_new_context`).
 
     * Otherwise, the argument is a URL that is opened by the system web browser.
@@ -486,7 +486,7 @@ Ruby Text
 
 Ruby text (also known as furigana or interlinear annotations) is a way
 of placing small text above a character or word. There are several
-steps required for your game to support Ruby text.
+steps required for your game to support ruby text.
 
 First, you must set up styles for the ruby text. The following style
 changes are required:
@@ -496,7 +496,7 @@ changes are required:
 2. A new named style must be created. The properties of this style,
    such as :propref:`size` should be set in a fashion appropriate
    for ruby text.
-3. The yoffset of the new style should be set, in order to move the
+3. The :propref:`yoffset` of the new style should be set, in order to move the
    ruby text above the baseline.
 4. The :propref:`ruby_style` field of the text's style should be set
    to the newly-created style.
@@ -511,12 +511,12 @@ For example::
         line_leading 12
         ruby_style style.ruby_style
 
-(Use style.style_name to refer to a style for this purpose.)
+(Use ``style.style_name`` to refer to a style for this purpose.)
 
 Once Ren'Py has been configured, ruby text can be included using the
-rt and rb text tags. The rt tag is used to mark one or more characters
+{rt} and {rb} text tags. The {rt} tag is used to mark one or more characters
 to be displayed as ruby text. If the ruby text is preceded by text
-enclosed in the rb tag, the ruby text is centered over that
+enclosed in the {rb} tag, the ruby text is centered over that
 text. Otherwise, it is centered over the preceding character.
 
 For example::
@@ -531,8 +531,8 @@ or spaces to the left and right of the text to prevent these errors
 from occurring.
 
 Ren'Py also supports alternate ruby text, which is a second kind of
-ruby top text. This is introduced with the art text tag (instead of rt),
-and the altruby_style property (instead of ruby_style).
+ruby top text. This is introduced with the {art} text tag (instead of {rt}),
+and the :propref:`altruby_style` property (instead of :propref:`ruby_style`).
 
 Fonts
 =====
@@ -541,7 +541,7 @@ Ren'Py supports TrueType/OpenType fonts and collections, and
 Image-Based fonts.
 
 A TrueType or OpenType font is specified by giving the name of the font
-file. The file must be present in the game directory, or one of the archive
+file. The file must be present in the game directory or one of the archive
 files.
 
 Ren'Py also supports TrueType/OpenType collections that define more than one
@@ -559,8 +559,8 @@ mapped to a similar combination. This allows a font with proper
 italics to be used instead of the automatically-generated italics.
 
 Once such mapping would be to replace the italic version of the Deja
-Vu Sans font with the official oblique version. (You'll need to
-download the oblique font from the web.)::
+Vu Sans font with the official oblique version (You'll need to
+download the oblique font from the web)::
 
     init python:
         config.font_replacement_map["DejaVuSans.ttf", False, True] = ("DejaVuSans-Oblique.ttf", False, False)
@@ -601,9 +601,9 @@ the mood the creator intends. To support this, Ren'Py supports font groups
 that can take characters from two or more fonts and combine them into a
 single font.
 
-To create a font group, create a FontGroup object and call the .add method
-on it once or more. a FontGroup can be used wherever a font name can be
-used. The add method takes the start and end of a range of unicode character
+To create a font group, create a :func:`FontGroup` object and call the ``.add`` method
+on it once or more. A FontGroup can be used wherever a font name can be
+used. The add method takes the start and end of a range of Unicode character
 points, and the first range to cover a point is used.
 
 For example::

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -601,7 +601,7 @@ the mood the creator intends. To support this, Ren'Py supports font groups
 that can take characters from two or more fonts and combine them into a
 single font.
 
-To create a font group, create a :func:`FontGroup` object and call the ``.add`` method
+To create a font group, create a :class:`FontGroup` object and call the ``.add`` method
 on it once or more. A FontGroup can be used wherever a font name can be
 used. The add method takes the start and end of a range of Unicode character
 points, and the first range to cover a point is used.

--- a/sphinx/source/voice.rst
+++ b/sphinx/source/voice.rst
@@ -3,14 +3,14 @@ Voice
 =====
 
 Ren'Py includes support for playing back voice in conjunction with
-dialogue. This is done through the voice statement, which gives the
+dialogue. This is done through the ``voice`` statement, which gives the
 voice filename to play::
 
   voice "line0001.ogg"
   "Welcome to Ren'Py"
 
 Normally, a playing voice is stopped at the start of the next
-interaction. The voice sustain statement can sustain voice playback
+interaction. The ``voice sustain`` statement can sustain voice playback
 through an interaction. ::
 
   voice "line0001.ogg"

--- a/sphinx/source/voice.rst
+++ b/sphinx/source/voice.rst
@@ -27,7 +27,7 @@ Voice Tags
 
 Ren'Py includes a voice tag system that makes it possible to selectively
 mute or unmute a character's voice. To take advantage of this system,
-supply a voice_tag argument to each :func:`Character`, and use the
+supply a ``voice_tag`` argument to each :func:`Character`, and use the
 :func:`SetVoiceMute` or :func:`ToggleVoiceMute` actions to allow the
 player to toggle the voice.
 
@@ -63,7 +63,7 @@ making it possible to play back voice without having to put voice statements
 before each line of dialogue.
 
 This is done by creating voice files that match the identifier for each line
-of dialogue. To determine the identifiers to use , first export the dialogue
+of dialogue. To determine the identifiers to use, first export the dialogue
 to a spreadsheet by choosing from the launcher "Extract Dialogue", "Tab-delimited
 Spreadsheet (dialogue.tab)", and "Continue". This will produce a file, dialogue.tab,
 that can be loaded in a spreadsheet program.
@@ -72,7 +72,7 @@ The first column of the spreadsheet is the identifier to use, with other
 columns giving more information about the dialogue.
 
 To make Ren'Py automatically play voices, set :var:`config.auto_voice` to
-a string containing `{id}`. When dialogue occurs, `{id}` is replaced with
+a string containing ``{id}``. When dialogue occurs, ``{id}`` is replaced with
 the dialogue identifier, forming a filename. If the filename exists, it is
 played.
 


### PR DESCRIPTION
The majority of documentation pages have been edited. Please verify that all names for functions, variables, properties, etc. are to be marked with two backticks rather than one. In this case, further editing passes will be required.