### PR TITLE
Fix typo (draw -> gl2draw)

### DIFF
--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -1219,7 +1219,7 @@ cdef class GL2DrawingContext:
         cdef bint old_nearest = self.nearest
 
         if isinstance(what, Surface):
-            what = self.draw.load_texture(what)
+            what = self.gl2draw.load_texture(what)
 
         if isinstance(what, Model):
             self.draw_model(what, transform, clip_polygon, subpixel)


### PR DESCRIPTION
Fixes `AttributeError` while trying to use `renpy.gl2.gl2draw.GL2DrawingContext.draw` with a Surface.