### PR TITLE
Allow for outlines when calculating text baselines

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -734,7 +734,7 @@ class Layout(object):
         self.size = size
 
         if all_glyphs:
-            self.baseline = all_glyphs[0].y
+            self.baseline = all_glyphs[0].y + self.yoffset
         else:
             self.baseline = 0
 


### PR DESCRIPTION
<details><summary>Original PR Text</summary>

UPDATE:

Alas, while this seems to be on the right track, it appears to drift out of proportion if the game window is enlarged. Looks like this will need more work, but as of right now I'm not sure where to look. 🙁 

---

Took a crack at solving the outlines issues observed in the `7.1.4-pre` in https://github.com/renpy/renpy/issues/1706#issuecomment-462019637.
Hopefully this is a sane solution. 🙂 

I'm not 100% on how `absolute` sizes for offsets work, so I'm unsure if additional work would be required to support any edge cases there. I did include some in the test case, but they appeared to behave just fine.

~~Fixes 1706~~

<details><summary>Before</summary>

![Before Fix](https://user-images.githubusercontent.com/591257/52526731-e9d07900-2cb4-11e9-8fb9-63b020671982.png)
</details>

<details><summary>After</summary>

![After Fix](https://user-images.githubusercontent.com/591257/52526732-eccb6980-2cb4-11e9-86ed-ce2cf9997979.png)
</details>

<details><summary>Test Case</summary>

```renpy
label main_menu:
    $ _confirm_quit = False
    return

label start:
    show screen default
    show screen outlines
    $ renpy.pause()

image annotation:
    Text('dynamically', outlines=((absolute(1), '0f77', 10, 10),
                                  (absolute(1), '70f7', -10, -10),
                                  (absolute(1), 'f707', 10, -10),
                                  (absolute(1), '7777', -10, 10)),
                        yanchor=renpy.BASELINE,
                        ypos=1.)
    align (.5, .5)
    rotate -20

screen default: # no outlines, everything behaving just fine
    fixed:
        pos 30, 30
        add Solid('#f00', maximum=(580, 1))
        text 'default' yanchor renpy.BASELINE
        text 'works {size=+5}well{/size}' xpos 100 yanchor renpy.BASELINE
        text '{size=-1}baselines{/size} {size=+15}align{/size} {size=-3}hooray!{/size}':
            xpos 250
            yanchor renpy.BASELINE

screen outlines: # outlines cause additional issues :(
    fixed:
        pos 30, 130
        add Solid('#f00', maximum=(580, 1))
        text 'perfect':
            yanchor renpy.BASELINE
            outlines ((absolute(1), '0f77', 0, 10), # 10 - 1 = +9
                      (absolute(1), '70f7', 0, -10), # -10 - 1 = -11 <-- max negative yoffset
                      (absolute(1), 'f707', 10, 0), # 0 - 1 = -1
                      (absolute(1), '7777', -10, 0)) # 0 - 1 = -1
        text 'bit {size=+5}low{/size}':
            xpos 100
            yanchor renpy.BASELINE
            outlines ((5, '0f77', 0, 0),) # 0 - 5 = -5 <-- max negative yoffset
        text '{size=-1}nicely{/size} {image=annotation} {size=-3}bound{/size}':
            xpos 250
            yanchor renpy.BASELINE
            outlines ((1, '0f77', 0, 0), # 0 - 1 = -1
                      (2, '70f7', 0, 1), # 1 - 2 = -1
                      (3, 'f707', 0, 0), # 0 - 3 = -3 <-- max negative yoffset
                      (4, '7777', 0, 2)) # 2 - 4 = -2
```
</details>
</details>

---

Took a **second** crack at solving the outlines issues observed in the `7.1.4-pre` in https://github.com/renpy/renpy/issues/1706#issuecomment-462019637.

In addition to the improved fix, I've also improved the test case, updated the before and after images and included steps to reproduce the issue seen when scaling the game window (using this fix).


<details><summary>Before</summary>

![Before Fix](https://user-images.githubusercontent.com/591257/52910683-08290c80-3293-11e9-83da-1ea3695f9da0.png)
</details>

<details><summary>After</summary>

![After Fix](https://user-images.githubusercontent.com/591257/52910681-fe070e00-3292-11e9-90fb-a988788303d2.png)
</details>

<details><summary>Test Case</summary>

```renpy
init python:
    gui.init(480, 270) # force a small game window so reproducing the scaling issue is easier

label main_menu:
    $ _confirm_quit = False
    return

label start:
    show screen outlines
    $ renpy.pause()

screen outlines:
    fixed:
        pos 30, 60
        add Solid('#f00', maximum=(580, 1))
        text 'perfect':
            yanchor renpy.BASELINE
        text 'above ol':
            xpos 100
            yanchor renpy.BASELINE
            outlines ((2, 'f707', 0, -10),)
        text 'below ol':
            xpos 200
            yanchor renpy.BASELINE
            outlines ((2, '0f77', 0, 10),)
        text 'abs ol':
            xpos 300
            yanchor renpy.BASELINE
            outlines ((absolute(2), '70f7', 0, -10),)
```
</details>

---

**Outstanding issue**

I've been unable to solve this, and would be happy to defer to @renpytom or anyone else with better knowledge of scaling mechanics.

When changing the game window size, the text aligned to the baseline with this fix jumps around at certain intervals. The clearest example of this is reproducible by expanding the game window to the full height of your monitor and then slowly expanding and contracting the game window width. When scaling larger than the default game window size the text gets higher above the baseline before periodically dropping back to it. When scaling below the default game window size, the text drops below the baseline.

The jumps appear to correspond with the outline size jumping from one whole pixel to the next.

Here are some examples:

<details><summary>Bigger</summary>

![Bigger](https://user-images.githubusercontent.com/591257/52910747-f09e5380-3293-11e9-88e0-c7c45d0a6b53.png)
</details>

<details><summary>Smaller</summary>

![Smaller](https://user-images.githubusercontent.com/591257/52910741-e7ad8200-3293-11e9-9166-9b2171c2a880.png)
</details>