### PR TITLE
History entries properly identify kind as nvl

### DIFF
--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -403,7 +403,7 @@ init -1500 python:
             if self.clear:
                 nvl_clear()
 
-            self.add_history("adv", who, what)
+            self.add_history("nvl", who, what)
 
         def do_extend(self):
             renpy.mode(self.mode)


### PR DESCRIPTION
When retrieving the `kind` argument from a `_history_list` entry, characters whose kind is declared as `nvl` now return the string `"nvl"` instead of `"adv"`.