### PR TITLE
Suppress hover/click-capture if screen insensitive

### DIFF
--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -680,8 +680,9 @@ class ScreenDisplayable(renpy.display.layout.Container):
         rv.focus_screen = self
 
         hiding = (self.phase == OLD) or (self.phase == HIDE)
+        sensitive = renpy.python.py_eval(self.screen.sensitive)
 
-        rv.blit(child, (0, 0), focus=not hiding, main=not hiding)
+        rv.blit(child, (0, 0), focus=sensitive and not hiding, main=not hiding)
         rv.modal = self.modal and not hiding
 
         return rv

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -118,6 +118,10 @@ expression. It takes the following properties:
     from interacting with displayables below it, except
     for the default keymap.
 
+`sensitive`
+    An expression that determines whether the screen is sensitive or not.
+    This expression is evaluated at least once per interaction.
+
 `tag`
     Parsed as a name, not an expression. This specifies a tag
     associated with this screen. Showing a screen replaces other


### PR DESCRIPTION
Related to https://github.com/renpy/renpy/issues/1755

The current implementation doesn't seem to fulfil all the "key features" or the original suggestion, specifically:
> - Events such as select and hover should not occur or trigger visual changes
> - The non-interactive screen should not obstruct interactivity with other screens/layers

This PR achieves those aims, however the `sensitive` expression is now eval'd in two separate places. Obviously this isn't ideal, so perhaps there's a better way.

Here's a test case demonstrating and describing expected functionality:

Test Case:
```renpy
image _ = Solid('000e')
image r = Solid('f773', xysize=(320, 240))
image b = Solid('7ff3', xysize=(320, 240))


label main_menu:
    $ _confirm_quit = False
    return


label start:
    scene _
    show screen example
    while True:
        call screen empty
    return

label act:
    'Button (red square) begins active, while the game is in screen mode.'
    'Clicking it moves the game into say mode, i.e. displaying these texts.'
    'The button should still visible, but inert, unable to be hovered ...'
    '... or capture clicks. Clicking it should advance this text.'
    'Now we leave say mode, and the button should be active once more.'
    return

screen example:
    sensitive renpy.get_mode() == 'screen'
    vbox:
        align .5, .5
        imagebutton idle 'r' hover 'b' action Call('act')
        text 'Click red square!' xalign .5

screen empty():
    pass
```