### PR TITLE
Add alias for `__` in Ren'Py exports as renpy.translate_string

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -86,7 +86,7 @@ from renpy.atl import atl_warper
 from renpy.easy import predict, displayable, split_properties
 from renpy.parser import unelide_filename, get_parse_errors
 
-from renpy.translation import change_language, known_languages
+from renpy.translation import change_language, known_languages, translate_string
 from renpy.translation.generation import generic_filter as transform_text
 
 from renpy.persistent import register_persistent
@@ -162,7 +162,7 @@ def public_api():
     predict, predict_screen
     displayable, split_properties
     unelide_filename, get_parse_errors
-    change_language, known_languages
+    change_language, known_languages, translate_string
     transform_text
     language_tailor
     register_persistent


### PR DESCRIPTION
This function is already documented as `renpy.translate_string` and it is strange that it is not part of the API.
1. It doesn't mark strings as translatable.
2. It (as opposed to `__`) has a documented `language` argument. 
And also `__(var, None)` looks ugly.