### PR TITLE
Flush log after write

### DIFF
--- a/renpy/log.py
+++ b/renpy/log.py
@@ -221,7 +221,7 @@ class StdioRedirector(object):
 
     def __init__(self):
         self.buffer = ''
-        self.log = open("log", developer=False, append=False)
+        self.log = open("log", developer=False, append=False, flush=True)
 
     def write(self, s):
 


### PR DESCRIPTION
This change adds enables flushing of the main log file `log.txt` after each write.
It results in the desirable behavior of writing output to the log file while the game is running, instead of writing it all at once when the game closes.

This makes it easier and quicker to debug things while the game is starting up as output is already able to be viewed while at the same time also capturing `stdio` output for easier debugging of things which are currently active.

This behavior existed in 7.3.5 already, so I assume it would be desirable to keep it consistent for 7.4+
I wasn't able to tell why this worked as it did in 7.3.5 though, given that the `flush` keyword was `False` by default there as well and thus shouldn't have flushed, while in reality it did.