### PR TITLE
Make config.use_cpickle work again in Python 2.x

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -59,7 +59,6 @@ from renpy.compat import *
 
 import sys
 import os
-import pickle
 import copy
 import types
 

--- a/renpy/compat/__init__.py
+++ b/renpy/compat/__init__.py
@@ -34,6 +34,9 @@ Right now, it does the following things:
 
 * Defines PY2 in the current context, to make Python 2 conditional.
 
+* Aliases pickle to cPickle on Python 3, to support Python 2 code
+  choosing between the implementations, where the choice is meaningful
+
 * Replaces open with a function that mimics the Python 3 behavior, of
   opening files in a unicode-friendly mode by default.
 
@@ -75,11 +78,14 @@ future.standard_library.install_aliases()
 PY2 = future.utils.PY2
 
 ################################################################################
-# On Python2, use cPickle as pickle.
+# Make both cPickle and pickle available to support config.use_cpickle on
+# Python 2 (on Python 3 it's a no-op)
 
 if PY2:
     import cPickle
-    sys.modules['pickle'] = cPickle
+    import pickle
+else:
+    import pickle, pickle as cPickle
 
 ################################################################################
 # Make open mimic Python 3.
@@ -125,7 +131,8 @@ else:
 ################################################################################
 # Sort key functions.
 
-__all__ = [ "PY2", "open", "basestring", "str", "pystr", "range", "bord", "bchr", "tobytes", "chr", ]
+__all__ = [ "PY2", "open", "basestring", "str", "pystr", "range",
+            "bord", "bchr", "tobytes", "chr", "pickle", "cPickle"]
 
 if PY2:
     __all__ = [ bytes(i) for i in __all__ ]

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -317,7 +317,7 @@ show = None
 # The callback that is used by the hide statement.
 hide = None
 
-# Should we use cPickle or pickle for load/save?
+# Python 2.x only: Should we use cPickle or pickle for load/save?
 use_cpickle = True
 
 # The function to call as the inspector.

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -25,7 +25,6 @@ from __future__ import division, absolute_import, with_statement, print_function
 from renpy.compat import *
 from future.utils import reraise
 
-import pickle
 import io
 import zipfile
 import re
@@ -39,17 +38,27 @@ import renpy
 
 from json import dumps as json_dumps
 
+# Dump that chooses which pickle to use:
 
 def dump(o, f):
-    pickle.dump(o, f, pickle.HIGHEST_PROTOCOL)
+    if renpy.config.use_cpickle:
+        cPickle.dump(o, f, cPickle.HIGHEST_PROTOCOL)
+    else:
+        pickle.dump(o, f, pickle.HIGHEST_PROTOCOL)
 
 
 def dumps(o):
-    return pickle.dumps(o, pickle.HIGHEST_PROTOCOL)
+    if renpy.config.use_cpickle:
+        return cPickle.dumps(o, cPickle.HIGHEST_PROTOCOL)
+    else:
+        return pickle.dumps(o, pickle.HIGHEST_PROTOCOL)
 
 
 def loads(s):
-    return pickle.loads(s)
+    if renpy.config.use_cpickle:
+        return cPickle.loads(s)
+    else:
+        return pickle.loads(s)
 
 
 # This is used as a quick and dirty way of versioning savegame

--- a/sphinx/source/save_load_rollback.rst
+++ b/sphinx/source/save_load_rollback.rst
@@ -147,8 +147,11 @@ There are certain types that cannot be pickled:
 * Inner functions and lambdas.
 
 By default, Ren'Py uses the cPickle module to save the game. Setting
-:var:`config.use_cpickle` will make Ren'Py use the pickle module instead. This
-makes the game slower, but is better at reporting save errors.
+:var:`config.use_cpickle` to False will make Ren'Py use the pickle
+module instead. This makes the game slower, but is better at reporting
+save errors under Python 2.x. Note that this setting has no effect on
+Python 3, as the system chooses the implementation transparently in
+that case.
 
 
 Save Functions and Variables


### PR DESCRIPTION
Also document that it has no effect under Python 3

Resolves #2175 

*Note*: it doesn't touch code that has never made the distinction between `pickle`  and `cPickle`, which means in effect it restores the behaviour prior to c2206245e in those parts.

Tested manually under Python 2.7 with the following script:

```renpy
init python:
    renpy.config.use_cpickle = False
    
    class PickleSurprise(object):
        pass
        def __init__(self):
            self.surprise = None

label start:
    # Cause a pickle error to test config.use_cpickle
    $ surprise = PickleSurprise()

    python hide:
        def foo():
            def bar():
                return 42
            return bar

        surprise.surprise = foo()

label breakme:
    "Try saving now for a pickle surprise"
```