### PR TITLE
Fix a bug that would cause the secondary volume to reset in some cases

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -143,6 +143,7 @@ class MusicContext(renpy.python.RevertableObject):
 
     pause = False
     tertiary_volume = 1.0
+    raw_secondary_volume = 1.0
 
     def __init__(self):
 
@@ -157,8 +158,11 @@ class MusicContext(renpy.python.RevertableObject):
         # The time the secondary volume was last ordered changed.
         self.secondary_volume_time = None
 
-        # The secondary volume.
+        # The computed secondary volume.
         self.secondary_volume = 1.0
+
+        # The raw secondary volume.
+        self.raw_secondary_volume = 1.0
 
         # The tertiary volume.
         self.tertiary_volume = 1.0
@@ -701,6 +705,7 @@ class Channel(object):
 
             now = get_serial()
             self.context.secondary_volume_time = now
+            self.context.raw_secondary_volume = volume
             self.context.secondary_volume = volume * self.context.tertiary_volume
 
             if pcm_ok:
@@ -709,7 +714,7 @@ class Channel(object):
 
     def set_tertiary_volume(self, volume):
         self.context.tertiary_volume = volume
-        self.set_secondary_volume(1.0, 0)
+        self.set_secondary_volume(self.context.raw_secondary_volume, 0)
 
     def pause(self):
         with lock:

--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -143,7 +143,6 @@ class MusicContext(renpy.python.RevertableObject):
 
     pause = False
     tertiary_volume = 1.0
-    raw_secondary_volume = 1.0
 
     def __init__(self):
 
@@ -158,11 +157,8 @@ class MusicContext(renpy.python.RevertableObject):
         # The time the secondary volume was last ordered changed.
         self.secondary_volume_time = None
 
-        # The computed secondary volume.
+        # The secondary volume.
         self.secondary_volume = 1.0
-
-        # The raw secondary volume.
-        self.raw_secondary_volume = 1.0
 
         # The tertiary volume.
         self.tertiary_volume = 1.0
@@ -582,8 +578,9 @@ class Channel(object):
 
             if self.secondary_volume_time != self.context.secondary_volume_time:
                 self.secondary_volume_time = self.context.secondary_volume_time
+                result_volume = self.context.secondary_volume * self.context.tertiary_volume
                 renpysound.set_secondary_volume(self.number,
-                                                self.context.secondary_volume,
+                                                result_volume,
                                                 0)
 
         if not self.queue and self.callback:
@@ -705,16 +702,16 @@ class Channel(object):
 
             now = get_serial()
             self.context.secondary_volume_time = now
-            self.context.raw_secondary_volume = volume
-            self.context.secondary_volume = volume * self.context.tertiary_volume
+            self.context.secondary_volume = volume
 
             if pcm_ok:
                 self.secondary_volume_time = self.context.secondary_volume_time
-                renpysound.set_secondary_volume(self.number, self.context.secondary_volume, delay)
+                result_volume = self.context.secondary_volume * self.context.tertiary_volume
+                renpysound.set_secondary_volume(self.number, result_volume, delay)
 
     def set_tertiary_volume(self, volume):
         self.context.tertiary_volume = volume
-        self.set_secondary_volume(self.context.raw_secondary_volume, 0)
+        self.set_secondary_volume(self.context.secondary_volume, 0)
 
     def pause(self):
         with lock:


### PR DESCRIPTION
Fixes #2383 and stems from a discussion with @Andykl 

When calling `set_tertiary_volume` the secondary volume would be reset due to a magic number remaining in the code.
This patch fixes this by introducing a storage field for the raw value of the secondary volume, which it subsequently uses when setting the tertiary volume, thus keeping the propagation intact and correct.