### PR TITLE
Fixed bug with edgescroll in viewport

### DIFF
--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -278,7 +278,7 @@ class Viewport(renpy.display.layout.Container):
 
         return rv
 
-    def check_edge_redraw(self, st):
+    def check_edge_redraw(self, st, reset_st=True):
         redraw = False
 
         if (self.edge_xspeed > 0) and (self.xadjustment.value < self.xadjustment.range):
@@ -293,7 +293,8 @@ class Viewport(renpy.display.layout.Container):
 
         if redraw:
             renpy.display.render.redraw(self, 0)
-            self.edge_last_st = st
+            if reset_st or self.edge_last_st is None:
+                self.edge_last_st = st
         else:
             self.edge_last_st = None
 
@@ -494,7 +495,7 @@ class Viewport(renpy.display.layout.Container):
             self.edge_yspeed = self.edge_speed * self.edge_function(yspeed)
 
             if xspeed or yspeed:
-                self.check_edge_redraw(st)
+                self.check_edge_redraw(st, reset_st=False)
             else:
                 self.edge_last_st = None
 


### PR DESCRIPTION
Fixed bug where viewport stops edgescrolling for a fraction of a second after every mousemotion event when mouse in the edgescroll area. It's caused by the event function setting edge_last_st = st when it calls check_edge_redraw. 

Fixed by adding a boolean parameter to check_edge_redraw that keeps the method exactly as before by default, but allows it to skip resetting edge_last_st when called from the event function.