### PR TITLE
Add linting for redefined define/default statements

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -53,6 +53,11 @@ image_prefixes = None
 # The node the report will be about:
 report_node = None
 
+# Collect define/default statements to check for duplication
+all_define_statments = {}
+all_default_statements = {}
+
+
 # Reports a message to the user.
 
 
@@ -528,7 +533,6 @@ def check_while(node):
 
 
 def check_if(node):
-
     for condition, _block in node.entries:
         try_compile("in a condition of the if statement", condition)
 
@@ -545,6 +549,35 @@ def check_define(node, kind):
 
     if node.varname in renpy_builtins:
         report("'%s %s' replaces a Ren'Py built-in name, which may cause problems.", kind, node.varname)
+
+
+def check_redefined(node, kind):
+    """
+    Check if a define or default statement has already been created.
+    """
+    if kind == 'default':
+        scanned = all_default_statements
+    elif kind == 'define':
+        scanned = all_define_statments
+
+    # Combine store name and varname
+    store_name = node.store.strip('store.')
+    if store_name:
+        full_name = "{}.{}".format(store_name, node.varname)
+    else:
+        full_name = node.varname
+
+    original_node = scanned.get(full_name)
+    if original_node:
+        report(
+            "{} {} already defined at {}:{}".format(
+                kind,
+                full_name,
+                original_node.filename,
+                original_node.linenumber,
+            )
+        )
+    scanned[full_name] = node
 
 
 def check_style_property_displayable(name, property, d):
@@ -807,9 +840,11 @@ def lint():
 
         elif isinstance(node, renpy.ast.Define):
             check_define(node, "define")
+            check_redefined(node, "define")
 
         elif isinstance(node, renpy.ast.Default):
             check_define(node, "default")
+            check_redefined(node, "default")
 
     report_node = None
 


### PR DESCRIPTION
Given the assumption that define/default statements shouldn't be duplicated, eg:

```
define pineapple = "pineapple"

default has_banana = False
default has_orange = False

define pineapple = "banana"
```

This PR adds a lint rule to inform the user when it happens:
```
game/script.rpy:9 define pineapple already defined at game/script.rpy:5
```

However, ren'py itself breaks this rule:
```
game/screens.rpy:567 define gui.about already defined at game/options.rpy:32
```

@renpytom If you like this rule but want to whitelist certain statements, we can do that. Or should gui.about not be duplicated?