### PR TITLE
Explicitely close audio on quit

### DIFF
--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -352,6 +352,9 @@ You may be using a system install of python. Please run {0}.sh,
         if renpy.display.draw:
             renpy.display.draw.quit()
 
+        renpy.audio.audio.quit()
+
+
         # Prevent subprocess from throwing errors while trying to run it's
         # __del__ method during shutdown.
         subprocess.Popen.__del__ = popen_del


### PR DESCRIPTION
With Emscripten, this tells the browser to stop calling the audio callback.