### PR TITLE
Small fix for Tutorial

### DIFF
--- a/tutorial/game/tl/french/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/french/tutorial_quickstart.rpy
@@ -498,10 +498,10 @@ translate french tutorial_simple_positions_2377e3b3:
     e "Habituellement les transformations sont définies au début du fichier, juste après les personnages, mais l’endroit où vous les définissez n’a pas vraiment d’importance."
 
 # game/tutorial_quickstart.rpy:347
-translate french tutorial_simple_positions_fa09596c:
+translate french tutorial_simple_positions_3ce7e367:
 
-    # e "The transform is given a name, sightleft, and then the xalign and yalign properties."
-    e "La transformation est définie par un nom 'sightleft' et ensuite par les propriétés 'xalign' et 'yalign'."
+    # e "The transform is given a name, slightleft, and then the xalign and yalign properties."
+    e "La transformation est définie par un nom 'slightleft' et ensuite par les propriétés 'xalign' et 'yalign'."
 
 # game/tutorial_quickstart.rpy:355
 translate french tutorial_simple_positions_82d640d9:

--- a/tutorial/game/tl/russian/indepth_displayables.rpy
+++ b/tutorial/game/tl/russian/indepth_displayables.rpy
@@ -61,7 +61,7 @@ translate russian simple_displayables_0befbee0:
     e "Это означает, что мы можем применять к нему и другие объекты, так же как и к изображениям, например, трансформацию."
 
 # game/indepth_displayables.rpy:91
-translate russian simple_displayables_fde549c4:
+translate russian simple_displayables_fcf2325f:
 
     # e "The Composite displayable lets us group multiple displayables together into a single one, from bottom to top."
     e "Объект Composite позволяет нам группировать разные объекты в один снизу вверх."

--- a/tutorial/game/tl/russian/screens.rpy
+++ b/tutorial/game/tl/russian/screens.rpy
@@ -141,187 +141,187 @@ translate russian strings:
     old "Language"
     new "Язык"
 
-    # screens.rpy:793
+    # screens.rpy:794
     old "Text Speed"
     new "Скорость текста"
 
-    # screens.rpy:797
+    # screens.rpy:798
     old "Auto-Forward Time"
     new "Скорость авточтения"
 
-    # screens.rpy:804
+    # screens.rpy:805
     old "Music Volume"
     new "Громкость музыки"
 
-    # screens.rpy:811
+    # screens.rpy:812
     old "Sound Volume"
     new "Громкость звука"
 
-    # screens.rpy:817
+    # screens.rpy:818
     old "Test"
     new "Тест"
 
-    # screens.rpy:821
+    # screens.rpy:822
     old "Voice Volume"
     new "Громкость голоса"
 
-    # screens.rpy:832
+    # screens.rpy:833
     old "Mute All"
     new "Без звука"
 
-    # screens.rpy:948
+    # screens.rpy:949
     old "The dialogue history is empty."
     new "История диалогов пуста."
 
-    # screens.rpy:1013
+    # screens.rpy:1014
     old "Keyboard"
     new "Клавиатура"
 
-    # screens.rpy:1014
+    # screens.rpy:1015
     old "Mouse"
     new "Мышь"
 
-    # screens.rpy:1017
+    # screens.rpy:1018
     old "Gamepad"
     new "Геймпад"
 
-    # screens.rpy:1030
+    # screens.rpy:1031
     old "Enter"
     new "Enter"
 
-    # screens.rpy:1031
+    # screens.rpy:1032
     old "Advances dialogue and activates the interface."
     new "Прохождение диалогов и активация интерфейса."
 
-    # screens.rpy:1034
+    # screens.rpy:1035
     old "Space"
     new "Пробел"
 
-    # screens.rpy:1035
+    # screens.rpy:1036
     old "Advances dialogue without selecting choices."
     new "Прохождение диалогов, но не позволяет делать выбор."
 
-    # screens.rpy:1038
+    # screens.rpy:1039
     old "Arrow Keys"
     new "Стрелки"
 
-    # screens.rpy:1039
+    # screens.rpy:1040
     old "Navigate the interface."
     new "Навигация по интерфейсу."
 
-    # screens.rpy:1042
+    # screens.rpy:1043
     old "Escape"
     new "Esc"
 
-    # screens.rpy:1043
+    # screens.rpy:1044
     old "Accesses the game menu."
     new "Вход в игровое меню."
 
-    # screens.rpy:1046
+    # screens.rpy:1047
     old "Ctrl"
     new "Ctrl"
 
-    # screens.rpy:1047
+    # screens.rpy:1048
     old "Skips dialogue while held down."
     new "Пропускает диалоги, пока зажат."
 
-    # screens.rpy:1050
+    # screens.rpy:1051
     old "Tab"
     new "Tab"
 
-    # screens.rpy:1051
+    # screens.rpy:1052
     old "Toggles dialogue skipping."
     new "Включает режим пропуска."
 
