### PR TITLE
Fixes #2292: Use utf-8 encoding when writing to lint file output

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -708,7 +708,7 @@ def lint():
     args = ap.parse_args()
 
     if args.filename:
-        f = open(args.filename, "w")
+        f = codecs.open(args.filename, "w", encoding="utf-8")
         sys.stdout = f
 
     renpy.game.lint = True


### PR DESCRIPTION
Using codecs.open here to do implicit conversion of any str to unicode while writing to the lint output file. If a filename is not provided as an argument to the lint command, then output is sent to sys.stdout for which the str to unicode conversion is already in place (using future.utils.text_type) in https://github.com/renpy/renpy/blob/master/renpy/log.py#L228-L229