### PR TITLE
translation: unify base path in string source comments

### DIFF
--- a/renpy/translation/generation.py
+++ b/renpy/translation/generation.py
@@ -32,6 +32,7 @@ import collections
 import shutil
 
 from renpy.translation import quote_unicode
+from renpy.parser import elide_filename
 
 ################################################################################
 # Translation Generation
@@ -291,7 +292,7 @@ def write_strings(language, filter, min_priority, max_priority, common_only):  #
         for s in sl:
             text = filter(s.text)
 
-            f.write(u"    # {}:{}\n".format(s.elided, s.line))
+            f.write(u"    # {}:{}\n".format(elide_filename(s.filename), s.line))
             f.write(u"    old \"{}\"\n".format(quote_unicode(s.text)))
             f.write(u"    new \"{}\"\n".format(quote_unicode(text)))
             f.write(u"\n")


### PR DESCRIPTION
In Ren'Py translations, there are comments about the original path containing the translatable string:
```
# game/script.rpy:27
translate french start_a170b500:

    # e "You've created a new Ren'Py game."
    e "You've created a new Ren'Py game."

translate french strings:

    # script.rpy:7
    old "Eileen"
    new "Eileen"
```

The script path is not consistent between translate blocks and single strings.

This patch makes them consistent (and incidentally improves the quality of my PO exporter's output ;)), using Ren'Py function `elide_filename`.

```
script.rpy:27 -> game/script.rpy:27
00accessibility.rpy:76 -> renpy/common/00accessibility.rpy:76
```