### PR TITLE
Fix menu_kwargs restore assignment from old value

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -992,7 +992,7 @@ def menu(items, set_expr, args=None, kwargs=None, item_arguments=None):
 
     finally:
         menu_args = old_menu_args
-        old_menu_kwargs = old_menu_kwargs
+        menu_kwargs = old_menu_kwargs
 
     # If we have a set, fill it in with the label of the chosen item.
     if set is not None and rv is not None:


### PR DESCRIPTION
It's mostly a "code typo" fix. I don't have a specific case where it fixes a bug, since the restore didn't seem to matter in my project, but it should now have the intended behavior.