### PR TITLE
Update Ren'Py parameters and arguments according python 3

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -301,16 +301,19 @@ class ArgumentInfo(renpy.object.Object):
 
     def after_upgrade(self, version):
         if version < 1:
-            length = len(self.arguments) + 2
-            if self.extrapos:
+            arguments = self.arguments
+            extrapos = self.extrapos
+            extrakw = self.extrakw
+            length = len(arguments) + bool(extrapos) + bool(extrakw)
+            if extrapos:
                 self.starred_indexes = { length - 1 }
-                self.arguments.append((None, self.extrapos))
+                arguments.append((None, extrapos))
 
-            if self.extrakw:
+            if extrakw:
                 self.doublestarred_indexes = { length - 1 }
-                self.arguments.append((None, self.extrakw))
+                arguments.append((None, extrakw))
 
-            if self.extrapos and self.extrakw:
+            if extrapos and extrakw:
                 self.starred_indexes = { length - 2 }
 
     def __init__(self, arguments, starred_indexes=None, doublestarred_indexes=None):

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -62,7 +62,10 @@ class ParameterInfo(object):
     label.
     """
 
-    def __init__(self, parameters, positional, extrapos, extrakw):
+    positional_only = [ ]
+    keyword_only = [ ]
+
+    def __init__(self, parameters, positional, extrapos, extrakw, last_posonly=None, first_kwonly=None):
 
         # A list of parameter name, default value pairs.
         self.parameters = parameters
@@ -79,6 +82,37 @@ class ParameterInfo(object):
         # any. None if no such variable exists.
         self.extrakw = extrakw
 
+        # A parameters that is positional-only, see
+        # https://www.python.org/dev/peps/pep-0570/
+        # None if / not presets.
+        if last_posonly is None:
+            self.positional_only = [ ]
+
+        else:
+            rv = [ ]
+            for param in parameters:
+                rv.append(param)
+                if param[0] == last_posonly:
+                    break
+
+            self.positional_only = rv
+
+        # A parameters that is keyword-only, see
+        # https://www.python.org/dev/peps/pep-3102/
+        # None if * or *args not preset, or there are no parameters afterwards.
+        if first_kwonly is None:
+            self.keyword_only = [ ]
+
+        else:
+            rv = [ ]
+            for param in reversed(parameters):
+                rv.append(param)
+                if param[0] == first_kwonly:
+                    break
+
+            rv.reverse()
+            self.keyword_only = rv
+
     def apply(self, args, kwargs, ignore_errors=False):
         """
         Applies `args` and `kwargs` to these parameters. Returns
