### PR TITLE
Make arm64 builds work properly

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -903,6 +903,16 @@ init python in distribute:
                     armfn,
                     True)
 
+            arm64fn = os.path.join(config.renpy_base, "lib/linux-aarch64/renpy")
+
+            if os.path.exists(arm64fn):
+
+                self.add_file(
+                    raspi,
+                    "lib/linux-aarch64/" + self.executable_name,
+                    arm64fn,
+                    True)
+
 
             self.add_file(
                 mac,

--- a/launcher/game/options.rpy
+++ b/launcher/game/options.rpy
@@ -376,6 +376,8 @@ init python:
     build.classify_renpy("lib/**/*steam_api*", None)
     build.classify_renpy("lib/linux-armv7l/", "raspi")
     build.classify_renpy("lib/linux-armv7l/**", "raspi")
+    build.classify_renpy("lib/linux-aarch64/", "raspi")
+    build.classify_renpy("lib/linux-aarch64/**", "raspi")
     build.classify_renpy("lib/**", "binary")
     build.classify_renpy("renpy.sh", "binary")
     # renpy.app is now built from scratch from distribute.rpy.


### PR DESCRIPTION
The Raspberry Pi is currently beta-testing an arm64 OS, and arm64 Chromebooks can also use this via crostini.