### PR TITLE
Add support for margin to grids

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -424,6 +424,11 @@ class Grid(Container):
         if yspacing is None:
             yspacing = self.style.spacing
 
+        left_margin = scale(self.style.left_margin, width)
+        right_margin = scale(self.style.right_margin, width)
+        top_margin = scale(self.style.top_margin, height)
+        bottom_margin = scale(self.style.bottom_margin, height)
+
         # For convenience and speed.
         cols = self.cols
         rows = self.rows
@@ -449,9 +454,9 @@ class Grid(Container):
         renheight = height
 
         if self.style.xfill:
-            renwidth = (width - (cols - 1) * xspacing) // cols
+            renwidth = (width - (cols - 1) * xspacing - left_margin - right_margin) // cols
         if self.style.yfill:
-            renheight = (height - (rows - 1) * yspacing) // rows
+            renheight = (height - (rows - 1) * yspacing - top_margin - bottom_margin) // rows
 
         renders = [ render(i, renwidth, renheight, st, at) for i in children ]
         sizes = [ i.get_size() for i in renders ]
@@ -469,8 +474,8 @@ class Grid(Container):
         if self.style.yfill:
             cheight = renheight
 
-        width = cwidth * cols + xspacing * (cols - 1)
-        height = cheight * rows + yspacing * (rows - 1)
+        width = cwidth * cols + xspacing * (cols - 1) + left_margin + right_margin
+        height = cheight * rows + yspacing * (rows - 1) + top_margin + bottom_margin
 
         rv = renpy.display.render.Render(width, height)
 
@@ -482,8 +487,8 @@ class Grid(Container):
                 child = children[ x + y * cols ]
                 surf = renders[x + y * cols]
 
-                xpos = x * (cwidth + xspacing)
-                ypos = y * (cheight + yspacing)
+                xpos = x * (cwidth + xspacing) + left_margin
+                ypos = y * (cheight + yspacing) + top_margin
 
                 offset = child.place(rv, xpos, ypos, cwidth, cheight, surf)
                 offsets.append(offset)

--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -572,21 +572,28 @@ class VPGrid(Viewport):
         if yspacing is None:
             yspacing = self.style.spacing
 
+        left_margin = renpy.display.layout.scale(self.style.left_margin, width)
+        right_margin = renpy.display.layout.scale(self.style.right_margin, width)
+        top_margin = renpy.display.layout.scale(self.style.top_margin, height)
+        bottom_margin = renpy.display.layout.scale(self.style.bottom_margin, height)
+
         rend = renpy.display.render.render(self.children[0], child_width, child_height, st, at)
         cw, ch = rend.get_size()
 
-        tw = (cw + xspacing) * cols - xspacing
-        th = (ch + yspacing) * rows - yspacing
+        tw = (cw + xspacing) * cols - xspacing + left_margin + right_margin
+        th = (ch + yspacing) * rows - yspacing + top_margin + bottom_margin
 
         if self.style.xfill:
             tw = child_width
-            cw = (tw - (cols - 1) * xspacing) // cols
+            cw = (tw - (cols - 1) * xspacing - left_margin - right_margin) // cols
 
         if self.style.yfill:
             th = child_height
-            ch = (th - (rows - 1) * yspacing) // rows
+            ch = (th - (rows - 1) * yspacing - top_margin - bottom_margin) // rows
 
         cxo, cyo, width, height = self.update_offsets(tw, th, st)
+        cxo += left_margin
+        cyo += top_margin
 
         self.offsets = [ ]
 