@@ -90,60 +124,160 @@ class ParameterInfo(object):
             best job it can.
         """
 
-        values = renpy.python.RevertableDict()
         rv = { }
 
         if args is None:
-            args = ()
+            args = [ ]
 
         if kwargs is None:
-            kwargs = { }
+            kwargs = renpy.python.RevertableDict()
+        else:
+            # Prevent original kwargs changes
+            kwargs = kwargs.copy()
 
-        for name, value in zip(self.positional, args):
-            if name in values:
-                if not ignore_errors:
-                    raise Exception("Parameter %s has two values." % name)
+        parameters = self.parameters
+        # Handle empty parameters in a fast way
+        if not parameters:
 
-            values[name] = value
+            if self.extrakw:
+                rv[self.extrakw] = kwargs
 
-        extrapos = tuple(args[len(self.positional):])
+            elif kwargs and (not ignore_errors):
+                if not kwargs.pop("_ignore_extra_kwargs", False):
+                    raise TypeError(
+                        "Unexpected keyword arguments: %s" %
+                        ", ".join("'%s'" % i for i in kwargs))
 
-        for name, value in kwargs.items():
-            if name in values:
-                if not ignore_errors:
-                    raise Exception("Parameter %s has two values." % name)
+            if self.extrapos:
+                rv[self.extrapos] = tuple(args)
 
-            values[name] = value
+            elif args and (not ignore_errors):
+                raise TypeError("Too many arguments in call (expected 0, got %d)." % len(args))
 
-        for name, default in self.parameters:
+            return rv
 
-            if name not in values:
-                if default is None:
-                    if not ignore_errors:
-                        raise Exception("Required parameter %s has no value." % name)
-                else:
+        # Fill positional-only slots and check whether its passed as keyword
+        slots = iter(self.positional_only)
+        argsi = iter(args)
+        missed_pos = [ ]
+        posonly_keyword = [ ]
+        for value in argsi:
+            try:
+                name, _ = next(slots)
+            except StopIteration:
+                argsi = iter([ value ] + list(argsi))
+                break
+
+            if name in kwargs:
+                posonly_keyword.append(name)
+
+            rv[name] = value
+
+        # Some parameters left
+        else:
+            for name, default in slots:
+                if name in kwargs:
+                    posonly_keyword.append(name)
+
+                if default is not None:
                     rv[name] = renpy.python.py_eval(default)
+                else:
+                    missed_pos.append(name)
 
+            argsi = iter([])
+
+        # Report positional-only as keyword if we have not **kwargs
+        if posonly_keyword and self.extrakw is None:
+            if not ignore_errors:
+                raise TypeError(
+                    "Some positional-only arguments passed as keyword arguments: %s" %
+                    ", ".join("'%s'" % i for i in posonly_keyword))
             else:
-                rv[name] = values[name]
-                del values[name]
+                for name in posonly_keyword:
+                    kwargs.pop(name)
 
-        # Now, values has the left-over keyword arguments, and extrapos
-        # has the left-over positional arguments.
+        # Fill positional_or_keyword slots with left args
+        poskw_slots = parameters[len(self.positional_only):-len(self.keyword_only) or None]
+        slots = iter(poskw_slots)
+        extraargs = [ ]
+        duplicated_names = [ ]
+        for value in argsi:
+            try:
+                name, _ = next(slots)
+            except StopIteration:
+                extraargs = [ value ] + list(argsi)
+                break
+
+            rv[name] = value
+
+            if name in kwargs:
+                kwargs.pop(name)
+                duplicated_names.append(name)
+
+        # Some parameters left
+        else:
+            for name, default in slots:
+                if name in kwargs:
+                    rv[name] = kwargs.pop(name)
+                elif default is not None:
+                    rv[name] = renpy.python.py_eval(default)
+                else:
+                    missed_pos.append(name)
+
+        # Report missing positional parameters
+        if missed_pos and (not ignore_errors):
+            raise TypeError(
+                "Missing required positional arguments: %s" %
+                ", ".join("'%s'" % i for i in missed_pos))
 
         if self.extrapos:
-            rv[self.extrapos] = extrapos
-        elif extrapos and not ignore_errors:
-            raise Exception("Too many arguments in call (expected %d, got %d)." % (len(self.positional), len(args)))
+            rv[self.extrapos] = tuple(extraargs)
+
+        # Report extra positional arguments
+        elif extraargs and (not ignore_errors):
+            positional = self.positional_only + poskw_slots
+            required = len([i for i in positional if i[1] is None])
+            total = len(positional)
+
+            if total == required:
+                expected = str(total)
+            else:
+                expected = "from %d to %d" % (required, total)
+
+            raise TypeError(
+                "Too many arguments in call (expected %s, got %d)." %
+                (expected, len(args)))
+
+        # Report duplicated positional parameters
+        if duplicated_names and (not ignore_errors):
+            raise TypeError(
+                "Got multiple values for arguments: %s" %
+                ", ".join("'%s'" % i for i in duplicated_names))
+
+        # Fill keyword-only parameters
+        missed_kw = [ ]
+        for name, default in self.keyword_only:
+            if name in kwargs:
+                rv[name] = kwargs.pop(name)
+            elif default is not None:
+                rv[name] = renpy.python.py_eval(default)
+            else:
+                missed_kw.append(name)
+
+        # Report missing keyword-only parameters
+        if missed_kw and (not ignore_errors):
+            raise TypeError(
+                "Missing required keyword-only arguments: %s" %
+                ", ".join("'%s'" % i for i in missed_kw))
 
         if self.extrakw:
-            rv[self.extrakw] = values
+            rv[self.extrakw] = kwargs
 
-        elif values.get("_ignore_extra_kwargs", False):
-            pass
-
-        elif values and (not ignore_errors):
-            raise Exception("Unknown keyword arguments: %s" % (", ".join(list(values.keys()))))
+        elif kwargs and (not ignore_errors):
+            if not kwargs.pop("_ignore_extra_kwargs", False):
+                raise TypeError(
+                    "Unexpected keyword arguments: %s" %
+                    ", ".join("'%s'" % i for i in kwargs))
 
         return rv
 
@@ -151,7 +285,7 @@ class ParameterInfo(object):
 def apply_arguments(parameters, args, kwargs, ignore_errors=False):
 
     if parameters is None:
-        if args or kwargs:
+        if (args or kwargs) and not ignore_errors:
             raise Exception("Arguments supplied, but parameter list not present")
         else:
             return { }
@@ -159,42 +293,60 @@ def apply_arguments(parameters, args, kwargs, ignore_errors=False):
     return parameters.apply(args, kwargs, ignore_errors)
 
 
-class ArgumentInfo(object):
+class ArgumentInfo(renpy.object.Object):
 
-    def __init__(self, arguments, extrapos, extrakw):
+    __version__ = 1
+    starred_indexes = set()
+    doublestarred_indexes = set()
+
+    def after_upgrade(self, version):
+        if version < 1:
+            length = len(self.arguments)
+            if self.extrapos:
+                self.starred_indexes = { length - 1 }
+                self.arguments.append((None, self.extrapos))
+
+            if self.extrakw:
+                self.doublestarred_indexes = { length - 1 }
+                self.arguments.append((None, self.extrakw))
+
+            if self.extrapos and self.extrakw:
+                self.starred_indexes = { length - 2 }
+
+    def __init__(self, arguments, starred_indexes=None, doublestarred_indexes=None):
 
         # A list of (keyword, expression) pairs. If an argument doesn't
         # have a keyword, it's thought of as positional.
         self.arguments = arguments
 
-        # An expression giving extra positional arguments being
-        # supplied to this function.
-        self.extrapos = extrapos
+        # Indexes of arguments to be considered as * unpacking
+        self.starred_indexes = starred_indexes or set()
 
-        # An expression giving extra keyword arguments that need
-        # to be supplied to this function.
-        self.extrakw = extrakw
+        # Indexes of arguments to be considered as ** unpacking.
+        self.doublestarred_indexes = doublestarred_indexes or set()
 
     def evaluate(self, scope=None):
         """
