### PR TITLE
Also use the location of screen as key of screen in SL2 cache

### DIFF
--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -2022,7 +2022,7 @@ class SLScreen(SLBlock):
         if self.const_ast:
             return
 
-        key = (self.name, self.variant)
+        key = (self.name, self.variant, self.location)
 
         if key in scache.const_analyzed:
             self.const_ast = scache.const_analyzed[key]


### PR DESCRIPTION
It fixes the bug with the SL2 cache which can be simply reproduced by
```
init:
    if renpy.loadable("test.txt"):
        screen test():
            add "#ff0"
    else:
        screen test():
            add "#0ff"

label start:
    show screen test
    pause
    return
```
If the value of the condition changes without changing the code, the screen that was in the cache last time will be used ignoring the real value of `Screen.ast`. 

Rationale:
In our project, we have added code that will be distributed as a DLC that also changes some screens. I tried to do something like:
```
# This screen is actually defined in a file that does not exist without a DLC
screen DLC_SCREEN():
    ...

screen main_menu():
    if renpy.has_screen("DLC_SCREEN"):
        use DLC_SCREEN
    else:
        # No DLC case.
    ...
```
But in this case, the game is not compiled in the absence of DLC due to lookup screen error during the `prepare_screen`. So I'm using something like:
```
init:
    if not HAS_DLC:
        screen main_menu_background():
            ...
```

As I understand it does not violate backward compatibility because the cache will just be recreated for all screens.