### PR TITLE
hw_video: use consistent platform testing

### DIFF
--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -532,7 +532,7 @@ def frequent():
 
         return False
 
-    elif fullscreen and not (renpy.mobile and renpy.config.hw_video):
+    elif fullscreen and not ((renpy.android or renpy.ios) and renpy.config.hw_video):
 
         c = renpy.audio.audio.get_channel("movie")
 


### PR DESCRIPTION
While experimenting with Emscripten, which is flagged as 'mobile', I saw a discrepancy between this patched test (renpy.mobile), and https://github.com/renpy/renpy/blob/92e037510861fa79c359ecc4b22e0e48231e3dcb/renpy/audio/audio.py#L722-L725 (renpy.android or renpy.ios).
So I changed the test to only reference platforms with explicit video hardware support, rather than all mobile platforms.
Not high-priority though :)