### PR TITLE
Adding im and im.MatrixColor workarounds in documentation

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -872,8 +872,8 @@ class FactorScale(ImageBase):
 
         image logo doubled = im.FactorScale("logo.png", 1.5)
 
-    The same effect can now be achieved with the :ref:`transform-property-zoom` or the
-    :ref:`transform-property-xzoom` and :ref:`transform-property-yzoom` transform properties.
+    The same effect can now be achieved with the :tpref:`zoom` or the
+    :tpref:`xzoom` and :tpref:`yzoom` transform properties.
     """
 
     def __init__(self, im, width, height=None, bilinear=True, **properties):
@@ -933,8 +933,8 @@ class Flip(ImageBase):
         image eileen flip = im.Flip("eileen_happy.png", vertical=True)
 
     The same effect can now be achieved by setting
-    :ref:`transform-property-xzoom` (for horizontal flip)
-    or :ref:`transform-property-yzoom` (for vertical flip) to a negative value.
+    :tpref:`xzoom` (for horizontal flip)
+    or :tpref:`yzoom` (for vertical flip) to a negative value.
     """
 
     def __init__(self, im, horizontal=False, vertical=False, **properties):
@@ -1022,7 +1022,7 @@ class Crop(ImageBase):
 
         image logo crop = im.Crop("logo.png", (0, 0, 100, 307))
 
-    The same effect can now be achieved by setting the :ref:`transform-property-crop` transform property.
+    The same effect can now be achieved by setting the :tpref:`crop` transform property.
     """
 
     def __init__(self, im, x, y=None, w=None, h=None, **properties):
@@ -1217,7 +1217,7 @@ class Blur(ImageBase):
 
         image logo blurred = im.Blur("logo.png", 1.5)
 
-    The same effect can now be achieved with the :ref:`transform-property-blur` transform property.
+    The same effect can now be achieved with the :tpref:`blur` transform property.
     """
 
     def __init__(self, im, xrad, yrad=None, **properties):
@@ -1417,7 +1417,7 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an identity matrix, one that does not change color or
         alpha.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is IdentityMatrix().
         """
 
@@ -1448,7 +1448,7 @@ im.matrix(%f, %f, %f, %f, %f.
             mostly sensitive to green, more of the green channel is
             kept then the other two channels.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is SaturationMatrix(value, desat).
         """
 
@@ -1472,7 +1472,7 @@ im.matrix(%f, %f, %f, %f, %f.
         grayscale). This is equivalent to calling
         im.matrix.saturation(0).
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is SaturationMatrix(0).
         """
 
@@ -1491,7 +1491,7 @@ im.matrix(%f, %f, %f, %f, %f.
         the value of the red channel is 100, the transformed color
         will have a red value of 50.)
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is TintMatrix(Color((r, g, b))).
         """
 
@@ -1509,7 +1509,7 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that inverts the red, green, and blue
         channels of the image without changing the alpha channel.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is InvertMatrix(1.0).
         """
 
@@ -1531,7 +1531,7 @@ im.matrix(%f, %f, %f, %f, %f.
             a number between -1 and 1, with -1 the darkest possible
             image and 1 the brightest.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is BrightnessMatrix(b).
         """
 
@@ -1549,7 +1549,7 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that alters the opacity of an image. An
         `o` of 0.0 is fully transparent, while 1.0 is fully opaque.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is OpacityMatrix(o).
         """
 
@@ -1568,7 +1568,7 @@ im.matrix(%f, %f, %f, %f, %f.
         be greater than 0.0, with values between 0.0 and 1.0 decreasing contrast, and
         values greater than 1.0 increasing contrast.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is ContrastMatrix(c).
         """
 
@@ -1584,7 +1584,7 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that rotates the hue by `h` degrees, while
         preserving luminosity.
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is HueMatrix(h).
         """
 
@@ -1619,7 +1619,7 @@ im.matrix(%f, %f, %f, %f, %f.
                 im.matrix.colorize("#f00", "#00f"))
 
 
-        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        A suitable equivalent for the :tpref:`matrixcolor` transform property
         is ColorizeMatrix(black_color, white_color).
         """
 
@@ -1648,7 +1648,7 @@ def Grayscale(im, desat=(0.2126, 0.7152, 0.0722), **properties):
     manipulator `im`.
 
     The same effect can now be achieved by supplying SaturationMatrix(0)
