### PR TITLE
Fix positional stepping when scaling outlines

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1198,10 +1198,10 @@ class Layout(object):
                 dslist = [ dslist ]
 
             for dsx, dsy in dslist:
-                outlines.append((0, style.drop_shadow_color, self.scale_outline(dsx), self.scale_outline(dsy)))
+                outlines.append((0, style.drop_shadow_color, self.scale_int(dsx), self.scale_int(dsy)))
 
         for size, color, xo, yo in style_outlines:
-            outlines.append((self.scale_outline(size), color, self.scale_outline(xo), self.scale_outline(yo)))
+            outlines.append((self.scale_outline(size), color, self.scale_int(xo), self.scale_int(yo)))
 
         # The outline borders we reserve.
         left = 0


### PR DESCRIPTION
Currently `figure_outlines` uses `scale_outline` to scale both the outline size/width _and_ the outline offsets.

If I understood [this comment](https://github.com/renpy/renpy/issues/1729#issuecomment-465858965) correctly, `scale_outline` purposely ensures that all outlines increase in size in tandem. This makes sense for outline sizes/widths, but less so for the associated offsets.

Switching the offsets to scale using `scale_int` instead eliminates stepping related to positioning while still ensuring that the outlines themselves step together when it comes to sizing. 