### PR TITLE
Add delay to renpy.sound.set_volume

### DIFF
--- a/renpy/audio/sound.py
+++ b/renpy/audio/sound.py
@@ -58,8 +58,8 @@ set_mixer = renpy.audio.music.set_mixer
 set_queue_empty_callback = renpy.audio.music.set_queue_empty_callback
 
 
-def set_volume(volume, channel="sound"):
-    renpy.audio.music.set_volume(volume, 0, channel=channel)
+def set_volume(volume, delay=0, channel="sound"):
+    renpy.audio.music.set_volume(volume, delay, channel=channel)
 
 
 def set_pan(pan, delay, channel="sound"):


### PR DESCRIPTION
Since renpy.sound is basiacaly a alias of renpy.music, I think set_volume should also have the delay parameter.