### PR TITLE
Make automatic_images support webp

### DIFF
--- a/renpy/common/00obsolete.rpy
+++ b/renpy/common/00obsolete.rpy
@@ -86,12 +86,13 @@ init 1900 python hide:
             if fn.startswith("_"):
                 continue
 
-            # Only .png and .jpg
-            if not fn.lower().endswith(".png") and not fn.lower().endswith(".jpg"):
+            # Only .png, .jpg, .webp
+            if not any(fn.lower().endswith(x)
+                       for x in ['.png', '.jpg', '.webp']):
                 continue
 
             # Strip the extension, replace slashes.
-            shortfn = fn[:-4].replace("\\", "/")
+            shortfn = fn.rsplit('.', 1)[0].replace("\\", "/")
 
             # Determine the name.
             name = ( shortfn, )


### PR DESCRIPTION
I am not sure just why is this feature in 00obsolete.rpy, but not supporting webp when RenPy itself does otherwise sounds like an oversight.