### PR TITLE
web: add progressive download configuration for demos

### DIFF
--- a/the_question/progressive_download.txt
+++ b/the_question/progressive_download.txt
@@ -1,0 +1,10 @@
+# RenPyWeb progressive download rules - first match applies
+# '+' = progressive download, '-' = keep in game.zip (default)
+# See https://www.renpy.org/doc/html/build.html#classifying-and-ignoring-files for matching
+#
+# +/- type path
+- image game/gui/**
++ image game/**
++ music game/music/**
++ music game/illurock.opus
++ voice game/voice/**

--- a/tutorial/progressive_download.txt
+++ b/tutorial/progressive_download.txt
@@ -1,0 +1,11 @@
+# RenPyWeb progressive download rules - first match applies
+# '+' = progressive download, '-' = keep in game.zip (default)
+# See https://www.renpy.org/doc/html/build.html#classifying-and-ignoring-files for matching
+#
+# +/- type path
+- image game/gui/**
++ image game/**
++ music game/music/**
++ music game/renpyallstars.ogg
++ music game/sunflower-slow-drag.ogg
++ voice game/voice/**


### PR DESCRIPTION
Provide web configuration for the_question and tutorial.

The default configuration doesn't make the music files downloadable, because they are at the top-level directory and the default targets 'music/' only (to avoid targetting non-music sounds) -- and this prevents showcasing music download :)
