### PR TITLE
Allow grids to be underfull

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -459,6 +459,9 @@ log_enable = True
 # Should we log text overflows?
 debug_text_overflow = False
 
+# Should underfull grids raise an exception?
+allow_underfull = False
+
 # Should we save the window size in the preferences?
 save_physical_size = True
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -434,7 +434,7 @@ class Grid(Container):
         rows = self.rows
 
         if len(self.children) != cols * rows:
-            if not config.allow_underfull and len(self.children) < cols * rows:
+            if not renpy.config.allow_underfull and len(self.children) < cols * rows:
                 raise Exception("Grid not completely full.")
             elif len(self.children) > cols * rows:
                 raise Exception("Grid overfull.")

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -434,10 +434,13 @@ class Grid(Container):
         rows = self.rows
 
         if len(self.children) != cols * rows:
-            if len(self.children) < cols * rows:
+            if not config.allow_underfull and len(self.children) < cols * rows:
                 raise Exception("Grid not completely full.")
-            else:
+            elif len(self.children) > cols * rows:
                 raise Exception("Grid overfull.")
+            else:
+                while len(self.children) < cols * rows:
+                    self.children.append(Null())
 
         if self.transpose:
             children = [ ]

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -226,6 +226,10 @@ Occasionally Used
     If not None, a function that is called with no arguments after a
     replay completes.
 
+.. var:: config.allow_underfull = False
+
+    If True, Ren'Py will not require grids to be full in order to display.
+
 .. var:: config.auto_channels = { "audio" : ( "sfx", "", ""  ) }
 
     This is used to define automatic audio channels. It's a map the


### PR DESCRIPTION
This update adds a config variable, `allow_underfull`, which is `False` by default. If set to `True`, Ren'Py will display grids which are not full.