### PR TITLE
web: set variants according to what the browser runs on

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -323,15 +323,15 @@ screen navigation():
 
         textbutton _("About") action ShowMenu("about")
 
-        if renpy.variant("pc"):
+        if renpy.variant("pc") or (renpy.variant("web") and not renpy.variant("mobile")):
 
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            if not renpy.variant("web"):
+        if renpy.variant("pc"):
 
-                ## The quit button is banned on iOS and unnecessary on Android and Web.
-                textbutton _("Quit") action Quit(confirm=not main_menu)
+            ## The quit button is banned on iOS and unnecessary on Android and Web.
+            textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button
@@ -727,7 +727,7 @@ screen preferences():
             hbox:
                 box_wrap True
 
-                if renpy.variant("pc"):
+                if renpy.variant("pc") or renpy.variant("web"):
 
                     vbox:
                         style_prefix "radio"

--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -328,8 +328,10 @@ screen navigation():
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            ## The quit button is banned on iOS and unnecessary on Android.
-            textbutton _("Quit") action Quit(confirm=not main_menu)
+            if not renpy.variant("web"):
+
+                ## The quit button is banned on iOS and unnecessary on Android and Web.
+                textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -2043,8 +2043,8 @@ and choosing the entries that apply to the current platform.
    to allow precise pointing.
 
 ``"web"``
-    Defined when running inside a web browser. There are no guarantees
-    as to what the hardware that runs the web browser is like.
+   Defined when running inside a web browser. Check other variants to
+   detect what the browser runs on.
 
 ``None``
    Always defined.

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -2035,7 +2035,7 @@ and choosing the entries that apply to the current platform.
    also defined).
 
 ``"mobile"``
-   Defined on mobile platforms, such as Android and iOS.
+   Defined on mobile platforms, such as Android, iOS and mobile web browsers.
 
 ``"pc"``
    Defined on Windows, Mac OS X, and Linux. A PC is expected to have
@@ -2043,8 +2043,7 @@ and choosing the entries that apply to the current platform.
    to allow precise pointing.
 
 ``"web"``
-   Defined when running inside a web browser. Check other variants to
-   detect what the browser runs on.
+   Defined when running inside a web browser.
 
 ``None``
    Always defined.

--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -323,8 +323,10 @@ screen navigation():
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            ## The quit button is banned on iOS and unnecessary on Android.
-            textbutton _("Quit") action Quit(confirm=not main_menu)
+            if not renpy.variant("web"):
+
+                ## The quit button is banned on iOS and unnecessary on Android and Web.
+                textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button

--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -318,15 +318,15 @@ screen navigation():
 
         textbutton _("About") action ShowMenu("about")
 
-        if renpy.variant("pc"):
+        if renpy.variant("pc") or (renpy.variant("web") and not renpy.variant("mobile")):
 
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            if not renpy.variant("web"):
+        if renpy.variant("pc"):
 
-                ## The quit button is banned on iOS and unnecessary on Android and Web.
-                textbutton _("Quit") action Quit(confirm=not main_menu)
+            ## The quit button is banned on iOS and unnecessary on Android and Web.
+            textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button
@@ -771,7 +771,7 @@ screen preferences():
             hbox:
                 box_wrap True
 
-                if renpy.variant("pc"):
+                if renpy.variant("pc") or renpy.variant("web"):
 
                     vbox:
                         style_prefix "radio"

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -328,15 +328,15 @@ screen navigation():
 
         textbutton _("About") action ShowMenu("about")
 
-        if renpy.variant("pc"):
+        if renpy.variant("pc") or (renpy.variant("web") and not renpy.variant("mobile")):
 
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            if not renpy.variant("web"):
+        if renpy.variant("pc"):
 
-                ## The quit button is banned on iOS and unnecessary on Android and Web.
-                textbutton _("Quit") action Quit(confirm=not main_menu)
+            ## The quit button is banned on iOS and unnecessary on Android and Web.
+            textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button
@@ -738,7 +738,7 @@ screen preferences():
             hbox:
                 box_wrap True
 
-                if renpy.variant("pc"):
+                if renpy.variant("pc") or renpy.variant("web"):
 
                     vbox:
                         style_prefix "radio"

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -333,8 +333,10 @@ screen navigation():
             ## Help isn't necessary or relevant to mobile devices.
             textbutton _("Help") action ShowMenu("help")
 
-            ## The quit button is banned on iOS and unnecessary on Android.
-            textbutton _("Quit") action Quit(confirm=not main_menu)
+            if not renpy.variant("web"):
+
+                ## The quit button is banned on iOS and unnecessary on Android and Web.
+                textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
 style navigation_button is gui_button


### PR DESCRIPTION
This proposal detects additional variants by querying the browser.

This allows the same web game to e.g. plays with a mobile UI on mobile, and with a full-blown UI on desktop/"pc". This can be tested with real hardware as well as "Responsive Design Mode" in browsers.

I'm not entirely sure about setting "android" and "ios", maybe some games use it to target OS-specific features not available through the browser.

(tested on 7.3.2.320, master is broken with the on-going GL work AFAICS)