### PR TITLE
add minsize transform property

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -119,6 +119,7 @@ PROPERTIES = {
     "crop_relative" : bool,
     "size" : (int, int),
     "maxsize" : (int, int),
+    "minsize" : (int, int),
     "corner1" : (float, float),
     "corner2" : (float, float),
     "subpixel" : bool,

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -202,11 +202,18 @@ def transform_render(self, widtho, heighto, st, at):
     # Size.
     size = state.size
     maxsize = state.maxsize
+    minsize = state.minsize
 
-    if (maxsize is not None) and (width != 0) and (height != 0):
-        maxsizex, maxsizey = maxsize
-        mul = min(maxsizex / width, maxsizey / height)
-        size = (width * mul, height * mul)
+    if (width != 0) and (height != 0):
+        mul = False
+        if (maxsize is not None):
+            maxsizex, maxsizey = maxsize
+            mul = min(maxsizex / width, maxsizey / height)
+        elif (minsize is not None):
+            minsizex, minsizey = minsize
+            mul = max(minsizex / width, minsizey / height)
+        if mul:
+            size = (width * mul, height * mul)
 
     if (size is not None) and (size != (width, height)) and (width != 0) and (height != 0):
         nw, nh = size

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -205,14 +205,14 @@ def transform_render(self, widtho, heighto, st, at):
     minsize = state.minsize
 
     if (width != 0) and (height != 0):
-        mul = False
+        mul = None
         if (maxsize is not None):
             maxsizex, maxsizey = maxsize
             mul = min(maxsizex / width, maxsizey / height)
         elif (minsize is not None):
             minsizex, minsizey = minsize
             mul = max(minsizex / width, minsizey / height)
-        if mul:
+        if mul is not None:
             size = (width * mul, height * mul)
 
     if (size is not None) and (size != (width, height)) and (width != 0) and (height != 0):

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -112,6 +112,7 @@ class TransformState(renpy.object.Object):
     ytile = 1
     last_angle = None
     maxsize = None
+    minsize = None
 
     def __init__(self):
         self.alpha = 1
@@ -149,6 +150,7 @@ class TransformState(renpy.object.Object):
         self.corner2 = None
         self.size = None
         self.maxsize = None
+        self.minsize = None
 
         self.delay = 0
 
@@ -194,6 +196,7 @@ class TransformState(renpy.object.Object):
         self.corner2 = ts.corner2
         self.size = ts.size
         self.maxsize = ts.maxsize
+        self.minsize = ts.minsize
 
         self.xpan = ts.xpan
         self.ypan = ts.ypan
@@ -266,6 +269,7 @@ class TransformState(renpy.object.Object):
         diff2("corner2", newts.corner2, self.corner2)
         diff2("size", newts.size, self.size)
         diff2("maxsize", newts.maxsize, self.maxsize)
+        diff2("minsize", newts.minsize, self.minsize)
 
         diff4("xpos", newts.xpos, newts.inherited_xpos, self.xpos, self.inherited_xpos)
         diff4("xanchor", newts.xanchor, newts.inherited_xanchor, self.xanchor, self.inherited_xanchor)
@@ -479,6 +483,7 @@ class Transform(Container):
     corner2 = Proxy("corner2")
     size = Proxy("size")
     maxsize = Proxy("maxsize")
+    minsize = Proxy("minsize")
 
     delay = Proxy("delay")
 


### PR DESCRIPTION
I added the `minsize` transform property.
It's useful when trying to fit a displayable to the background without changing its proportions, for example.
If maxsize is specified, minsize is ignored (better to have an underfull box than to have it overflow).

To paraphrase the words of the [doc](https://www.renpy.org/doc/html/atl.html#transform-property-maxsize) :
If not None, causes the displayable to be scaled so that it fills a box of this size, while preserving aspect ratio (Note that this means that one of the dimensions may be greater than the size of this box.). Maxsize takes priority over minsize.