### PR TITLE
Android additional archive loading on startup

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -374,7 +374,7 @@ def main():
         renpy.config.searchpath.extend(os.environ["RENPY_SEARCHPATH"].split("::"))
 
     if renpy.android:
-        renpy.config.searchpath = [ ]
+        renpy.config.searchpath = [ renpy.config.gamedir ]
         renpy.config.commondir = None
 
         android_searchpath()
@@ -392,22 +392,12 @@ def main():
             if not (ext in archive_extensions):
                 archive_extensions.append(ext)
 
-    # Find archives.
-    for dn in renpy.config.searchpath:
-
-        if os.path.isdir(dn):
-            continue
-
-        for i in sorted(os.listdir(dn)):
-            base, ext = os.path.splitext(i)
-
-            # Check if the archive does not have any of the extensions in archive_extensions
-            if not (ext in archive_extensions):
-                continue
-
-            renpy.config.archives.append(base)
-
-    renpy.config.archives.reverse()
+    # Collect archive names.
+    for dir in renpy.config.searchpath: # @ReservedAssignment
+        for fn in reversed(sorted(os.listdir(dir))):
+            base, ext = os.path.splitext(fn)
+            if ext in archive_extensions:
+                renpy.config.archives.append(base)
 
     # Initialize archives.
     renpy.loader.index_archives()

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -389,12 +389,13 @@ def main():
     archive_extensions = set(e for h in renpy.loader.archive_handlers
                                for e in h.get_supported_extensions())
 
-    # Collect archive names.
-    for dir in renpy.config.searchpath: # @ReservedAssignment
-        for fn in reversed(sorted(os.listdir(dir))):
-            base, ext = os.path.splitext(fn)
-            if ext in archive_extensions:
-                renpy.config.archives.append(base)
+    # Lazy iterator of potential archives (basename and extension.)
+    archive_candidates = (os.path.splitext(f) for d in renpy.config.searchpath
+                                              for f in os.listdir(d))
+
+    # Materialise reverse-sorted (load order) unique list of archive names.
+    renpy.config.archives = sorted(set(b for b, e in archive_candidates
+                                         if e in archive_extensions), reverse=True)
 
     # Initialize archives.
     renpy.loader.index_archives()

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -385,12 +385,9 @@ def main():
             if fn.lower().endswith(".rpe"):
                 load_rpe(dir + "/" + fn)
 
-    # Generate a list of extensions for each archive handler.
-    archive_extensions = [ ]
-    for handler in renpy.loader.archive_handlers:
-        for ext in handler.get_supported_extensions():
-            if not (ext in archive_extensions):
-                archive_extensions.append(ext)
+    # Generate a set of supported archive extensions.
+    archive_extensions = set(e for h in renpy.loader.archive_handlers
+                               for e in h.get_supported_extensions())
 
     # Collect archive names.
     for dir in renpy.config.searchpath: # @ReservedAssignment


### PR DESCRIPTION
**Problem:** Mod and patch `.rpa` files are ignored during startup on Android despite being in the `config.searchpath`.

---

At present archives are loadable when in `config.searchpath`, but their names are not collected for indexing during startup as `renpy.main.main()` only scans `config.gamedir`. In order to facilitate distributing mods and patches as `.rpa` files this change adds `config.gamedir` to Android's `config.searchpath` and then scans `config.searchpath` to populate `config.archives`.

It also makes use of sets and iterators to keep the process quick and prevent any duplicate processing later during the init sequence.

The end result is a `config.archives` containing a reverse sorted list of archive names as before, only now including names found in `config.searchpath` directories. As the list contains no path information, and `config.searchpath` precedence is handled by file loading code elsewhere, the thinking is that only a simple reverse sort over all members is required to ensure expected and predictable indexing and load order later on in the process.