### PR TITLE
Fix adjustment bug

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1576,7 +1576,7 @@ class Side(Container):
                 try:
                     rend = render(pos_d[pos], width, height, st, at)
                     rv = max(owidth, rend.width), max(oheight, rend.height)
-                    rend.kill()
+                    renpy.display.render.invalidate(pos_d[pos])
                     return rv
                 finally:
                     renpy.display.render.sizing = old_sizing

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -279,7 +279,7 @@ def invalidate(d):
     a redraw to start.
     """
 
-    if (not rendering) and (not per_frame):
+    if (not rendering) and (not per_frame) and (not sizing):
         redraw(d, 0)
         return
 


### PR DESCRIPTION
This is fix #1875 
Also added an additional condition to the `invalidate` that doesn't cause excessive redraw, in the case of sizing outside render.