### PR TITLE
doc: reference im.AlphaMask in AlphaMask

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1906,6 +1906,9 @@ class AlphaMask(Container):
 
     The `child` and `mask` parameters may be arbitrary displayables. The
     size of the AlphaMask is the size of `child`.
+    
+    Note that this takes different arguments from :func:`im.AlphaMask`,
+    which uses the mask's red channel.
     """
 
     def __init__(self, child, mask, **properties):


### PR DESCRIPTION
It took me forever to spot that there are 2 functions with the same name, and the first one in the documentation (which we find through Ctrl+F) did not mention that.