### PR TITLE
Extend say_attribute_transition_callback with canonical tag list

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -896,7 +896,7 @@ class ADVCharacter(object):
                 images.predict_show(new_image)
 
             else:
-                trans, layer = renpy.config.say_attribute_transition_callback(self.image_tag, mode)
+                trans, layer = renpy.config.say_attribute_transition_callback(self.image_tag, new_image, mode)
 
                 if not skip_trans:
                     if (trans is not None) and (layer is not None):
@@ -989,7 +989,8 @@ class ADVCharacter(object):
         if images.showing(None, (self.image_tag,)):
 
             if not predicting:
-                trans, layer = renpy.config.say_attribute_transition_callback(self.image_tag, "restore")
+                new_image = images.apply_attributes(None, self.image_tag, image_with_attrs)
+                trans, layer = renpy.config.say_attribute_transition_callback(self.image_tag, new_image, "restore")
 
                 if interact:
                     if (trans is not None) and (layer is not None):

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -940,11 +940,12 @@ auto_clear_screenshot = True
 allow_duplicate_labels = False
 
 
-def say_attribute_transition_callback(tag, mode):
+def say_attribute_transition_callback(tag, attrs, mode):
     """
     Returns the say attribute transition to use, and the layer the transition
     should be applied to (with None being a valid layer.
 
+    Attrs is the list of tags/attributes of the incoming image
     Mode is one of "permanent", "temporary", or "restore"
     """
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -165,8 +165,9 @@ These control transitions between various screens.
     This is a function that return a transition to apply and a layer to
     apply it on
 
-    This should be a function that takes two arguments, the image tag
-    being shown, and a `mode` parameter that is one of:
+    This should be a function that takes three arguments, the image tag
+    being shown, a tuple of tags describing the image being shown, and a
+    `mode` parameter that is one of:
 
     * "permanent", for permanent attribute change (one that lasts longer
       than the current say statement).


### PR DESCRIPTION
Follows from discussion and concept in https://github.com/renpy/renpy/issues/1761#issuecomment-473678693

This provides context to the callback about the incoming image it's affecting with the transition. This can be used in isolation, or with the current state to intelligently utilise a transition based upon the tags/attributes of the image being displayed.

---

For example, this would allow transitions to be selected based on which attributes are/will be changing:

```renpy
init python hide:
    dissolve_attrs = {'running', 'walking', 'jumping', 'skipping'}

    def example(tag, attrs, mode):
        current_attrs = _set(renpy.get_attributes(tag))
        future_attrs = _set(attrs)
        future_attrs.remove(tag)
        # calc attrs that are actually changing, not just those passed
        changed_attrs = current_attrs ^ future_attrs 
        if dissolve_attrs & changed_attrs:
            return dissolve, config.say_attribute_transition_layer
        return config.say_attribute_transition, config.say_attribute_transition_layer

    config.say_attribute_transition_callback = example
```