### PR TITLE
[Py3] Make Python 3 integer related changes

### DIFF
--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -30,6 +30,7 @@ init python in distribute:
     import shutil
     import threading
 
+    from builtins import int
     from zipfile import crc32
 
     zlib.Z_DEFAULT_COMPRESSION = 5
@@ -156,9 +157,9 @@ init python in distribute:
             zi.create_system = 3
 
             if xbit:
-                zi.external_attr = long(0100755) << 16
+                zi.external_attr = int(0100755) << 16
             else:
-                zi.external_attr = long(0100644) << 16
+                zi.external_attr = int(0100644) << 16
 
             self.zipfile.write_with_info(zi, path)
 
@@ -170,7 +171,7 @@ init python in distribute:
             zi.date_time = self.get_date_time(path)
             zi.compress_type = zipfile.ZIP_STORED
             zi.create_system = 3
-            zi.external_attr = (long(0040755) << 16) | 0x10
+            zi.external_attr = (int(0040755) << 16) | 0x10
 
             self.zipfile.write_with_info(zi, path)
 
@@ -396,7 +397,3 @@ init python in distribute:
         for i in parallel_threads:
             if i.done:
                 i.done()
-
-
-
-

--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -28,10 +28,16 @@ init python in distribute:
     import struct
     import stat
     import shutil
+    import sys
     import threading
 
-    from builtins import int as long
+    from renpy import six
     from zipfile import crc32
+
+
+    # Since the long type doesn't exist on py3, define it here
+    if six.PY3:
+        long = int
 
     zlib.Z_DEFAULT_COMPRESSION = 5
 

--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -30,7 +30,7 @@ init python in distribute:
     import shutil
     import threading
 
-    from builtins import int
+    from builtins import int as long
     from zipfile import crc32
 
     zlib.Z_DEFAULT_COMPRESSION = 5
@@ -157,9 +157,9 @@ init python in distribute:
             zi.create_system = 3
 
             if xbit:
-                zi.external_attr = int(0o100755) << 16
+                zi.external_attr = long(0o100755) << 16
             else:
-                zi.external_attr = int(0o100644) << 16
+                zi.external_attr = long(0o100644) << 16
 
             self.zipfile.write_with_info(zi, path)
 
@@ -171,7 +171,7 @@ init python in distribute:
             zi.date_time = self.get_date_time(path)
             zi.compress_type = zipfile.ZIP_STORED
             zi.create_system = 3
-            zi.external_attr = (int(0o040755) << 16) | 0x10
+            zi.external_attr = (long(0o040755) << 16) | 0x10
 
             self.zipfile.write_with_info(zi, path)
 

--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -157,9 +157,9 @@ init python in distribute:
             zi.create_system = 3
 
             if xbit:
-                zi.external_attr = int(0100755) << 16
+                zi.external_attr = int(0o100755) << 16
             else:
-                zi.external_attr = int(0100644) << 16
+                zi.external_attr = int(0o100644) << 16
 
             self.zipfile.write_with_info(zi, path)
 
@@ -171,7 +171,7 @@ init python in distribute:
             zi.date_time = self.get_date_time(path)
             zi.compress_type = zipfile.ZIP_STORED
             zi.create_system = 3
-            zi.external_attr = (int(0040755) << 16) | 0x10
+            zi.external_attr = (int(0o040755) << 16) | 0x10
 
             self.zipfile.write_with_info(zi, path)
 
@@ -202,9 +202,9 @@ init python in distribute:
                 info.type = tarfile.DIRTYPE
 
             if xbit:
-                info.mode = 0755
+                info.mode = 0o755
             else:
-                info.mode = 0644
+                info.mode = 0o644
 
             info.uid = 1000
             info.gid = 1000
@@ -268,7 +268,7 @@ init python in distribute:
 
         def mkdir(self, path):
             if not os.path.isdir(path):
