### PR TITLE
Python module bytecode

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -184,6 +184,7 @@ init -1900 python:
             config.menu_actions = False
 
         if version <= (7, 2, 2):
+            config.loadable_boolean = True
             config.say_attribute_transition_callback_attrs = False
 
     # The version of Ren'Py this script is intended for, or

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -825,6 +825,9 @@ preload_fonts = [ ]
 # Should Ren'Py process multiple ATL events in a single update?
 atl_multiple_events = True
 
+# Should renpy.loadable return a boolean?
+loadable_boolean = False
+
 # A callback that's called when checking to see if a file is loadable.
 loadable_callback = None
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1953,12 +1953,13 @@ def loadable(filename):
     """
     :doc: file
 
-    Returns True if the given filename is loadable, meaning that it
-    can be loaded from the disk or from inside an archive. Returns
-    False if this is not the case.
+    Returns an int representing the origin from which the given filename
+    is loadable, meaning that it can be loaded from the disk, or from
+    inside an archive/APK. Returns False if this is not the case.
     """
 
-    return renpy.loader.loadable(filename)
+    rv = renpy.loader.loadable(filename)
+    return bool(rv) if renpy.config.loadable_boolean else rv
 
 
 @renpy_pure

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1161,6 +1161,11 @@ Rarely or Internally Used
     images used by that interaction have loaded. (Yeah, it's a lousy
     name.)
 
+.. var:: config.loadable_boolean = False
+
+    If True, :func:`renpy.loadable` will return True rather than
+    an integer representing the origin of the loadable file.
+
 .. var:: config.loadable_callback = None
 
     When not None, a function that's called with a filename. It should return


### PR DESCRIPTION
This adds support for compiling `.py` files in `game/` and `game/site-packages/` (when on disk) to their `.pyo` equivalents to accelerate module loading, and to use those `.pyo` files when present in archives. Unfortunately it's not the most straight forward process. This sort of thing looks much more accessible in py3, but since py2 is well defined, and unlikely to change, I'm hoping this is acceptable (or at least on the road to being so) until py3 rolls around.

For this change it's necessary to know the origin of code (disk, rpa, apk). In order to do this `renpy.loadable` (and the cache that backs it) has been tweaked to return (truthy) `int` constants rather than `True`. An appropriate compat config has been added to maintain the public API for older script versions.

The search order for loadable files is defined thus (`__debug__` is `False` when running with `-O`):
https://github.com/renpy/renpy/blob/3165b2a08c45e105ff55a130e219cad4aea23d6b/renpy/loader.py#L699-L701

If a compiled file is selected, the corresponding `.py` file is looked for on disk, and if found, used to check the compiled file timestamp and if needed recompile it (if missing or mismatched timestamps). If the `.py` is _not_ found on disk, the compiled file found originally is used without further conditioning.

This results in a loading preference hierarchy of:
- `.pyo` files on disk that are in sync with their corresponding `.py` file (also on disk)
- `.py` files on disk (which will compile a `.pyo` for next load)
- `.pyo` files on disk (with no corresponding `.py` file)
- `.pyo` files in rpa or apks
- `.py` files in rpa or apks

I appreciate this isn't a small change and will likely require some time to mull over, so thanks for looking! 🙂 