### PR TITLE
Cater for restoring to empty attrs

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -966,9 +966,6 @@ class ADVCharacter(object):
 
     def restore_say_attributes(self, predicting, attrs, interact):
 
-        if not attrs:
-            return
-
         if not self.image_tag:
             return
 


### PR DESCRIPTION
In the case where the original image was using nothing but default attributes `attrs` will be an empty tuple, evaluate falsey, and short-circuit the restoration, leaving any temporary attributes still active. Removing the short circuit and only returning early once the `current_attrs` have been explicitly checked against `attrs` resolves this edge case.

Fixes https://github.com/renpy/renpy/issues/1725