### PR TITLE
render: typos in docstring

### DIFF
--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -797,12 +797,12 @@ cdef class Render:
     def render_to_texture(self, alpha=True):
         """
         Returns a texture constructed from this render. This may return
-        a cached textue, if one has already been rendered.
+        a cached texture, if one has already been rendered.
 
         `alpha` is a hint that controls if the surface should have
         alpha or not.
 
-        This returns a texture that's at the drawable resolultion, which
+        This returns a texture that's at the drawable resolution, which
         may be bigger than the virtual resolution. Use renpy.display.draw.draw_to_virt
         and draw.virt_to_draw to convert between the two resolutions. (For example,
         multiply reverse by draw_to_virt to scale this down for blitting.)


### PR DESCRIPTION
Note: I hope unlike #1491 this won't be rewritten followed by a wordless close. That was rude.