### PR TITLE
[Py3] Updated behavior of RevertableList

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -38,6 +38,8 @@ import re
 import sys
 import time
 
+from renpy import six
+
 import renpy.audio
 
 ##############################################################################
@@ -815,7 +817,11 @@ class RevertableList(list):
         list.__init__(self, *args)
 
     __delitem__ = mutator(list.__delitem__)
+    if six.PY2:
+        __delslice__ = mutator(list.__delslice__)
     __setitem__ = mutator(list.__setitem__)
+    if six.PY2:
+        __setslice__ = mutator(list.__setslice__)
     __iadd__ = mutator(list.__iadd__)
     __imul__ = mutator(list.__imul__)
     append = mutator(list.append)
@@ -834,6 +840,8 @@ class RevertableList(list):
         return newmethod
 
     __add__ = wrapper(list.__add__)
+    if six.PY2:
+        __getslice__ = wrapper(list.__getslice__)
 
     def __getitem__(self, index):
         rv = list.__getitem__(self, index)

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -788,10 +788,10 @@ class CompressedList(object):
             old_end += 1
 
         # Now that we have this, we can put together the object.
-        self.pre = list.__getslice__(old, 0, old_start)
+        self.pre = list.__getitem__(old, slice(0, old_start))
         self.start = new_start
         self.end = new_end
-        self.post = list.__getslice__(old, old_end, len_old)
+        self.post = list.__getitem__(old, slice(old_end, len_old))
 
     def decompress(self, new):
         return self.pre + new[self.start:self.end] + self.post
@@ -815,7 +815,6 @@ class RevertableList(list):
         list.__init__(self, *args)
 
     __delitem__ = mutator(list.__delitem__)
-    __delslice__ = mutator(list.__delslice__)
     __setitem__ = mutator(list.__setitem__)
     __iadd__ = mutator(list.__iadd__)
     __imul__ = mutator(list.__imul__)
@@ -835,7 +834,14 @@ class RevertableList(list):
         return newmethod
 
     __add__ = wrapper(list.__add__)
-    __getslice__ = wrapper(list.__getslice__)
+
+    def __getitem__(self, index):
+        rv = list.__getitem__(self, index)
+
+        if isinstance(index, slice):
+            return RevertableList(rv)
+        else:
+            return rv
 
     def __mul__(self, other):
         if not isinstance(other, int):

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -859,6 +859,12 @@ class RevertableList(list):
 
     __rmul__ = __mul__
 
+    def copy(self):
+        return self[:]
+
+    def clear(self):
+        self[:] = []
+
     def _clean(self):
         """
         Gets a clean copy of this object before any mutation occurs.


### PR DESCRIPTION
1. Fixed bug when `RevertableList[::1]` returns Python list.
2. Fixed bug when `RevertableList[:] = []` did not participate in the rollback.
3. Since slice methods are not available in Python 3 list, their use is wrapped in six.
4. Added useful `clear` and `copy` methods of Python 3 list.