### PR TITLE
Normalize unicode to NFC

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -30,6 +30,7 @@ import threading
 import zlib
 import re
 import io
+import unicodedata
 
 from renpy.compat.pickle import loads
 from renpy.webloader import DownloadNeeded
@@ -172,10 +173,10 @@ def index_archives():
             raise
 
     for dir, fn in listdirfiles(): # @ReservedAssignment
-        lower_map[fn.lower()] = fn
+        lower_map[unicodedata.normalize('NFC', fn.lower())] = fn
 
     for fn in remote_files:
-        lower_map[fn.lower()] = fn
+        lower_map[unicodedata.normalize('NFC', fn.lower())] = fn
 
 
 def walkdir(dir): # @ReservedAssignment
@@ -247,7 +248,7 @@ def scandirfiles():
 
         files.append((dn, fn))
         seen.add(fn)
-        loadable_cache[fn.lower()] = True
+        loadable_cache[unicodedata.normalize('NFC', fn.lower())] = True
 
     for apk in apks:
 
@@ -492,7 +493,7 @@ def load_core(name):
     Returns an open python file object of the given type.
     """
 
-    name = lower_map.get(name.lower(), name)
+    name = lower_map.get(unicodedata.normalize('NFC', name.lower()), name)
 
     if renpy.config.file_open_callback:
         rv = renpy.config.file_open_callback(name)
@@ -619,7 +620,7 @@ def loadable_core(name):
     Returns True if the name is loadable with load, False if it is not.
     """
 
-    name = lower_map.get(name.lower(), name)
+    name = lower_map.get(unicodedata.normalize('NFC', name.lower()), name)
 
     if name in loadable_cache:
         return loadable_cache[name]
@@ -675,7 +676,7 @@ def transfn(name):
     if renpy.config.reject_backslash and "\\" in name:
         raise Exception("Backslash in filename, use '/' instead: %r" % name)
 
-    name = lower_map.get(name.lower(), name)
+    name = lower_map.get(unicodedata.normalize('NFC', name.lower()), name)
 
     if isinstance(name, bytes):
         name = name.decode("utf-8")


### PR DESCRIPTION
Some environments (especially macOS on HFS+ filesystem) will automatically normalize filenames to a customized version of NFD (see also https://gist.github.com/JamesChevalier/8448512 ).

This will allow those files to be found, even if the filesystem is normalization sensitive.