### PR TITLE
Relocate order_reverse property to Box Style Properties

### DIFF
--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -979,6 +979,13 @@ These are used for the horizontal and vertical box layouts.
     or columns. (So it is the vertical spacing between lines in a wrapped
     hbox, and the horizontal spacing between columns in a wrapped vbox.)
 
+.. style-property:: order_reverse boolean
+
+    If False, the default, the items in the box will be drawn first-to-last,
+    with the first item in the box being below the second, and so on. If True,
+    this order will be reversed, and the first item in the box will be above
+    all other items in the box.
+
 
 .. _grid-style-properties:
 
@@ -1026,13 +1033,6 @@ These are used with the fixed layout.
 
     If True, the size of the fixed layout is shrunk vertically to match the
     bottom side of the bottommost child of the fixed.
-
-.. style-property:: order_reverse boolean
-
-    If False, the default, the items in the box will be drawn first-to-last,
-    with the first item in the box being below the second, and so on. If True,
-    this order will be reversed, and the first item in the box will be above
-    all other items in the box.
 
 
 .. _margin-style-properties:


### PR DESCRIPTION
The documentation for `order_reverse` was mistakenly located under the `Fixed Style Properties` header, rather than `Box Style Properties`, where it belongs. No changes were made to wording, just relocating it to the correct header.