### PR TITLE
Sl fixes

### DIFF
--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -786,13 +786,15 @@ def get_all_screen_variants(name):
     order.
     """
 
-    rv = [ ]
+    if isinstance(name, basestring):
+        name = tuple(name.split())
 
-    for k, v in screens.items():
-        if k[0] == name:
-            rv.append((k[1], v))
+    name = name[0]
 
-    return rv
+    if name not in screens_by_name:
+        return [ ]
+
+    return list(screens_by_name[name].items())
 
 
 # Have all screens been analyzed?

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -1882,7 +1882,8 @@ class SLUse(SLNode):
             self.ast.copy_on_change(c)
 
     def used_screens(self, callback):
-        callback(self.target)
+        if not isinstance(self.target, renpy.ast.PyExpr):
+            callback(self.target)
 
 
 class SLTransclude(SLNode):

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -336,6 +336,7 @@ class SLBlock(SLNode):
         rv = SLNode.instantiate(self, transclude)
         rv.keyword = self.keyword
         rv.children = [ i.copy(transclude) for i in self.children ]
+        rv.atl_transform = self.atl_transform
 
         return rv
 

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -1701,7 +1701,7 @@ class SLUse(SLNode):
             else:
                 const = False
         else:
-            const = False
+            const = True
 
         if isinstance(self.target, renpy.ast.PyExpr):
 

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -2016,9 +2016,11 @@ class SLCustomUse(SLNode):
 
         # If we have the id property, we're not constant - since we may get
         # our state via other screen on replace.
-        const = not block.keyword_exist("id")
+        if block.keyword_exist("id")
+            self.constant = NOT_CONST
+            self.ast = target.ast.not_const_ast
 
-        if const and block.constant == GLOBAL_CONST:
+        elif block.constant == GLOBAL_CONST:
             self.ast = target.ast.const_ast
         else:
             self.ast = target.ast.not_const_ast

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -396,14 +396,21 @@ class SLBlock(SLNode):
             const = self.atl_transform.constant
             self.constant = min(self.constant, const)
 
+        was_last_keyword = False
         for i in self.children:
             if i.has_keyword:
+
+                if was_last_keyword:
+                    raise Exception("Properties are not allowed here.")
+
                 self.keyword_children.append(i)
                 self.has_keyword = True
 
             if i.last_keyword:
                 self.last_keyword = True
-                break
+                was_last_keyword = True
+                if not renpy.config.developer:
+                    break
 
     def execute(self, context):
 
@@ -1303,7 +1310,6 @@ class SLIf(SLNode):
                     except:
                         pass
 
-            # Not-taken branches, only if not already predicted.
             else:
                 false_blocks.append(block)
 
@@ -1314,6 +1320,7 @@ class SLIf(SLNode):
 
         context.predicted.add(self.serial)
 
+        # Not-taken branches.
         for block in false_blocks:
             ctx = SLContext(context)
             ctx.children = [ ]
@@ -1977,6 +1984,8 @@ class SLCustomUse(SLNode):
         return rv
 
     def analyze(self, analysis):
+
+        self.last_keyword = True
 
         self.block.analyze(analysis)
 

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -577,7 +577,7 @@ class SLDisplayable(SLBlock):
             The base name of the main style.
 
         `pass_context`
-            If given, the context is passed in as the first positonal argument
+            If given, the context is passed in as the first positional argument
             of the displayable.
 
         `imagemap`
@@ -820,21 +820,20 @@ class SLDisplayable(SLBlock):
 
             SLBlock.keywords(self, ctx)
 
+            arguments = keywords.pop("arguments", None)
+            if arguments:
+                positional += arguments
+
+            properties = keywords.pop("properties", None)
+            if properties:
+                keywords.update(properties)
+
             # Get the widget id and transform, if any.
             widget_id = keywords.pop("id", None)
             transform = keywords.pop("at", None)
 
-            arguments = keywords.pop("arguments", None)
-            properties = keywords.pop("properties", None)
-            style_suffix = keywords.pop("style_suffix", None) or self.style
-
-            if arguments:
-                positional += arguments
-
-            if properties:
-                keywords.update(properties)
-
             # If we don't know the style, figure it out.
+            style_suffix = keywords.pop("style_suffix", None) or self.style
             if ("style" not in keywords) and style_suffix:
                 if ctx.style_prefix is None:
                     keywords["style"] = style_suffix
@@ -1247,8 +1246,8 @@ class SLIf(SLNode):
             self.constant = min(self.constant, block.constant)
             self.prepared_entries.append((cond, block))
 
-            self.has_keyword = self.has_keyword or block.has_keyword
-            self.last_keyword = self.last_keyword or block.last_keyword
+            self.has_keyword |= block.has_keyword
+            self.last_keyword |= block.last_keyword
 
     def execute(self, context):
 

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -916,9 +916,6 @@ class CustomParser(Parser):
         This must be a word. It's the name of the custom screen language
         statement.
 
-    `positional`
-        The number of positional parameters this statement takes.
-
     `children`
         The number of children this custom statement takes. This should
         be 0, 1, or "many", which means zero or more.
@@ -931,7 +928,7 @@ class CustomParser(Parser):
     returned by :class:`renpy.register_sl_displayable`.
     """
 
-    def __init__(self, name, positional=0, children="many", screen=None):
+    def __init__(self, name, children="many", screen=None):
         Parser.__init__(self, name)
 
         if children == "many":
