### PR TITLE
Consistent loading on all OSes

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -603,7 +603,7 @@ def load(name, tl=True):
     if renpy.config.reject_backslash and "\\" in name:
         raise Exception("Backslash in filename, use '/' instead: %r" % name)
 
-    name = re.sub(r'/+', '/', name).lstrip('/')
+    name = re.sub(r'/+', '/', name)
 
     for p in get_prefixes(tl):
         rv = load_core(p + name)
@@ -651,7 +651,7 @@ def loadable_core(name):
 
 def loadable(name):
 
-    name = name.lstrip('/')
+    name = name
 
     if (renpy.config.loadable_callback is not None) and renpy.config.loadable_callback(name):
         return True
@@ -669,7 +669,7 @@ def transfn(name):
     searched directories.
     """
 
-    name = name.lstrip('/')
+    name = name
 
     if renpy.config.reject_backslash and "\\" in name:
         raise Exception("Backslash in filename, use '/' instead: %r" % name)


### PR DESCRIPTION
Linking [#5901](https://github.com/Monika-After-Story/MonikaModDev/pull/5901) from another repository.

When working on a small script to allow music to play from a folder in the basedir (easy access to anyone who wishes to add their own), my script worked absolutely fine on windows, until I had an issue opened which indicated that it did not on Linux.

Eventually got my own Linux VM and began testing it, noticed when I tried to load the files myself via console (or other means) the traceback returned always returned a path of `home/user/...` instead of `/home/user/...`, which is an invalid path, of course.

After looking into the source code, I noticed the `lstrip('/')`. I tested without it and all loading seems to still work completely fine without it, and I've had it tested on Linux, Mac, and Windows, all returning with no issues.

I consider the behaviour here a bug because of the fact that it is inconsistent across OSes (Since Windows filepaths begin with a letter rather than a `/`, their paths work absolutely fine). This provides a false assumption to those who do not know the nuances of Ren'Py, and given that the team I'm working with on a Ren'Py project carries out development on an open source repository with numerous contributors with varying degrees of experience. This becomes a problem when people come in with programming backgrounds from different languages where this sort of file access manner works completely fine cross-platform).

Additionally, the files can still be pythonically accessed, meaning that if you were doing some processing on it prior to passing it to Ren'Py to use it, it'd work completely fine up until that point (which is more of just an annoying caveat which can be avoided)

So with testing showing no issues in being able to simply remove the `lstrip` at all, it seems like we can just do without it to effectively maintain all other workflows but allow this one as well.