### PR TITLE
[Py3] Use print function in pure python files

### DIFF
--- a/launcher/game/change_icon.py
+++ b/launcher/game/change_icon.py
@@ -317,7 +317,7 @@ def change_icons(oldexe, icofn):
 
     alignment = pe.OPTIONAL_HEADER.SectionAlignment
 
-    # print "Alignment is", alignment
+    # print("Alignment is", alignment)
 
     if len(rsrc) % alignment:
         pad = alignment - (len(rsrc) % alignment)

--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -606,12 +606,12 @@ init python in distribute:
                     if match(match_name, pattern):
                         break
                 else:
-                    print >> self.log, match_name.encode("utf-8"), "doesn't match anything."
+                    print(match_name.encode("utf-8"), "doesn't match anything.", file=self.log)
 
                     pattern = None
                     file_list = None
 
-                print >> self.log, match_name.encode("utf-8"), "matches", pattern, "(" + str(file_list) + ")."
+                print(match_name.encode("utf-8"), "matches", pattern, "(" + str(file_list) + ").", file=self.log)
 
                 if file_list is None:
                     return
@@ -1026,7 +1026,7 @@ init python in distribute:
 
             cmd = [ renpy.fsencode(i.format(**kwargs)) for i in command ]
 
-            # print "\"" + "\" \"".join(cmd) + "\""
+            # print("\"" + "\" \"".join(cmd) + "\"")
 
             try:
                 import sys, os
@@ -1396,13 +1396,13 @@ init python in distribute:
 
         def dump(self):
             for k, v in sorted(self.file_lists.items()):
-                print
-                print k + ":"
+                print()
+                print(k + ":")
 
                 v.sort()
 
                 for i in v:
-                    print "   ", i.name, "xbit" if i.executable else ""
+                    print("   ", i.name, "xbit" if i.executable else "")
 
     class GuiReporter(object):
         """
@@ -1441,7 +1441,7 @@ init python in distribute:
             what = what.replace("[", "{")
             what = what.replace("]", "}")
             what = what.format(**kwargs)
-            print what
+            print(what)
 
         def progress(self, what, done, total, **kwargs):
             what = what.replace("[", "{")

--- a/launcher/game/pefile.py
+++ b/launcher/game/pefile.py
@@ -890,7 +890,7 @@ class SectionStructure(Structure):
         return self.VirtualAddress <= rva < self.VirtualAddress + size
 
     def contains(self, rva):
-        #print "DEPRECATION WARNING: you should use contains_rva() instead of contains()"
+        #print("DEPRECATION WARNING: you should use contains_rva() instead of contains()")
         return self.contains_rva(rva)
 
 

--- a/renpy/common/_developer/developer.rpym
+++ b/renpy/common/_developer/developer.rpym
@@ -573,8 +573,8 @@ label _filename_list:
             for fn in files:
                 fn = os.path.join(dirname, fn)
                 fn = fn[len(config.gamedir) + 1:]
-                print >>f, fn.encode("utf-8", "replace")
-                print fn.encode("utf-8", "replace")
+                print(fn.encode("utf-8", "replace"), file=f)
+                print(fn.encode("utf-8", "replace"))
 
         f.close()
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3533,7 +3533,7 @@ class Interface(object):
 
             renpy.plog(1, "end interact_core")
 
-            # print "It took", frames, "frames."
+            # print("It took", frames, "frames.")
 
     def timeout(self, offset):
         if offset < 0:

--- a/scripts/style_to_statement.py
+++ b/scripts/style_to_statement.py
@@ -4,6 +4,7 @@
 # The result of this probably won't be legal Ren'Py, but it should be
 # a reasonable starting point for conversions.
 
+from __future__ import print_function
 import argparse
 import sys
 import os
@@ -15,6 +16,7 @@ import renpy
 renpy.import_all()
 renpy.config.basedir = '/'
 renpy.config.renpy_base = '/'
+
 
 def main():
 
@@ -30,22 +32,22 @@ def main():
         if not current_name:
             return
 
-        print
+        print()
 
         if current_parent and current_entries:
-            print "style {} is {}:".format(current_name, current_parent)
+            print("style {} is {}:".format(current_name, current_parent))
         elif current_parent:
-            print "style {} is {}".format(current_name, current_parent)
+            print("style {} is {}".format(current_name, current_parent))
         elif current_entries:
-            print "style {}:".format(current_name)
+            print("style {}:".format(current_name))
         else:
-            print "style {}".format(current_name)
+            print("style {}".format(current_name))
 
         for name, expr in current_entries:
             if expr:
-                print "    {} {}".format(name, expr.strip())
+                print("    {} {}".format(name, expr.strip()))
             else:
-                print "    {}".format(name)
+                print("    {}".format(name))
 
 
     for _fn, _lineno, l in renpy.parser.list_logical_lines(args.script):

--- a/scripts/utflf.py
+++ b/scripts/utflf.py
@@ -1,7 +1,10 @@
 # Fixes line endings and adds UTF-8 BOM to all rpy files in a
 # directory.
 
+from __future__ import print_function
+import os
 import sys
+
 
 def process(fn):
     with open(fn, "rb") as f:
@@ -16,7 +19,6 @@ def process(fn):
     with open(fn, "wb") as f:
         f.write(data)
 
-import os
 
 for directory, dirs, files in os.walk(sys.argv[1]):
     for fn in files:
@@ -25,5 +27,5 @@ for directory, dirs, files in os.walk(sys.argv[1]):
         if not fn.endswith(".rpy"):
             continue
 
-        print fn
+        print(fn)
         process(fn)

--- a/scripts/zip_size_change.py
+++ b/scripts/zip_size_change.py
@@ -3,8 +3,10 @@
 # Given two zip files, shows how files have changed in size between
 # them.
 
+from __future__ import print_function
 import argparse
 import zipfile
+
 
 def size_zip(fn):
     zf = zipfile.ZipFile(fn)
@@ -16,6 +18,7 @@ def size_zip(fn):
         rv[filename] = zi.compress_size
 
     return rv
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -37,7 +40,8 @@ def main():
         if old_size == new_size:
             continue
 
-        print "{: 6d} {}".format((new_size - old_size), fn)
+        print("{: 6d} {}".format((new_size - old_size), fn))
+
 
 if __name__ == "__main__":
     main()

--- a/sphinx/source/renpydoc.py
+++ b/sphinx/source/renpydoc.py
@@ -1,4 +1,5 @@
 #@PydevCodeAnalysisIgnore
+from __future__ import print_function
 from pygments.lexers.agile import PythonLexer
 from pygments.token import Token, Name, Operator
 
@@ -67,7 +68,7 @@ def parse_style_node(env, sig, signode):
     ref = m.group(1)
 
     while ref in style_seen_ids:
-        print "duplicate id:", ref
+        print("duplicate id:", ref)
         ref = ref + "_alt"
 
     style_seen_ids.add(ref)


### PR DESCRIPTION
Use the print function in pure Python files.

`launcher/game/distribute.rpy` and `renpy/common/_developer/developer.rpym` both also use the old python2 print statements, but I'm not sure how they get turned into Python code and `from __future__ import print_function` has to be declared at the top of a Python file for it to work properly. So some guidance would be helpful for those two files.