### PR TITLE
[Py3] Import print_function, remove tuple unpacking

### DIFF
--- a/launcher/game/webserver.py
+++ b/launcher/game/webserver.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import BaseHTTPServer
 import threading
 

--- a/module/uguu/xml_to_pyx.py
+++ b/module/uguu/xml_to_pyx.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from __future__ import print_function
 from xml.etree.ElementTree import parse, tostring
 import collections
 import itertools

--- a/renpy/display/pgrender.py
+++ b/renpy/display/pgrender.py
@@ -94,14 +94,14 @@ class Surface(pygame.Surface):
         return rv
 
 
-def surface((width, height), alpha):
+def surface(rect, alpha):
     """
     Constructs a new surface. The allocated surface is actually a subsurface
     of a surface that has a 2 pixel border in all directions.
 
     `alpha` - True if the new surface should have an alpha channel.
     """
-
+    (width, height) = rect
     if isinstance(alpha, pygame.Surface):
         alpha = alpha.get_masks()[3]
 

--- a/renpy/gl2/gl2shadercache.py
+++ b/renpy/gl2/gl2shadercache.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import re
 import io
 import os

--- a/scripts/future_print.py
+++ b/scripts/future_print.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from __future__ import print_function
 import sys
 
 

--- a/scripts/rt.py
+++ b/scripts/rt.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from __future__ import print_function
 import time
 import argparse
 import os

--- a/scripts/zip_size_by_directory.py
+++ b/scripts/zip_size_by_directory.py
@@ -3,6 +3,7 @@
 # Given two zip files, shows how files have changed in size between
 # them.
 
+from __future__ import print_function
 import argparse
 import zipfile
 import collections

--- a/scripts/zip_size_by_file.py
+++ b/scripts/zip_size_by_file.py
@@ -3,6 +3,7 @@
 # Given two zip files, shows how files have changed in size between
 # them.
 
+from __future__ import print_function
 import argparse
 import zipfile
 import collections


### PR DESCRIPTION
Some files had print calls added without the import. It appears some of them are already meant to run under python 3, but I added the import to all files that had print without the import for safety.

I also removed an instance of tuple unpacking which is no longer supported in Py3.