### PR TITLE
Allow specification of per-play/per-queue volume

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -142,6 +142,7 @@ class MusicContext(renpy.python.RevertableObject):
     __version__ = 0
 
     pause = False
+    tertiary_volume = 1.0
 
     def __init__(self):
 

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -33,7 +33,7 @@ from renpy.audio.audio import register_channel, alias_channel
 register_channel; alias_channel
 
 
-def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=False, fadein=0, tight=None, if_changed=False):
+def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=False, fadein=0, tight=None, if_changed=False, relative_volume=1.0):
     """
     :doc: audio
 
@@ -73,6 +73,12 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
         then it will not be stopped/faded out and faded back in again, but
         instead will be kept playing. (This will always queue up an additional
         loop of the music.)
+
+    `relative_volume`
+        This is the volume relative to the current channel volume.
+        The specified file will be played at that relative volume. If not
+        specified, it will always default to 1.0, which plays the file at the
+        original volume as determined by the mixer, channel and secondary volume.
 
     This clears the pause flag for `channel`.
     """
@@ -118,7 +124,7 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
                 enqueue = True
 
             if enqueue:
-                c.enqueue(filenames, loop=loop, synchro_start=synchro_start, fadein=fadein, tight=tight, loop_only=loop_only)
+                c.enqueue(filenames, loop=loop, synchro_start=synchro_start, fadein=fadein, tight=tight, loop_only=loop_only, relative_volume=relative_volume)
 
             t = get_serial()
             ctx.last_changed = t
@@ -138,7 +144,7 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
                 raise
 
 
-def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tight=None):
+def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tight=None, relative_volume=1.0):
     """
     :doc: audio
 
@@ -167,6 +173,12 @@ def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tig
     `tight`
         If this is True, then fadeouts will span into the next-queued sound. If
         None, this is true when loop is True, and false otherwise.
+
+    `relative_volume`
+        This is the volume relative to the current channel volume.
+        The specified file will be played at that relative volume. If not
+        specified, it will always default to 1.0, which plays the file at the
+        original volume as determined by the mixer, channel and secondary volume.
 
     This clears the pause flag for `channel`.
     """
@@ -206,7 +218,7 @@ def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tig
                 enqueue = True
 
             if enqueue:
-                c.enqueue(filenames, loop=loop, fadein=fadein, tight=tight)
+                c.enqueue(filenames, loop=loop, fadein=fadein, tight=tight, relative_volume=relative_volume)
 
             t = get_serial()
             ctx.last_changed = t

--- a/renpy/audio/sound.py
+++ b/renpy/audio/sound.py
@@ -30,22 +30,24 @@ import renpy.audio
 # channel set to "sound".
 
 
-def play(filename, channel="sound", fadeout=0, fadein=0, tight=False, loop=False):
+def play(filename, channel="sound", fadeout=0, fadein=0, tight=False, loop=False, relative_volume=1.0):
     renpy.audio.music.play(filename,
                            channel=channel,
                            fadeout=fadeout,
                            fadein=fadein,
                            tight=tight,
-                           loop=loop)
+                           loop=loop,
+                           relative_volume=relative_volume)
 
 
-def queue(filename, channel="sound", clear_queue=True, fadein=0, tight=False, loop=False):
+def queue(filename, channel="sound", clear_queue=True, fadein=0, tight=False, loop=False, relative_volume=1.0):
     renpy.audio.music.queue(filename,
                             channel=channel,
                             clear_queue=clear_queue,
                             fadein=fadein,
                             tight=tight,
-                            loop=loop)
+                            loop=loop,
+                            relative_volume=relative_volume)
 
 
 def stop(channel="sound", fadeout=0):

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -313,7 +313,7 @@ python early hide:
         if loop is None:
             loop = config.default_sound_loop
 
-        renpy.sound.queue(_audio_eval(p["file"]), channel=channel, loop=loop, relative_volume=eval(p["volume"]))
+        renpy.sound.queue(_audio_eval(p["file"]), channel=channel, loop=loop, relative_volume=eval(p.get("volume", "1.0")))
 
 
     renpy.register_statement('queue sound',

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -62,6 +62,7 @@ python early hide:
         channel = None
         loop = None
         if_changed = False
+        volume = "1.0"
 
         while True:
 
@@ -101,6 +102,10 @@ python early hide:
                 if_changed = True
                 continue
 
+            if l.keyword('volume'):
+                volume = l.simple_expression()
+                continue
+
             renpy.error('could not parse statement.')
 
         return dict(file=file,
@@ -108,7 +113,8 @@ python early hide:
                     fadein=fadein,
                     channel=channel,
                     loop=loop,
-                    if_changed=if_changed)
+                    if_changed=if_changed,
+                    volume=volume)
 
     def execute_play_music(p):
 
@@ -122,7 +128,8 @@ python early hide:
                          fadein=eval(p["fadein"]),
                          channel=channel,
                          loop=p.get("loop", None),
-                         if_changed=p.get("if_changed", False))
+                         if_changed=p.get("if_changed", False),
+                         relative_volume=eval(p["volume"]))
 
     def predict_play_music(p):
         if renpy.emscripten or os.environ.get('RENPY_SIMULATE_DOWNLOAD', False):
@@ -169,6 +176,7 @@ python early hide:
 
         channel = None
         loop = None
+        volume = "1.0"
 
         while not l.eol():
 