-                os.makedirs(path, 0755)
+                os.makedirs(path, 0o755)
 
         def __init__(self, path):
             self.path = path
@@ -283,9 +283,9 @@ init python in distribute:
             shutil.copy2(path, fn)
 
             if xbit:
-                os.chmod(fn, 0755)
+                os.chmod(fn, 0o755)
             else:
-                os.chmod(fn, 0644)
+                os.chmod(fn, 0o644)
 
         def add_directory(self, name, path):
             fn = os.path.join(self.path, name)

--- a/launcher/game/pefile.py
+++ b/launcher/game/pefile.py
@@ -86,8 +86,8 @@ IMAGE_OS2_SIGNATURE_LE          = 0x454C
 IMAGE_VXD_SIGNATURE             = 0x454C
 IMAGE_NT_SIGNATURE              = 0x00004550
 IMAGE_NUMBEROF_DIRECTORY_ENTRIES= 16
-IMAGE_ORDINAL_FLAG              = 0x80000000L
-IMAGE_ORDINAL_FLAG64            = 0x8000000000000000L
+IMAGE_ORDINAL_FLAG              = 0x80000000
+IMAGE_ORDINAL_FLAG64            = 0x8000000000000000
 OPTIONAL_HEADER_MAGIC_PE        = 0x10b
 OPTIONAL_HEADER_MAGIC_PE_PLUS   = 0x20b
 
@@ -170,7 +170,7 @@ section_characteristics = [
     ('IMAGE_SCN_MEM_SHARED',                0x10000000),
     ('IMAGE_SCN_MEM_EXECUTE',               0x20000000),
     ('IMAGE_SCN_MEM_READ',                  0x40000000),
-    ('IMAGE_SCN_MEM_WRITE',                 0x80000000L) ]
+    ('IMAGE_SCN_MEM_WRITE',                 0x80000000) ]
 
 SECTION_CHARACTERISTICS = dict([(e[1], e[0]) for e in
     section_characteristics]+section_characteristics)
@@ -1558,7 +1558,7 @@ class PE:
                 'Normal values are never larger than 0x10, the value is: 0x%x' %
                 self.OPTIONAL_HEADER.NumberOfRvaAndSizes )
 
-        for i in xrange(int(0x7fffffffL & self.OPTIONAL_HEADER.NumberOfRvaAndSizes)):
+        for i in xrange(int(0x7fffffff & self.OPTIONAL_HEADER.NumberOfRvaAndSizes)):
 
             if len(self.__data__[offset:]) == 0:
                 break
@@ -2356,13 +2356,13 @@ class PE:
             return None
 
         #resource.NameIsString = (resource.Name & 0x80000000L) >> 31
-        resource.NameOffset = resource.Name & 0x7FFFFFFFL
+        resource.NameOffset = resource.Name & 0x7FFFFFFF
 
-        resource.__pad = resource.Name & 0xFFFF0000L
-        resource.Id = resource.Name & 0x0000FFFFL
+        resource.__pad = resource.Name & 0xFFFF0000
+        resource.Id = resource.Name & 0x0000FFFF
 
-        resource.DataIsDirectory = (resource.OffsetToData & 0x80000000L) >> 31
-        resource.OffsetToDirectory = resource.OffsetToData & 0x7FFFFFFFL
+        resource.DataIsDirectory = (resource.OffsetToData & 0x80000000) >> 31
+        resource.OffsetToDirectory = resource.OffsetToData & 0x7FFFFFFF
 
         return resource
 

--- a/launcher/game/pefile.py
+++ b/launcher/game/pefile.py
@@ -55,6 +55,7 @@ import math
 import exceptions
 import string
 import array
+from renpy import six
 
 sha1, sha256, sha512, md5 = None, None, None, None
 
@@ -816,7 +817,7 @@ class Structure:
             for key in keys:
 
                 val = getattr(self, key)
