### PR TITLE
Allow Transform subclasses to spawn sub instances

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -896,7 +896,7 @@ class Transform(Container):
         if (child is not None) and (child._duplicatable):
             child = child._duplicate(_args)
 
-        rv = Transform(
+        rv = self.__class__(
             child=child,
             function=self.function,
             style=self.style_arg,


### PR DESCRIPTION
The idea here is to better facilitate custom dynamic transforms. In the example use-case below Transform is sub-classed so that it may react to events and update the rotation property based on the current mouse location relative to the displayable.

As of 7.3.5 only one of the three displayables functions as expected, because the `Transform` constructor is hard-coded inside the `__call__` method, meaning that sub-classes always end up creating vanilla Transform instances when following that code path. This change switches this to make use of the current instance type's constructor in an effort to resolve this.

```rpy
label main_menu:
    $ _confirm_quit = False
    return

init python:
    import math
    import pygame

    gui.init(1024, 768)

    class PointOfInterest(renpy.display.layout.Transform):
        def event(self, ev, x, y, st):
            if ev.type in (pygame.MOUSEMOTION,
                           pygame.MOUSEBUTTONDOWN,
                           pygame.MOUSEBUTTONUP):
                w, h = self.render_size
                x -= w / 2.
                y -= h / 2.
                self.rotate = math.atan2(x, y) * (180 / -math.pi)
                renpy.redraw(self, 0)
            return super(PointOfInterest, self).event(ev, x, y, st)

define follow = PointOfInterest()
image pointer1 = Solid('f777', xysize=(20, 300))
image pointer2 = Solid('7f77', xysize=(20, 300))
image pointer3 = Solid('77f7', xysize=(20, 300))

label start:
    scene
    show expression PointOfInterest('pointer1', align=(.5, .2)) # works in 7.3.5
    show pointer2 at follow, Transform(align=(.5, .4), xoffset=-200) # works after patch
    show expression PointOfInterest('pointer3') at Transform(align=(.5, .4), xoffset=200) # works after patch
    "The red line will track the mouse in 7.3.5."
    "However the green and blue lines are not functional, as they've become vanilla transform instances."
    "Using this fix, the green and blue lines retain their subclass and work as expected."
    return
```