### PR TITLE
Unbreak ARM build on BSDs

### DIFF
--- a/module/ffmedia.c
+++ b/module/ffmedia.c
@@ -10,7 +10,7 @@
 
 #if defined(__arm__) && !(__MACOS__ || __IPHONEOS__)
 #define USE_MEMALIGN
-#include <malloc.h>
+#include <stdlib.h>
 #endif
 
 /* The output audio sample rate. */
@@ -723,7 +723,7 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 
 
 #ifdef USE_MEMALIGN
-    rv->pixels = memalign(16, rv->pitch * rv->h);
+    posix_memalign(&rv->pixels, 16, rv->pitch * rv->h);
     memset(rv->pixels, 0, rv->pitch * rv->h);
 #else
     rv->pixels = SDL_calloc(1, rv->pitch * rv->h);


### PR DESCRIPTION
[FreeBSD](https://github.com/freebsd/freebsd/commit/2ffad81b1757554bf9413d11af0e92c93a94575b), [DragonFly](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/02b66c54cac986a0bf93435b8d5ae1b17521515b), [OpenBSD](https://github.com/openbsd/src/commit/d88f57029e5acaaaf028633c7fa15c5d7325c5cc) don't support `<malloc.h>`. `aligned_alloc` would work on all platforms but it's C11 while module/setuplib.py currently passes `-std=gnu99`, so use `posix_memalign` for now.

http://beefy8.nyi.freebsd.org/data/head-armv6-default/p494472_s344734/logs/errors/renpy-7.1.3.log
http://www.ipv6proxy.net/go.php?u=http://beefy15.nyi.freebsd.org/data/112armv6-quarterly/499227/logs/errors/renpy-7.2.2.log
http://www.ipv6proxy.net/go.php?u=http://beefy15.nyi.freebsd.org/data/120armv6-quarterly/498627/logs/errors/renpy-7.2.2.log
http://www.ipv6proxy.net/go.php?u=http://beefy16.nyi.freebsd.org/data/head-armv7-default/p499067_s346255/logs/errors/renpy-7.2.2.log
http://www.ipv6proxy.net/go.php?u=http://beefy13.nyi.freebsd.org/data/120armv7-quarterly/499069/logs/errors/renpy-7.2.2.log