@@ -187,9 +195,13 @@ python early hide:
                 loop = False
                 continue
 
+            if l.keyword('volume'):
+                volume = l.simple_expression()
+                continue
+
             renpy.error('expected end of line')
 
-        return dict(file=file, channel=channel, loop=loop)
+        return dict(file=file, channel=channel, loop=loop, volume=volume)
 
     def execute_queue_music(p):
         if p["channel"] is not None:
@@ -200,7 +212,8 @@ python early hide:
         renpy.music.queue(
             _audio_eval(p["file"]),
             channel=channel,
-            loop=p.get("loop", None))
+            loop=p.get("loop", None),
+            relative_volume=eval(p["volume"]))
 
 
     renpy.register_statement('queue music',
@@ -277,7 +290,8 @@ python early hide:
                          fadeout=fadeout,
                          fadein=eval(p["fadein"]),
                          loop=loop,
-                         channel=channel)
+                         channel=channel,
+                         relative_volume=eval(p["volume"]))
 
     def lint_play_sound(p, lint_play_music=lint_play_music):
         return lint_play_music(p, channel="sound")
@@ -299,7 +313,7 @@ python early hide:
         if loop is None:
             loop = config.default_sound_loop
 
-        renpy.sound.queue(_audio_eval(p["file"]), channel=channel, loop=loop)
+        renpy.sound.queue(_audio_eval(p["file"]), channel=channel, loop=loop, relative_volume=eval(p["volume"]))
 
 
     renpy.register_statement('queue sound',

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -129,7 +129,7 @@ python early hide:
                          channel=channel,
                          loop=p.get("loop", None),
                          if_changed=p.get("if_changed", False),
-                         relative_volume=eval(p["volume"]))
+                         relative_volume=eval(p.get("volume", "1.0")))
 
     def predict_play_music(p):
         if renpy.emscripten or os.environ.get('RENPY_SIMULATE_DOWNLOAD', False):
@@ -213,7 +213,7 @@ python early hide:
             _audio_eval(p["file"]),
             channel=channel,
             loop=p.get("loop", None),
-            relative_volume=eval(p["volume"]))
+            relative_volume=eval(p.get("volume", "1.0")))
 
 
     renpy.register_statement('queue music',
@@ -291,7 +291,7 @@ python early hide:
                          fadein=eval(p["fadein"]),
                          loop=loop,
                          channel=channel,
-                         relative_volume=eval(p["volume"]))
+                         relative_volume=eval(p.get("volume", "1.0")))
 
     def lint_play_sound(p, lint_play_music=lint_play_music):
         return lint_play_music(p, channel="sound")


### PR DESCRIPTION
## What
This change enables users to specify `volume` in `play` and `queue` statements as well as via the Python API `renpy.music.play`, `renpy.sound.play` and the `queue` variants respectively.  
Specifically it adds a tertiary volume which in turn affects the secondary volume such that it still works fine with mixer controls and with minimal changes to the codebase.

## Why
It is highly likely that a lot of users utilize music from multiple sources, which is almost never loudness-normalized. Few users do this themselves.  
Thus it can be the case that some music or sound effects are louder or more quiet than others, which can be a hassle to deal with as a player, because one would have to constantly change the mixer controls around depending on what's playing.

While this change does not resolve the loudness issue itself, it gives game authors an easy way out of this by enabling them to specify per-play/per-queue volumes, circumventing these jumps in loudness.

In addition, it is sometimes desirable to play an existing sound effect at a higher or lower volume to fit a specific scene, for example contrasting regular knocking on a door with forceful knocking (the latter of which should be louder).

This was previously possible as well, using constructs like the following:
```renpy
# First
$ renpy.music.set_volume(0.75)
play music my_music_var

# Later
$ renpy.music.set_volume(1.0)
```

The proposed change is a more convenient solution for this issue as it has the advantage of not having to remember to re-set the volume back to its original level after tweaking it. Additionally it does not mess with the secondary volume, which is already modified by the audio emphasis system.

## Code Talk
I changed the affected statements (namely `play` and `queue` and their sub-statements where necessary) as well as the matching Python API points.  
Regarding naming conventions, I named the parameter in the Python API `relative_volume`, however the tag used for statements is simply `volume` for convenience.
This can of course be changed if a different naming scheme would be more clear.

I added a tertiary volume which is multiplied with the secondary volume. This way it does not interfere with the audio emphasis system, which may lift or reduce secondary volume at times. Using this method, we remain relative to the actual volume, even when audio emphasis is active.

I added basic docs to the affected Python methods, which can be expanded upon if required.

## Samples
```renpy
play music my_music_var volume 0.75
queue music "audio/music.mp3" fadein 1.5 volume 0.3 fadeout 2.3
play sound "audio/some_file.opus" volume 1.2
queue sound some_sfx_var volume 1.2
```

This also plays well with emphasized audio:
```renpy
# Configuration
define config.emphasize_audio_channels = ["sound"]  # reduce music when sound effects are playing
init python:
    renpy.game.preferences.emphasize_audio = True

# In the script
play music my_music_var  # full loudness
"dialogue"
play music my_music_var volume 0.5  # half loudness
"dialogue"
play sound sfx  # reduces "music" channel further, plays sound, ramps back up to 0.5
"dialogue"
play music my_music_var  # full loudness again
```

Let me know your thoughts.