### PR TITLE
Fix parse error on `queue music [expr] channel [expr]`

### DIFF
--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -177,6 +177,8 @@ python early hide:
                 if channel is None:
                     renpy.error('expected simple expression')
 
+                continue
+
             if l.keyword('loop'):
                 loop = True
                 continue


### PR DESCRIPTION
Added missing `continue` in parse_queue_music for `channel` parameter parsing
Continues a series of fixes/refactoring done on music statement parsing in https://github.com/renpy/renpy/pull/2159