### PR TITLE
Quick menu request per issue #2022

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -244,23 +244,23 @@ screen quick_menu():
 
     ## Ensure this appears on top of other screens.
     zorder 100
+    if renpy.get_screen("say"):
+        if quick_menu:
 
-    if quick_menu:
+            hbox:
+                style_prefix "quick"
 
-        hbox:
-            style_prefix "quick"
+                xalign 0.5
+                yalign 1.0
 
-            xalign 0.5
-            yalign 1.0
-
-            textbutton _("Back") action Rollback()
-            textbutton _("History") action ShowMenu('history')
-            textbutton _("Skip") action Skip() alternate Skip(fast=True, confirm=True)
-            textbutton _("Auto") action Preference("auto-forward", "toggle")
-            textbutton _("Save") action ShowMenu('save')
-            textbutton _("Q.Save") action QuickSave()
-            textbutton _("Q.Load") action QuickLoad()
-            textbutton _("Prefs") action ShowMenu('preferences')
+                textbutton _("Back") action Rollback()
+                textbutton _("History") action ShowMenu('history')
+                textbutton _("Skip") action Skip() alternate Skip(fast=True, confirm=True)
+                textbutton _("Auto") action Preference("auto-forward", "toggle")
+                textbutton _("Save") action ShowMenu('save')
+                textbutton _("Q.Save") action QuickSave()
+                textbutton _("Q.Load") action QuickLoad()
+                textbutton _("Prefs") action ShowMenu('preferences')
 
 
 ## This code ensures that the quick_menu screen is displayed in-game, whenever

--- a/sphinx/source/oshs/game/screens.rpy
+++ b/sphinx/source/oshs/game/screens.rpy
@@ -239,23 +239,23 @@ screen quick_menu():
 
     ## Ensure this appears on top of other screens.
     zorder 100
+    if renpy.get_screen("say"):
+        if quick_menu:
 
-    if quick_menu:
+            hbox:
+                style_prefix "quick"
 
-        hbox:
-            style_prefix "quick"
+                xalign 0.5
+                yalign 1.0
 
-            xalign 0.5
-            yalign 1.0
-
-            textbutton _("Back") action Rollback()
-            textbutton _("History") action ShowMenu('history')
-            textbutton _("Skip") action Skip() alternate Skip(fast=True, confirm=True)
-            textbutton _("Auto") action Preference("auto-forward", "toggle")
-            textbutton _("Save") action ShowMenu('save')
-            textbutton _("Q.Save") action QuickSave()
-            textbutton _("Q.Load") action QuickLoad()
-            textbutton _("Prefs") action ShowMenu('preferences')
+                textbutton _("Back") action Rollback()
+                textbutton _("History") action ShowMenu('history')
+                textbutton _("Skip") action Skip() alternate Skip(fast=True, confirm=True)
+                textbutton _("Auto") action Preference("auto-forward", "toggle")
+                textbutton _("Save") action ShowMenu('save')
+                textbutton _("Q.Save") action QuickSave()
+                textbutton _("Q.Load") action QuickLoad()
+                textbutton _("Prefs") action ShowMenu('preferences')
 
 
 ## This code ensures that the quick_menu screen is displayed in-game, whenever


### PR DESCRIPTION
"It's becoming a popular desire to only show the quick menu while the dialogue box is being shown. Some people have been asking how to hide the quick menu when the dialogue is hidden via showing screens or hiding the textbox (without setting quick_menu to true or false every time for the ones who do know of this option)

Not everyone wants the quick menu attached to the textbox but I'm assuming that those in that category would have a higher-level knowledge on GUI customization in general.

So maybe we could possibly consider making this the default? At least for PC"
This is the proposed solution if interested.