### PR TITLE
Add ability to parse kerning messages of BMFont fonts

### DIFF
--- a/renpy/text/font.py
+++ b/renpy/text/font.py
@@ -384,6 +384,10 @@ class BMFont(ImageFont):
                 self.width[c] = w + xo
                 self.advance[c] = xadvance
                 self.offsets[c] = (xo, yo)
+            elif kind == "kerning":
+                first = unichr(int(args["first"]))
+                second = unichr(int(args["second"]))
+                self.kerns[first + second] = int(args["amount"])
 
         f.close()
 


### PR DESCRIPTION
This allows the BMFont object to understand "kerning" lines embedded within BMFont definitions whereas previously they would be ignored.
The kerning information is added to the existing "self.kerns" property.

I suspect this should have originally been the case as well, given that the entire kerning support system is already in place and kerning support is mentioned in the documentation for BMFonts.