### PR TITLE
Typos in Spanish translation

### DIFF
--- a/launcher/game/tl/spanish/screens.rpy
+++ b/launcher/game/tl/spanish/screens.rpy
@@ -459,7 +459,7 @@ translate spanish strings:
 
     # screens.rpy:1009
     old "Advances dialogue without selecting choices."
-    new "Avanza el dilogo sin seleccionar opciones."
+    new "Avanza el diálogo sin seleccionar opciones."
 
     # screens.rpy:1012
     old "Arrow Keys"

--- a/the_question/game/tl/spanish/screens.rpy
+++ b/the_question/game/tl/spanish/screens.rpy
@@ -275,7 +275,7 @@ translate spanish strings:
 
     # screens.rpy:1066
     old "Advances dialogue without selecting choices."
-    new "Avanza el dilogo sin seleccionar opciones."
+    new "Avanza el diálogo sin seleccionar opciones."
 
     # screens.rpy:1069
     old "Arrow Keys"

--- a/tutorial/game/tl/spanish/screens.rpy
+++ b/tutorial/game/tl/spanish/screens.rpy
@@ -199,7 +199,7 @@ translate spanish strings:
 
     # screens.rpy:1040
     old "Advances dialogue without selecting choices."
-    new "Avanza el dilogo sin seleccionar opciones."
+    new "Avanza el diálogo sin seleccionar opciones."
 
     # screens.rpy:1043
     old "Arrow Keys"


### PR DESCRIPTION
"dilogo" -> "diálogo"