### PR TITLE
doc: _window_show and _window_hide don't disable auto

### DIFF
--- a/renpy/common/000window.rpy
+++ b/renpy/common/000window.rpy
@@ -40,7 +40,7 @@ init -1200 python:
         """
         :doc: window
 
-        The Python equivalent of the "window show" statement.
+        The Python equivalent of the "window auto show" statement.
 
         `trans`
             If False, the default window show transition is used. If None,
@@ -65,7 +65,7 @@ init -1200 python:
         """
         :doc: window
 
-        The Python equivalent of the "window hide" statement.
+        The Python equivalent of the "window auto hide" statement.
 
         `trans`
             If False, the default window hide transition is used. If None,


### PR DESCRIPTION
Since `_window_show` and `_window_hide` don't do `store._window_auto = False`, they're equivalent to `window auto show` and `window auto hide`, not `window show` and `window hide`.