### PR TITLE
Updated URL to avoid redirect to HTTPS version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Building
 
 Building the documentation requires Ren'Py to work. You'll either need to
 link in a nightly build, or compile the modules as described above. You'll
-also need the `Sphinx <http://sphinx-doc.org/>`_ documentation generator.
+also need the `Sphinx <https://www.sphinx-doc.org>`_ documentation generator.
 If you have pip working, install Sphinx using::
 
     pip install -U sphinx


### PR DESCRIPTION
Updated URL in readme to use HTTPS instead of HTTP to avoid redirect to HTTPS version.