### PR TITLE
Fix speaking_attribute suppression

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -945,8 +945,10 @@ class ADVCharacter(object):
             else:
                 temporary_attrs = [ ]
 
+            # Prepend speaking_attribute, if present. This allows it to
+            # be suppressed by a negative temporary_attr, if desired.
             if renpy.config.speaking_attribute is not None:
-                temporary_attrs.append(renpy.config.speaking_attribute)
+                temporary_attrs.insert(0, renpy.config.speaking_attribute)
 
         self.resolve_say_attributes(predicting, attrs, skip_trans=temporary_attrs)
 


### PR DESCRIPTION
Switch back to prepending temporary_attrs with speaking_attribute so
that temporary say attributes have the chance to suppress the
speaking_attribute.

The use case for this is catering for infrequent lines of a character's
internal monologue, for which they are responsible, but do not actively
speak.

Fixes #1738 