### PR TITLE
Typo corrections in documentation

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1225,9 +1225,9 @@ def Character(name=NotSet, kind=None, **properties):
         and additional elements can be added to the screen.
 
     `advance`
-        If True, the default, the player can click to advance through
+        If true, the default, the player can click to advance through
         the statement, and other means of advancing (such as skip and
-        auto-forward mode) will also work. If False, the player will be
+        auto-forward mode) will also work. If false, the player will be
         unable to move past the say statement unless an alternate means
         (such as a jump hyperlink or screen) is provided.
 

--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1206,7 +1206,7 @@ def Character(name=NotSet, kind=None, **properties):
     These options help to control the display of the name.
 
     `dynamic`
-        If true, then `name` should be a string containing a python
+        If true, then `name` should be a string containing a Python
         expression. That string will be evaluated before each line
         of dialogue, and the result used as the name of the character.
 
@@ -1215,7 +1215,7 @@ def Character(name=NotSet, kind=None, **properties):
     interaction occurs, and the mode that is entered upon display.
 
     `condition`
-        If given, this should be a string containing a python
+        If given, this should be a string containing a Python
         expression. If the expression is false, the dialogue
         does not occur, as if the say statement did not happen.
 

--- a/renpy/common/000window.rpy
+++ b/renpy/common/000window.rpy
@@ -40,7 +40,7 @@ init -1200 python:
         """
         :doc: window
 
-        The python equivalent of the "window show" statement.
+        The Python equivalent of the "window show" statement.
 
         `trans`
             If False, the default window show transition is used. If None,
@@ -65,7 +65,7 @@ init -1200 python:
         """
         :doc: window
 
-        The python equivalent of the "window hide" statement.
+        The Python equivalent of the "window hide" statement.
 
         `trans`
             If False, the default window hide transition is used. If None,

--- a/renpy/common/00action_data.rpy
+++ b/renpy/common/00action_data.rpy
@@ -309,7 +309,7 @@ init -1600 python:
         Adds `value` to `set`.
 
         `set`
-            The set to add to. This may be a python set or list, in which
+            The set to add to. This may be a Python set or list, in which
             case the value is appended to the list.
         `value`
             The value to add or append.

--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -576,7 +576,7 @@ init -1500 python in _console:
         :name: renpy.watch
         :doc: debug
 
-        This watches the given python expression, by displaying it in the
+        This watches the given Python expression, by displaying it in the
         upper-right corner of the screen.
         """
 
@@ -607,7 +607,7 @@ init -1500 python in _console:
         :name: renpy.unwatch
         :doc: debug
 
-        Stops watching the given python expression.
+        Stops watching the given Python expression.
         """
 
         block = [ ( "<console>", 1, expr, [ ]) ]
@@ -629,7 +629,7 @@ init -1500 python in _console:
         :name: renpy.unwatch
         :doc: debug
 
-        Stops watching all python expressions.
+        Stops watching all Python expressions.
         """
 
         unwatchall(None)

--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -284,7 +284,7 @@ init -1500 python:
             A condition that is satisfied when an expression evaluates to true.
 
             `expression`
-                A string giving a python expression.
+                A string giving a Python expression.
             """
 
             if not isinstance(expression, basestring):
@@ -400,7 +400,7 @@ init -1500 python:
             named `name`.
 
             `format`
-                A python format string that's used to format the numbers. This has three values that
+                A Python format string that's used to format the numbers. This has three values that
                 can be substituted in:
 
                 {seen}

--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -240,7 +240,7 @@ init -1500 python:
         """
         :doc: nvl
 
-        The python equivalent of the ``nvl show`` statement.
+        The Python equivalent of the ``nvl show`` statement.
 
         `with_`
             The transition to use to show the NVL-mode window.
@@ -254,7 +254,7 @@ init -1500 python:
         """
         :doc: nvl
 
-        The python equivalent of the ``nvl hide`` statement.
+        The Python equivalent of the ``nvl hide`` statement.
 
         `with_`
             The transition to use to hide the NVL-mode window.
@@ -434,7 +434,7 @@ init -1500 python:
         """
         :doc: nvl
 
-        The python equivalent of the ``nvl clear`` statement.
+        The Python equivalent of the ``nvl clear`` statement.
         """
 
         store.nvl_list = [ ]

--- a/renpy/common/00start.rpy
+++ b/renpy/common/00start.rpy
@@ -247,7 +247,7 @@ label _start:
         # Implement config.window
         _init_window()
 
-    # This has to be python, to deal with a case where _restart may
+    # This has to be Python, to deal with a case where _restart may
     # change across a shift-reload.
     python:
         if _restart is None:
@@ -260,7 +260,7 @@ label _start:
 
 label _invoke_main_menu:
 
-    # Again, this has to be python.
+    # Again, this has to be Python.
     python:
         if _restart:
             renpy.call_in_new_context(_restart[2])

--- a/renpy/common/00style.rpy
+++ b/renpy/common/00style.rpy
@@ -24,7 +24,7 @@
 
 init -1800 python:
 
-    # The style hierarchy root has to be initialized through python
+    # The style hierarchy root has to be initialized through Python
     # code.
     style.default = Style(None)
     style.empty = Style(None)

--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -273,7 +273,7 @@ in parenthesis after the say statement. For example, one can write::
 
     e "Hello, world." (what_color="#8c8")
 
-Arguments to the say statement are first processed by var:`config.say_arguments_callback`,
+Arguments to the say statement are first processed by :var:`config.say_arguments_callback`,
 if it is not None. If any remain, they are then passed to the character,
 which treats them as if they were present when the character was defined.
 So, the example above displays the dialogue in green.


### PR DESCRIPTION
Please verify the capitalization of "true" and "false" in renpy/character.py.