-        Evaluates the arguments, returning a list of arguments and a
+        Evaluates the arguments, returning a tuple of arguments and a
         dictionary of keyword arguments.
         """
 
         args = [ ]
         kwargs = renpy.python.RevertableDict()
 
-        for k, v in self.arguments:
-            if k is not None:
-                kwargs[k] = renpy.python.py_eval(v, locals=scope)
+        for i, (k, v) in enumerate(self.arguments):
+            value = renpy.python.py_eval(v, locals=scope)
+
+            if i in self.starred_indexes:
+                args.extend(value)
+
+            elif i in self.doublestarred_indexes:
+                kwargs.update(value)
+
+            elif k is not None:
+                kwargs[k] = value
             else:
-                args.append(renpy.python.py_eval(v, locals=scope))
-
-        if self.extrapos is not None:
-            args.extend(renpy.python.py_eval(self.extrapos, locals=scope))
-
-        if self.extrakw is not None:
-            kwargs.update(renpy.python.py_eval(self.extrakw, locals=scope))
+                args.append(value)
 
         return tuple(args), kwargs
 
@@ -202,17 +354,18 @@ class ArgumentInfo(object):
 
         l = [ ]
 
-        for keyword, expression in self.arguments:
-            if keyword is not None:
+        for i, (keyword, expression) in enumerate(self.arguments):
+
+            if i in self.starred_indexes:
+                l.append("*" + expression)
+
+            elif i in self.doublestarred_indexes:
+                l.append("**" + expression)
+
+            elif keyword is not None:
                 l.append("{}={}".format(keyword, expression))
             else:
                 l.append(expression)
-
-        if self.extrapos is not None:
-            l.append("*" + self.extrapos)
-
-        if self.extrakw is not None:
-            l.append("**" + self.extrakw)
 
         return "(" + ", ".join(l) + ")"
 

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -301,7 +301,7 @@ class ArgumentInfo(renpy.object.Object):
 
     def after_upgrade(self, version):
         if version < 1:
-            length = len(self.arguments)
+            length = len(self.arguments) + 2
             if self.extrapos:
                 self.starred_indexes = { length - 1 }
                 self.arguments.append((None, self.extrapos))

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -652,8 +652,9 @@ def check_label(node):
 
     if pi is not None:
 
-        for i in pi.positional:
+        for i, _ in pi.parameters:
             add_arg(i)
+
         add_arg(pi.extrapos)
         add_arg(pi.extrakw)
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1703,18 +1703,42 @@ def parse_menu(stmtl, loc, arguments):
 
 
 def parse_parameters(l):
-
-    parameters = [ ]
-    positional = [ ]
-    extrapos = None
-    extrakw = None
-
-    add_positional = True
-
-    names = set()
+    """
+    Parse a list of parameters according to PEP 570 semantic, if one is present.
+    """
 
     if not l.match(r'\('):
         return None
+
+    # Result list of parameters, by (name, default value) pairs
+    parameters = [ ]
+
+    positional = [ ]
+
+    # Name of parameter that is starred
+    extrapos = None
+
+    # Name of parameter that is double starred
+    extrakw = None
+
+    # Name of parameter that is last positional-only
+    last_posonly = None
+
+    # Name of parameter that is first keyword-only
+    first_kwonly = None
+
+    add_positional = True
+
+    pending_kwonly = False
+
+    has_default = False
+
+    names = set()
+    def name_parsed(name, value):
+        if name in names:
+            l.error("duplicate parameter '%s'" % name)
+        else:
+            names.add(name)
 
     while True:
 
@@ -1723,47 +1747,64 @@ def parse_parameters(l):
 
         if l.match(r'\*\*'):
 
-            if extrakw is not None:
-                l.error('a label may have only one ** parameter')
-
             extrakw = l.require(l.name)
 
-            if extrakw in names:
-                l.error('parameter %s appears twice.' % extrakw)
+            name_parsed(extrakw, None)
 
-            names.add(extrakw)
+            # Allow trailing comma
+            l.match(r',')
+
+            # extrakw is always last parameter
+            l.require('\)')
+            break
 
         elif l.match(r'\*'):
 
-            if not add_positional:
-                l.error('a label may have only one * parameter')
+            if first_kwonly or pending_kwonly:
+                l.error("* may appear only once")
 
             add_positional = False
+
+            pending_kwonly = True
 
             extrapos = l.name()
 
             if extrapos is not None:
+                name_parsed(extrapos, None)
 
-                if extrapos in names:
-                    l.error('parameter %s appears twice.' % extrapos)
+        elif l.match('/'):
 
-                names.add(extrapos)
+            if first_kwonly or pending_kwonly:
+                l.error("/ must be ahead of *")
+
+            elif last_posonly is not None:
+                l.error("/ may appear only once")
+
+            elif not parameters:
+                l.error("at least one parameter must precede /")
+
+            last_posonly = parameters[-1][0]
 
         else:
 
             name = l.require(l.name)
 
-            if name in names:
-                l.error('parameter %s appears twice.' % name)
-
-            names.add(name)
+            if pending_kwonly:
+                pending_kwonly = False
+                first_kwonly = name
 
             if l.match(r'='):
                 l.skip_whitespace()
                 default = l.delimited_python("),")
+                has_default = True
+
+            elif first_kwonly is None and has_default:
+                l.error("non-default argument follows default argument")
+
             else:
                 default = None
 
+            name_parsed(name, default)
             parameters.append((name, default))
 
             if add_positional:
@@ -1774,57 +1815,74 @@ def parse_parameters(l):
 
         l.require(r',')
 
-    return renpy.ast.ParameterInfo(parameters, positional, extrapos, extrakw)
+    if pending_kwonly and extrapos is None:
+        l.error("named arguments must follow bare *")
+
+    return renpy.ast.ParameterInfo(parameters, positional, extrapos, extrakw, last_posonly, first_kwonly)
 
 
 def parse_arguments(l):
     """