@@ -950,6 +947,9 @@ class CustomParser(Parser):
             for i in all_statements:
                 self.add(i)
 
+        self.add_property("arguments")
+        self.add_property("properties")
+
         self.add(if_statement)
         self.add(pass_statement)
 
@@ -962,35 +962,32 @@ class CustomParser(Parser):
         else:
             self.screen = name
 
-        # The number of positional parameters required.
-        self.positional = positional
-
     def parse(self, loc, l, parent, keyword):
 
         arguments = [ ]
 
         # Parse positional arguments.
-        for _i in range(self.positional):
-            expr = l.require(l.simple_expression)
-            arguments.append((None, expr))
+        for _i in self.positional:
+            expr = l.simple_expression()
+
+            if expr is None:
+                break
+
+            arguments.append(expr)
 
         # Parser keyword arguments and children.
         block = slast.SLBlock(loc)
         can_has = (self.nchildren == 1)
         self.parse_contents(l, block, can_has=can_has, can_tag=False)
 
-        # Add the keyword arguments, and create an ArgumentInfo object.
-        arguments.extend(block.keyword)
-        block.keyword = [ ]
+        if len(arguments) != len(self.positional):
+            for i in block.keyword:
+                if i[0] == 'arguments':
+                    break
+            else:
+                l.error("{} statement expects {} positional arguments, got {}.".format(self.name, len(self.positional), len(arguments)))
 
-        args = renpy.ast.ArgumentInfo(arguments, None, None)
-
-        # We only need a SLBlock if we have children.
-        if not block.children:
-            block = None
-
-        # Create the Use statement.
-        return slast.SLUse(loc, self.screen, args, None, block)
+        return slast.SLCustomUse(loc, self.screen, arguments, block)
 
 
 class ScreenParser(Parser):

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -616,10 +616,7 @@ class DisplayableParser(Parser):
         self.parse_contents(l, rv, layout_mode=layout_mode, can_has=can_has, can_tag=False)
 
         if len(rv.positional) != len(self.positional):
-            for i in rv.keyword:
-                if i[0] == 'arguments':
-                    break
-            else:
+            if not rv.keyword_exist("arguments"):
                 l.error("{} statement expects {} positional arguments, got {}.".format(self.name, len(self.positional), len(rv.positional)))
 
         return rv
@@ -981,10 +978,7 @@ class CustomParser(Parser):
         self.parse_contents(l, block, can_has=can_has, can_tag=False)
 
         if len(arguments) != len(self.positional):
-            for i in block.keyword:
-                if i[0] == 'arguments':
-                    break
-            else:
+            if not block.keyword_exist("arguments"):
                 l.error("{} statement expects {} positional arguments, got {}.".format(self.name, len(self.positional), len(arguments)))
 
         return slast.SLCustomUse(loc, self.screen, arguments, block)

--- a/sphinx/source/screen_python.rst
+++ b/sphinx/source/screen_python.rst
@@ -362,7 +362,7 @@ call looks like::
 
 
     python early:
-        renpy.register_sl_statement("titledwindow", positional=1, children=1).add_property("icon").add_property("pos")
+        renpy.register_sl_statement("titledwindow", children=1).add_positional("title").add_property("icon").add_property("pos")
 
 Then, we define a screen that implements the custom statement. This screen can be defined in
 any file. One such screen is::
@@ -385,3 +385,26 @@ any file. One such screen is::
                 null height 15
 
                 transclude
+
+
+When are used large property groups like a `add_property_group`, it makes sense to use
+the \*\*properties syntax with a properties keyword in some place. For example::
+
+    screen titledwindow(title, icon=None, **properties):
+        frame:
+            # When background not in properties it will use it as default value.
+            background "#00000080"
+
+            properties properties
+
+            has vbox
+
+            hbox:
+                if icon is not None:
+                    add icon
+
+                text title
+
+            null height 15
+
+            transclude


### PR DESCRIPTION
1. Fixed a performance leak for SLUse when use without a block was referring to `not_const_ast`.
2. Fixed lost copying `SLBlock.atl_transform`
3. Fixed a bug when `at` property inside `properties` has not updated the parsed keyword. Per #2187
```
screen some():
    fixed:
        at transform:
            alpha 0.5
        properties dict(at=Transform(alpha=1.0))
```
4. Slightly redesigned `SLIf.execute_predicting` so that the true block will perform the prediction exactly first. I.e. `false_screen` will predict its images first for:
```
define SOME_SCREEN_COND = False
screen some():
    if SOME_SCREEN_COND:
        use true_screen
    else:
        use false_screen
```
5. Stop add expressions in cycle finder for SLUse
```
screen expr():
    use false_cycle

default expr = "some"
screen false_cycle():
    use expression expr
```
6. Added a `SLBlock.keyword_exist` method to check if some keyword was parsed and use of it for `id` property and `arguments` property.
7. Added an error message if keyword children follow after last_keyword children. Per #2154 
8. Added separate ast class for CD SLS. It works the same as SLUse but creates arguments on each execute with processing if statements. Per #2187 
This change is backwards compatible with the compiled code. 
But to fix the bug with `add_positional` this requires an update `renpy.register_sl_statement("name", positional=1)` to `renpy.register_sl_statement("name").add_positional("name")`