### PR TITLE
Don't allow toggle skip when skip is disabled

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -187,6 +187,12 @@ init -1600 python:
 
     def _toggle_skipping():
 
+        if not renpy.config.allow_skipping:
+            return
+
+        if not renpy.store._skipping:
+            return
+
         if not config.skipping:
             config.skipping = "slow"
         else:


### PR DESCRIPTION
When `config.allow_skipping` or `store._skipping` are set to False, turning skip on is disabled. However, toggling skip is not. ie: ctrl stops skipping, but tab doesn't.