### PR TITLE
rapt: prevent gradle from stopping Ren'Py when run in the background

### DIFF
--- a/launcher/game/mobilebuild.rpy
+++ b/launcher/game/mobilebuild.rpy
@@ -194,7 +194,9 @@ init -1 python:
                     kwargs["stdin"] = subprocess.PIPE
 
                 try:
-                    self.process = subprocess.Popen(cmd, cwd=renpy.fsencode(RAPT_PATH), stdout=f, stderr=f, startupinfo=startupinfo, **kwargs)
+                    self.process = subprocess.Popen(cmd, cwd=renpy.fsencode(RAPT_PATH), stdout=f, stderr=f, stdin=subprocess.PIPE, startupinfo=startupinfo, **kwargs)
+                    # avoid SIGTTIN caused by e.g. gradle doing empty read on terminal stdin
+                    self.process.stdin.close()
                 except:
                     import traceback
                     traceback.print_exc(file=f)


### PR DESCRIPTION
I've eventually tracked down this annoying bug that silently paused the Ren'Py process whenever I started an Android build, if Ren'Py was running in the background (e.g. `./renpy.sh &`).

I couldn't find a way to make gradle behave, so I implemented the equivalent of `< /dev/null`.