### PR TITLE
Set start_interact before call start_interact_callbacks

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -2855,12 +2855,12 @@ class Interface(object):
         self.preloads = [ ]
 
         try:
+            self.start_interact = True
+
             for i in renpy.config.start_interact_callbacks:
                 i()
 
             repeat = True
-
-            self.start_interact = True
 
             while repeat:
                 repeat, rv = self.interact_core(preloads=preloads, trans_pause=trans_pause, **kwargs)


### PR DESCRIPTION
This change allows to get the correct value of `start_interact` (via renpy.is_start_interact) in `config.start_interact_callbacks`.
It allows to use the same function in also `config.interact_callbacks` and reduce code duplication.