### PR TITLE
Rework presplash processing

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -47,6 +47,10 @@ def log_clock(s):
     if renpy.android and not renpy.config.log_to_stdout:
         print(s)
 
+    # Pump the presplash window to prevent marking
+    # our process as unresponsive by OS
+    renpy.display.presplash.pump_window()
+
     last_clock = now
 
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -268,6 +268,10 @@ class Script(object):
                 import emscripten
                 emscripten.sleep(0)
 
+            # Pump the presplash window to prevent marking
+            # our process as unresponsive by OS
+            renpy.display.presplash.pump_window()
+
             self.load_appropriate_file(".rpyc", ".rpy", dir, fn, initcode)
 
         # Make the sort stable.


### PR DESCRIPTION
Since pygame_sdl cannot handle events by threads, we pump the presplash window after each file loading. Also checks that the user asked to close the game without waiting end of loading.