### PR TITLE
Remove `\n` replacement in log files, because `io.open` is dealing with it

### DIFF
--- a/renpy/log.py
+++ b/renpy/log.py
@@ -159,8 +159,6 @@ class LogFile(object):
             if not isinstance(s, str):
                 s = s.decode("latin-1")
 
-            s = s.replace("\n", "\r\n")
-
             self.file.write(s)
 
             if self.flush:


### PR DESCRIPTION
Without it, the raw line is written to the file as `LINE\r\r\n` and some text editors treat it as Mac line endings.