### PR TITLE
Improve dynamic image

### DIFF
--- a/renpy/easy.py
+++ b/renpy/easy.py
@@ -152,10 +152,10 @@ def dynamic_image(d, scope=None, prefix=None, search=None):
 
     def find(name):
 
-        if renpy.loader.loadable(name):
+        if renpy.exports.image_exists(name):
             return True
 
-        if renpy.exports.image_exists(name):
+        if renpy.loader.loadable(name):
             return True
 
         if lookup_displayable_prefix(name):


### PR DESCRIPTION
With this change `image test = "[var]"` will not ask OS about (almost always) unexisting files. 
On the other hand, `image test = "[var].png"` will quickly be recognized as a non-existent image.