### PR TITLE
config.cache_surfaces is False by default

### DIFF
--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -290,7 +290,7 @@ Occasionally Used
 
     The number of slots used by autosaves.
 
-.. var:: config.cache_surfaces = True
+.. var:: config.cache_surfaces = False
 
     If True, the underlying data of an image is stored in RAM, allowing
     image manipulators to be applied to that image without reloading it


### PR DESCRIPTION
AFAICS the only place where it's set to True is in a `version <= (6, 99, 14)` compatibility block.
I only read and test it to False otherwise.