### PR TITLE
Clear edgescroll timer when mouse moved out of bounds

### DIFF
--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -346,6 +346,7 @@ class Viewport(renpy.display.layout.Container):
         if not ((0 <= x < self.width) and (0 <= y <= self.height)):
             self.edge_xspeed = 0
             self.edge_yspeed = 0
+            self.edge_last_st = None
 
             inside = False
 


### PR DESCRIPTION
Fixed a bug I caused in #2002, where the viewport would jump to a different position when mouse re-enters the viewport.