### PR TITLE
[Py3] Replace exec, execfile, reload with Py3 compatible versions

### DIFF
--- a/distribute.py
+++ b/distribute.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import argparse
 import time
+import importlib
 
 if not sys.flags.optimize:
     raise Exception("Optimization disabled.")
@@ -95,11 +96,11 @@ def main():
         return
 
     try:
-        reload(sys.modules['renpy.vc_version'])  # @UndefinedVariable
+        importlib.reload(sys.modules['renpy.vc_version'])  # @UndefinedVariable
     except:
         import renpy.vc_version  # @UnusedImport
 
-    reload(sys.modules['renpy'])
+    importlib.reload(sys.modules['renpy'])
 
     # Check that the versions match.
     full_version = renpy.version_only  # @UndefinedVariable

--- a/distribute.py
+++ b/distribute.py
@@ -10,7 +10,12 @@ import shutil
 import subprocess
 import argparse
 import time
-import importlib
+
+try:
+    # reload is built-in in Python 2, in importlib in Python 3
+    reload
+except NameError:
+    from importlib import reload
 
 if not sys.flags.optimize:
     raise Exception("Optimization disabled.")
@@ -96,11 +101,11 @@ def main():
         return
 
     try:
-        importlib.reload(sys.modules['renpy.vc_version'])  # @UndefinedVariable
+        reload(sys.modules['renpy.vc_version'])  # @UndefinedVariable
     except:
         import renpy.vc_version  # @UnusedImport
 
-    importlib.reload(sys.modules['renpy'])
+    reload(sys.modules['renpy'])
 
     # Check that the versions match.
     full_version = renpy.version_only  # @UndefinedVariable

--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -24,7 +24,11 @@ import os.path
 import sys
 import subprocess
 import io
-import importlib
+try:
+    # reload is built-in in Python 2, in importlib in Python 3
+    reload
+except NameError:
+    from importlib import reload
 
 FSENCODING = sys.getfilesystemencoding() or "utf-8"
 
@@ -32,7 +36,7 @@ FSENCODING = sys.getfilesystemencoding() or "utf-8"
 old_stdout = sys.stdout
 old_stderr = sys.stderr
 
-importlib.reload(sys)
+reload(sys)
 sys.setdefaultencoding(FSENCODING)  # @UndefinedVariable
 
 sys.stdout = old_stdout

--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -24,6 +24,7 @@ import os.path
 import sys
 import subprocess
 import io
+import importlib
 
 FSENCODING = sys.getfilesystemencoding() or "utf-8"
 
@@ -31,7 +32,7 @@ FSENCODING = sys.getfilesystemencoding() or "utf-8"
 old_stdout = sys.stdout
 old_stderr = sys.stderr
 
-reload(sys)
+importlib.reload(sys)
 sys.setdefaultencoding(FSENCODING)  # @UndefinedVariable
 
 sys.stdout = old_stdout

--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -173,7 +173,9 @@ def bootstrap(renpy_base):
     # If environment.txt exists, load it into the os.environ dictionary.
     if os.path.exists(renpy_base + "/environment.txt"):
         evars = { }
-        execfile(renpy_base + "/environment.txt", evars)
+        with open(renpy_base + "/environment.txt", "rb") as f:
+            code = compile(f.read(), renpy_base + "/environment.txt", 'exec')
+            exec(code, evars)
         for k, v in evars.iteritems():
             if k not in os.environ:
                 os.environ[k] = str(v)
@@ -186,7 +188,9 @@ def bootstrap(renpy_base):
 
         if os.path.exists(alt_path + "/environment.txt"):
             evars = { }
-            execfile(alt_path + "/environment.txt", evars)
+            with open(alt_path + "/environment.txt", "rb") as f:
+                code = compile(f.read(), alt_path + "/environment.txt", 'exec')
+                exec(code, evars)
             for k, v in evars.iteritems():
                 if k not in os.environ:
                     os.environ[k] = str(v)

--- a/renpy/editor.py
+++ b/renpy/editor.py
@@ -130,7 +130,7 @@ def init():
     code = compile(source, path, "exec")
 
     scope = { "__file__" : path }
-    exec code in scope, scope
+    exec(code, scope, scope)
 
     if "Editor" in scope:
         editor = scope["Editor"]()

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -751,7 +751,7 @@ class RenpyImporter(object):
                 if encoding == "latin-1":
                     raise
 
-        exec code in mod.__dict__
+        exec(code, mod.__dict__)
 
         return sys.modules[fullname]
 

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -146,7 +146,7 @@ def load_rpe(fn):
     zfn.close()
 
     sys.path.insert(0, fn)
-    exec autorun in dict()
+    exec(autorun, dict())
 
 
 def choose_variants():

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -2005,7 +2005,7 @@ def py_exec_bytecode(bytecode, hide=False, globals=None, locals=None, store="sto
     if locals is None:
         locals = globals  # @ReservedAssignment
 
-    exec bytecode in globals, locals
+    exec(bytecode, globals, locals)
 
 
 def py_exec(source, hide=False, store=None):
@@ -2018,7 +2018,7 @@ def py_exec(source, hide=False, store=None):
     else:
         locals = store  # @ReservedAssignment
 
-    exec py_compile(source, 'exec') in store, locals
+    exec(py_compile(source, 'exec'), store, locals)
 
 
 def py_eval_bytecode(bytecode, globals=None, locals=None):  # @ReservedAssignment
@@ -2062,7 +2062,7 @@ def raise_at_location(e, loc):
     code = compile(node, filename, 'exec')
 
     # PY3 - need to change to exec().
-    exec code in { "e" : e }
+    exec(code, { "e" : e })
 
 
 # This was used to proxy accesses to the store. Now it's kept around to deal

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -1577,7 +1577,7 @@ class SLPython(SLNode):
         analysis.python(self.code.source)
 
     def execute(self, context):
-        exec self.code.bytecode in context.globals, context.scope
+        exec(self.code.bytecode, context.globals, context.scope)
 
     def prepare(self, analysis):
         self.constant = NOT_CONST


### PR DESCRIPTION
1. Detect if reload is built-in (Py2.7 only) and import it from importlib if not (Py3 only).
2. Replace exec built-in with exec function call.
3. Replace execfile built-in with file read + compile + exec calls.