### PR TITLE
add "mobile" screen variant to iOS builds

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -215,6 +215,7 @@ def choose_variants():
             renpy.config.variants.insert(0, 'small')
 
     elif renpy.ios:
+        renpy.config.variants.insert(0, 'mobile')
         renpy.config.variants.insert(0, 'ios')
         renpy.config.variants.insert(0, 'touch')
 


### PR DESCRIPTION
According to [here](https://github.com/renpy/renpy/commit/118d39d83b40620f15033a707680b51c04ba19ce#diff-3deaadb5853b1b2467152b00910bbfe9L240-L246) and [here](https://www.renpy.org/doc/html/screens.html#screen-variants), iOS builds should define the "mobile" screen variant.