### PR TITLE
Improve documentation

### DIFF
--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -84,8 +84,8 @@ Character is a Python function that takes a large number of keyword
 arguments. These keyword arguments control the behavior of the
 character.
 
-The define statement causes its expression to be evaluated, and assigned to the
-supplied name. If not inside an ``init`` block, the define statement will
+The ``define`` statement causes its expression to be evaluated, and assigned to the
+supplied name. If not inside an ``init`` block, the ``define`` statement will
 automatically be run with init priority 0.
 
 .. include:: inc/character
@@ -398,7 +398,7 @@ This character can then be used alongside a variable in the default store::
     label start:
 
         # This is a terrible variable name.
-        e = 100
+        $ e = 100
 
         e "Our starting energy is [e] units."
 
@@ -408,11 +408,11 @@ A say with arguments sees the arguments passed to the function. For example::
 
 is equivalent to::
 
-    e("Hello, world.", interact=True, what_size=32)
+    $ e("Hello, world.", interact=True, what_size=32)
 
 When e is a Character, this is further equivalent to::
 
-    Character(kind=e, what_size=32)("Hello, world.", interact=True)
+    $ Character(kind=e, what_size=32)("Hello, world.", interact=True)
 
 But it's possible to use :var:`config.say_arguments_callback` or
 have ``e`` wrap a character to do things differently.

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -222,7 +222,7 @@ Some example show statements are::
     # Basic show.
     show mary night sad
 
-    # Since 'mary night happy' is showing, the following statement is
+    # Since 'mary night sad' is showing, the following statement is
     # equivalent to:
     # show mary night happy
     show mary happy

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -90,7 +90,7 @@ stacks can return to the proper place when loaded on a changed script. ::
 
     call subroutine(2)
 
-    call expression "subroutine" pass (count=3)
+    call expression "sub" + "routine" pass (count=3)
 
     # ...
 


### PR DESCRIPTION
Changes in this PR:

* Update typos in dialogues and displaying images.
* Propose a more explicit example when using `expression` in label