-    to the :ref:`transform-property-matrixcolor` transform property.
+    to the :tpref:`matrixcolor` transform property.
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat), **properties)
@@ -1663,7 +1663,7 @@ def Sepia(im, tint=(1.0, .94, .76), desat=(0.2126, 0.7152, 0.0722), **properties
     manipulator `im`.
 
     The same effect can now be achieved by supplying SepiaMatrix()
-    to the :ref:`transform-property-matrixcolor` transform property.
+    to the :tpref:`matrixcolor` transform property.
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat) * matrix.tint(tint[0], tint[1], tint[2]), **properties)

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -871,6 +871,9 @@ class FactorScale(ImageBase):
     ::
 
         image logo doubled = im.FactorScale("logo.png", 1.5)
+
+    The same effect can now be achieved with the :ref:`transform-property-zoom` or the
+    :ref:`transform-property-xzoom` and :ref:`transform-property-yzoom` transform properties.
     """
 
     def __init__(self, im, width, height=None, bilinear=True, **properties):
@@ -928,6 +931,10 @@ class Flip(ImageBase):
     ::
 
         image eileen flip = im.Flip("eileen_happy.png", vertical=True)
+
+    The same effect can now be achieved by setting
+    :ref:`transform-property-xzoom` (for horizontal flip)
+    or :ref:`transform-property-yzoom` (for vertical flip) to a negative value.
     """
 
     def __init__(self, im, horizontal=False, vertical=False, **properties):
@@ -1014,6 +1021,8 @@ class Crop(ImageBase):
     ::
 
         image logo crop = im.Crop("logo.png", (0, 0, 100, 307))
+
+    The same effect can now be achieved by setting the :ref:`transform-property-crop` transform property.
     """
 
     def __init__(self, im, x, y=None, w=None, h=None, **properties):
@@ -1207,6 +1216,8 @@ class Blur(ImageBase):
     ::
 
         image logo blurred = im.Blur("logo.png", 1.5)
+
+    The same effect can now be achieved with the :ref:`transform-property-blur` transform property.
     """
 
     def __init__(self, im, xrad, yrad=None, **properties):
