### PR TITLE
remove callback on stop

### DIFF
--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -279,6 +279,7 @@ def stop(channel="music", fadeout=None):
             c.last_changed = t
             ctx.last_filenames = [ ]
             ctx.last_tight = False
+            c.callback = None
 
         except:
             if renpy.config.debug_sound:


### PR DESCRIPTION
Remove callback when a channel is stopped, otherwise the empty queue triggers the the callback, which then fills the queue and filling the queue starts the playback again.