### PR TITLE
Add missing history_allow_tags set to tutorial and The question.

### DIFF
--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -974,6 +974,7 @@ screen history():
         if not _history_list:
             label _("The dialogue history is empty.")
 
+define gui.history_allow_tags = set()
 
 style history_window is empty
 

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -951,6 +951,7 @@ screen history():
         if not _history_list:
             label _("The dialogue history is empty.")
 
+define gui.history_allow_tags = set()
 
 style history_window is empty
 


### PR DESCRIPTION
This will fix crash when trying to open history in these two example projects.