### PR TITLE
fix layeredimages to take any transform property

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -588,6 +588,7 @@ python early in layeredimage:
             kwargs.setdefault("xfit", True)
             kwargs.setdefault("yfit", True)
 
+            self.transform_args = {k : kwargs.pop(k) for k, v in kwargs.items() if k not in (renpy.sl2.slproperties.position_property_names + renpy.sl2.slproperties.box_property_names)}
             self.fixed_args = kwargs
 
         def format(self, what, attribute=None, group=None, variant=None, image=None):
@@ -688,7 +689,7 @@ python early in layeredimage:
                 rv = Fixed(rv, text, fit_first=True)
 
 
-            for i in self.at:
+            for i in self.at+[Transform(**self.transform_args)]:
                 rv = i(rv)
 
             return rv
@@ -1052,7 +1053,8 @@ python early in layeredimage:
 
                 while parse_property(ll, rv, [ "image_format", "format_function", "attribute_function", "at" ] +
                     renpy.sl2.slproperties.position_property_names +
-                    renpy.sl2.slproperties.box_property_names
+                    renpy.sl2.slproperties.box_property_names +
+                    ATL_PROPERTIES
                     ):
                     pass
 


### PR DESCRIPTION
fix for #2456 
After being wrapped into each Transform given by the at statement(s), the layeredimage is then wrapped in another Transform, taking all the given properties that can't be taken by the Fixed.