### PR TITLE
Add K_key keysyms to default Ren'Py keymap

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -26,27 +26,27 @@ init -1600 python:
         # Bindings present almost everywhere, unless explicitly
         # disabled.
         rollback = [ 'K_PAGEUP', 'repeat_K_PAGEUP', 'K_AC_BACK', 'mousedown_4' ],
-        screenshot = [ 's', 'alt_K_s', 'alt_shift_K_s' ],
+        screenshot = [ 's', 'alt_K_s', 'alt_shift_K_s', 'noshift_K_s' ],
         toggle_afm = [ ],
-        toggle_fullscreen = [ 'f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11' ],
+        toggle_fullscreen = [ 'f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11', 'noshift_K_f' ],
         game_menu = [ 'K_ESCAPE', 'K_MENU', 'K_PAUSE', 'mouseup_3' ],
-        hide_windows = [ 'mouseup_2', 'h' ],
-        launch_editor = [ 'E' ],
+        hide_windows = [ 'mouseup_2', 'h', 'noshift_K_h' ],
+        launch_editor = [ 'E', 'shift_K_e' ],
         dump_styles = [ ],
-        reload_game = [ 'R', 'alt_shift_K_r' ],
-        inspector = [ 'I' ],
+        reload_game = [ 'R', 'alt_shift_K_r', 'shift_K_r' ],
+        inspector = [ 'I', 'shift_K_i' ],
         full_inspector = [ 'alt_shift_K_i' ],
-        developer = [ 'D', 'alt_shift_K_d' ],
+        developer = [ 'shift_K_d', 'alt_shift_K_d' ],
         quit = [ ],
         iconify = [ ],
         help = [ 'K_F1', 'meta_shift_/' ],
-        choose_renderer = [ 'G', 'alt_shift_K_g' ],
+        choose_renderer = [ 'G', 'alt_shift_K_g', 'shift_K_g' ],
         progress_screen = [ 'alt_shift_K_p', 'meta_shift_K_p', 'K_F2' ],
         accessibility = [ "K_a" ],
 
         # Accessibility.
-        self_voicing = [ 'v', 'V', 'alt_K_v'  ],
-        clipboard_voicing = [ 'C', 'alt_shift_K_c' ],
+        self_voicing = [ 'v', 'V', 'alt_K_v', 'K_v' ],
+        clipboard_voicing = [ 'C', 'alt_shift_K_c', 'shift_K_c' ],
         debug_voicing = [ 'alt_shift_K_v', 'meta_shift_K_v' ],
 
         # Say.
@@ -79,8 +79,8 @@ init -1600 python:
         input_delete = [ 'K_DELETE', 'repeat_K_DELETE' ],
         input_home = [ 'K_HOME' ],
         input_end = [ 'K_END' ],
-        input_copy = [ 'ctrl_K_INSERT', 'ctrl_K_c' ],
-        input_paste = [ 'shift_K_INSERT', 'ctrl_K_v' ],
+        input_copy = [ 'ctrl_noshift_K_INSERT', 'ctrl_noshift_K_c' ],
+        input_paste = [ 'shift_K_INSERT', 'ctrl_noshift_K_v' ],
 
         # Viewport.
         viewport_leftarrow = [ 'K_LEFT', 'repeat_K_LEFT' ],
@@ -91,14 +91,14 @@ init -1600 python:
         viewport_wheeldown = [ 'mousedown_5' ],
         viewport_drag_start = [ 'mousedown_1' ],
         viewport_drag_end = [ 'mouseup_1' ],
-        viewport_pageup = [  'K_PAGEUP', 'repeat_K_PAGEUP' ],
-        viewport_pagedown = [  'K_PAGEDOWN', 'repeat_K_PAGEDOWN' ],
+        viewport_pageup = [ 'K_PAGEUP', 'repeat_K_PAGEUP' ],
+        viewport_pagedown = [ 'K_PAGEDOWN', 'repeat_K_PAGEDOWN' ],
 
         # These keys control skipping.
         skip = [ 'K_LCTRL', 'K_RCTRL' ],
         stop_skipping = [ ],
         toggle_skip = [ 'K_TAB' ],
-        fast_skip = [ '>' ],
+        fast_skip = [ '>', 'shift_K_PERIOD' ],
 
         # Bar.
         bar_activate = [ 'mousedown_1', 'K_RETURN', 'K_KP_ENTER', 'K_SELECT' ],
