### PR TITLE
Rename IMG_SavePNG* to avoid conflict with PygameSDL2's

### DIFF
--- a/module/IMG_savepng.c
+++ b/module/IMG_savepng.c
@@ -34,7 +34,7 @@
 #define png_voidp voidp
 #endif
 
-int IMG_SavePNG(const char *file, SDL_Surface *surf,int compression){
+int renpy_IMG_SavePNG(const char *file, SDL_Surface *surf,int compression){
 	SDL_RWops *fp;
 	int ret;
 
@@ -44,7 +44,7 @@ int IMG_SavePNG(const char *file, SDL_Surface *surf,int compression){
 		return (-1);
 	}
 
-	ret=IMG_SavePNG_RW(fp,surf,compression);
+	ret=renpy_IMG_SavePNG_RW(fp,surf,compression);
 	SDL_RWclose(fp);
 	return ret;
 }
@@ -54,12 +54,12 @@ static void png_write_data(png_structp png_ptr,png_bytep data, png_size_t length
 	SDL_RWwrite(rp,data,1,length);
 }
 
-int IMG_SavePNG_RW(SDL_RWops *src, SDL_Surface *surf,int compression){
+int renpy_IMG_SavePNG_RW(SDL_RWops *src, SDL_Surface *surf,int compression){
 	png_structp png_ptr;
 	png_infop info_ptr;
 	SDL_PixelFormat *fmt=NULL;
 	SDL_Surface *tempsurf=NULL;
-	int ret,funky_format;
+	int ret;
 	unsigned int i;
 	png_colorp palette;
 	Uint8 *palette_alpha=NULL;

--- a/module/IMG_savepng.h
+++ b/module/IMG_savepng.h
@@ -36,14 +36,14 @@ extern "C" {
  * Takes a filename, a surface to save, and a compression level.  The
  * compression level can be 0(min) through 9(max), or -1(default).
  */
-DECLSPEC int SDLCALL    IMG_SavePNG(const char  *file,
+DECLSPEC int SDLCALL    renpy_IMG_SavePNG(const char  *file,
                                     SDL_Surface *surf,
                                     int          compression);
 /**
  * Takes a SDL_RWops pointer, a surface to save, and a compression level.
  * compression can be 0(min) through 9(max), or -1(default).
  */
-DECLSPEC int SDLCALL IMG_SavePNG_RW(SDL_RWops   *src,
+DECLSPEC int SDLCALL renpy_IMG_SavePNG_RW(SDL_RWops   *src,
                                     SDL_Surface *surf,
                                     int          compression);
 #ifdef __cplusplus

--- a/module/core.c
+++ b/module/core.c
@@ -31,7 +31,7 @@ void save_png_core(PyObject *pysurf, SDL_RWops *rw, int compress) {
     surf = PySurface_AsSurface(pysurf);
 
     /* Can't release GIL, since we're not using threaded RWops. */
-    IMG_SavePNG_RW(rw, surf, compress);
+    renpy_IMG_SavePNG_RW(rw, surf, compress);
 }
 
 /* This pixellates a 32-bit RGBA pygame surface to a destination


### PR DESCRIPTION
The conflict appears when linking statically, which I do when working on the emscripten port.
(dynamic linking is partially supported in emscripten but not in our case, and it also introduces a performance penalty.)

The 2 functions sets are not exactly the same and do not have the same signatures, hence why I didn't merge them. Note: there is a 3rd set of IMG_SavePNG functions in SDL2_image.