@@ -1405,6 +1416,9 @@ im.matrix(%f, %f, %f, %f, %f.
 
         Returns an identity matrix, one that does not change color or
         alpha.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is IdentityMatrix().
         """
 
         return matrix(1, 0, 0, 0, 0,
@@ -1433,6 +1447,9 @@ im.matrix(%f, %f, %f, %f, %f.
             of an NTSC television signal. Since the human eye is
             mostly sensitive to green, more of the green channel is
             kept then the other two channels.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is SaturationMatrix(value, desat).
         """
 
         r, g, b = desat
@@ -1454,6 +1471,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that desaturates the image (makes it
         grayscale). This is equivalent to calling
         im.matrix.saturation(0).
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is SaturationMatrix(0).
         """
 
         return matrix.saturation(0.0)
@@ -1470,6 +1490,9 @@ im.matrix(%f, %f, %f, %f, %f.
         placed into the final image. (For example, if `r` is .5, and
         the value of the red channel is 100, the transformed color
         will have a red value of 50.)
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is TintMatrix(Color((r, g, b))).
         """
 
         return matrix(r, 0, 0, 0, 0,
@@ -1485,6 +1508,9 @@ im.matrix(%f, %f, %f, %f, %f.
 
         Returns an im.matrix that inverts the red, green, and blue
         channels of the image without changing the alpha channel.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is InvertMatrix(1.0).
         """
 
         return matrix(-1, 0, 0, 0, 1,
@@ -1504,6 +1530,9 @@ im.matrix(%f, %f, %f, %f, %f.
             The amount of change in image brightness. This should be
             a number between -1 and 1, with -1 the darkest possible
             image and 1 the brightest.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is BrightnessMatrix(b).
         """
 
         return matrix(1, 0, 0, 0, b,
@@ -1519,6 +1548,9 @@ im.matrix(%f, %f, %f, %f, %f.
 
         Returns an im.matrix that alters the opacity of an image. An
         `o` of 0.0 is fully transparent, while 1.0 is fully opaque.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is OpacityMatrix(o).
         """
 
         return matrix(1, 0, 0, 0, 0,
@@ -1535,6 +1567,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that alters the contrast of an image. `c` should
         be greater than 0.0, with values between 0.0 and 1.0 decreasing contrast, and
         values greater than 1.0 increasing contrast.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is ContrastMatrix(c).
         """
 
         return matrix.brightness(-.5) * matrix.tint(c, c, c) * matrix.brightness(.5)
@@ -1548,6 +1583,9 @@ im.matrix(%f, %f, %f, %f, %f.
 
         Returns an im.matrix that rotates the hue by `h` degrees, while
         preserving luminosity.
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is HueMatrix(h).
         """
 
         h = h * math.pi / 180
@@ -1580,6 +1618,9 @@ im.matrix(%f, %f, %f, %f, %f.
                 "bwlogo.png",
                 im.matrix.colorize("#f00", "#00f"))
 
+
+        A suitable equivalent for the :ref:`transform-property-matrixcolor` transform property
+        is ColorizeMatrix(black_color, white_color).
         """
 
         (r0, g0, b0, _a0) = renpy.easy.color(black_color)
@@ -1605,6 +1646,9 @@ def Grayscale(im, desat=(0.2126, 0.7152, 0.0722), **properties):
 
     An image manipulator that creates a desaturated version of the image
     manipulator `im`.
+
+    The same effect can now be achieved by supplying SaturationMatrix(0)
+    to the :ref:`transform-property-matrixcolor` transform property.
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat), **properties)
@@ -1617,6 +1661,9 @@ def Sepia(im, tint=(1.0, .94, .76), desat=(0.2126, 0.7152, 0.0722), **properties
 
     An image manipulator that creates a sepia-toned version of the image
     manipulator `im`.
+
+    The same effect can now be achieved by supplying SepiaMatrix()
+    to the :ref:`transform-property-matrixcolor` transform property.
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat) * matrix.tint(tint[0], tint[1], tint[2]), **properties)
@@ -1656,6 +1703,8 @@ class Tile(ImageBase):
     `size`
         If not None, a (width, height) tuple. If None, this defaults to
         (:var:`config.screen_width`, :var:`config.screen_height`).
+
+    The same effect can now be achieved with Tile(im, size=size)
     """
 
     def __init__(self, im, size=None, **properties):

--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -239,6 +239,12 @@ The im.MatrixColor image manipulator has been replaced by Transforms
 and ATL transforms that specify the matrixcolor property. Each `im.matrix`
 generator has been given a new `Matrix` equivalent, as shown.
 
+.. warning::
+    
+    The new Matrix objects multiply in the opposite order as the im.Matrixcolor
+    ones. With X being the Matrix corresponding to im.Matrixcolor.x,
+    ``C*B*A`` will be the Matrix corresponding to ``im.a*im.b*im.c``.
+
 .. include:: inc/im_matrixcolor
 
 Placeholders

--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -210,8 +210,9 @@ Image can be used whenever an image manipulator is required.
 With the few exceptions listed below, the use of image manipulators is
 historic. A number of image manipulators that had been documented in the
 past should no longer be used, as they suffer from inherent problems.
-In many cases, the :func:`Transform` displayable provides similar
-functionality in a more general manner, while fixing the problems.
+In any case except for `im.Data`, the :func:`Transform` displayable provides
+similar functionality in a more general manner, while fixing the problems,
+although it sometimes requires gl2 to be enabled.
 
 .. include:: inc/im_im
 
@@ -235,7 +236,8 @@ more efficient, in both time and image cache space, than using
 two im.MatrixColors.
 
 The im.MatrixColor image manipulator has been replaced by Transforms
-and ATL transforms that specify the matrixcolor property.
+and ATL transforms that specify the matrixcolor property. Each `im.matrix`
+generator has been given a new `Matrix` equivalent, as shown.
 
 .. include:: inc/im_matrixcolor
 


### PR DESCRIPTION
As discussed in #2427.

I didn't include `im.Data` because I don't think the same can be done without it (I have no idea how to do it, and it's a kinda obsolete functionality anyway).
I didn't include `im.AlphaMask` either because `Alphamask` is already linked in `im.AlphaMask`'s docline. Furthermore, using `Alphamask` to do `im.AlphaMask`'s work would require passing the control displayable through a Matrix to replace its alpha layer with its red layer (and even then it wouldn't override the base displayable's alpha channel, it would multiply it), resulting in a more complex workaround than the other examples I gave.