### PR TITLE
Add Sublime Text and VSCode support

### DIFF
--- a/launcher/Sublime Text.edit.py
+++ b/launcher/Sublime Text.edit.py
@@ -1,0 +1,10 @@
+import subprocess
+
+import renpy.editor
+
+class Editor(renpy.editor.Editor):
+
+    def open(self, filename, line=None, **kwargs):
+        filename = renpy.exports.fsencode(filename)
+        address = filename if line is None else "%s:%d" % (filename, line)
+        subprocess.call(["subl", arg], shell=True)

--- a/launcher/VSCode.py
+++ b/launcher/VSCode.py
@@ -1,0 +1,10 @@
+import subprocess
+
+import renpy.editor
+
+class Editor(renpy.editor.Editor):
+
+    def open(self, filename, line=None, **kwargs):
+        filename = renpy.exports.fsencode(filename)
+        address = filename if line is None else "%s:%d" % (filename, line)
+        subprocess.call(["code", "-g", address], shell=True)

--- a/launcher/game/editor.rpy
+++ b/launcher/game/editor.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2020 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2020 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -148,7 +148,7 @@ init 1 python in editor:
 
         fei = fancy_editors = [ ]
 
-        # Atom.
+        # Atom
         AD = _("(Recommended) A modern and approachable text editor.")
 
         if renpy.windows:

--- a/launcher/game/editor.rpy
+++ b/launcher/game/editor.rpy
@@ -173,6 +173,20 @@ init 1 python in editor:
 
         fei.append(e)
 
+        # VSCode
+        fei.append(FancyEditorInfo(
+            0,
+            "VSCode",
+            _("An open source lightweight IDE maintained by Microsoft. Available for download on {a=https://code.visualstudio.com/}the official website{/a}.\nMake sure the code command is added to your {b}PATH{/b}."),
+            None))
+
+        # Sublime Text
+        fei.append(FancyEditorInfo(
+            1,
+            "Sublime Text",
+            _("A sophisticated text editor for code, markup and prose. You can buy Sublime Text {a=https://www.sublimetext.com/}on their official website{/a}.\nMake sure the subl command is added to your {b}PATH{/b}."),
+            None))
+
         # jEdit
         fei.append(FancyEditorInfo(
             2,

--- a/launcher/game/editor.rpy
+++ b/launcher/game/editor.rpy
@@ -1,4 +1,4 @@
-# Copyright 2004-2020 Tom Rothamel <pytom@bishoujo.us>
+﻿# Copyright 2004-2020 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -147,6 +147,8 @@ init 1 python in editor:
         scan_all()
 
         fei = fancy_editors = [ ]
+        systemEditorName = "System Editor"
+        disabledEditorName = "None"
 
         # Atom
         AD = _("(Recommended) A modern and approachable text editor.")
@@ -199,12 +201,15 @@ init 1 python in editor:
 
         fei.append(FancyEditorInfo(
             3,
-            _("System Editor"),
+            _(systemEditorName),
             _("Invokes the editor your operating system has associated with .rpy files."),
             None))
 
-        for k in editors:
-            if k in [ "Atom", "jEdit", "System Editor", "None" ]:
+        for editor in editors:
+            if (
+                    any(editor == fancyEditor.name for fancyEditor in fei) or
+                    editor == disabledEditorName or
+                    editor == systemEditorName):
                 continue
 
             fei.append(FancyEditorInfo(
@@ -215,7 +220,7 @@ init 1 python in editor:
 
         fei.append(FancyEditorInfo(
             5,
-            _("None"),
+            _(disabledEditorName),
             _("Prevents Ren'Py from opening a text editor."),
             None))
 


### PR DESCRIPTION
This PR adds support for `Sublime Text` and `VSCode`.
Adding a plugin for Sublime Text or VSCode won't be necessary as the description of the editor provides a link for downloading the editors alongside with the remark to add the editor to `PATH`.

Thanks to @kobaltcore for providing me the code-snippets which are necessary for integrating said editors into `Ren'Py`.

Merging this PR fixes #2348