### PR TITLE
Config exception handler

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1006,6 +1006,10 @@ depth_size = None
 # A list of screens to remove when the context is copied.
 context_copy_remove_screens = [ "notify" ]
 
+# A function which will be called in new context to handle excpetion or
+# None to use default handler.
+exception_handler = None
+
 del os
 del collections
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1524,6 +1524,14 @@ Rarely or Internally Used
     is occurring. It is expected to return a transition, which may or may not
     be the transition supplied as its argument.
 
+.. var:: config.exception_handler = None
+
+    If not None, this should be a function that will be invoked in new context
+    on clear scene. If this function returns True, Ren'Py will try to advance
+    to the next line, otherwise the exception will be passed to default handler.
+    Note that an exception may occur while executing init code, which can be
+    checked by :func:`renpy.is_init_phase`.
+
 
 Garbage Collection
 ------------------


### PR DESCRIPTION
Some details:
1. I have placed it in this place because handle before the screen can be initialized (e.g. an error in early) have no sense. I'm not sure if I need to docs it.
2. This handles CONTROL_EXCEPTIONS, so technically it is possible to use `config.exception_handler = Jump(label)` or `config.exception_handler = renpy.full_restart` and it will work, but only during the execution of the game. But maybe it's a good side effect if the developer is sure what he's doing.
3. It doesn't pass `(short, full, traceback_fn)` because these data are very raw and I don't think that it should be processed outside the Ren'Py.
