### PR TITLE
Enable the fit mechanism whenever the fit property is set

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -108,9 +108,6 @@ def transform_render(self, widtho, heighto, st, at):
     ysize = state.ysize
     fit = state.fit
 
-    if fit is None:
-        fit = 'fill'
-
     if xsize is not None:
         widtho = xsize
     if ysize is not None:
@@ -242,6 +239,12 @@ def transform_render(self, widtho, heighto, st, at):
             scale.append(xsize / width)
         if ysize is not None:
             scale.append(ysize / height)
+        
+        if fit and not scale:
+            scale = [widtho / width, heighto / height]
+
+        if fit is None:
+            fit = 'fill'
 
         if scale:
             if fit == 'scale-up':


### PR DESCRIPTION
If `fit` is set but not `xsize` nor `ysize`, the available size is fed to the fit algorithm instead.
The `width` and `height` parameters given to the `render()` method are interpreted as the available size.
Also since the `fit` property replaces the `maxsize` property, and this is a case when the `fit` property is supplied, the `maxsize` property is ignored.

An example of its use : it allows for backgrounds to be given only `fit='cover'` for them to cover the whole screen (if shown directly), so that the code using it doesn't have to be modified following the size of the screen.

**This code remains to be tested**, because as modifying or even deleting the `accelerator.pyx` file doesn't keep Ren'py from executing the function it contains (meaning it has to be compiled somehow, I guess), I can't test it from a ren'py distrib.
If you have the means to test it, please do and review my changes or leave a comment !