### PR TITLE
Reuse dict and list objects

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -291,13 +291,11 @@ def compile_all():
     to compile all transforms.
     """
 
-    global compile_queue
-
     for i in compile_queue:
         if i.atl.constant == GLOBAL_CONST:
             i.compile()
 
-    compile_queue = [ ]
+    del compile_queue[:]
 
 
 # This is the context used when compiling an ATL statement. It stores the

--- a/renpy/audio/androidhw.py
+++ b/renpy/audio/androidhw.py
@@ -164,7 +164,7 @@ class AndroidVideoChannel(object):
         """
 
         if self.get_playing():
-            self.queue = [ ]
+            del self.queue[:]
         else:
             self.queue = self.queue[:1]
 
@@ -182,7 +182,7 @@ class AndroidVideoChannel(object):
         """
 
         self.stop()
-        self.queue = [ ]
+        del self.queue[:]
 
     def enqueue(self, filenames, loop=True, synchro_start=False, fadein=0, tight=None, loop_only=False):
         self.queue.extend(filenames)

--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -426,7 +426,7 @@ class Channel(object):
             if self.loop:
                 self.queue = self.queue[-len(self.loop):]
             else:
-                self.queue = [ ]
+                del self.queue[:]
             return
 
         topq = None
@@ -551,7 +551,7 @@ class Channel(object):
         with lock:
 
             self.queue = self.queue[:self.keep_queue]
-            self.loop = [ ]
+            del self.loop[:]
 
             if not pcm_ok:
                 return
@@ -646,7 +646,7 @@ class Channel(object):
             if loop:
                 self.loop = list(filenames)
             else:
-                self.loop = [ ]
+                del self.loop[:]
 
     def get_playing(self):
 
@@ -960,8 +960,8 @@ def quit(): # @ReservedAssignment
         c.dequeue()
         c.fadeout(0)
 
-        c.queue = [ ]
-        c.loop = [ ]
+        del c.queue[:]
+        del c.loop[:]
         c.playing = False
         c.playing_midi = False
         c.wait_stop = False

--- a/renpy/audio/ioshw.py
+++ b/renpy/audio/ioshw.py
@@ -141,7 +141,7 @@ class IOSVideoChannel(object):
         """
 
         if self.get_playing():
-            self.queue = [ ]
+            del self.queue[:]
         else:
             self.queue = self.queue[:1]
 
@@ -159,7 +159,7 @@ class IOSVideoChannel(object):
         """
 
         self.stop()
-        self.queue = [ ]
+        del self.queue[:]
 
     def enqueue(self, filenames, loop=True, synchro_start=False, fadein=0, tight=None, loop_only=False):
         self.queue.extend(filenames)

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -134,7 +134,7 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
                 ctx.last_filenames = filenames
                 ctx.last_tight = tight
             else:
-                ctx.last_filenames = [ ]
+                del ctx.last_filenames[:]
                 ctx.last_tight = False
 
             ctx.pause = False
@@ -228,7 +228,7 @@ def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tig
                 ctx.last_filenames = filenames
                 ctx.last_tight = tight
             else:
-                ctx.last_filenames = [ ]
+                del ctx.last_filenames[:]
                 ctx.last_tight = False
 
             ctx.pause = False
@@ -290,7 +290,7 @@ def stop(channel="music", fadeout=None):
             t = get_serial()
             ctx.last_changed = t
             c.last_changed = t
-            ctx.last_filenames = [ ]
+            del ctx.last_filenames[:]
             ctx.last_tight = False
 
         except:

--- a/renpy/character.py
+++ b/renpy/character.py
@@ -92,9 +92,10 @@ class DialogueTextTags(object):
                     self.no_wait = True
 
                 elif tag == "fast":
-                    self.pause_start = [ len(self.text) ]
-                    self.pause_end = [ ]
-                    self.pause_delay = [ ]
+                    del self.pause_start[:]
+                    self.pause_start.append(len(self.text))
+                    del self.pause_end[:]
+                    del self.pause_delay[:]
                     self.no_wait = False
 
                 elif tag == "done":

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -188,7 +188,7 @@ init -1500 python in build:
         Clears the list of patterns used to classify files.
         """
 
-        base_patterns[:] = [ ]
+        del base_patterns[:]
 
     def remove(l, pattern):
         """

--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -386,7 +386,7 @@ init -1500 python in _console:
                     self.pop(0)
 
         def clear(self):
-            self[:] = [ ]
+            del self[:]
 
     class ConsoleHistoryEntry(object):
         """
