### PR TITLE
Documentation corrections

### DIFF
--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -448,25 +448,25 @@ def register_sl_displayable(*args, **kwargs):
 
         Adds a positional argument with `name`
 
-    .. method:: add_property(name):
+    .. method:: add_property(name)
 
         Adds a property with `name`. Properties are passed as keyword
         arguments.
 
-    .. method:: add_style_property(name):
+    .. method:: add_style_property(name)
 
         Adds a family of properties, ending with `name` and prefixed with
         the various style property prefixes. For example, if called with
         ("size"), this will define size, idle_size, hover_size, etc.
 
-    .. method:: add_prefix_style_property(prefix, name):
+    .. method:: add_prefix_style_property(prefix, name)
 
         Adds a family of properties with names consisting of `prefix`,
         a style property prefix, and `name`. For example, if called
         with a prefix of `text_` and a name of `size`, this will
         create text_size, text_idle_size, text_hover_size, etc.
 
-    .. method:: add_property_group(group, prefix=''):
+    .. method:: add_property_group(group, prefix='')
 
         Adds a group of properties, prefixed with `prefix`. `Group` may
         be one of the strings:

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -58,7 +58,7 @@ Text
 There have been a number of text changes that affect text when a window
 is scaled to a non-default size:
 
-* The text is now aligned on it's baseline, rather than at the top of
+* The text is now aligned on its baseline, rather than at the top of
   the text. This is relevant when an absolute outline offset is
   used.
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1013,8 +1013,8 @@ Rarely or Internally Used
 .. var:: config.help = "README.html"
 
     This controls the functionality of the help system invoked by the
-    help button on the main and game menus, or by pressing f1 or
-    command-?.
+    help button on the main and game menus, or by pressing F1 or
+    Command-?.
 
     If None, the help system is disabled and does not show up on
     menus.  If a string corresponding to a label found in the script,
@@ -1259,9 +1259,9 @@ Rarely or Internally Used
 
 .. var:: config.rollback_side_size = .2
 
-	If the rollback side is enabled, the fraction of of the screen on the
-	rollback side that, when clicked or touched, causes a rollback to
-	occur.
+    If the rollback side is enabled, the fraction of of the screen on the
+    rollback side that, when clicked or touched, causes a rollback to
+    occur.
 
 .. var:: config.say_allow_dismiss = None
 

--- a/sphinx/source/screen_optimization.rst
+++ b/sphinx/source/screen_optimization.rst
@@ -24,7 +24,7 @@ Parameter List
 ==============
 
 For best performance, all screens should be defined with a parameter list.
-When a screen doesn't take parameters, it should be define with an empty
+When a screen doesn't take parameters, it should be defined with an empty
 parameter list. The screen::
 
     screen test():
@@ -40,7 +40,7 @@ is faster than::
                 text "[i]"
 
 When a screen is defined without a parameter list, any name used in that
-screen can be redefined when the screen is show. This requires Ren'Py to be
+screen can be redefined when the screen is shown. This requires Ren'Py to be
 more conservative when analyzing the screen, which can limit the optimization
 it performs.
 
@@ -55,7 +55,7 @@ There are two ways Ren'Py automatically predicts screens:
 
 * Ren'Py will predict screens shown by the ``show screen`` and ``call screen``
   statements.
-* Ren'Py will predict screen that will be shown by the :func:`Show` and :func:`ShowMenu`
+* Ren'Py will predict screens that will be shown by the :func:`Show` and :func:`ShowMenu`
   actions.
 
 If screens are shown from Python, it's a good idea to start predicting

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -290,7 +290,7 @@ language, to translate the Ren'Py user interface. ::
          old "Start Game"
          new "Artstay Amegay"
 
-Translating substitutions
+Translating Substitutions
 -------------------------
 
 String substitutions can be translated using the ``!t`` conversion
@@ -306,7 +306,7 @@ the dialogue and string translation systems::
 
 .. _extract-merge-translations:
 
-Extracting and merging string translations
+Extracting and Merging String Translations
 ------------------------------------------
 
 String translations can be extracted from one project, and moved to
@@ -327,8 +327,8 @@ Replace existing translations
 
 Reverse languages
     Reverses the strings before merging. This can be used, for example,
-    to use a set of english -> russian translations to create a
-    russian -> english translation.
+    to use a set of English -> Russian translations to create a
+    Russian -> English translation.
 
 Image and File Translations
 ===========================


### PR DESCRIPTION
Colons were deleted in renpy/sl2/slparser.py to unify the markup on method names.