### PR TITLE
Porting ImageDissolve to the new matrixcolor system

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -408,9 +408,9 @@ class ImageDissolve(Transition):
     dissolve in first, and black pixels will dissolve in last.
 
     `image`
-        A control image to use. This must be either an image file or
-        image manipulator. The control image should be the size of
-        the scenes being dissolved.
+        A control image to use. This can be any displayable. The control image
+        should be the size of the scenes being dissolved, and if `reverse=True`,
+        it should be fully opaque.
 
     `time`
         The time the dissolve will take.

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -473,7 +473,7 @@ class ImageDissolve(Transition):
         self.alpha = alpha
         self.time_warp = time_warp
 
-        if config.gl2:
+        if renpy.config.gl2:
             if not reverse:
                 # Copies red -> alpha
                 matrix = renpy.display.matrix.Matrix([0, 0, 0, 0,

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -475,22 +475,22 @@ class ImageDissolve(Transition):
         if not reverse:
 
             # Copies red -> alpha
-            matrix = renpy.display.im.matrix(
-                0, 0, 0, 0, 1,
-                0, 0, 0, 0, 1,
-                0, 0, 0, 0, 1,
-                1, 0, 0, 0, 0)
+            matrix = renpy.display.matrix.Matrix([0, 0, 0, 0,
+                                                  0, 0, 0, 0,
+                                                  0, 0, 0, 0,
+                                                  1, 0, 0, 0, ])
 
         else:
 
             # Copies 1-red -> alpha
-            matrix = renpy.display.im.matrix(
-                0, 0, 0, 0, 1,
-                0, 0, 0, 0, 1,
-                0, 0, 0, 0, 1,
-                -1, 0, 0, 0, 1)
+            matrix = renpy.display.matrix.Matrix([0, 0, 0, 0,
+                                                  0, 0, 0, 0,
+                                                  0, 0, 0, 0,
+                                                  -1, 0, 0, 1, ])
+            # asserts the displayable is not transparent at all
+            # just like InvertMatrix does
 
-        self.image = renpy.display.im.MatrixColor(image, matrix)
+        self.image = renpy.display.motion.Transform(image, matrixcolor=matrix)
 
         if ramp is not None:
             ramplen = len(ramp)

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -473,7 +473,7 @@ class ImageDissolve(Transition):
         self.alpha = alpha
         self.time_warp = time_warp
 
-        if renpy.config.gl2:
+        if renpy.display.render.models:
             if not reverse:
                 # Copies red -> alpha
                 matrix = renpy.display.matrix.Matrix([0, 0, 0, 0,


### PR DESCRIPTION
Allowed any displayable to take the role of the image controlling the transition.
Formerly only proper images were allowed, due to the use of the im. matrixes.