@@ -769,7 +769,7 @@ init -1500 python in _console:
 
     @command(_("clear: clear the console history"))
     def clear(l):
-        console.history[:] = [ ]
+        del console.history[:]
 
     @command(_("exit: exit the console"))
     def exit(l):
@@ -883,7 +883,7 @@ init -1500 python in _console:
 
     @command(_("unwatchall: stop watching all expressions"))
     def unwatchall(l):
-        traced_expressions[:] = [ ]
+        del traced_expressions[:]
         renpy.hide_screen("_trace_screen")
 
     def renpy_unwatchall():

--- a/renpy/common/00director.rpy
+++ b/renpy/common/00director.rpy
@@ -232,7 +232,7 @@ init python in director:
         # the actions used to edit those lines.
         for lle in lines[-30:]:
             if isinstance(lle.node, renpy.ast.Say):
-                state.lines = [ ]
+                del state.lines[:]
                 break
 
         for lle in lines[-30:]:
@@ -770,17 +770,17 @@ init python in director:
             state.tag = None
             state.original_tag = None
 
-            state.attributes = [ ]
-            state.original_attributes = [ ]
+            del state.attributes[:]
+            del state.original_attributes[:]
 
-            state.transforms = [ ]
-            state.original_transforms = [ ]
+            del state.transforms[:]
+            del state.original_transforms[:]
 
             state.transition = None
             state.original_transition = None
 
-            state.behind = [ ]
-            state.original_behind = [ ]
+            del state.behind[:]
+            del state.original_behind[:]
 
             state.channel = None
             state.original_channel = None
@@ -904,9 +904,9 @@ init python in director:
                 else:
 
                     self.tag = None
-                    self.attributes = [ ]
-                    self.transforms = [ ]
-                    self.behind = [ ]
+                    del self.attributes[:]
+                    del self.transforms[:]
+                    del self.behind[:]
 
                 self.sensitive = is_scene_show_hide_editable(node)
 
@@ -971,7 +971,7 @@ init python in director:
             state.tag = self.tag
             state.original_tag = self.tag
 
-            state.attributes = self.attributes
+            state.attributes = list(self.attributes)
             state.original_attributes = list(self.attributes)
 
             state.transforms = list(self.transforms)
@@ -980,7 +980,7 @@ init python in director:
             state.transition = self.transition
             state.original_transition = self.transition
 
-            state.behind = self.behind
+            state.behind = list(self.behind)
             state.original_behind = list(self.behind)
 
             state.channel = self.channel
@@ -1005,7 +1005,7 @@ init python in director:
             if self.kind != state.kind:
                 state.kind = self.kind
                 state.tag = None
-                state.attributes = [ ]
+                del state.attributes[:]
 
             if self.kind in ("scene", "show", "hide"):
                 state.mode = "tag"
@@ -1037,7 +1037,7 @@ init python in director:
             if state.tag != self.tag:
 
                 state.tag = self.tag
-                state.attributes = [ ]
+                del state.attributes[:]
 
             if state.kind != "hide":
                 state.mode = "attributes"

--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -343,7 +343,7 @@ init -1500 python:
                 store.nvl_list = [ ]
 
             if store._nvl_language != _preferences.language:
-                store.nvl_list = [ ]
+                del store.nvl_list[:]
                 store._nvl_language = _preferences.language
 
             while config.nvl_list_length and (len(nvl_list) + 1 > config.nvl_list_length):
@@ -438,7 +438,10 @@ init -1500 python:
         The Python equivalent of the ``nvl clear`` statement.
         """
 
-        store.nvl_list = [ ]
+        if store.nvl_list is None:
+            store.nvl_list = [ ]
+
+        del store.nvl_list[:]
 
     # Run clear at the start of the game.
     config.start_callbacks.append(nvl_clear)

--- a/renpy/common/00performance.rpy
+++ b/renpy/common/00performance.rpy
@@ -24,7 +24,7 @@
 init python:
 
     def _clear_performance():
-        renpy.display.interface.frame_times[:] = [ ]
+        del renpy.display.interface.frame_times[:]
 
 screen _performance:
 

--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -741,7 +741,7 @@ init -1500 python in updater:
             rv = None
 
             # A list of names of modules we want to update.
-            self.modules = [ ]
+            del self.modules[:]
 
             # DLC?
             if self.add:

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1085,12 +1085,10 @@ inputs = [ ]
 
 
 def input_pre_per_interact():
-    global input_values
-    global inputs
     global default_input_value
 
-    input_values = [ ]
-    inputs = [ ]
+    del input_values[:]
+    del inputs[:]
     default_input_value = None
 
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -895,7 +895,7 @@ class SceneLists(renpy.object.Object):
         for layer, tag in self.additional_transient:
             self.remove(layer, tag, prefix=prefix)
 
-        self.additional_transient = [ ]
+        del self.additional_transient[:]
 
     def transient_is_empty(self):
         """
