### PR TITLE
Option to specify transition in ShowMenu (for #2194)

### DIFF
--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -58,8 +58,9 @@ init -1500 python:
          Extra arguments and keyword arguments are passed on to the screen
          """
 
-        def __init__(self, screen=None, *args, **kwargs):
+        def __init__(self, screen=None, transition=None, *args, **kwargs):
             self.screen = screen
+            self.transition = transition
             self.args = args
             self.kwargs = kwargs
 
@@ -83,7 +84,7 @@ init -1500 python:
 
                 if renpy.has_screen(screen):
 
-                    renpy.transition(config.intra_transition)
+                    renpy.transition(self.transition or config.intra_transition)
                     renpy.show_screen(screen, _transient=True, *self.args, **self.kwargs)
                     renpy.restart_interaction()
 

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -58,9 +58,9 @@ init -1500 python:
          Extra arguments and keyword arguments are passed on to the screen
          """
 
-        def __init__(self, screen=None, transition=None, *args, **kwargs):
+        def __init__(self, screen=None, _transition=None, *args, **kwargs):
             self.screen = screen
-            self.transition = transition
+            self.transition = _transition
             self.args = args
             self.kwargs = kwargs
 

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -41,6 +41,10 @@ init -1500 python:
          `screen` is usually the name of a screen, which is shown using
          the screen mechanism. If the screen doesn't exist, then "_screen"
          is appended to it, and that label is jumped to.
+         
+         `_transition`, if set, manually specifies the transition used when
+         changing screens. If omitted, the default transition is
+         config.intra_transition.
 
          * ShowMenu("load")
          * ShowMenu("save")
@@ -57,10 +61,11 @@ init -1500 python:
 
          Extra arguments and keyword arguments are passed on to the screen
          """
+        transition = None  # For save compatability; see renpy#2376
 
-        def __init__(self, screen=None, _transition=None, *args, **kwargs):
+        def __init__(self, screen=None, *args, **kwargs):
             self.screen = screen
-            self.transition = _transition
+            self.transition = kwargs.pop("_transition", None)
             self.args = args
             self.kwargs = kwargs
 

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -42,9 +42,10 @@ init -1500 python:
          the screen mechanism. If the screen doesn't exist, then "_screen"
          is appended to it, and that label is jumped to.
          
-         `_transition`, if set, manually specifies the transition used when
-         changing screens. If omitted, the default transition is
-         config.intra_transition.
+         If the optional keyword argument `_transition` is given, the
+         menu will change screens using the provided transition.
+         If not manually specified, the default transition is 
+         `config.intra_transition`.
 
          * ShowMenu("load")
          * ShowMenu("save")


### PR DESCRIPTION
Draft to implement #2194 (Add transition variable to ShowMenu action), please review.

Please also do note that this is technically a breaking change, since the `transition` kwarg was previously consumed by `**kwargs` and passed to the screen. `transition` could be renamed, but any new kwarg to `ShowMenu` has this issue.

Resolves #2194 

~~this isn't hacktober spam I promise~~