### PR TITLE
Add equality comparison to HistoryEntry

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -648,6 +648,9 @@ class HistoryEntry(renpy.object.Object):
 
     multiple = None
 
+    def __eq__(self, other):
+        return self.who == other.who and self.what == other.what
+    
     def __repr__(self):
         return "<History {!r} {!r}>".format(self.who, self.what)
 


### PR DESCRIPTION
I'm currently working on a game where dialogue can be repeated by revisiting the same label.  Using an equality check, I can use a callback to prevent the history from showing the same line multiple times in a row.