### PR TITLE
Fast im.Blur implementation

### DIFF
--- a/module/_renpy.pyx
+++ b/module/_renpy.pyx
@@ -60,7 +60,11 @@ cdef extern from "renpy.h":
                     int,
                     int)
 
-    void xblur32_core(object, object, int)
+    void blur32_core(object, object, object, float, float)
+    void blur24_core(object, object, object, float, float)
+
+    void linblur32_core(object, object, int, int)
+    void linblur24_core(object, object, int, int)
 
     void alphamunge_core(object, object, int, int, int, char *)
 
@@ -198,6 +202,80 @@ def linmap(pysrc, pydst, r, g, b, a):
     # pysrc.unlock()
 
 
+def blur(pysrc, pywrk, pydst, xrad, yrad=None):
+
+    if not isinstance(pysrc, PygameSurface):
+        raise Exception("blur requires a pygame Surface as its first argument.")
+
+    if not isinstance(pywrk, PygameSurface):
+        raise Exception("blur requires a pygame Surface as its second argument.")
+
+    if not isinstance(pydst, PygameSurface):
+        raise Exception("blur requires a pygame Surface as its third argument.")
+
+    if pysrc.get_bitsize() not in (24, 32):
+        raise Exception("blur requires a 24 or 32 bit surface.")
+
+    if pywrk.get_bitsize() != pysrc.get_bitsize() \
+            or pydst.get_bitsize() != pysrc.get_bitsize():
+        raise Exception("blur requires all surfaces have the same bitsize.")
+
+    if pywrk.get_size() != pysrc.get_size() \
+            or pydst.get_size() != pysrc.get_size():
+        raise Exception("blur requires all surfaces have the same size.")
+
+    if yrad is None:
+        yrad = xrad
+
+    if xrad < 0 or yrad < 0:
+        raise Exception("blur requires a positive radius.")
+
+#     pysrc.lock()
+#     pywrk.lock()
+#     pydst.lock()
+
+    if pysrc.get_bitsize() == 32:
+        blur32_core(pysrc, pywrk, pydst, xrad, yrad)
+    else:
+        blur24_core(pysrc, pywrk, pydst, xrad, yrad)
+
+#     pydst.unlock()
+#     pywrk.unlock()
+#     pysrc.unlock()
+
+
+def linblur(pysrc, pydst, radius, vertical=0):
+
+    if not isinstance(pysrc, PygameSurface):
+        raise Exception("linblur requires a pygame Surface as its first argument.")
+
+    if not isinstance(pydst, PygameSurface):
+        raise Exception("linblur requires a pygame Surface as its second argument.")
+
+    if pysrc.get_bitsize() not in (24, 32):
+        raise Exception("linblur requires a 24 or 32 bit surface.")
+
+    if pydst.get_bitsize() != pysrc.get_bitsize():
+        raise Exception("linblur requires both surfaces have the same bitsize.")
+
+    if pydst.get_size() != pysrc.get_size():
+        raise Exception("linblur requires both surfaces have the same size.")
+
+    if radius < 1:
+        raise Exception("linblur requires a non-zero radius.")
+
+#     pysrc.lock()
+#     pydst.lock()
+
+    if pysrc.get_bitsize() == 32:
+        linblur32_core(pysrc, pydst, radius, vertical)
+    else:
+        linblur24_core(pysrc, pydst, radius, vertical)
+
+#     pydst.unlock()
+#     pysrc.unlock()
+
+
 def alpha_munge(pysrc, pydst, srcchan, dstchan, amap):
 
     if not isinstance(pysrc, PygameSurface):
@@ -228,39 +306,6 @@ def alpha_munge(pysrc, pydst, srcchan, dstchan, amap):
 
     # pydst.unlock()
     # pysrc.unlock()
-
-
-
-
-# def xblur(pysrc, pydst, radius):
-
-#     if not isinstance(pysrc, PygameSurface):
-#         raise Exception("blur requires a pygame Surface as its first argument.")
-
-#     if not isinstance(pydst, PygameSurface):
-#         raise Exception("blur requires a pygame Surface as its second argument.")
-
-#     if pysrc.get_bitsize() not in (24, 32):
-#         raise Exception("blur requires a 24 or 32 bit surface.")
-
-#     if pydst.get_bitsize() != pysrc.get_bitsize():
-#         raise Exception("blur requires both surfaces have the same bitsize.")
-
-#     if pydst.get_size() != pysrc.get_size():
-#         raise Exception("blur requires both surfaces have the same size.")
-
-#     pysrc.lock()
-#     pydst.lock()
-
-#     if pysrc.get_bitsize() == 32:
-#         xblur32_core(pysrc, pydst, radius)
-#     else:
-#         # blur24_core(pysrc, pydst, radius)
-#         assert False
-
-
-#     pydst.unlock()
-#     pysrc.unlock()
 
 
 # def stretch(pysrc, pydst, rect):

