### PR TITLE
Add splashscreen and presplash documentation

### DIFF
--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -97,6 +97,7 @@ Other Functionality
    achievement
    history
    multiple
+   splashscreen_presplash
 
 Python and Ren'Py
 -----------------

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -139,7 +139,7 @@ The following labels are used by Ren'Py:
 
 ``splashscreen``
     If it exists, this label is called when the game is first run, before
-    showing the main menu.
+    showing the main menu. Please see :ref:`Adding a Splashscreen <adding_a_splashscreen>`.
 
 ``before_main_menu``
     If it exists, this label is called before the main menu. It is used in

--- a/sphinx/source/splashscreen_presplash.rst
+++ b/sphinx/source/splashscreen_presplash.rst
@@ -1,0 +1,59 @@
+Splashscreen and Presplash
+==========================
+
+Adding a Splashscreen
+---------------------
+A splash screen is an image or movie that appears when the game is starting up
+and before it goes to the menu. Usually these are logos or intro videos. The
+"splashscreen" label automatically plays before the main menu. However, same
+code applies to a splashscreen located anywhere in your game under a different
+label.
+
+To add a text splashscreen to your game, insert code like this into anywhere in
+your script file (as long as it is not itself in a block): ::
+
+    label splashscreen:
+        scene black
+        with Pause(1)
+
+        show text "American Bishoujo Presents..." with dissolve
+        with Pause(2)
+
+        hide text with dissolve
+        with Pause(1)
+
+        return
+
+Here's another example of a splashscreen, this time using an image and
+sound: ::
+
+    image splash = "splash.png"
+
+    label splashscreen:
+        scene black 
+        with Pause(1)
+        
+        play sound "ping.ogg"
+
+        show splash with dissolve
+        with Pause(2)
+        
+        scene black with dissolve
+        with Pause(1)
+
+        return
+
+And finally, with a movie file: ::
+
+    label splashscreen:
+
+        $ renpy.movie_cutscene('movie.ogv')
+
+        return
+
+Adding a Presplash
+------------------
+
+A presplash is an image shown while Ren'py is reading the scripts and
+launching the game. Make an image named `presplash.png` (or `presplash.jpg`),
+and put that image into the game directory.


### PR DESCRIPTION
I reused the documentation found [here](https://www.renpy.org/wiki/renpy/doc/cookbook/Adding_a_Splashscreen) and [here](https://www.renpy.org/wiki/renpy/doc/cookbook/Preloader_Image) (with some minor tweaks) since they seem to still be valid.

**Disclaimer**: I had some issues setting up the environment to build the documentation so I couldn't test it.