### PR TITLE
More say transition changes

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -951,7 +951,7 @@ class ADVCharacter(object):
             attrs = images.get_attributes(None, self.image_tag)
 
             if self.resolve_say_attributes(predicting, temporary_attrs):
-                mode = 'hybrid' if mode else 'temporary'
+                mode = 'both' if mode else 'temporary'
 
         if mode:
             after = images.get_attributes(None, self.image_tag)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -144,8 +144,8 @@ The new :var:`config.notify` variable makes it possible to intercept the
 notification system and do your own thing.
 
 The interface of :var:`config.say_attribute_transition_callback` has been
-changed in an incompatible way, to allow a reason for the transition
-to be given.
+changed in an incompatible way, to allow the lists of old and new tags to be
+given.
 
 Fixes
 -----

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -144,7 +144,7 @@ The new :var:`config.notify` variable makes it possible to intercept the
 notification system and do your own thing.
 
 The interface of :var:`config.say_attribute_transition_callback` has been
-changed in an incompatible way, to allow the lists of old and new tags to be
+changed in an incompatible way, to allow sets of old and new tags to be
 given.
 
 Fixes

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -174,10 +174,10 @@ These control transitions between various screens.
       than the current say statement).
     * "temporary", for a temporary attribute change (one that is restored
       at the end of the current say statement).
-    * "hybrid", for a simultaneous permanent and temporary attribute change
+    * "both", for a simultaneous permanent and temporary attribute change
       (one that in part lasts longer than the current say statement, and in
       part is restored at the end of the current say statement).
-    * "restore", for when a temporary (or hybrid) change is being restored.
+    * "restore", for when a temporary (or both) change is being restored.
 
     This should return a 2-component tuple, consiting of:
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -165,15 +165,19 @@ These control transitions between various screens.
     This is a function that return a transition to apply and a layer to
     apply it on
 
-    This should be a function that takes three arguments, the image tag
-    being shown, a tuple of tags describing the image being shown, and a
-    `mode` parameter that is one of:
+    This should be a function that takes four arguments, the image tag
+    being shown, a `mode` parameter, a `set` containing pre-transition tags
+    and a `set` containing post-transition tags. Where the value of the
+    `mode` paramater is one of:
 
     * "permanent", for permanent attribute change (one that lasts longer
       than the current say statement).
     * "temporary", for a temporary attribute change (one that is restored
       at the end of the current say statement).
-    * "restore", for when a temporary change is being restored.
+    * "hybrid", for a simultaneous permanent and temporary attribute change
+      (one that in part lasts longer than the current say statement, and in
+      part is restored at the end of the current say statement).
+    * "restore", for when a temporary (or hybrid) change is being restored.
 
     This should return a 2-component tuple, consiting of:
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -23,9 +23,15 @@ taken from the control string. To revert to the old fixed order, use::
 
     define config.keep_side_render_order = False
 
-The interface of :var:`config.say_attribute_transition_callback` has been
-changed in an incompatible way, to allow a the reason for the transition
-to be given.
+The interface of :var:`config.say_attribute_transition_callback` has
+been changed in an incompatible way, to allow the lists of old and new
+tags to be given. To revert to the old interface, use::
+
+    define config.say_attribute_transition_callback_attrs = False
+
+It's mode parameter has also been slightly changed, and will now return
+a value of ``hybrid`` when a hybrid ``permanent`` and ``temporary``
+attribute transition is occuring.
 
 .. _incompatible-7.2.2:
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -24,8 +24,8 @@ taken from the control string. To revert to the old fixed order, use::
     define config.keep_side_render_order = False
 
 The interface of :var:`config.say_attribute_transition_callback` has
-been changed in an incompatible way, to allow the lists of old and new
-tags to be given. To revert to the old interface, use::
+been changed in an incompatible way, to allow sets of old and new tags
+to be given. To revert to the old interface, use::
 
     define config.say_attribute_transition_callback_attrs = False
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -19,7 +19,7 @@ such changes only take effect when the GUI is regenerated.
 -----
 
 The order in which children of the ``side`` layout are drawn is now
-taken from the control string. To reverty to the old fixed order, use::
+taken from the control string. To revert to the old fixed order, use::
 
     define config.keep_side_render_order = False
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -30,7 +30,7 @@ tags to be given. To revert to the old interface, use::
     define config.say_attribute_transition_callback_attrs = False
 
 It's mode parameter has also been slightly changed, and will now return
-a value of ``hybrid`` when a hybrid ``permanent`` and ``temporary``
+a value of ``both`` when both a ``permanent`` and ``temporary``
 attribute transition is occuring.
 
 .. _incompatible-7.2.2:


### PR DESCRIPTION
Fixes #1850.

The proposed solution is alter the behaviour of `handle_say_attributes` to:
- Store the image before state
- Resolve permanent attributes
- Resolve temporary attributes if necessary
- Store the image after state
- Calculate the transition only once, and only if the before and after states differ

This also allows the interface of `say_attribute_transition_callback` to be made more useful by passing down the before and after states, rather than the current API which only passes down the before state. The relevant documentation has been updated to explain and reflect this.

A new value for the `mode` parameter has been added to cover the case where a transition is being built to cover a simultaneous change to permanent and temporary attributes: `hybrid`. This too has been documented as appropriate.