### PR TITLE
Python3 Readiness

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -72,7 +72,7 @@ def load(fn):
 
     try:
         rv = renpy.loader.load(fn)
-    except renpy.webloader.DownloadNeeded, exception:
+    except renpy.webloader.DownloadNeeded as exception:
         if exception.rtype == 'music':
             renpy.webloader.enqueue(exception.relpath, 'music', None)
         elif exception.rtype == 'voice':

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -136,7 +136,7 @@ python early hide:
             fn = _audio_eval(p["file"])
             try:
                 renpy.loader.load(fn)
-            except renpy.webloader.DownloadNeeded, exception:
+            except renpy.webloader.DownloadNeeded as exception:
                 renpy.webloader.enqueue(exception.relpath, 'music', None)
         return [ ]
 

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -539,7 +539,7 @@ python early hide:
             fn = config.voice_filename_format.format(filename=_audio_eval(fn))
             try:
                 renpy.loader.load(fn)
-            except renpy.webloader.DownloadNeeded, exception:
+            except renpy.webloader.DownloadNeeded as exception:
                 renpy.webloader.enqueue(exception.relpath, 'voice', None)
         return [ ]
 

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -643,7 +643,7 @@ class Image(ImageBase):
             try:
                 filelike = renpy.loader.load(self.filename)
                 filename = self.filename
-            except renpy.webloader.DownloadNeeded, exception:
+            except renpy.webloader.DownloadNeeded as exception:
                 renpy.webloader.enqueue(exception.relpath, 'image', self.filename)
                 # temporary placeholder:
                 filelike = open(os.path.join('_placeholders', exception.relpath), 'rb')

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -549,7 +549,7 @@ def load_core(name):
 
         return rv
 
-    if remote_files.has_key(name):
+    if name in remote_files:
         raise DownloadNeeded(relpath=name, rtype=remote_files[name]['type'], size=remote_files[name]['size'])
 
     return None
@@ -641,7 +641,7 @@ def loadable_core(name):
             loadable_cache[name] = True
             return True
 
-    if remote_files.has_key(name):
+    if name in remote_files:
         loadable_cache[name] = True
         return name
 

--- a/renpy/webloader.py
+++ b/renpy/webloader.py
@@ -128,11 +128,11 @@ elif os.environ.get('RENPY_SIMULATE_DOWNLOAD', False):
                     with queue_lock:
                         with open(fullpath, 'wb') as f:
                             f.write(r.read())
-                except urllib2.URLError, e:
+                except urllib2.URLError as e:
                     self.error = str(e.reason)
-                except httplib.HTTPException, e:
+                except httplib.HTTPException as e:
                     self.error = 'HTTPException'
-                except Exception, e:
+                except Exception as e:
                     self.error = 'Error: ' + str(e)
                 self.done = True
             threading.Thread(target=thread_main, name="XMLHttpRequest").start()


### PR DESCRIPTION
I have made a few adjustments to project code to allow for compiling and running with Python 3.

## Changes
- Replaced all instances of `except <type>, <var>` with `except <type> as <var>` in Python and RenPy code. The ladder format is valid in both Python 3.X and 2.7.
- Replaced all instances of `<dict>.has_key(<key>)` with `<key> in <dict>` in Python and RenPy code. The ladder format is also valid in both Python 3.X and 2.7.

## Goals
- Do the bare minimum to let RenPy use Python 3.X.
- To be a stepping stone in getting RenPy completely Python 3.X compliant.

### Non-Goals
- Change how RenPy projects are packaged or provide configuration options to change the Python runtime's version.
- Refactor code that uses deprecated methods / functions. (Except of those deprecated methods / functions that have been *removed*.)

## Notes
Before, you would need to use the `python2` command to build and run RenPy projects. This pull request allows the `python` / `python3` command to be able to do the same things, without errors. Using Python 3 will run RenPy code using Python 3, this can be seen by adding this snippet to anywhere in a RenPy script:
```renpy
python:
  import sys
  print(sys.version_info)
```