@@ -1216,7 +1216,7 @@ class SceneLists(renpy.object.Object):
             return
 
         if not hide:
-            self.layers[layer] = [ ]
+            del self.layers[layer][:]
 
         else:
 
@@ -2261,7 +2261,7 @@ class Interface(object):
         self.profile_once = False
 
         # Clear the frame times.
-        self.frame_times = [ ]
+        del self.frame_times[:]
 
     def set_mode(self):
         """
@@ -2885,8 +2885,8 @@ class Interface(object):
 
         # These things can be done once per interaction.
 
-        preloads = self.preloads
-        self.preloads = [ ]
+        preloads = list(self.preloads)
+        del self.preloads[:]
 
         try:
             self.start_interact = True

--- a/renpy/display/emulator.py
+++ b/renpy/display/emulator.py
@@ -142,32 +142,32 @@ def init_emulator():
     """
 
     global emulator
-    global overlay
     global ios
+
+    del overlay[:]
 
     name = os.environ.get("RENPY_EMULATOR", "")
 
     if name == "touch":
         emulator = touch_emulator
-        overlay = [ renpy.store.DynamicDisplayable(dynamic_keyboard) ]
+        overlay.append(renpy.store.DynamicDisplayable(dynamic_keyboard))
 
     elif name == "ios-touch":
         emulator = touch_emulator
-        overlay = [ renpy.store.DynamicDisplayable(dynamic_keyboard) ]
+        overlay.append(renpy.store.DynamicDisplayable(dynamic_keyboard))
         ios = True
 
     elif name == "tv":
         emulator = tv_emulator
-        overlay = [ renpy.display.motion.Transform(
+        overlay.append(renpy.display.motion.Transform(
             "_tv_unsafe.png",
             xalign=0.5,
             yalign=0.5,
             size=(int(renpy.config.screen_height * 16.0 / 9.0), renpy.config.screen_height),
-            ) ]
+            ))
 
     else:
         emulator = null_emulator
-        overlay = [ ]
 
     if emulator is not null_emulator:
         renpy.exports.windows = False

--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -172,8 +172,7 @@ focus_list = [ ]
 
 
 def take_focuses():
-    global focus_list
-    focus_list = [ ]
+    del focus_list[:]
 
     renpy.display.render.take_focuses(focus_list)
 

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -185,9 +185,9 @@ class Cache(object):
 
         self.lock.acquire()
 
-        self.preloads = [ ]
-        self.pin_cache = { }
-        self.cache = { }
+        del self.preloads[:]
+        self.pin_cache.clear()
+        self.cache.clear()
         self.first_preload_in_tick = True
 
         self.added.clear()
@@ -200,7 +200,7 @@ class Cache(object):
 
         with self.lock:
             self.time += 1
-            self.preloads = [ ]
+            del self.preloads[:]
             self.first_preload_in_tick = True
             self.added.clear()
 
@@ -212,7 +212,7 @@ class Cache(object):
     # The preload thread can deal with this update, so we don't need
     # to lock things.
     def end_tick(self):
-        self.preloads = [ ]
+        del self.preloads[:]
 
     # This returns the pygame surface corresponding to the provided
     # image. It also takes care of updating the age of images in the
@@ -476,7 +476,7 @@ class Cache(object):
                         for i in self.preloads:
                             renpy.display.ic_log.write("Overfull %r", i)
 
-                    self.preloads = [ ]
+                    del self.preloads[:]
 
                     break
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -496,7 +496,7 @@ class Grid(Container):
                 offsets.append(offset)
 
         if self.transpose:
-            self.offsets = [ ]
+            del self.offsets[:]
             for x in range(cols):
                 for y in range(rows):
                     self.offsets.append(offsets[y * cols + x])
