### PR TITLE
web: detect when fullscreen status changed externally

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3419,6 +3419,11 @@ class Interface(object):
 
                     size = (ev.w // self.dpi_scale, ev.h // self.dpi_scale)
 
+                    # Refresh fullscreen status (e.g. user pressed Esc. in browser)
+                    main_window = pygame.display.get_window()
+                    self.fullscreen = main_window is not None and bool(main_window.get_window_flags() & (pygame.WINDOW_FULLSCREEN_DESKTOP|pygame.WINDOW_FULLSCREEN))
+                    renpy.game.preferences.fullscreen = self.fullscreen
+
                     if pygame.display.get_surface().get_size() != ev.size:
                         self.set_mode(size)
 

--- a/renpy/gl/gldraw.pyx
+++ b/renpy/gl/gldraw.pyx
@@ -186,6 +186,10 @@ cdef class GLDraw:
         if renpy.android:
             fullscreen = False
 
+        # Refresh fullscreen status (e.g. user pressed Esc. in browser)
+        main_window = pygame.display.get_window()
+        self.old_fullscreen = main_window is not None and bool(main_window.get_window_flags() & (pygame.WINDOW_FULLSCREEN_DESKTOP|pygame.WINDOW_FULLSCREEN))
+
         if fullscreen != self.old_fullscreen:
 
             self.did_init = False


### PR DESCRIPTION
When Ren'Py "caches" the fullscreen status, this lead to issues in RenPyWeb, as exiting fullscreen can be triggered directly by the user pressing "Esc." (handled by the browser, rather than requested by Ren'Py/SDL2). This makes Ren'Py keep requesting fullscreen right after the user exits it.

Getting the low-level fullscreen status is a bit convoluted but I could do it without modifying the API.