### PR TITLE
Let temp attrs and speaking attr to work together

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -940,15 +940,13 @@ class ADVCharacter(object):
         renpy.game.context().say_attributes = None
 
         if interact:
-            if renpy.config.speaking_attribute is not None:
-                speaking = [ renpy.config.speaking_attribute ]
-            else:
-                speaking = [ ]
-
             if temporary_attrs:
-                temporary_attrs = list(temporary_attrs) + speaking
+                temporary_attrs = list(temporary_attrs)
             else:
                 temporary_attrs = [ ]
+
+            if renpy.config.speaking_attribute is not None:
+                temporary_attrs.insert(0, renpy.config.speaking_attribute)
 
         self.resolve_say_attributes(predicting, attrs, skip_trans=temporary_attrs)
 

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -900,17 +900,18 @@ class ShownImageInfo(renpy.object.Object):
 
         nametag = name[0]
 
-        # The set of attributes a matching image must have.
-        required = set(name[1:])
-
         # The set of attributes a matching image may have.
         optional = set(wanted) | set(self.attributes.get((layer, tag), [ ]))
 
-        # Deal with banned attributes..
+        # The set of attributes a matching image must have/not have.
+        # Evaluated in order.
+        required = set()
         for i in name[1:]:
             if i[0] == "-":
                 optional.discard(i[1:])
-                required.discard(i)
+                required.discard(i[1:])
+            else:
+                required.add(i)
 
         for i in remove:
             optional.discard(i)


### PR DESCRIPTION
The use case for this is long dialogues with many temporary attribute expression changes. Currently the `config.speaking_attribute` is only active when using temporary attributes (believe this is a bug). The combination of the two makes sense, however there's currently no way to suppress the `speaking_attribute` for the odd line where, for example, a character is internally monologuing.

In order for the suppression to be possible, a slight change to tag evaluation was required:

At present all tags become part of a `required` set, then those tags are processed, their positive counterparts are removed from the `optional` set, and they themselves are removed from the `required` set. The missing element here is that negative tags do not check the `required` set for their positive counterparts.

The proposed solution slightly alters how `required` image tags are processed such that they are evaluated in order, with negative tags affecting both the `optional` set as before _and_ any tags already added to the `required` set. This results in a last tag wins situation.

For example:
```
e speak -speak #=> ()
e -speak speak #=> ('speak',)
e -speak speak -speak #=> ()
e speak -speak speak #=> ('speak',)
```
You get the idea.

With this done, the original use case can be solved by simply prepending (rather than appending) the `speaking_attribute` to the list of temporary attributes (even if that list is empty, to fix the bug mentioned earlier), allowing it to be overridden by negating it in the temporary attributes. Here's a simple example:

```renpy
label main_menu:
    $ _confirm_quit = False
    pass

layeredimage alice:
    always:
        Text('always', yoffset=-20)
    group A:
        attribute alpha default Text('alpha')
        attribute beta Text('beta')
    group B:
        attribute nospeak default Null(height=21, yoffset=20)
        attribute speak Text('speak', yoffset=20)

define config.speaking_attribute = 'speak'

define alice = Character('Alice', image='alice')

label start:
    show alice at Position(pos=(.25, .5)) with dissolve
    alice 'With no explicit attrs, use the speaking attr.'
    alice @ beta 'Use speaking attr when using tmp attrs too.'
    alice @ -speak 'But allow speaking attr to be suppressed by tmp attrs.'
```

Hope this all makes sense! 😅