@@ -569,8 +569,8 @@ class MultiBox(Container):
     def _clear(self):
         super(MultiBox, self)._clear()
 
-        self.start_times = [ ]
-        self.anim_times = [ ]
+        del self.start_times[:]
+        del self.anim_times[:]
         self.layers = None
         self.scene_list = None
 

--- a/renpy/display/particle.py
+++ b/renpy/display/particle.py
@@ -328,7 +328,7 @@ class SpriteManager(renpy.display.core.Displayable):
         return rv
 
     def destroy_all(self):
-        self.children = [ ]
+        del self.children[:]
 
 
 class Particles(renpy.display.core.Displayable, renpy.python.NoRollback):

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -1060,7 +1060,7 @@ cdef class Render:
             if not cache:
                 del render_cache[id_ro]
 
-        self.render_of = [ ]
+        del self.render_of[:]
         self.focuses = None
         self.pass_focuses = None
 
@@ -1116,7 +1116,7 @@ cdef class Render:
             screen = self.focus_screen
 
         if self.modal:
-            focuses[:] = [ ]
+            del focuses[:]
 
         if self.focuses:
 
@@ -1324,7 +1324,7 @@ cdef class Render:
                 cw, ch = child.get_size()
                 if cw + xo < self.width or ch + yo < self.height:
                     if child.is_opaque():
-                        vc = [ ]
+                        del vc[:]
                         rv = True
 
             vc.append(i)

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -315,16 +315,16 @@ class ScreenDisplayable(renpy.display.layout.Container):
     def after_setstate(self):
         self.screen = get_screen_variant(self.screen_name[0])
         self.child = None
-        self.children = [ ]
-        self.transforms = { }
-        self.widgets = { }
+        del self.children[:]
+        self.transforms.clear()
+        self.widgets.clear()
         self.old_widgets = None
         self.old_transforms = None
-        self.hidden_widgets = { }
-        self.cache = { }
+        self.hidden_widgets.clear()
+        self.cache.clear()
         self.phase = UPDATE
-        self.use_cache = { }
-        self.miss_cache = { }
+        self.use_cache.clear()
+        self.miss_cache.clear()
 
         self.profile = profile.get(self.screen_name, None)
 
@@ -602,10 +602,10 @@ class ScreenDisplayable(renpy.display.layout.Container):
                     debug = True
 
         # Cycle widgets and transforms.
-        self.old_widgets = self.widgets
-        self.old_transforms = self.transforms
-        self.widgets = { }
-        self.transforms = { }
+        self.old_widgets = self.widgets.copy()
+        self.old_transforms = self.transforms.copy()
+        self.widgets.clear()
+        self.transforms.clear()
 
         push_current_screen(self)
 

--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -267,7 +267,8 @@ class Viewport(renpy.display.layout.Container):
         cw, ch = surf.get_size()
         cxo, cyo, width, height = self.update_offsets(cw, ch, st)
 
-        self.offsets = [ (cxo, cyo) ]
+        del self.offsets[:]
+        self.offsets.append((cxo, cyo))
 
         rv = renpy.display.render.Render(width, height)
         rv.blit(surf, (cxo, cyo))
@@ -543,7 +544,7 @@ class VPGrid(Viewport):
         child_height = self.child_height or height
 
         if not self.children:
-            self.offsets = [ ]
+            del self.offsets[:]
             return renpy.display.render.Render(0, 0)
 
         # The number of children.
@@ -595,7 +596,7 @@ class VPGrid(Viewport):
         cxo += left_margin
         cyo += top_margin
 
-        self.offsets = [ ]
+        del self.offsets[:]
 
         # Render everything.
         rv = renpy.display.render.Render(width, height)

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3575,7 +3575,7 @@ def clear_line_log():
     Clears the line log.
     """
 
-    renpy.game.context().line_log = [ ]
+    del renpy.game.context().line_log[:]
 
 
 def add_layer(layer, above=None, below=None, menu_clear=True):

--- a/renpy/gl/gltexture.pyx
+++ b/renpy/gl/gltexture.pyx
@@ -608,7 +608,7 @@ def dealloc_textures():
     for i in npot_free_textures:
         i.deallocate()
 
-    npot_free_textures[:] = [ ]
+    del npot_free_textures[:]
 
     if not renpy.game.preferences.gl_npot:
 
@@ -642,7 +642,7 @@ def cleanup():
     for i in npot_free_textures:
         i.deallocate()
 
-    npot_free_textures[:] = [ ]
+    del npot_free_textures[:]
 
 def compute_subrow(row, offset, width):
     """

