### PR TITLE
added linking to the nighly build renpy.sh in after_checkout.sh 

### DIFF
--- a/after_checkout.sh
+++ b/after_checkout.sh
@@ -12,4 +12,5 @@ if [ "$1" != "" ]; then
     ln -s "$1/lib" "$ROOT/lib"
     ln -s "$1/renpy.app" "$ROOT"
     ln -s "$1/renpy.exe" "$ROOT"
+    ln -s "$1/renpy.sh" "$ROOT"
 fi


### PR DESCRIPTION
This is a minor change for running the nightly build in Linux. The documentation mentioned being able to run `renpy.sh` after running `after_checkout.sh`. Issue is that `renpy.sh` is never linked in the script. This change adds that link in.