--- a/module/renpy.h
+++ b/module/renpy.h
@@ -49,13 +49,27 @@ void linmap24_core(PyObject *pysrc,
                 int gmap,
                 int bmap);
 
-#if 0
+void blur32_core(PyObject *pysrc,
+                 PyObject *pywrk,
+                 PyObject *pydst,
+                 float xrad,
+                 float yrad);
 
-void xblur32_core(PyObject *pysrc,
-                  PyObject *pydst,
-                  int radius);
+void blur24_core(PyObject *pysrc,
+                 PyObject *pywrk,
+                 PyObject *pydst,
+                 float xrad,
+                 float yrad);
 
-#endif
+void linblur32_core(PyObject *pysrc,
+                    PyObject *pydst,
+                    int radius,
+                    int vertical);
+
+void linblur24_core(PyObject *pysrc,
+                    PyObject *pydst,
+                    int radius,
+                    int vertical);
 
 void alphamunge_core(PyObject *pysrc,
                      PyObject *pydst,

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -1160,6 +1160,49 @@ class Recolor(ImageBase):
         return self.image.predict_files()
 
 
+class Blur(ImageBase):
+    """
+    :doc: im_im
+
+    An image manipulator that blurs the image manipulator `im` using
+    an elliptical kernel described by `xrad` and optionally `yrad`.
+
+    If `yrad` is None, it will take the value of `xrad` resulting in
+    a circular kernel being used.
+
+    ::
+
+        image logo blurred = im.Blur("logo.png", 1.5)
+    """
+
+    def __init__(self, im, xrad, yrad=None, **properties):
+
+        im = image(im)
+
+        super(Blur, self).__init__(im, xrad, yrad, **properties)
+
+        self.image = im
+        self.rx = xrad
+        self.ry = xrad if yrad is None else yrad
+
+    def get_hash(self):
+        return self.image.get_hash()
+
+    def load(self):
+
+        surf = cache.get(self.image)
+
+        ws = renpy.display.pgrender.surface(surf.get_size(), True)
+        rv = renpy.display.pgrender.surface(surf.get_size(), True)
+
+        renpy.display.module.blur(surf, ws, rv, self.rx, self.ry)
+
+        return rv
+
+    def predict_files(self):
+        return self.image.predict_files()
+
+
 class MatrixColor(ImageBase):
     """
     :doc: im_matrixcolor

--- a/renpy/display/module.py
+++ b/renpy/display/module.py
@@ -152,6 +152,23 @@ def map(src, dst, rmap, gmap, bmap, amap):  # @ReservedAssignment
                      *endian_order(dst, rmap, gmap, bmap, amap))
 
 
+def blur(src, wrk, dst, xrad, yrad=None):  # @ReservedAssignment
+    """
+    This blurs the source surface. It approximates a Gaussian blur
+    using several box blurs with box sizes based on the desired
+    standard deviation.
+
+    Unlike other operations, blur requires an additional surface
+    to use as a holding location for intermediate results. This
+    surface should not be expected to contain anything usable and
+    it's final state is not defined.
+
+    The surfaces must all be the same size and colour depth.
+    """
+
+    convert_and_call(_renpy.blur, src, wrk, dst, xrad, yrad)
+
+
 def twomap(src, dst, white, black):
     """
     Given colors for white and black, linearly maps things


### PR DESCRIPTION
Implements `im.Blur` as a fast Gaussian blur approximation. This is done by combining three passes of a box blur, each of which is done in turn by combining two passes of a linear time one-dimensional blur (existing `xblur` code was refactored and used for this). The final result is a blur method that also operates in linear time. It works with both 32 and 24-bit surfaces, and supports both circular and (symmetrical) elliptical kernels.

Details of the research involved can be found in the material linked in the code comments on the relevant functions, along with a much more detailed explanation that it doesn't make sense to replicate in full here.

Details of usage are documented on the `renpy.display.im.Blur` class.

---

**Examples with Eileen**

<details><summary>Normal</summary>

![norm](https://user-images.githubusercontent.com/591257/50798058-dd7c8900-12ce-11e9-9f9d-542c5d3e26ce.png)
</details>

<details><summary>Foreground focus (background blur)</summary>

```renpy
image bg washington blur = im.Blur('bg washington.jpg', 2)
```
![fore](https://user-images.githubusercontent.com/591257/50798067-e4a39700-12ce-11e9-9182-ecd0e7f41a56.png)
</details>

<details><summary>Background focus (foreground blur)</summary>

```renpy
image eileen happy blur = im.Blur('eileen happy.png', 1.5)
```
![back](https://user-images.githubusercontent.com/591257/50798072-e79e8780-12ce-11e9-8d61-559e12dec578.png)
</details>

<details><summary>Elliptical blur</summary>

```renpy
image bg whitehouse blur = im.Blur('bg whitehouse.jpg', 20, 3)
```
![ellip](https://user-images.githubusercontent.com/591257/50798847-b3789600-12d1-11e9-98a1-b4eb5d745932.png)
</details>