### PR TITLE
Print exception which caused on write_rpyc

### DIFF
--- a/renpy/script.py
+++ b/renpy/script.py
@@ -35,6 +35,7 @@ import time
 import marshal
 import struct
 import zlib
+import traceback
 
 from pickle import loads, dumps
 import shutil
@@ -619,7 +620,8 @@ class Script(object):
                     self.write_rpyc_header(f)
                     self.write_rpyc_data(f, 1, dumps((data, stmts), 2))
                 except:
-                    pass
+                    import traceback
+                    traceback.print_exc()
 
             self.static_transforms(stmts)
 
@@ -635,7 +637,8 @@ class Script(object):
 
                     f.close()
                 except:
-                    pass
+                    import traceback
+                    traceback.print_exc()
 
             self.loaded_rpy = True
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -35,7 +35,6 @@ import time
 import marshal
 import struct
 import zlib
-import traceback
 
 from pickle import loads, dumps
 import shutil


### PR DESCRIPTION
This will print picking error for case:
```py
python early hide:
    class Test():
        pass

    def parse_test(l):
        rv= Test()
        rv.a = 3
        return rv

    def execute_test(rv):
        print(rv.a)

    renpy.register_statement(
        "test",
        parse=parse_test,
        execute=execute_test,
    )
```