--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -217,7 +217,7 @@ cdef class TextureLoader:
 
             self.allocated.discard(texture_number)
 
-        self.free_list = [ ]
+        del self.free_list[:]
 
 
     def ready_one_texture(self):

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -35,7 +35,7 @@ import builtins
 python_builtins = set(dir(builtins))
 renpy_builtins = set()
 
-image_prefixes = None
+image_prefixes = {}
 
 # Things to check in lint.
 #
@@ -758,8 +758,7 @@ def lint():
     print("\ufeff" + renpy.version + " lint report, generated at: " + time.ctime())
 
     # This supports check_hide.
-    global image_prefixes
-    image_prefixes = { }
+    image_prefixes.clear()
 
     for k in renpy.display.image.images:
         image_prefixes[k[0]] = True

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -332,7 +332,7 @@ def main():
         renpy.config.searchpath.extend(os.environ["RENPY_SEARCHPATH"].split("::"))
 
     if renpy.android:
-        renpy.config.searchpath = [ ]
+        del renpy.config.searchpath[:]
         renpy.config.commondir = None
 
         if "ANDROID_PUBLIC" in os.environ:
@@ -485,7 +485,7 @@ def main():
         log_clock("Loading persistent")
 
         # Clear the list of seen statements in this game.
-        game.seen_session = { }
+        game.seen_session.clear()
 
         # Initialize persistent variables.
         renpy.store.persistent = game.persistent

--- a/renpy/minstore.py
+++ b/renpy/minstore.py
@@ -129,11 +129,11 @@ def _p(s):
     for l in lines:
         if not l:
             rv += " ".join(para) + "\n\n"
-            para = [ ]
+            del para[:]
         elif re.search(r'\{p[^}]*\}$', l):
             para.append(l)
             rv += " ".join(para)
-            para = [ ]
+            del para[:]
         else:
             para.append(l)
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -274,13 +274,13 @@ def list_logical_lines(filename, filedata=None, linenumber=1, add_lines=False):
 
             if c == u'\n' and not parendepth:
 
-                line = ''.join(line)
+                line_str = ''.join(line)
 
                 # If not blank...
-                if not re.match(u"^\s*$", line):
+                if not re.match(u"^\s*$", line_str):
 
                     # Add to the results.
-                    rv.append((filename, start_number, line))
+                    rv.append((filename, start_number, line_str))
 
                 if endpos is None:
                     endpos = pos
@@ -298,7 +298,7 @@ def list_logical_lines(filename, filedata=None, linenumber=1, add_lines=False):
                 number += 1
                 endpos = None
                 # This helps out error checking.
-                line = [ ]
+                del line[:]
                 break
 
             if c == u'\n':
@@ -2910,9 +2910,8 @@ def parse(fn, filedata=None, linenumber=1):
 
 
 def get_parse_errors():
-    global parse_errors
-    rv = parse_errors
-    parse_errors = [ ]
+    rv = parse_errors[:]
+    del parse_errors[:]
     return rv
 
 

--- a/renpy/performance.py
+++ b/renpy/performance.py
@@ -39,8 +39,7 @@ running = False
 
 
 def clear():
-    global fpl
-    fpl = [ ]
+    del fpl[:]
 
     global running
     running = True

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1485,7 +1485,7 @@ class RollbackLog(renpy.object.Object):
         self.force_checkpoint = False
 
     def after_setstate(self):
-        self.mutated = { }
+        self.mutated.clear()
         self.rolled_forward = False
 
     def after_upgrade(self, version):

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -113,6 +113,13 @@ class Script(object):
         else:
             self.key = None
 
+        # A list of directory, filename w/o extension pairs. This is
+        # what we will load immediately.
+        self.script_files = [ ]
+
+        # Similar, but for modules:
+        self.module_files = [ ]
+
         self.namemap = { }
         self.all_stmts = [ ]
         self.all_pycode = [ ]
@@ -169,8 +176,8 @@ class Script(object):
 
     def make_backups(self):
 
-        backup_list = self.backup_list
-        self.backup_list = [ ]
+        backup_list = self.backup_list[:]
+        del self.backup_list[:]
 
         if os.environ.get("RENPY_DISABLE_BACKUPS", "") == "I take responsibility for this.":
             return