-    Parse a list of arguments, if one is present.
+    Parse a list of arguments according to PEP 448 semantics, if one is present.
     """
-
-    arguments = [ ]
-    extrakw = None
-    extrapos = None
 
     if not l.match(r'\('):
         return None
 
+    arguments = [ ]
+    starred_indexes = set()
+    doublestarred_indexes = set()
+
+    index = 0
+    keyword_parsed = False
+    names = set()
+
     while True:
+        expect_starred = False
+        expect_doublestarred = False
+        name = None
 
         if l.match('\)'):
             break
 
         if l.match(r'\*\*'):
-
-            if extrakw is not None:
-                l.error('a call may have only one ** argument')
-
-            extrakw = l.delimited_python("),")
+            expect_doublestarred = True
+            doublestarred_indexes.add(index)
 
         elif l.match(r'\*'):
-            if extrapos is not None:
-                l.error('a call may have only one * argument')
+            expect_starred = True
+            starred_indexes.add(index)
 
-            extrapos = l.delimited_python("),")
+        state = l.checkpoint()
 
-        else:
-
-            state = l.checkpoint()
-
+        if not (expect_starred or expect_doublestarred):
             name = l.name()
-            if not (name and l.match(r'=')):
+
+            if name and l.match(r'='):
+                if name in names:
+                    l.error("keyword argument repeated: '%s'" % name)
+                else:
+                    names.add(name)
+                keyword_parsed = True
+
+            elif keyword_parsed:
+                l.error("positional argument follows keyword argument")
+
+            # If we have not '=' after name, the name itself may be expression.
+            else:
                 l.revert(state)
                 name = None
 
-            l.skip_whitespace()
-            arguments.append((name, l.delimited_python("),")))
+        l.skip_whitespace()
+        arguments.append((name, l.delimited_python("),")))
 
         if l.match(r'\)'):
             break
 
         l.require(r',')
+        index += 1
 
-    return renpy.ast.ArgumentInfo(arguments, extrapos, extrakw)
+    return renpy.ast.ArgumentInfo(arguments, starred_indexes, doublestarred_indexes)
 
 ##############################################################################
 # The parse trie.

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -39,7 +39,7 @@ declared in or by their full name, consisting of global and local name parts: ::
         jump global_label.local_name
 
 The label statement may take an optional list of parameters. These parameters
-are processed as described in :pep:`3102`, with two exceptions:
+are processed as described in :pep:`570`, with two exceptions:
 
 * The values of default parameters are evaluated at call time.
 * The variables are dynamically, rather than lexically, scoped.
@@ -101,7 +101,7 @@ stacks can return to the proper place when loaded on a changed script. ::
 
         return
 
-The call statement may take arguments, which are processed as described in :pep:`3102`.
+The call statement may take arguments, which are processed as described in :pep:`448`.
 
 When using a call expression with an arguments list, the ``pass`` keyword must
 be inserted between the expression and the arguments list. Otherwise, the


### PR DESCRIPTION
Parser and AST of parameters and arguments have been updated to follow PEP 448 and PEP 570.
If I don't miss anything, this update is backwards compatible with the old code.
