### PR TITLE
Keep vanilla python's late import binding

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -744,7 +744,7 @@ class RenpyImporter(object):
         code = compile(source, filename, 'exec', renpy.python.old_compile_flags, 1)
         exec code in mod.__dict__
 
-        return mod
+        return sys.modules[fullname]
 
     def get_data(self, filename):
         return load(filename).read()


### PR DESCRIPTION
In python it's possible for a module to meddle with `sys.modules` during it's initialisation, this allows it to dynamically redefine itself on-the-fly, it's not common, but it happens. In vanilla python assignments of imported modules take place after the module is exec'd, however in renpy the opposite is true. This early assignment can lead to a case where the imported module does not match the value in `sys.modules` and subsequent `import`s yield a different result. This is shown in the simple (albeit contrived) test case provided, along with output samples pre- and post-patch.

#### Test Case

**game/lib.py**
```py
from sys import modules
from types import ModuleType
mod = modules[__name__] = ModuleType(__name__)
del ModuleType, modules

mod.a = 'hello'
```

**game/script.rpy**
```renpy
init python:
    import sys
    import lib
    print('1 ', lib is sys.modules['lib'])
    try:
        print('1a', lib.a)
    except AttributeError as e:
        print('1a', e)
    import lib
    print('2 ', lib is sys.modules['lib'])
    print('2a', lib.a)

label start:
    $ _confirm_quit = False
    $ renpy.pause()
```

**before patch**
```
1  False
1a 'module' object has no attribute 'a'
2  True
2a hello
```

**after patch**
```
1  True
1a hello
2  True
2a hello
```