--- a/renpy/sl2/slproperties.py
+++ b/renpy/sl2/slproperties.py
@@ -104,9 +104,7 @@ text_property_names = [
 text_properties = [ Style(i) for i in text_property_names ]
 text_text_properties = [ PrefixStyle("text_", i) for i in text_property_names ]
 
-window_properties = [ Style(i) for i in [
-    "background",
-    "foreground",
+margin_properties = [ Style(i) for i in [
     "left_margin",
     "right_margin",
     "bottom_margin",
@@ -114,6 +112,9 @@ window_properties = [ Style(i) for i in [
     "xmargin",
     "ymargin",
     "margin",
+    ] ]
+
+padding_properties = [ Style(i) for i in [
     "left_padding",
     "right_padding",
     "top_padding",
@@ -121,8 +122,13 @@ window_properties = [ Style(i) for i in [
     "xpadding",
     "ypadding",
     "padding",
-    "size_group",
     ] ]
+
+window_properties = [ Style(i) for i in [
+    "background",
+    "foreground",
+    "size_group",
+    ] ] + margin_properties + padding_properties
 
 button_properties = [ Style(i) for i in [
     "sound",
@@ -188,7 +194,7 @@ grid_properties = [ Style(i) for i in [
     "spacing",
     "xspacing",
     "yspacing",
-    ] ]
+    ] ] + margin_properties
 
 
 ui_properties = [

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -95,6 +95,7 @@ text.::
          color "#fff"
          selected_color "#ff0"
 
+
 Style Property Values
 =====================
 
@@ -229,6 +230,7 @@ List of All Style Properties
 The style properties control the look of the various displayables. Not all
 style properties apply to all displayables, so we've divided them up into
 groups.
+
 
 .. _position-style-properties:
 
@@ -596,7 +598,7 @@ Text Style Properties
 
     Outlines only work with TrueType fonts.
 
-.. style-property: outline_scaling string
+.. style-property:: outline_scaling string
 
     This determines how outline suzels or offsets are scaled when the
     window is scaled.
@@ -644,7 +646,6 @@ Text Style Properties
     The speed of the text is multiplied by this number. This can be
     used to have a character that speaks at a faster-than-normal rate
     of speed.
-
 
 .. style-property:: strikethrough boolean
 
@@ -696,6 +697,7 @@ Text Style Properties
         Uses bytecode hinting information found in the font.
     "none"
         Does not hint the font.
+
 
 .. _window-style-properties:
 

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -704,7 +704,8 @@ Text Style Properties
 Window Style Properties
 -----------------------
 
-Window properties are used to specify the look of windows, frames, and buttons.
+Window properties are used to specify the look of windows, frames, and
+buttons. :ref:`margin-style-properties` also form part of this group.
 
 .. style-property:: background displayable or None
 
@@ -719,41 +720,6 @@ Window properties are used to specify the look of windows, frames, and buttons.
 
     If not None, this displayable is drawn above the contents of the
     window.
-
-.. style-property:: left_margin int
-
-    The amount of transparent space to the left of the background, in
-    pixels.
-
-.. style-property:: right_margin int
-
-    The amount of transparent space to the right of the background, in
-    pixels.
-
-.. style-property:: xmargin int
-
-    Equivalent to setting left_margin and right_margin to the same
-    value.
-
-.. style-property:: top_margin int
-
-    The amount of transparent space above the background, in pixels.
-
-.. style-property:: bottom_margin int
-
-    The amount of transparent space below the background, in pixels.
-
-.. style-property:: ymargin int
-
-    Equivalent to setting top_margin and bottom_margin to the same
-    value.
-
-.. style-property:: margin tuple
-
-    When given a two-item tuple, equivalent to setting xmargin and
-    ymargin to the two items. When given a four-item tuple, equivalent
-    to setting left_margin, top_margin, right_margin, and bottom_margin
-    to the four items.
 
 .. style-property:: left_padding int
 
@@ -1019,7 +985,8 @@ These are used for the horizontal and vertical box layouts.
 Grid Style Properties
 ---------------------
 
-These are the use by the grid and vpgrid displayables.
+These are the properties used by the grid and vpgrid displayables.
+:ref:`margin-style-properties` also form part of this group.
 
 .. style-property:: spacing int
 
@@ -1066,3 +1033,47 @@ These are used with the fixed layout.
     with the first item in the box being below the second, and so on. If True,
     this order will be reversed, and the first item in the box will be above
     all other items in the box.
+
+
+.. _margin-style-properties:
+
+Margin Style Properties
+-----------------------
+
+Margin properties are used to add transparent space around some
+displyables. Most notably: windows, frames, buttons and grids.
+
+.. style-property:: left_margin int
+
+    The amount of transparent space to the left of the displayable, in
+    pixels.
+
+.. style-property:: right_margin int
+
+    The amount of transparent space to the right of the displayable, in
+    pixels.
+
+.. style-property:: xmargin int
+
+    Equivalent to setting left_margin and right_margin to the same
+    value.
+
+.. style-property:: top_margin int
+
+    The amount of transparent space above the displayable, in pixels.
+
+.. style-property:: bottom_margin int
+
+    The amount of transparent space below the displayable, in pixels.
+
+.. style-property:: ymargin int
+
+    Equivalent to setting top_margin and bottom_margin to the same
+    value.
+
+.. style-property:: margin tuple
+
+    When given a two-item tuple, equivalent to setting xmargin and
+    ymargin to the two items. When given a four-item tuple, equivalent
+    to setting left_margin, top_margin, right_margin, and bottom_margin
+    to the four items.


### PR DESCRIPTION
Allows `margin` family of properties to be used to specify additional space around grids. While this was previously possible for vanilla grids by nesting them within a `Window` layout, it was not possible to do this with vpgrids such that the additional space appeared inside the embedded viewport, which is the primary motivation for this addition.

<details><summary>Diagram showing exactly how this applies</summary>

![vpgrid-margin](https://user-images.githubusercontent.com/591257/86540090-347e1100-befa-11ea-8b00-585c326a27ae.png)
</details>