### PR TITLE
GitIgnore: Ignore several undesirable system files on macOS and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# macOS-related files
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows-related files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+[Dd]esktop.ini
+
 *.rpyc
 *.rpyb
 *.rpymc


### PR DESCRIPTION
This PR adds several system files to this project's `.gitignore` to avoid them showing up in the Git workflow while working.
This chiefly includes auto-generated system files regarding `Thumbs.db` on Windows and `.DS_Store` on macOS.

Excluding these files ensures that the output of things like `git status` and `git diff` is less polluted.