-    # screens.rpy:1054
+    # screens.rpy:1055
     old "Page Up"
     new "Page Up"
 
-    # screens.rpy:1055
+    # screens.rpy:1056
     old "Rolls back to earlier dialogue."
     new "Откат назад по сюжету игры."
 
-    # screens.rpy:1058
+    # screens.rpy:1059
     old "Page Down"
     new "Page Down"
 
-    # screens.rpy:1059
+    # screens.rpy:1060
     old "Rolls forward to later dialogue."
     new "Откатывает предыдущее действие вперёд."
 
-    # screens.rpy:1063
+    # screens.rpy:1064
     old "Hides the user interface."
     new "Скрывает интерфейс пользователя."
 
-    # screens.rpy:1067
+    # screens.rpy:1068
     old "Takes a screenshot."
     new "Делает снимок экрана."
 
-    # screens.rpy:1071
+    # screens.rpy:1072
     old "Toggles assistive {a=https://www.renpy.org/l/voicing}self-voicing{/a}."
     new "Включает поддерживаемый {a=https://www.renpy.org/l/voicing}синтезатор речи{/a}."
 
-    # screens.rpy:1077
+    # screens.rpy:1078
     old "Left Click"
     new "Левый клик"
 
-    # screens.rpy:1081
+    # screens.rpy:1082
     old "Middle Click"
     new "Клик колёсиком"
 
-    # screens.rpy:1085
+    # screens.rpy:1086
     old "Right Click"
     new "Правый клик"
 
-    # screens.rpy:1089
+    # screens.rpy:1090
     old "Mouse Wheel Up\nClick Rollback Side"
     new "Колёсико вверх\nКлик на сторону отката"
 
-    # screens.rpy:1093
+    # screens.rpy:1094
     old "Mouse Wheel Down"
     new "Колёсико вниз"
 
-    # screens.rpy:1100
+    # screens.rpy:1101
     old "Right Trigger\nA/Bottom Button"
     new "Правый триггер\nA/Нижняя кнопка"
 
-    # screens.rpy:1104
+    # screens.rpy:1105
     old "Left Trigger\nLeft Shoulder"
     new "Левый Триггер\nЛевый Бампер"
 
-    # screens.rpy:1108
+    # screens.rpy:1109
     old "Right Shoulder"
     new "Правый бампер"
 
-    # screens.rpy:1112
+    # screens.rpy:1113
     old "D-Pad, Sticks"
     new "Крестовина, Стики"
 
-    # screens.rpy:1116
+    # screens.rpy:1117
     old "Start, Guide"
     new "Start, Guide"
 
-    # screens.rpy:1120
+    # screens.rpy:1121
     old "Y/Top Button"
     new "Y/Верхняя кнопка"
 
-    # screens.rpy:1123
+    # screens.rpy:1124
     old "Calibrate"
     new "Калибровка"
 
-    # screens.rpy:1188
+    # screens.rpy:1189
     old "Yes"
     new "Да"
 
-    # screens.rpy:1189
+    # screens.rpy:1190
     old "No"
     new "Нет"
 
-    # screens.rpy:1235
+    # screens.rpy:1236
     old "Skipping"
     new "Пропускаю"
 
-    # screens.rpy:1456
+    # screens.rpy:1457
     old "Menu"
     new "Меню"
 

--- a/tutorial/game/tl/russian/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/russian/tutorial_quickstart.rpy
@@ -498,10 +498,10 @@ translate russian tutorial_simple_positions_2377e3b3:
     e "Обычно трансформации определяются выше основного скрипта, сразу после определения персонажей, но в Ren'Py не имеет значения, где вы будете их определять."
 
 # game/tutorial_quickstart.rpy:347
-translate russian tutorial_simple_positions_fa09596c:
+translate russian tutorial_simple_positions_3ce7e367:
 
-    # e "The transform is given a name, sightleft, and then the xalign and yalign properties."
-    e "Нашей трансформации даётся имя sightleft, а затем параметры xalign и yalign."
+    # e "The transform is given a name, slightleft, and then the xalign and yalign properties."
+    e "Нашей трансформации даётся имя slightleft, а затем параметры xalign и yalign."
 
 # game/tutorial_quickstart.rpy:355
 translate russian tutorial_simple_positions_82d640d9:

--- a/tutorial/game/tutorial_quickstart.rpy
+++ b/tutorial/game/tutorial_quickstart.rpy
@@ -344,7 +344,7 @@ label tutorial_simple_positions:
 
     e "Usually transforms are defined at the top of a file, right after the characters. But it doesn't matter to Ren'Py where you define them."
 
-    e "The transform is given a name, sightleft, and then the xalign and yalign properties."
+    e "The transform is given a name, slightleft, and then the xalign and yalign properties."
 
     example:
         show eileen vhappy at slightleft


### PR DESCRIPTION
Transform named 'slightleft', not 'sightleft'. This PQ fix it for all translations (well, not Piglatin. We're antipiglatiners...)
Also, fix one string in Russian.