### PR TITLE
Resolves #2394 Itch.io butler download 403 failure

### DIFF
--- a/launcher/game/itch.rpy
+++ b/launcher/game/itch.rpy
@@ -51,8 +51,9 @@ init python:
         import ssl
 
         with interface.error_handling(_("Downloading the itch.io butler.")):
-            context = ssl._create_unverified_context()
-            response = urllib2.urlopen("https://broth.itch.ovh/butler/{}/LATEST/archive/default".format(platform), context=context)
+            url = "https://broth.itch.ovh/butler/{}/LATEST/archive/default".format(platform)
+            req = urllib2.Request(url, headers={'User-Agent' : "Renpy"})
+            response = urllib2.urlopen(req)
 
             with open(zip, "wb") as f:
                 while True:


### PR DESCRIPTION
Adds User-Agent header info the web request which resolves #2394, at least on my machine.
The ssl unverified context was removed as it caused some issues with the Request