@@ -116,12 +116,12 @@ init -1600 python:
         drag_deactivate = [ 'mouseup_1' ],
 
         # Debug console.
-        console = [ 'shift_O', 'alt_shift_K_o' ],
+        console = [ 'shift_K_o', 'alt_shift_K_o' ],
         console_older = [ 'K_UP', 'repeat_K_UP' ],
         console_newer = [ 'K_DOWN', 'repeat_K_DOWN'],
 
         # Director
-        director = [ 'd' ],
+        director = [ 'noshift_K_d' ],
 
         # Ignored (kept for backwards compatibility).
         toggle_music = [ 'm' ],
@@ -134,7 +134,7 @@ init -1600 python:
         profile_once = [ 'K_F8' ],
         memory_profile = [ 'K_F7' ],
 
-        )
+    )
 
     config.default_keymap = { k : list(v) for k, v in config.keymap.items() }
 
@@ -163,7 +163,7 @@ init -1600 python:
         "pad_rightx_pos" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
 
         "pad_dpup_press" : [ "focus_up", "bar_up", "viewport_uparrow" ],
-        "pad_lefty_neg" :  [ "focus_up", "bar_up", "viewport_uparrow" ],
+        "pad_lefty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
         "pad_righty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
 
         "pad_dpdown_press" : [ "focus_down", "bar_down", "viewport_downarrow" ],

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -285,11 +285,11 @@ init python:
 
         # Bindings present almost everywhere, unless explicitly
         # disabled.
-        toggle_fullscreen = [ 'f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11' ],
-        reload_game = [ 'R' ],
+        toggle_fullscreen = [ 'noshift_K_f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11' ],
+        reload_game = [ 'shift_K_r' ],
         quit = [ 'meta_q', 'alt_K_F4', 'alt_q' ],
         iconify = [ 'meta_m', 'alt_m' ],
-        choose_renderer = [ 'G' ],
+        choose_renderer = [ 'shift_K_g' ],
 
         # Focus.
         focus_left = [ 'K_LEFT' ],
@@ -637,7 +637,7 @@ screen _exception:
                     hovered tt.action(_("Quits the game."))
 
     if config.developer and reload_action:
-        key "R" action reload_action
+        key "reload_game" action reload_action
 
     key "console" action __EnterConsole()
 
@@ -703,4 +703,4 @@ screen _parse_errors:
             text tt.value
 
     if config.developer and reload_action:
-        key "R" action reload_action
+        key "reload_game" action reload_action

--- a/sphinx/source/keymap.rst
+++ b/sphinx/source/keymap.rst
@@ -25,6 +25,7 @@ scroll wheel to the top.
 There are two kinds of keyboard keysyms. The first is a string containing a
 character that is generated when a key is pressed. This is useful for
 binding alphabetic keys and numbers. Examples of these keysyms include "a", "A", and "7".
+Note that these are case sensitive, "a" does not match "A".
 
 Keyboard keysyms can also be the symbolic name for the key. This can be any of
 the K\_ constants taken from pygame.constants. This type of keysym looks like
@@ -69,34 +70,35 @@ statement, and removes the space key from that list. ::
         $ config.keymap['dismiss'].remove('K_SPACE')
 
 The default keymap is contained inside renpy/common/00keymap.rpy, and
