### PR TITLE
Documentation corrections

### DIFF
--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -4325,7 +4325,7 @@ Other Changes
 * The new ``input``, ``side``, ``grid``, and ``fixed`` styles were created,
   and the corresponding displayables use them by default.
 
-* When a style is accessed at init-time, and doesn't exist, we divide it
+* When a style is accessed at init time, and doesn't exist, we divide it
   into two parts at the first underscore. If the second part corresponds to
   an existing style, we create a new style instead of causing an error.
 

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -140,7 +140,7 @@ game/eileen/happy.png, then you can write::
 
     image eileen happy = "eileen/happy.png"
 
-The image statement is run at init-time, before the menus are shown
+The image statement is run at init time, before the menus are shown
 or the start label runs. When not contained inside an ``init`` block,
 image statements are run as if they were placed inside an ``init`` block of
 priority 500.

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -10,7 +10,7 @@ these changes to be reverted, at the cost of losing access to recent
 features.
 
 Incompatible changes to the GUI are documented at :ref:`gui-changes`, as
-such changes only take effect when the gui is regenerated.
+such changes only take effect when the GUI is regenerated.
 
 
 .. _incompatible-7.0:
@@ -26,11 +26,11 @@ init level. To revert to the prior behavior, add to your game::
 
 The :func:`Dissolve`, :func:`ImageDissolve`, and :func:`AlphaDissolve`
 transitions now default to using the alpha channel of the source
-displayables, as if alpha=True was given. To revert this change, add::
+displayables, as if ``alpha=True`` was given. To revert this change, add::
 
     define config.dissolve_force_alpha = False
 
-Showing a movie sprite that is already showing will now re-play the movie.
+Showing a movie sprite that is already showing will now replay the movie.
 To revert to the previous behavior::
 
     define config.replay_movie_sprites = False

--- a/sphinx/source/layeredimage.rst
+++ b/sphinx/source/layeredimage.rst
@@ -264,7 +264,7 @@ Statement Reference
 -------------------
 
 Note that with the conditions in the ``if`` statement, all expressions are
-evaluated at init-time, when the layered image is first defined.
+evaluated at init time, when the layered image is first defined.
 
 Layeredimage
 ^^^^^^^^^^^^

--- a/sphinx/source/style.rst
+++ b/sphinx/source/style.rst
@@ -157,7 +157,7 @@ Examples of style statements are::
         variant "touch"
         take big_red
 
-Style statements are always run at init-time. If a style statement is not
+Style statements are always run at init time. If a style statement is not
 in an ``init`` block, it is automatically placed into an ``init 0`` block.
 
 

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -201,12 +201,12 @@ especially when that dialogue is repeated in more than one place
 inside a label. In some cases, it may be necessary to assign
 a translation identifier directly, using a statement like::
 
-    translate None mylable_03ac197e_1:
+    translate None mylabel_03ac197e_1:
         "..."
 
 Adding labels can also confuse the translation process. To prevent
-translations.::
 this, labels that are given the ``hide`` clause are ignored when generating
+translations.::
 
     label ignored_by_translation hide:
         "..."


### PR DESCRIPTION
This pull request changes the spelling of "init-time" to the more commonly used "init time."