-                if isinstance(val, int) or isinstance(val, long):
+                if isinstance(val, six.integer_types):
                     val_str = '0x%-8X' % (val)
                     if key == 'TimeDateStamp' or key == 'dwTimeStamp':
                         try:
@@ -2683,7 +2684,7 @@ class PE:
                                 raw_data[varword_offset+2:varword_offset+4], 0)
                             varword_offset += 4
 
-                            if isinstance(word1, (int, long)) and isinstance(word1, (int, long)):
+                            if isinstance(word1, six.integer_types):
                                 var_struct.entry = {var_string: '0x%04x 0x%04x' % (word1, word2)}
 
                         var_offset = self.dword_align(

--- a/launcher/game/pefile.py
+++ b/launcher/game/pefile.py
@@ -55,6 +55,7 @@ import math
 import exceptions
 import string
 import array
+from builtins import int as long
 from renpy import six
 
 sha1, sha256, sha512, md5 = None, None, None, None
@@ -87,7 +88,7 @@ IMAGE_VXD_SIGNATURE             = 0x454C
 IMAGE_NT_SIGNATURE              = 0x00004550
 IMAGE_NUMBEROF_DIRECTORY_ENTRIES= 16
 IMAGE_ORDINAL_FLAG              = 0x80000000
-IMAGE_ORDINAL_FLAG64            = 0x8000000000000000
+IMAGE_ORDINAL_FLAG64            = long(0x8000000000000000)
 OPTIONAL_HEADER_MAGIC_PE        = 0x10b
 OPTIONAL_HEADER_MAGIC_PE_PLUS   = 0x20b
 

--- a/launcher/game/pefile.py
+++ b/launcher/game/pefile.py
@@ -55,8 +55,13 @@ import math
 import exceptions
 import string
 import array
-from builtins import int as long
 from renpy import six
+
+
+# Since the long type doesn't exist on py3, define it here
+if six.PY3:
+    long = int
+
 
 sha1, sha256, sha512, md5 = None, None, None, None
 

--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -835,9 +835,9 @@ init -1500 python in updater:
                 info.gname = "renpy"
 
                 if xbit or directory:
-                    info.mode = 0777
+                    info.mode = 0o777
                 else:
-                    info.mode = 0666
+                    info.mode = 0o666
 
                 if info.isreg():
                     with open(path, "rb") as f:
@@ -1090,7 +1090,7 @@ init -1500 python in updater:
                         umask = os.umask(0)
                         os.umask(umask)
 
-                        os.chmod(new_path, 0777 & (~umask))
+                        os.chmod(new_path, 0o777 & (~umask))
                     except:
                         pass
 

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -229,7 +229,7 @@ def get_ordered_image_attributes(tag, attributes=(), sort=None):
 
     for attr in attrcount:
         if attr not in rv:
-            l.append((attrtotalpos[attr] / attrcount[attr], sort(attr), attr))
+            l.append((attrtotalpos[attr] // attrcount[attr], sort(attr), attr))
 
     l.sort()
     for i in l:

--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -310,11 +310,11 @@ def draw_special(what, dest, x, y):
         ramp = "\x00" * 256
 
         for i in xrange(0, ramplen):
-            ramp += chr(255 * i / ramplen)
+            ramp += chr(255 * i // ramplen)
 
         ramp += "\xff" * 256
 
-        step = int( what.operation_complete * (256 + ramplen) )
+        step = int(what.operation_complete * (256 + ramplen))
         ramp = ramp[step:step+256]
 
         renpy.display.module.imageblend(

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -116,7 +116,7 @@ def save_dump(roots, log):
             size = 1
 
         elif isinstance(o, (str, unicode)):
-            size = len(o) / 40 + 1
+            size = len(o) // 40 + 1
 
         elif isinstance(o, (tuple, list)):
             size = 1


### PR DESCRIPTION
Continuing the work from #1098, #2003 and related PRs.

1. Remove the L suffix from integers.
2. Fix integer division in Python 3.
3. Use the new octal syntax to prevent breakage in Python 3.