### PR TITLE
Minor documentation corrections

### DIFF
--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -11,29 +11,24 @@ With no configuration, Ren'Py is able to build the following kinds of
 packages:
 
 PC: Windows and Linux
-
     A zip file targeting Windows x86, Linux x86, and Linux x86_64.
 
 Linux x86/x86_64
-
     A tar.bz2 file targeting Linux x86 and Linux x86_64.
 
 Macintosh x86_64
-
     A zip file containing a Macintosh application targeting Macintosh
     OS X on Intel processors. Game data will be included inside the
     application, which appears to the user as a single file.
 
 Windows x86
-
-   A zip file targeting Windows x86.
+     A zip file targeting Windows x86.
 
 Windows, Mac, and Linux for Markets
-
-   A distribution that contains the information required to run on
-   software markets like itch.io and Steam. This isn't meant to be
-   run directly (and probably won't work on the Mac), but should be
-   fed to the app store upload process.
+     A distribution that contains the information required to run on
+     software markets like itch.io and Steam. This isn't meant to be
+     run directly (and probably won't work on the Mac), but should be
+     fed to the app store upload process.
 
 .. warning::
 

--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -99,7 +99,7 @@ These functions are useful in writing lint functions.
 Example
 -------
 
-This creates a new statement "line" that allows lines of text to be specified
+This creates a new statement ``line`` that allows lines of text to be specified
 without quotes. ::
 
     python early:

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -1868,7 +1868,7 @@ pixel art stays sharp when scaled up.
 The new :func:`renpy.predicting` function returns true if Ren'Py is running
 a screen for prediction purposes.
 
-The new :func:`renpy.return_statement` function is a python equivalent to
+The new :func:`renpy.return_statement` function is a Python equivalent to
 the Ren'Py return statement.
 
 The new :var:`_dismiss_pause` and :var:`_skipping` variables make it possible to
@@ -2610,7 +2610,7 @@ style, this has the potential to lead to a substantial performance
 improvement.
 
 This release also introduced a new style statement that can be used
-to define styles, in place of python code. (Of course, the older form
+to define styles, in place of Python code. (Of course, the older form
 remains fully supported.) Lengthy and redundant code like::
 
     init python:
@@ -2946,7 +2946,7 @@ This release includes many bugfixes. Some of the more important are:
   slow video card, and present the user with the appropriate error message.
 
 * A fix to a problem where Ren'Py would fail to display the proper error
-  message when python code containing non-ASCII characters fails to compile.
+  message when Python code containing non-ASCII characters fails to compile.
 
 
 
@@ -3088,8 +3088,8 @@ The console can be used to:
 
 * Jump to a label.
 * Interactively try out Ren'Py script statements.
-* Evaluate a python expression or statement to see the result.
-* Trace python expressions as the game progresses.
+* Evaluate a Python expression or statement to see the result.
+* Trace Python expressions as the game progresses.
 
 The console was originally written by Shiz, C, and delta.
 
@@ -3113,7 +3113,7 @@ Ren'Py now includes support for :ref:`replaying <replay>` scenes. A scene
 replay can be invoked from anywhere in Ren'Py (for example, from a main menu
 or game menus screen, even when the game has started). When the replay ends,
 Ren'Py will return to the location the replay was invoked from, even if that
-location is in a screen or in python code. Rollback works inside a replay,
+location is in a screen or in Python code. Rollback works inside a replay,
 but saving and loading is disabled.
 
 The :func:`Replay` action begins a replay. The :func:`renpy.end_replay` ends a
@@ -3161,7 +3161,7 @@ lib/ directory. Ren'Py itself has now been placed in the renpy/ directory.
 The common/ directory has been moved to renpy/common/, as it's considered an
 integral part of Ren'Py.
 
-Ren'Py now uses renamed but otherwise unmodified python binaries on all
+Ren'Py now uses renamed but otherwise unmodified Python binaries on all
 desktop platforms. (Previously, it used platform-specific binaries.) Portions
 of the library are shared between the desktop builds.
 
@@ -3214,7 +3214,7 @@ Other Changes
   :var:`config.exit_yesno_transition` variables allow a creator to supply
   transitions that are used upon entering and exiting yes/no prompts.
 
-* The python decimal module is now included in the default builds of Ren'Py.
+* The Python decimal module is now included in the default builds of Ren'Py.
 
 Bugfixes
 --------
@@ -3431,7 +3431,7 @@ where the user is able to add new slots to the list.
 Multiple Store Support
 ----------------------
 
-Ren'Py now supports multiple stores – multiple namespaces in which python code
+Ren'Py now supports multiple stores – multiple namespaces in which Python code
 can be run. Variables in these stores are saved, loaded, and rolled-back in
 the same way that variables in the default store are.
 
@@ -3567,7 +3567,7 @@ Side images can now be limited to showing a single character, or only showing
 characters that are not on the screen. See :var:`config.side_image_tag` and
 :var:`config.side_image_only_not_showing`.
 
-Added :var:`config.python_callbacks`, a list of python functions that are
+Added :var:`config.python_callbacks`, a list of Python functions that are
 called at the end of each python block.
 
 Ren'Py now tests the video card it is running on for functionality. If it
@@ -4329,8 +4329,8 @@ Other Changes
   into two parts at the first underscore. If the second part corresponds to
   an existing style, we create a new style instead of causing an error.
 
-* The python compiler has been rewritten to use the python ast module. This
-  should both improve performance, and improve error handling for python
+* The Python compiler has been rewritten to use the Python ast module. This
+  should both improve performance, and improve error handling for Python
   syntax.
 
   Because of this change, Ren'Py now ships with and requires Python 2.6.

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -38,8 +38,8 @@ Dict Transitions
 :ref:`Dict Transitions <dict-transitions>` makes it
 possible to use the with statement and certain other functions to apply
 transitions to one or more layers. Ren'Py will not pause for these
-transitions to occur. Dict transitions make it possible—and even
-convenient—to have a transition apply to the sprites alone while dialogue is
+transitions to occur. Dict transitions make it possible – and even
+convenient – to have a transition apply to the sprites alone while dialogue is
 being displayed.
 
 Changes
@@ -966,7 +966,7 @@ improved. When a new project is created, it includes translations of the
 interface strings into the project's language, allowing the translation
 of text presented to the player by Ren'Py.
 
-There is now a single place for translating Ren'Py—translating
+There is now a single place for translating Ren'Py – translating
 the launcher also now translates the comments of a generated game. The process
 of translating Ren'Py (the launcher and the GUI) is now documented
 on the :ref:`Translating Ren'py <translating-renpy>` page. This page also
@@ -1291,7 +1291,7 @@ returned when enter is pressed.
 
 Ren'Py support a :func:`renpy.get_refresh_rate` function, which returns the
 referesh rate of the primary screen. This allows games using nearest neighbor
-mode to move at a whole-pixel rate—just like a Commodore 64 did.
+mode to move at a whole-pixel rate – just like a Commodore 64 did.
 
 Ren'Py can now automatically upload your game to itch.io, if
 :var:`build.itch_project` is set.
@@ -1665,7 +1665,7 @@ set.
 Android/iOS
 -----------
 
-The android SELECT key—present on remote controls—is now supported
+The android SELECT key – present on remote controls – is now supported
 for advancing text and selecting buttons, bars, etc. This means most
 TV-based android consoles should be supported.
 
@@ -1971,7 +1971,7 @@ Ren'Py 6.99.2
 =============
 
 Ren'Py now supports an images directory underneath the game directory.
-Images found inside this directory—or in subdirectories of this directory—will
+Images found inside this directory – or in subdirectories of this directory – will
 be automatically defined as images in Ren'Py. This will likely render the use of
 the image statement obsolete in simple games.
 
@@ -3045,8 +3045,8 @@ combined at the translator's discretion. As most Ren'Py statements are
 allowed inside the new translation blocks, it's possible to use logic (like
 conditions) to tailor the translations to your language.
 
-The launcher includes a new "Generate Translations" button, which—as part of
-a sanctioned translation where the full script is present—will generate
+The launcher includes a new "Generate Translations" button, which – as part of
+a sanctioned translation where the full script is present – will generate
 empty translation files for a new language.
 
 Improved Japanese Support
@@ -3431,7 +3431,7 @@ where the user is able to add new slots to the list.
 Multiple Store Support
 ----------------------
 
-Ren'Py now supports multiple stores—multiple namespaces in which python code
+Ren'Py now supports multiple stores – multiple namespaces in which python code
 can be run. Variables in these stores are saved, loaded, and rolled-back in
 the same way that variables in the default store are.
 
@@ -3487,7 +3487,7 @@ that have occurred are:
 Other Changes
 -------------
 
-* The :func:`renpy.call` function allows—with major and important caveats—
+* The :func:`renpy.call` function allows – with major and important caveats – 
   a call to a Ren'Py label to begin from inside Python code. Such a call
   immediately terminates the current statement.
 
@@ -3774,7 +3774,7 @@ Image Attributes
 
 The process of showing images is now attribute-based. Image names now consist
 of a tag, and zero or more attributes. When showing an image, the order of
-attributes is no longer important—it's now possible to define an image
+attributes is no longer important – it's now possible to define an image
 using one set of attributes, and show it using those attributes in a
 different order.
 
@@ -3936,7 +3936,7 @@ Android support required several changes in Ren'Py:
   when the android device suspends, and reloads (if necessary) upon resume.
 
 * We added the concept of :ref:`screen-variants`. This allows a single game
-  to have multiple interfaces—such a mouse interface for computer
+  to have multiple interfaces – such a mouse interface for computer
   platforms, and a touch interface for Android-based smartphones and tablets.
 
 * We built a system that allows one to package a game separately from
@@ -3980,7 +3980,7 @@ automatic, but only occurs when using screens.
 Screens may be invoked at any time, in order to allow for image prediction,
 unless they have a predict property of False. This means that displaying a
 screen should not have side effects. (Most screens only have side effects
-when a button is clicked or a bar changed—that's still fine.)
+when a button is clicked or a bar changed – that's still fine.)
 
 Ren'Py now supports hotspot caching for screen language imagemaps. When
 :var:`config.developer` is true, Ren'Py will write a PNG file in the
@@ -4003,7 +4003,7 @@ Ren'Py now ships with a default set of screens, which are used by the demo and
 installed by default when a new game is created. You can find them in
 template/game/screens.rpy, and they can be used by copying that file into
 your project. These screens are not 100% compatible with the previous layout
-system—for example, some styles have changed. That's why games must opt-in
+system – for example, some styles have changed. That's why games must opt-in
 to them.
 
 The definition of the `items` parameter of the :ref:`choice-screen` and

--- a/sphinx/source/custom_text_tags.rst
+++ b/sphinx/source/custom_text_tags.rst
@@ -61,7 +61,7 @@ text tag, or passed through unchanged.
 Examples
 --------
 
-The example big text tag works like the {size} text tag, but applies a
+The example ``big`` text tag works like the {size} text tag, but applies a
 multiplier to its argument. ::
 
     init python:
@@ -82,7 +82,7 @@ multiplier to its argument. ::
     "This is {big=3}BIG!{/big}"
 
 The example ``rot13`` text tag applies the ROT13 transform to text. Note that
-ROT26 â€“ ROT13 applied twice â€“ is just normal text. ::
+ROT26—ROT13 applied twice—is just normal text. ::
 
     init python:
 

--- a/sphinx/source/custom_text_tags.rst
+++ b/sphinx/source/custom_text_tags.rst
@@ -1,4 +1,4 @@
-.. _custom-text-tags:
+ï»¿.. _custom-text-tags:
 
 ================
 Custom Text Tags
@@ -82,7 +82,7 @@ multiplier to its argument. ::
     "This is {big=3}BIG!{/big}"
 
 The example ``rot13`` text tag applies the ROT13 transform to text. Note that
-ROT26—ROT13 applied twice—is just normal text. ::
+ROT26 â€“ ROT13 applied twice â€“ is just normal text. ::
 
     init python:
 

--- a/sphinx/source/developer_tools.rst
+++ b/sphinx/source/developer_tools.rst
@@ -60,7 +60,7 @@ size it is being rendered at.
 Shift+Y Style Dumping
 ---------------------
 
-When :var:`config.developer` is True, pressing the dump_styles key (by default,
+When :var:`config.developer` is True, pressing the `dump_styles` key (by default,
 Shift+Y), will write a description of every style Ren'Py knows about to the
 file "styles.txt". This description includes every property that is part of the
 style, the value of that property, and the style the property is inherited
@@ -70,7 +70,7 @@ from.
 ---------------
 
 When :var:`config.developer` or :var:`config.fast_skipping` is True, pressing
-the ``fast_skip`` key (by default, ">") causes the the game to immediately skip to
+the `fast_skip` key (by default, ">") causes the the game to immediately skip to
 the next important interaction.  For this purpose, an important interaction is
 one that is not caused by a say statement, transition, or pause command.
 Usually, this means skipping to the next menu, but it will also stop when

--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -6,8 +6,8 @@ Displayables
 A displayable is an object that can be shown to the user. Ren'Py
 displayables can be used in many ways.
 
-* Assignment to an image name using the image statement.
-* Added to a screen using the screen language add statement.
+* Assignment to an image name using the ``image`` statement.
+* Added to a screen using the screen language ``add`` statement.
 * Assignment to certain config variables.
 * Assignment to certain style properties.
 
@@ -16,9 +16,9 @@ five things that can be provided:
 
 * An object of type Displayable, created by calling one of the
   functions given below.
-* A string with a colon (:) in it. These are rare, but see the section on
+* A string with a colon ``:`` in it. These are rare, but see the section on
   :ref:`displayable prefixes <displayable-prefix>` below.
-* A string with a dot (.) in it. Such a string is interpreted as
+* A string with a dot ``.`` in it. Such a string is interpreted as
   a filename by :func:`Image`.
 * A color. A color may either be given as a hexadecimal color string in "#rgb",
   "#rgba", "#rrggbb", or "#rrggbbaa" form, a :class:`Color`, or an (r, g, b, a) tuple,
@@ -64,14 +64,14 @@ properties.
 
 There are three image file formats we recommend you use:
 
-* Webp
-* Png
-* Jpg
+* WEBP
+* PNG
+* JPG
 
-Non-animated Gif and Bmp files are also supported, but should not be
+Non-animated GIF and BMP files are also supported, but should not be
 used in modern games.
 
-Loading an Image from from a file on disk and decoding it so it can be
+Loading an Image from a file on disk and decoding it so it can be
 drawn to the screen takes a long amount of time. While measured in the
 tenths or hundreds of seconds, the duration of the loading process is
 long enough that it can prevent an acceptable framerate, and become
@@ -79,7 +79,7 @@ annoying to the user.
 
 Since an Image is of a fixed size, and doesn't change in response to
 input, game state, or the size of the area available to it, an Image
-can be loaded before it is needed, and placed into an area of memory
+can be loaded before it is needed and placed into an area of memory
 known as the image cache. Once an Image is decoded and in the cache,
 it can be quickly drawn to the screen.
 
@@ -91,7 +91,7 @@ that are no longer being used.
 By default, Ren'Py will predictively cache up to 8 screens worth of
 image data. (If your screen is 800x600, then a screen's worth of data
 is one 800x600 image, two 400x600 images, and so on.) This can be
-changed with the :var:config.image_cache_size configuration
+changed with the :var:`config.image_cache_size` configuration
 variable.
 
 Although the precise amount is dependent on implementation details and
@@ -271,7 +271,7 @@ big as the original. ::
 
         config.displayable_prefix["big"] = embiggen
 
-The init -10 makes sure the prefix is defined before any images that use it.
+The ``init -10`` makes sure the prefix is defined before any images that use it.
 The prefix can then be used to define images::
 
     image eileen big = "big:eileen happy"

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -122,7 +122,7 @@ Image Statement
 
 The ``image`` statement is used to define an image. An image statement
 consists of a single logical line beginning with the keyword ``image``,
-followed by an image name, an equals sign (``=``), and a
+followed by an image name, an equals sign ``=``, and a
 displayable. For example::
 
     image eileen happy = "eileen_happy.png"
@@ -219,7 +219,7 @@ Assuming we have the following images defined::
 
 Some example show statements are::
 
-    # Basic show
+    # Basic show.
     show mary night sad
 
     # Since 'mary night happy' is showing, the following statement is

--- a/sphinx/source/gui.rst
+++ b/sphinx/source/gui.rst
@@ -1298,7 +1298,7 @@ and later on::
 
     define gui.button_text_font = gui.interface_text_font
 
-Since both of these statements run before any translate block runs, both
+Since both of these statements run before any ``translate`` block runs, both
 variables need to be changed. ::
 
     translate japanese python::

--- a/sphinx/source/multiple.rst
+++ b/sphinx/source/multiple.rst
@@ -11,7 +11,7 @@ argument. For example::
     l "About bloody time! I've been waiting for this for years." (multiple=2)
 
 Multiple dialogue is invoked by passing a line of dialogue the `multiple` argument
-with the number of lines of dialogue to combine together. (So if we had multiple=3,
+with the number of lines of dialogue to combine together. (So if we had ``multiple=3``,
 three blocks of dialogue would be combined.)
 
 Multiple dialogue works by showing the say screen more than once, with

--- a/sphinx/source/python.rst
+++ b/sphinx/source/python.rst
@@ -38,7 +38,7 @@ behavior:
     Python block terminates.
 
     This allows Python to use temporary variables that can't be
-    saved—but it means that the store needs to be accessed as fields
+    saved – but it means that the store needs to be accessed as fields
     on the store object, rather than directly.
 
 ``in``
@@ -276,7 +276,7 @@ First and Third-Party Python Modules and Packages
 -------------------------------------------------
 
 Ren'Py can import pure-Python modules and packages. First-party modules
-and packages—ones written for the game—can be placed directly
+and packages – ones written for the game – can be placed directly
 into the game directory. Third party packages can be placed into the
 game/python-packages directory.
 

--- a/sphinx/source/raspi.rst
+++ b/sphinx/source/raspi.rst
@@ -6,7 +6,7 @@ demonstrated to run on the Raspberry Pi 3B, but may run on other models.
 
 It's important to realize that the Raspberry Pi is a very limited system,
 even compared to iOS and Android smartphones. As a result, not every Ren'Py
-game will run well—or at all—on a Raspberry Pi. What's more, it's possible
+game will run well – or at all – on a Raspberry Pi. What's more, it's possible
 to crash Ren'Py by allowing a game to use more RAM than the system has available
 to it.
 

--- a/sphinx/source/screen_python.rst
+++ b/sphinx/source/screen_python.rst
@@ -22,7 +22,9 @@ with the same id. Ids are generated automatically by the screen
 language, but when doing things by hand, they must be manually
 specified.
 
-Warning: UI Functions are deprecated and not recommended.
+.. warning::
+
+    UI Functions are deprecated and not recommended.
 
 Here's an example Python screen::
 

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -57,11 +57,11 @@ ensure that their writing is not accidentally misinterpreted by the engine.
 [ (left bracket)
     The left bracket is used to introduce interpolation of a value
     into the text. To include a single left bracket in your text,
-    double it—write ``[[``.
+    double it – write ``[[``.
 
 { (left brace)
     The left brace is used to introduce a text tag. To include a left
-    brace in your text, double it—write ``{{``.
+    brace in your text, double it – write ``{{``.
 
 
 .. _text-interpolation:
@@ -127,7 +127,7 @@ tags to every line of text, consider using a style instead.
 
 There are two types of text tags. Some text tags are self-closing, while others
 require a closing tag. When multiple closing tags are used, they
-should be closed last open, first closed order—Ren'Py will reject
+should be closed last open, first closed order – Ren'Py will reject
 incorrect nesting. For example::
 
     # This line is correct.

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -362,7 +362,7 @@ or equivalently::
 
 When a language is activated – either at the start of the game, or
 after a language change – Ren'Py resets the styles to their contents
-at the end of the init phase. It then runs all translate python blocks
+at the end of the init phase. It then runs all ``translate python`` blocks
 and translate style blocks associated with the current language, guaranteeing
 that blocks appearing earlier in a file are executed first. Finally, it
 rebuilds styles, allowing the changes to take effect.
@@ -467,7 +467,7 @@ This will update the "game/tl/language/strings.rpy" file with a
 translation template that contains all of the strings in it.
 
 If a game doesn't include support for changing the language, it may be
-appropriate to use an init python block to set :var:`config.language`
+appropriate to use an ``init python`` block to set :var:`config.language`
 to the target language.
 
 Along with the use of string translations for dialogue, unsanctioned


### PR DESCRIPTION
Following from https://github.com/renpy/renpy/commit/f1fbbc740dc4565db85c344e69ec111e84e3fb2c, em dashes have been changed to en dashes to minimize issues with encoding.