### PR TITLE
shortcut for change_language

### DIFF
--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -623,7 +623,9 @@ def change_language(language, force=False):
     global old_language
 
     renpy.game.preferences.language = language
-
+    if old_language == language and not force:
+        return
+    
     tl = renpy.game.script.translator
 
     renpy.style.restore(style_backup)  # @UndefinedVariable
@@ -640,16 +642,12 @@ def change_language(language, force=False):
     for i in renpy.config.change_language_callbacks:
         i()
 
-    if force or (old_language != language):
+    # Reset various parts of the system. Most notably, this clears the image
+    # cache, letting us load translated images.
+    renpy.exports.free_memory()
 
-        # Reset various parts of the system. Most notably, this clears the image
-        # cache, letting us load translated images.
-        renpy.exports.free_memory()
-
-        # Rebuild the styles.
-        renpy.style.rebuild()  # @UndefinedVariable
-
-        old_language = language
+    # Rebuild the styles.
+    renpy.style.rebuild()  # @UndefinedVariable
 
     for i in renpy.config.translate_clean_stores:
         renpy.python.reset_store_changes(i)
@@ -660,6 +658,7 @@ def change_language(language, force=False):
     if language != old_language:
         renpy.exports.block_rollback()
 
+        old_language = language
 
 def check_language():
     """


### PR DESCRIPTION
change_language is called often even if there was no real language change -> better to shortcut it as early as possible
also block_rollback was never called due to the setting of old_language earlier