### PR TITLE
web: mobile: browser virtual keyboard support

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -152,6 +152,8 @@ def compile_event(key, keydown):
 
     return rv
 
+if renpy.emscripten:
+    import emscripten, json
 
 # These store a lambda for each compiled key in the system.
 event_cache = { }
@@ -1243,6 +1245,9 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
                 l = len(content)
                 self.set_text([self.prefix, content[0:self.caret_pos].replace("{", "{{"), edit_text, caret,
                                content[self.caret_pos:l].replace("{", "{{"), self.suffix])
+                if renpy.emscripten and renpy.display.touch:
+                    emscripten.run_script(r'''rpw_set_text_input(%s)''' % (
+                        json.dumps(content)))
             else:
                 self.set_text([self.prefix, content.replace("{", "{{"), self.suffix ])
 
@@ -1312,6 +1317,53 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
 
         raw_text = None
 
+        def parse_raw_text():
+
+            text = ""
+
+            for c in raw_text:
+
+                # Allow is given
+                if self.allow:
+
+                    # Allow is regex
+                    if isinstance(self.allow, re._pattern_type):
+
+                        # Character doesn't match
+                        if self.allow.search(c) is None:
+                            continue
+
+                    # Allow is string
+                    elif c not in self.allow:
+                        continue
+
+                # Exclude is given
+                if self.exclude:
+
+                    # Exclude is regex
+                    if isinstance(self.exclude, re._pattern_type):
+
+                        # Character matches
+                        if self.exclude.search(c) is not None:
+                            continue
+
+                    # Exclude is string
+                    elif c in self.exclude:
+                        continue
+
+                text += c
+
+            if self.length:
+                remaining = self.length - len(self.content)
+                text = text[:remaining]
+
+            if text:
+
+                content = self.content[0:self.caret_pos] + text + self.content[self.caret_pos:l]
+                self.caret_pos += len(text)
+
+                self.update_text(content, self.editable, check_size=True)
+
         if map_event(ev, "input_backspace"):
 
             if self.content and self.caret_pos > 0:
@@ -1323,6 +1375,11 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
             raise renpy.display.core.IgnoreEvent()
 
         elif map_event(ev, "input_enter"):
+
+            if renpy.emscripten and renpy.display.touch:
+                self.content = ''
+                raw_text = emscripten.run_script_string(r'''rpw_grab_text_input()''')
+                parse_raw_text()
 
             content = self.content
 
@@ -1403,50 +1460,7 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
 
         if raw_text is not None:
 
-            text = ""
-
-            for c in raw_text:
-
-                # Allow is given
-                if self.allow:
-
-                    # Allow is regex
-                    if isinstance(self.allow, re._pattern_type):
-
-                        # Character doesn't match
-                        if self.allow.search(c) is None:
-                            continue
-
-                    # Allow is string
-                    elif c not in self.allow:
-                        continue
-
-                # Exclude is given
-                if self.exclude:
-
-                    # Exclude is regex
-                    if isinstance(self.exclude, re._pattern_type):
-
-                        # Character matches
-                        if self.exclude.search(c) is not None:
-                            continue
-
-                    # Exclude is string
-                    elif c in self.exclude:
-                        continue
-
-                text += c
-
-            if self.length:
-                remaining = self.length - len(self.content)
-                text = text[:remaining]
-
-            if text:
-
-                content = self.content[0:self.caret_pos] + text + self.content[self.caret_pos:l]
-                self.caret_pos += len(text)
-
-                self.update_text(content, self.editable, check_size=True)
+            parse_raw_text()
 
             raise renpy.display.core.IgnoreEvent()
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -48,6 +48,9 @@ try:
 except:
     android = None
 
+if renpy.emscripten:
+    import emscripten
+
 TIMEEVENT = pygame.event.register("TIMEEVENT")
 PERIODIC = pygame.event.register("PERIODIC")
 REDRAW = pygame.event.register("REDRAW")
@@ -2405,7 +2408,6 @@ class Interface(object):
         try:
             renpy.display.scale.image_save_unscaled(window, filename)
             if renpy.emscripten:
-                import emscripten
                 emscripten.run_script(r'''FSDownload('%s');''' % filename)
             return True
         except:
@@ -2788,6 +2790,8 @@ class Interface(object):
         if self.text_rect is not None:
 
             not_shown = pygame.key.has_screen_keyboard_support() and not pygame.key.is_screen_keyboard_shown() # @UndefinedVariable
+            if renpy.emscripten and self.touch:
+                not_shown = emscripten.run_script_int(r'''rpw_is_screen_keyboard_shown()''')
 
             if self.old_text_rect != self.text_rect:
                 x, y, w, h = self.text_rect
@@ -2796,14 +2800,22 @@ class Interface(object):
                 rect = (x0, y0, x1 - x0, y1 - y0)
 
                 pygame.key.set_text_input_rect(rect) # @UndefinedVariable
+                if renpy.emscripten and self.touch:
+                    emscripten.run_script(r'''rpw_set_text_input_rect(%d,%d,%d,%d)''' % (
+                        x, y, w, h))  # keep translated coordinates
 
             if not self.old_text_rect or not_shown:
                 pygame.key.start_text_input() # @UndefinedVariable
+                if renpy.emscripten and self.touch:
+                    emscripten.run_script(r'''rpw_start_text_input()''')
 
         else:
             if self.old_text_rect:
                 pygame.key.stop_text_input() # @UndefinedVariable
                 pygame.key.set_text_input_rect(None) # @UndefinedVariable
+                if renpy.emscripten and self.touch:
+                    emscripten.run_script(r'''rpw_stop_text_input()''')
+                    emscripten.run_script(r'''rpw_set_text_input_rect(null)''')
 
         self.old_text_rect = self.text_rect
 


### PR DESCRIPTION
Currently players on mobile web are stuck whenever the game asks text input (typically "what's your name").

As usual web support is tricky, and there's no API for the mobile browser virtual keyboard. My leads are:

(1) Map a HTML text input with SDL2 (character-based): cf. https://github.com/emscripten-ports/SDL2/issues/80 -- APIs/events don't match, security policies are in the way, little external interest, probably not feasible

(2) Implement a virtual keyboard within Ren'Py: sounds OK; it won't support many characters or input methods but integration would be best

(3) Map a HTML text input with Ren'Py (line-based): sounds OK; supports the characters / input methods that the browser supports, integration is a bit rough (translucent text input at the top) but works

(4) Give up and tell devs/porters to do their [own keyboard in Screen Language](https://lemmasoft.renai.us/forums/viewtopic.php?f=51&t=25972): hopefully not, I think we can provide a default something that works in the common case 

This PR is a working attempt at (3).

I just see now that there's some issue with Firefox who simulates _some_ keys events (space, /... but not letters) and messes things up, so this isn't ready yet, but I thought I'd be good to start the conversation.

![virtual-keyboard](https://user-images.githubusercontent.com/980977/87857255-a0fb0600-c925-11ea-8753-107f7ba81cc6.png)