-as of version 6.99 is as follows::
+as of version 7.4 is as follows::
 
     config.keymap = dict(
 
         # Bindings present almost everywhere, unless explicitly
         # disabled.
         rollback = [ 'K_PAGEUP', 'repeat_K_PAGEUP', 'K_AC_BACK', 'mousedown_4' ],
-        screenshot = [ 's' ],
+        screenshot = [ 's', 'alt_K_s', 'alt_shift_K_s', 'noshift_K_s' ],
         toggle_afm = [ ],
-        toggle_fullscreen = [ 'f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11' ],
+        toggle_fullscreen = [ 'f', 'alt_K_RETURN', 'alt_K_KP_ENTER', 'K_F11', 'noshift_K_f' ],
         game_menu = [ 'K_ESCAPE', 'K_MENU', 'K_PAUSE', 'mouseup_3' ],
-        hide_windows = [ 'mouseup_2', 'h' ],
-        launch_editor = [ 'E' ],
+        hide_windows = [ 'mouseup_2', 'h', 'noshift_K_h' ],
+        launch_editor = [ 'E', 'shift_K_e' ],
         dump_styles = [ ],
-        reload_game = [ 'R' ],
-        inspector = [ 'I' ],
-        full_inspector = [ 'alt_I' ],
-        developer = [ 'D' ],
+        reload_game = [ 'R', 'alt_shift_K_r', 'shift_K_r' ],
+        inspector = [ 'I', 'shift_K_i' ],
+        full_inspector = [ 'alt_shift_K_i' ],
+        developer = [ 'shift_K_d', 'alt_shift_K_d' ],
         quit = [ ],
         iconify = [ ],
         help = [ 'K_F1', 'meta_shift_/' ],
-        choose_renderer = [ 'G' ],
+        choose_renderer = [ 'G', 'alt_shift_K_g', 'shift_K_g' ],
         progress_screen = [ 'alt_shift_K_p', 'meta_shift_K_p', 'K_F2' ],
+        accessibility = [ "K_a" ],
 
         # Accessibility.
-        self_voicing = [ 'v', 'V' ],
-        clipboard_voicing = [ 'C' ],
-        debug_voicing = [ 'alt_V', 'meta_V' ],
+        self_voicing = [ 'v', 'V', 'alt_K_v', 'K_v' ],
+        clipboard_voicing = [ 'C', 'alt_shift_K_c', 'shift_K_c' ],
+        debug_voicing = [ 'alt_shift_K_v', 'meta_shift_K_v' ],
 
         # Say.
         rollforward = [ 'mousedown_5', 'K_PAGEDOWN', 'repeat_K_PAGEDOWN' ],
@@ -128,8 +130,8 @@ as of version 6.99 is as follows::
         input_delete = [ 'K_DELETE', 'repeat_K_DELETE' ],
         input_home = [ 'K_HOME' ],
         input_end = [ 'K_END' ],
-        input_copy = [ 'ctrl_K_INSERT', 'ctrl_K_c' ],
-        input_paste = [ 'shift_K_INSERT', 'ctrl_K_v' ],
+        input_copy = [ 'ctrl_noshift_K_INSERT', 'ctrl_noshift_K_c' ],
+        input_paste = [ 'shift_K_INSERT', 'ctrl_noshift_K_v' ],
 
         # Viewport.
         viewport_leftarrow = [ 'K_LEFT', 'repeat_K_LEFT' ],
@@ -140,12 +142,14 @@ as of version 6.99 is as follows::
         viewport_wheeldown = [ 'mousedown_5' ],
         viewport_drag_start = [ 'mousedown_1' ],
         viewport_drag_end = [ 'mouseup_1' ],
+        viewport_pageup = [ 'K_PAGEUP', 'repeat_K_PAGEUP' ],
+        viewport_pagedown = [ 'K_PAGEDOWN', 'repeat_K_PAGEDOWN' ],
 
         # These keys control skipping.
         skip = [ 'K_LCTRL', 'K_RCTRL' ],
         stop_skipping = [ ],
         toggle_skip = [ 'K_TAB' ],
-        fast_skip = [ '>' ],
+        fast_skip = [ '>', 'shift_K_PERIOD' ],
 
         # Bar.
         bar_activate = [ 'mousedown_1', 'K_RETURN', 'K_KP_ENTER', 'K_SELECT' ],
@@ -163,9 +167,12 @@ as of version 6.99 is as follows::
         drag_deactivate = [ 'mouseup_1' ],
 
         # Debug console.
-        console = [ 'shift_O' ],
+        console = [ 'shift_K_o', 'alt_shift_K_o' ],
         console_older = [ 'K_UP', 'repeat_K_UP' ],
         console_newer = [ 'K_DOWN', 'repeat_K_DOWN'],
+
+        # Director
+        director = [ 'noshift_K_d' ],
 
         # Ignored (kept for backwards compatibility).
         toggle_music = [ 'm' ],
@@ -173,10 +180,12 @@ as of version 6.99 is as follows::
         viewport_down = [ 'mousedown_5' ],
 
         # Profile commands.
+        performance = [ 'K_F3' ],
+        image_load_log = [ 'K_F4' ],
         profile_once = [ 'K_F8' ],
         memory_profile = [ 'K_F7' ],
 
-        )
+    )
 
 Gamepad bindings work a little differently. Gamepad bindings work by mapping
 a gamepad event to one or more Ren'Py event names. The default set of


### PR DESCRIPTION
For "director" and "developer" keysyms are replaced so that CapsLock does not swap them.
For "input_copy" and "input_paste" added noshift modifiers.
In all other cases K_keys are added, so it doesn't break backward compatibility.
Also updated the table in the documentation.