### PR TITLE
Handle common directory in renpy.zip

### DIFF
--- a/renpy.py
+++ b/renpy.py
@@ -174,13 +174,13 @@ def main():
 
     # Add paths.
     if os.path.exists(renpy_base + "/module"):
-        sys.path.append(renpy_base + "/module")
+        sys.path.insert(0, renpy_base + "/module")
 
-    sys.path.append(renpy_base)
+    sys.path.insert(0, renpy_base)
 
     # This is looked for by the mac launcher.
     if os.path.exists(renpy_base + "/renpy.zip"):
-        sys.path.append(renpy_base + "/renpy.zip")
+        sys.path.insert(0, renpy_base + "/renpy.zip")
 
     # Ignore warnings that happen.
     warnings.simplefilter("ignore", DeprecationWarning)

--- a/renpy.py
+++ b/renpy.py
@@ -37,6 +37,8 @@ import warnings
 
 
 def path_to_common(renpy_base):
+    if (renpy_base + "/renpy.zip") in sys.path:
+        return (renpy_base + "/renpy.zip", "renpy/common/")
     return renpy_base + "/renpy/common"
 
 # Given a directory holding a Ren'Py game, this is expected to return

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -327,11 +327,13 @@ def main():
     # Find the common directory.
     commondir = __main__.path_to_common(renpy.config.renpy_base) # E1101 @UndefinedVariable
 
-    if os.path.isdir(commondir):
-        renpy.config.searchpath.append(commondir)
-        renpy.config.commondir = commondir
-    else:
-        renpy.config.commondir = None
+    renpy.config.commondir = None
+    if commondir is not None: 
+        if isinstance(commondir, str) and os.path.isdir(commondir):
+            renpy.config.searchpath.append(commondir)
+            renpy.config.commondir = commondir
+        elif isinstance(commondir, tuple) and len(commondir) >= 2 and os.path.isfile(commondir[0]):
+            renpy.config.commondir = commondir
 
     # Add path from env variable, if any
     if "RENPY_SEARCHPATH" in os.environ:


### PR DESCRIPTION
Handle common directory in `renpy.zip`.

When the `renpy` folder is added into a zip archive, around 612 files can be combined into 1 file, increasing performance on slow filesystems.  
