### PR TITLE
Capitialise first character only with !c

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -189,8 +189,8 @@ class Formatter(string.Formatter):
         if "l" in conversion:
             value = value.lower()
 
-        if "c" in conversion:
-            value = value.capitalize()
+        if "c" in conversion and value:
+            value = value[0].upper() + value[1:]
 
         return value
 

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -104,7 +104,7 @@ Images Directory
 
 The image directory is named "images", and is placed under the game directory.
 When a file with the .jpg or .png extension is placed underneath this directory,
-the extension is stripped, the rest of the filename is forced to lower case,
+the extension is stripped, the rest of the filename is forced to lowercase,
 and the resulting filename is used as the image name if an image with that
 name has not been previously defined.
 

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -112,8 +112,10 @@ The ``!t`` flag will translate the interpolated string::
     g "I'm [mood!t] to see you."
 
 
-The ``!u`` flag forces the text to upper case, the ``!l`` flag forces the
-text to lower-case, and the ``!c`` flag capitalizes the text.
+The ``!u`` flag forces the text to uppercase and the ``!l`` flag forces the
+text to lowercase. The ``!c`` flag acts only on the first character,
+capitalizing it. These flags may be combined, for example using ``!cl`` would
+capitalize the first character, and force the remaining text to lowercase.
 
 
 Styling and Text Tags

--- a/sphinx/source/translating_renpy.rst
+++ b/sphinx/source/translating_renpy.rst
@@ -16,7 +16,7 @@ To create a new translation:
 2. On the preferences page, choose "Open launcher project".
 3. Choose "Generate Translations."
 4. Enter the name of the language to translate to. This should consist of
-   lower-case ASCII characters and underscores, so "japanese", "russian",
+   lowercase ASCII characters and underscores, so "japanese", "russian",
    or "ancient_klingon" are all valid language names.
 5. Choose "Generate Translations."
 


### PR DESCRIPTION
`str.capitalize` not only uppercases the first character, but also lowercases the remainder of the string. This presents problems in some conditions:

Example:
```py
>>> surname = 'da Silva'
>>> surname.capitalize()
'Da silva'
>>> c = lambda s: s[0].upper() + s[1:] if s else s
>>> c(surname)
'Da Silva'
>>> c('') # value check is so we don't throw on empty string
''
```
```renpy
eileen "Hello, [firstname] [surname]!"
ds "Please, Eileen, just call me [surname!c]."
```

The alternative presented here seems like it should cover most cases where capitalisation is wanted, i.e. beginning of sentences, while providing a better experience when dealing with multipart names and other strings with intentional capitalisation. Another good example might be `the University of Massachusetts`.

Ref: [Initial capitalization of foreign surnames when starting a sentence](https://english.stackexchange.com/questions/185852/initial-capitalization-of-foreign-surnames-when-starting-a-sentence)

---

**EDIT** - Also worth noting, that this really doesn't take anything away as, if the behaviour of Python's `capitialize` is truly desired for a given situation, it can be achieved by simply combining flags: `!lc`.