### PR TITLE
Add Gtk support for project directory chooser

### DIFF
--- a/launcher/game/choose_directory.rpy
+++ b/launcher/game/choose_directory.rpy
@@ -90,10 +90,10 @@ init python:
                 choice = ""
                 path = None
 
-                interface.error(_("Ren'Py was unable to run python with tkinter or PyGObject to choose the directory. Please install the python3-tk, tkinter, or python3-gobject package."), label=None)
+                interface.error(_("Ren'Py was unable to run python with tkinter to choose the directory. Please install the python3-tk or tkinter package."), label=None)
 
             if code:
-                interface.error(_("Ren'Py was unable to run python with tkinter or PyGobject to choose the directory. Please install the python3-tk, tkinter, or python3-gobject package."), label=None)
+                interface.error(_("Ren'Py was unable to run python with tkinter to choose the directory. Please install the python3-tk or tkinter package."), label=None)
 
             elif choice:
                 path = choice.decode("utf-8")

--- a/launcher/game/choose_directory.rpy
+++ b/launcher/game/choose_directory.rpy
@@ -90,10 +90,10 @@ init python:
                 choice = ""
                 path = None
 
-                interface.error(_("Ren'Py was unable to run python with tkinter to choose the directory. Please install the python3-tk or tkinter package."), label=None)
+                interface.error(_("Ren'Py was unable to run python with tkinter or PyGObject to choose the directory. Please install the python3-tk, tkinter, or python3-gobject package."), label=None)
 
             if code:
-                interface.error(_("Ren'Py was unable to run python with tkinter to choose the directory. Please install the python3-tk or tkinter package."), label=None)
+                interface.error(_("Ren'Py was unable to run python with tkinter or PyGobject to choose the directory. Please install the python3-tk, tkinter, or python3-gobject package."), label=None)
 
             elif choice:
                 path = choice.decode("utf-8")

--- a/launcher/game/tkaskdir.py
+++ b/launcher/game/tkaskdir.py
@@ -26,29 +26,46 @@
 
 import sys
 
-# Python3 and Python2-style imports.
-try:
-    from tkinter import Tk
-    from tkinter.filedialog import askdirectory
-except ImportError:
-    from Tkinter import Tk
-    from tkFileDialog import askdirectory
+# Gtk generally has better support than TKinter on various Linux distributions
+def gtk_select_directory(title):
+    dialog = Gtk.FileChooserNative(title=title,
+                                   action=Gtk.FileChooserAction.SELECT_FOLDER)
 
-# Binary mode stdout for python3.
-try:
-    sys.stdout = sys.stdout.buffer
-except:
-    pass
+    dialog.run()
 
-# Create the TK canvas.
+    return dialog.get_filename()
 
-if __name__ == "__main__":
+
+# Fall back to TKinter if Gtk isn't available
+def tk_select_directory(initialdir, title):
     root = Tk()
     root.withdraw()
 
-    result = askdirectory(initialdir=sys.argv[1], parent=root, title="Select Ren'Py Projects Directory")
+    return skdirectory(initialdir=initialdir, parent=root, title=title)
 
-    if result == ():
-        result = ""
+try:
+    import gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk
+    
+    def select_directory(title):
+        result = gtk_select_directory(title)
 
-    sys.stdout.write(result.encode("utf8"))
+        return result if result else ''
+    
+except:
+# Python3 and Python2-style imports.
+    try:
+        from tkinter import Tk
+        from tkinter.filedialog import askdirectory
+    except ImportError:
+        from Tkinter import Tk
+        from tkFileDialog import askdirectory
+
+    def select_directory(title):
+        return tk_select_directory(title, sys.argv[1])
+
+if __name__ == '__main__':
+    directory = select_directory('Select Ren\'Py Projects Directory')
+
+    sys.stdout.write(directory)


### PR DESCRIPTION
This PR hopes to make RenPy's project directory chooser more robust by supporting multiple backends. In theory Tkinter should be readily-available on Linux distributions, but in practice I find it surprisingly difficult to set up when trying to build and run RenPy when python3-tkinter is an optional package that doesn't come preinstalled on many distributions.

Neither the [Freedesktop SDK](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/NEWS) nor the [Gnome SDK](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/tree/gnome-3-38/elements/sdk) include Tkinter, even excluding it from their Python builds, and even more problematic that there doesn't appear to be a complete tkinter package available on PyPi. Gtk on the other hand is much better supported and is straightforward to set up on Linux.

I've only added dialog messages referencing PyGObject in the English translation so far. More languages can be added if there's interest in upstreaming this support.