@@ -228,12 +235,8 @@ class Script(object):
         # A list of all files in the search directories.
         dirlist = renpy.loader.listdirfiles()
 
-        # A list of directory, filename w/o extension pairs. This is
-        # what we will load immediately.
-        self.script_files = [ ]
-
-        # Similar, but for modules:
-        self.module_files = [ ]
+        del self.script_files[:]
+        del self.module_files[:]
 
         for dir, fn in dirlist: # @ReservedAssignment
 
@@ -807,7 +810,7 @@ class Script(object):
             except:
                 pass
 
-        self.all_pyexpr = [ ]
+        del self.all_pyexpr[:]
 
         # Update all of the PyCode objects in the system with the loaded
         # bytecode.
@@ -862,7 +865,7 @@ class Script(object):
             self.bytecode_newcache[key] = code
             i.bytecode = marshal.loads(code)
 
-        self.all_pycode = [ ]
+        del self.all_pycode[:]
 
     def save_bytecode(self):
         if renpy.macapp:
@@ -938,7 +941,7 @@ class Script(object):
         for i in self.need_analysis:
             i.analyze()
 
-        self.need_analysis = [ ]
+        del self.need_analysis[:]
 
     def report_duplicate_labels(self):
         if not renpy.config.developer:

--- a/renpy/style.pyx
+++ b/renpy/style.pyx
@@ -397,7 +397,7 @@ cdef class StyleCore:
         self.parent = get_tuple_name(parent)
 
     def clear(self):
-        self.properties = [ ]
+        del self.properties[:]
 
     def take(self, other):
         """

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1410,13 +1410,11 @@ def layout_cache_clear():
     Clears the old and new layout caches.
     """
 
-    global layout_cache_old, layout_cache_new
-    layout_cache_old = { }
-    layout_cache_new = { }
+    layout_cache_old.clear()
+    layout_cache_new.clear()
 
-    global virtual_layout_cache_old, virtual_layout_cache_new
-    virtual_layout_cache_old = { }
-    virtual_layout_cache_new = { }
+    virtual_layout_cache_old.clear()
+    virtual_layout_cache_new.clear()
 
 
 # A list of slow text that's being displayed right now.
@@ -1428,16 +1426,13 @@ def text_tick():
     Called once per interaction, to merge the old and new layout caches.
     """
 
-    global layout_cache_old, layout_cache_new
-    layout_cache_old = layout_cache_new
-    layout_cache_new = { }
+    layout_cache_old = layout_cache_new.copy()
+    layout_cache_new.clear()
 
-    global virtual_layout_cache_old, virtual_layout_cache_new
-    virtual_layout_cache_old = layout_cache_new
-    virtual_layout_cache_new = { }
+    virtual_layout_cache_old = layout_cache_new.copy()
+    virtual_layout_cache_new.clear()
 
-    global slow_text
-    slow_text = [ ]
+    del slow_text[:]
 
 
 VERT_REVERSE = renpy.display.render.Matrix2D(0, -1, 1, 0)
@@ -2135,7 +2130,7 @@ class Text(renpy.display.core.Displayable):
         # Blit displayables.
         if layout.displayable_blits:
 
-            self.displayable_offsets = [ ]
+            del self.displayable_offsets[:]
 
             drend = renpy.display.render.Render(w, h)
             drend.forward = layout.reverse

--- a/renpy/ui.py
+++ b/renpy/ui.py
@@ -238,13 +238,10 @@ imagemap_stack = [ ]
 # Called at the end of the init phase, and from the screen
 # prediction code.
 def reset():
-    global stack
-    global at_stack
-    global imagemap_stack
-
-    stack = [ Layer('transient') ]
-    at_stack = [ ]
-    imagemap_stack = [ ]
+    del stack[:]
+    stack.append(Layer('transient'))
+    del at_stack[:]
+    del imagemap_stack[:]
 
 
 renpy.game.post_init.append(reset)
@@ -392,7 +389,7 @@ def reopen(w, clear):
     stack.append(Many(w))
 
     if clear:
-        w.children[:] = [ ]
+        del w.children[:]
 
 
 def context_enter(w):


### PR DESCRIPTION
Small optimization by reusing `dict` and `list` objects whenever possible.  

Instead of assigning a new empty `list` or `dict`, or slicing with a new empty `list`, clear the existing one using `del x[:]` or `x.clear()`.  
