### PR TITLE
Revert "web: Avoid the use of float arguments."

### DIFF
--- a/renpy/gl/gldraw.pxd
+++ b/renpy/gl/gldraw.pxd
@@ -90,7 +90,7 @@ cdef class Environ:
     cdef void imageblend(self, double fraction, int ramp)
     cdef void set_vertex(self, float *vertices)
     cdef void set_texture(self, int unit, float *coords)
-    cdef void set_color(self, double r, double g, double b, double a)
+    cdef void set_color(self, float r, float g, float b, float a)
     cdef void set_clip(self, tuple clip_box, GLDraw draw)
     cdef void unset_clip(self, GLDraw draw)
     cdef void ortho(self, double left, double right, double bottom, double top, double near, double far)

--- a/renpy/gl/gldraw.pyx
+++ b/renpy/gl/gldraw.pyx
@@ -1394,7 +1394,7 @@ cdef class Environ(object):
         Sets the array of texture coordinates for unit `unit`.
         """
 
-    cdef void set_color(self, double r, double g, double b, double a):
+    cdef void set_color(self, float r, float g, float b, float a):
         """
         Sets the color to be shown.
         """

--- a/renpy/gl/glenviron_shader.pyx
+++ b/renpy/gl/glenviron_shader.pyx
@@ -541,7 +541,7 @@ cdef class ShaderEnviron(Environ):
         else:
             glDisableVertexAttribArray(tex)
 
-    cdef void set_color(self, double r, double g, double b, double a):
+    cdef void set_color(self, float r, float g, float b, float a):
         glUniform4f(self.program.Color, r, g, b, a)
 
     cdef void ortho(self, double left, double right, double bottom, double top, double near, double far):


### PR DESCRIPTION
This work-around was specific to Emterpreter, which is obsoleted by ASYNCIFY.

This reverts commit dce59141a7f940da9f5b2820ee4b61016b9113b3.