### PR TITLE
Translate tutorial game into simplified Chinese

### DIFF
--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -778,7 +778,8 @@ screen preferences():
                     textbutton "Español" text_font "DejaVuSans.ttf" action Language("spanish")
                     textbutton "한국어" text_font "../../launcher/game/fonts/SourceHanSansLite.ttf" action Language("korean")
                     textbutton "日本語" text_font "../../launcher/game/fonts/SourceHanSansLite.ttf" action Language("japanese")
-                    
+                    textbutton "简体中文" text_font "../../launcher/game/fonts/SourceHanSansLite.ttf" action Language("schinese")
+
                     # This should be last.
                     textbutton "Pig Latin" text_font "DejaVuSans.ttf" action Language("piglatin")
 

--- a/tutorial/game/tl/schinese/01example.rpy
+++ b/tutorial/game/tl/schinese/01example.rpy
@@ -1,0 +1,11 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+translate schinese strings:
+
+    # game/01example.rpy:473
+    old "Copied the example to the clipboard."
+    new "复制示例到剪贴板。"
+
+    # game/01example.rpy:546
+    old "copy"
+    new "复制"

--- a/tutorial/game/tl/schinese/common.rpy
+++ b/tutorial/game/tl/schinese/common.rpy
@@ -1,0 +1,1178 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+translate schinese strings:
+
+    # renpy/common/00accessibility.rpy:28
+    old "Self-voicing disabled."
+    new "自动语音关闭。"
+
+    # renpy/common/00accessibility.rpy:29
+    old "Clipboard voicing enabled. "
+    new "剪贴板语音启用。"
+
+    # renpy/common/00accessibility.rpy:30
+    old "Self-voicing enabled. "
+    new "自动语音启用。"
+
+    # renpy/common/00accessibility.rpy:32
+    old "bar"
+    new "条"
+
+    # renpy/common/00accessibility.rpy:33
+    old "selected"
+    new "选中"
+
+    # renpy/common/00accessibility.rpy:34
+    old "viewport"
+    new "视口"
+
+    # renpy/common/00accessibility.rpy:35
+    old "horizontal scroll"
+    new "水平滚动"
+
+    # renpy/common/00accessibility.rpy:36
+    old "vertical scroll"
+    new "垂直滚动"
+
+    # renpy/common/00accessibility.rpy:37
+    old "activate"
+    new "激活"
+
+    # renpy/common/00accessibility.rpy:38
+    old "deactivate"
+    new "关闭"
+
+    # renpy/common/00accessibility.rpy:39
+    old "increase"
+    new "增加"
+
+    # renpy/common/00accessibility.rpy:40
+    old "decrease"
+    new "减少"
+
+    # renpy/common/00accessibility.rpy:128
+    old "Font Override"
+    new "字体覆盖"
+
+    # renpy/common/00accessibility.rpy:132
+    old "Default"
+    new "默认"
+
+    # renpy/common/00accessibility.rpy:136
+    old "DejaVu Sans"
+    new "DejaVu Sans"
+
+    # renpy/common/00accessibility.rpy:140
+    old "Opendyslexic"
+    new "Opendyslexic"
+
+    # renpy/common/00accessibility.rpy:146
+    old "Text Size Scaling"
+    new "文本字体缩放"
+
+    # renpy/common/00accessibility.rpy:152
+    old "Reset"
+    new "重置"
+
+    # renpy/common/00accessibility.rpy:157
+    old "Line Spacing Scaling"
+    new "行间距缩放"
+
+    # renpy/common/00accessibility.rpy:169
+    old "Self-Voicing"
+    new "自动语音"
+
+    # renpy/common/00accessibility.rpy:173
+    old "Off"
+    new "关"
+
+    # renpy/common/00accessibility.rpy:177
+    old "Text-to-speech"
+    new "语音合成"
+
+    # renpy/common/00accessibility.rpy:181
+    old "Clipboard"
+    new "剪贴板"
+
+    # renpy/common/00accessibility.rpy:185
+    old "Debug"
+    new "调试"
+
+    # renpy/common/00accessibility.rpy:191
+    old "The options on this menu are intended to improve accessibility. They may not work with all games, and some combinations of options may render the game unplayable. This is not an issue with the game or engine. For the best results when changing fonts, try to keep the text size the same as it originally was."
+    new "这个菜单上的选项意在改善可用性。也许不是在所有的游戏中都起作用，一些选项的组合甚至可能让游戏没法玩。这不是游戏或引擎的问题。为了在改变字体时获得最好的结果，请保持字体大小和原来一样。"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Monday"
+    new "{#weekday}星期一"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Tuesday"
+    new "{#weekday}星期二"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Wednesday"
+    new "{#weekday}星期三"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Thursday"
+    new "{#weekday}星期四"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Friday"
+    new "{#weekday}星期五"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Saturday"
+    new "{#weekday}星期六"
+
+    # renpy/common/00action_file.rpy:26
+    old "{#weekday}Sunday"
+    new "{#weekday}星期日"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Mon"
+    new "{#weekday_short}一"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Tue"
+    new "{#weekday_short}二"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Wed"
+    new "{#weekday_short}三"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Thu"
+    new "{#weekday_short}四"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Fri"
+    new "{#weekday_short}五"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Sat"
+    new "{#weekday_short}六"
+
+    # renpy/common/00action_file.rpy:37
+    old "{#weekday_short}Sun"
+    new "{#weekday_short}日"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}January"
+    new "{#month}一月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}February"
+    new "{#month}二月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}March"
+    new "{#month}三月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}April"
+    new "{#month}四月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}May"
+    new "{#month}五月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}June"
+    new "{#month}六月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}July"
+    new "{#month}七月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}August"
+    new "{#month}八月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}September"
+    new "{#month}九月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}October"
+    new "{#month}十月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}November"
+    new "{#month}十一月"
+
+    # renpy/common/00action_file.rpy:47
+    old "{#month}December"
+    new "{#month}十二月"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Jan"
+    new "{#month_short}一"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Feb"
+    new "{#month_short}二"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Mar"
+    new "{#month_short}三"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Apr"
+    new "{#month_short}四"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}May"
+    new "{#month_short}五"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Jun"
+    new "{#month_short}六"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Jul"
+    new "{#month_short}七"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Aug"
+    new "{#month_short}八"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Sep"
+    new "{#month_short}九"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Oct"
+    new "{#month_short}十"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Nov"
+    new "{#month_short}十一"
+
+    # renpy/common/00action_file.rpy:63
+    old "{#month_short}Dec"
+    new "{#month_short}十二"
+
+    # renpy/common/00action_file.rpy:240
+    old "%b %d, %H:%M"
+    new "%b %d, %H:%M"
+
+    # renpy/common/00action_file.rpy:353
+    old "Save slot %s: [text]"
+    new "存档 %s: [text]"
+
+    # renpy/common/00action_file.rpy:434
+    old "Load slot %s: [text]"
+    new "存档 %s: [text]"
+
+    # renpy/common/00action_file.rpy:487
+    old "Delete slot [text]"
+    new "删除存档 [text]"
+
+    # renpy/common/00action_file.rpy:569
+    old "File page auto"
+    new "自动存档页"
+
+    # renpy/common/00action_file.rpy:571
+    old "File page quick"
+    new "快速存档页"
+
+    # renpy/common/00action_file.rpy:573
+    old "File page [text]"
+    new "存档页 [text]"
+
+    # renpy/common/00action_file.rpy:772
+    old "Next file page."
+    new "下一页。"
+
+    # renpy/common/00action_file.rpy:845
+    old "Previous file page."
+    new "上一页。"
+
+    # renpy/common/00action_file.rpy:906
+    old "Quick save complete."
+    new "快速保存完毕。"
+
+    # renpy/common/00action_file.rpy:924
+    old "Quick save."
+    new "快速保存。"
+
+    # renpy/common/00action_file.rpy:943
+    old "Quick load."
+    new "快速读取。"
+
+    # renpy/common/00action_other.rpy:375
+    old "Language [text]"
+    new "语言 [text]"
+
+    # renpy/common/00director.rpy:708
+    old "The interactive director is not enabled here."
+    new "这里不能用交互式编导器。"
+
+    # renpy/common/00director.rpy:1481
+    old "⬆"
+    new "⬆"
+
+    # renpy/common/00director.rpy:1487
+    old "⬇"
+    new "⬇"
+
+    # renpy/common/00director.rpy:1551
+    old "Done"
+    new "完成"
+
+    # renpy/common/00director.rpy:1561
+    old "(statement)"
+    new "(statement)"
+
+    # renpy/common/00director.rpy:1562
+    old "(tag)"
+    new "(tag)"
+
+    # renpy/common/00director.rpy:1563
+    old "(attributes)"
+    new "(attributes)"
+
+    # renpy/common/00director.rpy:1564
+    old "(transform)"
+    new "(transform)"
+
+    # renpy/common/00director.rpy:1589
+    old "(transition)"
+    new "(transition)"
+
+    # renpy/common/00director.rpy:1601
+    old "(channel)"
+    new "(channel)"
+
+    # renpy/common/00director.rpy:1602
+    old "(filename)"
+    new "(filename)"
+
+    # renpy/common/00director.rpy:1631
+    old "Change"
+    new "改变"
+
+    # renpy/common/00director.rpy:1633
+    old "Add"
+    new "加"
+
+    # renpy/common/00director.rpy:1636
+    old "Cancel"
+    new "取消"
+
+    # renpy/common/00director.rpy:1639
+    old "Remove"
+    new "移除"
+
+    # renpy/common/00director.rpy:1674
+    old "Statement:"
+    new "语句："
+
+    # renpy/common/00director.rpy:1695
+    old "Tag:"
+    new "标签："
+
+    # renpy/common/00director.rpy:1711
+    old "Attributes:"
+    new "属性："
+
+    # renpy/common/00director.rpy:1729
+    old "Transforms:"
+    new "变换："
+
+    # renpy/common/00director.rpy:1748
+    old "Behind:"
+    new "Behind:"
+
+    # renpy/common/00director.rpy:1767
+    old "Transition:"
+    new "转场："
+
+    # renpy/common/00director.rpy:1785
+    old "Channel:"
+    new "频道："
+
+    # renpy/common/00director.rpy:1803
+    old "Audio Filename:"
+    new "音频文件名："
+
+    # renpy/common/00gui.rpy:374
+    old "Are you sure?"
+    new "你确定？"
+
+    # renpy/common/00gui.rpy:375
+    old "Are you sure you want to delete this save?"
+    new "你确定要删除这个存档吗？"
+
+    # renpy/common/00gui.rpy:376
+    old "Are you sure you want to overwrite your save?"
+    new "你确定要覆盖这个存档吗？"
+
+    # renpy/common/00gui.rpy:377
+    old "Loading will lose unsaved progress.\nAre you sure you want to do this?"
+    new "读取会失去未保存的进度。\n你确定要这么做吗？"
+
+    # renpy/common/00gui.rpy:378
+    old "Are you sure you want to quit?"
+    new "你确定要退出吗？"
+
+    # renpy/common/00gui.rpy:379
+    old "Are you sure you want to return to the main menu?\nThis will lose unsaved progress."
+    new "你确定要返回主菜单吗？\n未保存的进度会丢失。"
+
+    # renpy/common/00gui.rpy:380
+    old "Are you sure you want to end the replay?"
+    new "你确定要结束回想吗？"
+
+    # renpy/common/00gui.rpy:381
+    old "Are you sure you want to begin skipping?"
+    new "你确定要开始跳过吗？"
+
+    # renpy/common/00gui.rpy:382
+    old "Are you sure you want to skip to the next choice?"
+    new "你确定要跳到下一个选项吗？"
+
+    # renpy/common/00gui.rpy:383
+    old "Are you sure you want to skip unseen dialogue to the next choice?"
+    new "你确定要跳过还没看过的对话，直到下一个选项吗？"
+
+    # renpy/common/00keymap.rpy:267
+    old "Failed to save screenshot as %s."
+    new "无法将截屏保存为%s。"
+
+    # renpy/common/00keymap.rpy:279
+    old "Saved screenshot as %s."
+    new "截屏保存为%s。"
+
+    # renpy/common/00library.rpy:195
+    old "Skip Mode"
+    new "跳过模式"
+
+    # renpy/common/00library.rpy:281
+    old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
+    new "这个程序包含了许多许可证下的免费软件，包括MIT许可证和GNU Lesser通用公共许可证。完整的软件列表，包括全部源代码的链接，可以在{a=https://www.renpy.org/l/license}这里{/a}找到。"
+
+    # renpy/common/00preferences.rpy:233
+    old "display"
+    new "显示"
+
+    # renpy/common/00preferences.rpy:245
+    old "transitions"
+    new "转场"
+
+    # renpy/common/00preferences.rpy:254
+    old "skip transitions"
+    new "跳过转场"
+
+    # renpy/common/00preferences.rpy:256
+    old "video sprites"
+    new "视频精灵"
+
+    # renpy/common/00preferences.rpy:265
+    old "show empty window"
+    new "显示空窗口"
+
+    # renpy/common/00preferences.rpy:274
+    old "text speed"
+    new "文本速度"
+
+    # renpy/common/00preferences.rpy:282
+    old "joystick"
+    new "摇杆"
+
+    # renpy/common/00preferences.rpy:282
+    old "joystick..."
+    new "摇杆……"
+
+    # renpy/common/00preferences.rpy:289
+    old "skip"
+    new "跳过"
+
+    # renpy/common/00preferences.rpy:292
+    old "skip unseen [text]"
+    new "跳过未读[text]"
+
+    # renpy/common/00preferences.rpy:297
+    old "skip unseen text"
+    new "跳过未读文本"
+
+    # renpy/common/00preferences.rpy:299
+    old "begin skipping"
+    new "开始跳过"
+
+    # renpy/common/00preferences.rpy:303
+    old "after choices"
+    new "选择后"
+
+    # renpy/common/00preferences.rpy:310
+    old "skip after choices"
+    new "选择后跳过"
+
+    # renpy/common/00preferences.rpy:312
+    old "auto-forward time"
+    new "自动前进时间"
+
+    # renpy/common/00preferences.rpy:326
+    old "auto-forward"
+    new "自动前进"
+
+    # renpy/common/00preferences.rpy:333
+    old "Auto forward"
+    new "自动前进"
+
+    # renpy/common/00preferences.rpy:336
+    old "auto-forward after click"
+    new "点击后自动前进"
+
+    # renpy/common/00preferences.rpy:345
+    old "automatic move"
+    new "自动移动"
+
+    # renpy/common/00preferences.rpy:354
+    old "wait for voice"
+    new "等待语音"
+
+    # renpy/common/00preferences.rpy:363
+    old "voice sustain"
+    new "voice sustain"
+
+    # renpy/common/00preferences.rpy:372
+    old "self voicing"
+    new "自动语音"
+
+    # renpy/common/00preferences.rpy:381
+    old "clipboard voicing"
+    new "剪贴板语音"
+
+    # renpy/common/00preferences.rpy:390
+    old "debug voicing"
+    new "调试语音"
+
+    # renpy/common/00preferences.rpy:399
+    old "emphasize audio"
+    new "强调音"
+
+    # renpy/common/00preferences.rpy:408
+    old "rollback side"
+    new "rollback side"
+
+    # renpy/common/00preferences.rpy:418
+    old "gl powersave"
+    new "gl省电"
+
+    # renpy/common/00preferences.rpy:424
+    old "gl framerate"
+    new "gl帧率"
+
+    # renpy/common/00preferences.rpy:427
+    old "gl tearing"
+    new "gl tearing"
+
+    # renpy/common/00preferences.rpy:430
+    old "font transform"
+    new "字体变换"
+
+    # renpy/common/00preferences.rpy:433
+    old "font size"
+    new "字体大小"
+
+    # renpy/common/00preferences.rpy:441
+    old "font line spacing"
+    new "字体行距"
+
+    # renpy/common/00preferences.rpy:460
+    old "music volume"
+    new "音乐"
+
+    # renpy/common/00preferences.rpy:461
+    old "sound volume"
+    new "音效"
+
+    # renpy/common/00preferences.rpy:462
+    old "voice volume"
+    new "语音"
+
+    # renpy/common/00preferences.rpy:463
+    old "mute music"
+    new "音乐静音"
+
+    # renpy/common/00preferences.rpy:464
+    old "mute sound"
+    new "音效静音"
+
+    # renpy/common/00preferences.rpy:465
+    old "mute voice"
+    new "语音静音"
+
+    # renpy/common/00preferences.rpy:466
+    old "mute all"
+    new "全部静音"
+
+    # renpy/common/00preferences.rpy:547
+    old "Clipboard voicing enabled. Press 'shift+C' to disable."
+    new "剪贴板语音已启用。按 'shift+C' 关闭。"
+
+    # renpy/common/00preferences.rpy:549
+    old "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
+    new "自动语音会说“[renpy.display.tts.last]”。按 'alt+shift+V' 关闭。"
+
+    # renpy/common/00preferences.rpy:551
+    old "Self-voicing enabled. Press 'v' to disable."
+    new "自动语音已启动。按 'v' 关闭。"
+
+    # renpy/common/_compat/gamemenu.rpym:198
+    old "Empty Slot."
+    new "无存档。"
+
+    # renpy/common/_compat/gamemenu.rpym:355
+    old "Previous"
+    new "前"
+
+    # renpy/common/_compat/gamemenu.rpym:362
+    old "Next"
+    new "后"
+
+    # renpy/common/_compat/preferences.rpym:428
+    old "Joystick Mapping"
+    new "摇杆映射"
+
+    # renpy/common/_developer/developer.rpym:38
+    old "Developer Menu"
+    new "开发者菜单"
+
+    # renpy/common/_developer/developer.rpym:43
+    old "Interactive Director (D)"
+    new "交互式编导器 (D)"
+
+    # renpy/common/_developer/developer.rpym:45
+    old "Reload Game (Shift+R)"
+    new "重新载入游戏 (Shift+R)"
+
+    # renpy/common/_developer/developer.rpym:47
+    old "Console (Shift+O)"
+    new "控制台 (Shift+O)"
+
+    # renpy/common/_developer/developer.rpym:49
+    old "Variable Viewer"
+    new "变量查看器"
+
+    # renpy/common/_developer/developer.rpym:51
+    old "Image Location Picker"
+    new "图像位置选择器"
+
+    # renpy/common/_developer/developer.rpym:53
+    old "Filename List"
+    new "文件名列表"
+
+    # renpy/common/_developer/developer.rpym:57
+    old "Show Image Load Log (F4)"
+    new "显示图像加载日志(F4)"
+
+    # renpy/common/_developer/developer.rpym:60
+    old "Hide Image Load Log (F4)"
+    new "隐藏图像加载日志(F4)"
+
+    # renpy/common/_developer/developer.rpym:63
+    old "Image Attributes"
+    new "图像属性"
+
+    # renpy/common/_developer/developer.rpym:90
+    old "[name] [attributes] (hidden)"
+    new "[name] [attributes] (hidden)"
+
+    # renpy/common/_developer/developer.rpym:94
+    old "[name] [attributes]"
+    new "[name] [attributes]"
+
+    # renpy/common/_developer/developer.rpym:143
+    old "Nothing to inspect."
+    new "无需检查。"
+
+    # renpy/common/_developer/developer.rpym:154
+    old "Hide deleted"
+    new "隐藏已删除"
+
+    # renpy/common/_developer/developer.rpym:154
+    old "Show deleted"
+    new "显示已删除"
+
+    # renpy/common/_developer/developer.rpym:278
+    old "Return to the developer menu"
+    new "返回开发者菜单"
+
+    # renpy/common/_developer/developer.rpym:443
+    old "Rectangle: %r"
+    new "矩形: %r"
+
+    # renpy/common/_developer/developer.rpym:448
+    old "Mouse position: %r"
+    new "鼠标位置: %r"
+
+    # renpy/common/_developer/developer.rpym:453
+    old "Right-click or escape to quit."
+    new "右击或Esc退出。"
+
+    # renpy/common/_developer/developer.rpym:485
+    old "Rectangle copied to clipboard."
+    new "矩形已复制到剪贴板。"
+
+    # renpy/common/_developer/developer.rpym:488
+    old "Position copied to clipboard."
+    new "位置已复制到剪贴板。"
+
+    # renpy/common/_developer/developer.rpym:507
+    old "Type to filter: "
+    new "输入筛选条件："
+
+    # renpy/common/_developer/developer.rpym:635
+    old "Textures: [tex_count] ([tex_size_mb:.1f] MB)"
+    new "材质: [tex_count] ([tex_size_mb:.1f] MB)"
+
+    # renpy/common/_developer/developer.rpym:639
+    old "Image cache: [cache_pct:.1f]% ([cache_size_mb:.1f] MB)"
+    new "图像缓存: [cache_pct:.1f]% ([cache_size_mb:.1f] MB)"
+
+    # renpy/common/_developer/developer.rpym:649
+    old "✔ "
+    new "✔ "
+
+    # renpy/common/_developer/developer.rpym:652
+    old "✘ "
+    new "✘ "
+
+    # renpy/common/_developer/developer.rpym:657
+    old "\n{color=#cfc}✔ predicted image (good){/color}\n{color=#fcc}✘ unpredicted image (bad){/color}\n{color=#fff}Drag to move.{/color}"
+    new "\n{color=#cfc}✔ 预测图像 (good){/color}\n{color=#fcc}✘ 未预测图像 (bad){/color}\n{color=#fff}拖曳移动。{/color}"
+
+    # renpy/common/_developer/inspector.rpym:38
+    old "Displayable Inspector"
+    new "可视组件检查器"
+
+    # renpy/common/_developer/inspector.rpym:61
+    old "Size"
+    new "大小"
+
+    # renpy/common/_developer/inspector.rpym:65
+    old "Style"
+    new "样式"
+
+    # renpy/common/_developer/inspector.rpym:71
+    old "Location"
+    new "位置"
+
+    # renpy/common/_developer/inspector.rpym:122
+    old "Inspecting Styles of [displayable_name!q]"
+    new "检查样式 [displayable_name!q]"
+
+    # renpy/common/_developer/inspector.rpym:139
+    old "displayable:"
+    new "可视组件："
+
+    # renpy/common/_developer/inspector.rpym:145
+    old "        (no properties affect the displayable)"
+    new "        (no properties affect the displayable)"
+
+    # renpy/common/_developer/inspector.rpym:147
+    old "        (default properties omitted)"
+    new "        (default properties omitted)"
+
+    # renpy/common/_developer/inspector.rpym:185
+    old "<repr() failed>"
+    new "<repr() failed>"
+
+    # renpy/common/_layout/classic_load_save.rpym:170
+    old "a"
+    new "a"
+
+    # renpy/common/_layout/classic_load_save.rpym:179
+    old "q"
+    new "q"
+
+    # renpy/common/00iap.rpy:217
+    old "Contacting App Store\nPlease Wait..."
+    new "正在连接应用商店\n请等待……"
+
+    # renpy/common/00updater.rpy:375
+    old "The Ren'Py Updater is not supported on mobile devices."
+    new "Ren'Py更新器不支持移动设备。"
+
+    # renpy/common/00updater.rpy:494
+    old "An error is being simulated."
+    new "正在模拟错误。"
+
+    # renpy/common/00updater.rpy:678
+    old "Either this project does not support updating, or the update status file was deleted."
+    new "此工程不支持更新，或者更新状态文件已删除。"
+
+    # renpy/common/00updater.rpy:692
+    old "This account does not have permission to perform an update."
+    new "此帐户没有执行更新的权限。"
+
+    # renpy/common/00updater.rpy:695
+    old "This account does not have permission to write the update log."
+    new "此帐户没有写入更新日志的权限。"
+
+    # renpy/common/00updater.rpy:722
+    old "Could not verify update signature."
+    new "不能验证更新签名。"
+
+    # renpy/common/00updater.rpy:997
+    old "The update file was not downloaded."
+    new "更新文件未下载。"
+
+    # renpy/common/00updater.rpy:1015
+    old "The update file does not have the correct digest - it may have been corrupted."
+    new "更新文件没有正确的摘要 - 可能已损坏。"
+
+    # renpy/common/00updater.rpy:1071
+    old "While unpacking {}, unknown type {}."
+    new "解压 {} 时，未知类型 {}."
+
+    # renpy/common/00updater.rpy:1439
+    old "Updater"
+    new "更新器"
+
+    # renpy/common/00updater.rpy:1446
+    old "An error has occured:"
+    new "发生错误："
+
+    # renpy/common/00updater.rpy:1448
+    old "Checking for updates."
+    new "检查更新"
+
+    # renpy/common/00updater.rpy:1450
+    old "This program is up to date."
+    new "本程序已最新。"
+
+    # renpy/common/00updater.rpy:1452
+    old "[u.version] is available. Do you want to install it?"
+    new "[u.version]可用。你想安装吗？"
+
+    # renpy/common/00updater.rpy:1454
+    old "Preparing to download the updates."
+    new "准备下载更新。"
+
+    # renpy/common/00updater.rpy:1456
+    old "Downloading the updates."
+    new "下载更新。"
+
+    # renpy/common/00updater.rpy:1458
+    old "Unpacking the updates."
+    new "解压更新。"
+
+    # renpy/common/00updater.rpy:1460
+    old "Finishing up."
+    new "完成。"
+
+    # renpy/common/00updater.rpy:1462
+    old "The updates have been installed. The program will restart."
+    new "更新已安装。程序将重新启动。"
+
+    # renpy/common/00updater.rpy:1464
+    old "The updates have been installed."
+    new "更新已安装。"
+
+    # renpy/common/00updater.rpy:1466
+    old "The updates were cancelled."
+    new "更新取消。"
+
+    # renpy/common/00updater.rpy:1481
+    old "Proceed"
+    new "继续"
+
+    # renpy/common/00gallery.rpy:592
+    old "Image [index] of [count] locked."
+    new "图像 [index] / [count] 锁定。"
+
+    # renpy/common/00gallery.rpy:612
+    old "prev"
+    new "前"
+
+    # renpy/common/00gallery.rpy:613
+    old "next"
+    new "后"
+
+    # renpy/common/00gallery.rpy:614
+    old "slideshow"
+    new "幻灯片"
+
+    # renpy/common/00gallery.rpy:615
+    old "return"
+    new "返回"
+
+    # renpy/common/00gltest.rpy:70
+    old "Renderer"
+    new "渲染器"
+
+    # renpy/common/00gltest.rpy:74
+    old "Automatically Choose"
+    new "自动选择"
+
+    # renpy/common/00gltest.rpy:79
+    old "Force Angle/DirectX Renderer"
+    new "强制Angle/DirectX渲染器"
+
+    # renpy/common/00gltest.rpy:83
+    old "Force OpenGL Renderer"
+    new "强制OpenGL渲染"
+
+    # renpy/common/00gltest.rpy:87
+    old "Force Software Renderer"
+    new "强制软件渲染器"
+
+    # renpy/common/00gltest.rpy:93
+    old "NPOT"
+    new "NPOT材质"
+
+    # renpy/common/00gltest.rpy:97
+    old "Enable"
+    new "启用"
+
+    # renpy/common/00gltest.rpy:101
+    old "Disable"
+    new "关闭"
+
+    # renpy/common/00gltest.rpy:131
+    old "Powersave"
+    new "省电"
+
+    # renpy/common/00gltest.rpy:145
+    old "Framerate"
+    new "帧率"
+
+    # renpy/common/00gltest.rpy:149
+    old "Screen"
+    new "屏幕"
+
+    # renpy/common/00gltest.rpy:153
+    old "60"
+    new "60"
+
+    # renpy/common/00gltest.rpy:157
+    old "30"
+    new "30"
+
+    # renpy/common/00gltest.rpy:163
+    old "Tearing"
+    new "Tearing"
+
+    # renpy/common/00gltest.rpy:179
+    old "Changes will take effect the next time this program is run."
+    new "更改将在下次运行此程序时生效。"
+
+    # renpy/common/00gltest.rpy:213
+    old "Performance Warning"
+    new "性能警告"
+
+    # renpy/common/00gltest.rpy:218
+    old "This computer is using software rendering."
+    new "此电脑正在使用软件渲染。"
+
+    # renpy/common/00gltest.rpy:220
+    old "This computer is not using shaders."
+    new "此电脑未使用着色器。"
+
+    # renpy/common/00gltest.rpy:222
+    old "This computer is displaying graphics slowly."
+    new "此电脑显示图形缓慢。"
+
+    # renpy/common/00gltest.rpy:224
+    old "This computer has a problem displaying graphics: [problem]."
+    new "此电脑显示图形遇到问题：[problem]."
+
+    # renpy/common/00gltest.rpy:229
+    old "Its graphics drivers may be out of date or not operating correctly. This can lead to slow or incorrect graphics display. Updating DirectX could fix this problem."
+    new "图形驱动程序可能已过期或无法正常工作。这可能导致图形显示缓慢或错误。更新DirectX可能解决此问题。"
+
+    # renpy/common/00gltest.rpy:231
+    old "Its graphics drivers may be out of date or not operating correctly. This can lead to slow or incorrect graphics display."
+    new "图形驱动程序可能已过期或无法正常工作。这可能导致图形显示缓慢或错误。"
+
+    # renpy/common/00gltest.rpy:236
+    old "Update DirectX"
+    new "更新DirectX"
+
+    # renpy/common/00gltest.rpy:242
+    old "Continue, Show this warning again"
+    new "继续，下次显示此警告"
+
+    # renpy/common/00gltest.rpy:246
+    old "Continue, Don't show warning again"
+    new "继续，不再出现警告"
+
+    # renpy/common/00gltest.rpy:264
+    old "Updating DirectX."
+    new "更新DirectX."
+
+    # renpy/common/00gltest.rpy:268
+    old "DirectX web setup has been started. It may start minimized in the taskbar. Please follow the prompts to install DirectX."
+    new "DirectX网页安装已开始。可能最小化到任务栏。请按照提示安装DirectX。"
+
+    # renpy/common/00gltest.rpy:272
+    old "{b}Note:{/b} Microsoft's DirectX web setup program will, by default, install the Bing toolbar. If you do not want this toolbar, uncheck the appropriate box."
+    new "{b}注意：{/b} 默认情况下，Microsoft的DirectX web安装程序将安装Bing工具栏。如果不需要此工具栏，请取消选择。"
+
+    # renpy/common/00gltest.rpy:276
+    old "When setup finishes, please click below to restart this program."
+    new "安装完成后，请单击下面重新启动此程序。"
+
+    # renpy/common/00gltest.rpy:278
+    old "Restart"
+    new "重启"
+
+    # renpy/common/00gamepad.rpy:32
+    old "Select Gamepad to Calibrate"
+    new "选择要校准的游戏手柄"
+
+    # renpy/common/00gamepad.rpy:35
+    old "No Gamepads Available"
+    new "没有可用的游戏手柄"
+
+    # renpy/common/00gamepad.rpy:54
+    old "Calibrating [name] ([i]/[total])"
+    new "校准 [name] ([i]/[total])"
+
+    # renpy/common/00gamepad.rpy:58
+    old "Press or move the [control!r] [kind]."
+    new "按下或移动 [control!r] [kind]."
+
+    # renpy/common/00gamepad.rpy:66
+    old "Skip (A)"
+    new "跳过 (A)"
+
+    # renpy/common/00gamepad.rpy:69
+    old "Back (B)"
+    new "返回 (B)"
+
+    # renpy/common/_errorhandling.rpym:538
+    old "Open"
+    new "打开"
+
+    # renpy/common/_errorhandling.rpym:540
+    old "Opens the traceback.txt file in a text editor."
+    new "在文本编辑器中打开 traceback.txt 。"
+
+    # renpy/common/_errorhandling.rpym:542
+    old "Copy BBCode"
+    new "复制BBCode"
+
+    # renpy/common/_errorhandling.rpym:544
+    old "Copies the traceback.txt file to the clipboard as BBcode for forums like https://lemmasoft.renai.us/."
+    new "以BBcode复制 traceback.txt 文件到论坛如 https://lemmasoft.renai.us/ 。"
+
+    # renpy/common/_errorhandling.rpym:546
+    old "Copy Markdown"
+    new "Copy Markdown"
+
+    # renpy/common/_errorhandling.rpym:548
+    old "Copies the traceback.txt file to the clipboard as Markdown for Discord."
+    new "以Markdown复制 traceback.txt 文件到Discord。"
+
+    # renpy/common/_errorhandling.rpym:577
+    old "An exception has occurred."
+    new "发生异常。"
+
+    # renpy/common/_errorhandling.rpym:597
+    old "Rollback"
+    new "Rollback"
+
+    # renpy/common/_errorhandling.rpym:599
+    old "Attempts a roll back to a prior time, allowing you to save or choose a different choice."
+    new "Attempts a roll back to a prior time, allowing you to save or choose a different choice."
+
+    # renpy/common/_errorhandling.rpym:602
+    old "Ignore"
+    new "忽略"
+
+    # renpy/common/_errorhandling.rpym:606
+    old "Ignores the exception, allowing you to continue."
+    new "忽略异常，允许您继续。"
+
+    # renpy/common/_errorhandling.rpym:608
+    old "Ignores the exception, allowing you to continue. This often leads to additional errors."
+    new "忽略异常，允许您继续。这通常会导致额外的错误。"
+
+    # renpy/common/_errorhandling.rpym:612
+    old "Reload"
+    new "重新加载"
+
+    # renpy/common/_errorhandling.rpym:614
+    old "Reloads the game from disk, saving and restoring game state if possible."
+    new "从硬盘重新加载游戏，并尝试保存和恢复游戏状态。"
+
+    # renpy/common/_errorhandling.rpym:617
+    old "Console"
+    new "控制台"
+
+    # renpy/common/_errorhandling.rpym:619
+    old "Opens a console to allow debugging the problem."
+    new "打开控制台以允许调试问题。"
+
+    # renpy/common/_errorhandling.rpym:629
+    old "Quits the game."
+    new "退出游戏。"
+
+    # renpy/common/_errorhandling.rpym:653
+    old "Parsing the script failed."
+    new "解析脚本失败。"
+
+    # renpy/common/_errorhandling.rpym:679
+    old "Opens the errors.txt file in a text editor."
+    new "在文本编辑器中打开 errors.txt 文件。"
+
+    # renpy/common/_errorhandling.rpym:683
+    old "Copies the errors.txt file to the clipboard as BBcode for forums like https://lemmasoft.renai.us/."
+    new "以BBcode复制 errors.txt 文件到论坛如 https://lemmasoft.renai.us/ 。"
+
+    # renpy/common/_errorhandling.rpym:687
+    old "Copies the errors.txt file to the clipboard as Markdown for Discord."
+    new "以Markdown复制 errors.txt 文件到Discord。"
+# TODO: Translation updated at 2020-11-01 00:00
+
+translate schinese strings:
+
+    # renpy/common/00accessibility.rpy:193
+    old "Self-Voicing Volume Drop"
+    new "自动语音音量降低"
+
+    # renpy/common/00preferences.rpy:384
+    old "self voicing volume drop"
+    new "自动语音音量降低"
+
+    # renpy/common/00gltest.rpy:100
+    old "Force GL Renderer"
+    new "强制GL渲染器"
+
+    # renpy/common/00gltest.rpy:105
+    old "Force ANGLE Renderer"
+    new "强制ANGLE渲染器"
+
+    # renpy/common/00gltest.rpy:110
+    old "Force GLES Renderer"
+    new "强制GLES渲染器"
+
+    # renpy/common/00gltest.rpy:116
+    old "Force GL2 Renderer"
+    new "强制GL2渲染器"
+
+    # renpy/common/00gltest.rpy:121
+    old "Force ANGLE2 Renderer"
+    new "强制ANGLE2渲染器"
+
+    # renpy/common/00gltest.rpy:126
+    old "Force GLES2 Renderer"
+    new "强制GLES2渲染器"
+
+    # renpy/common/00gltest.rpy:245
+    old "This game requires use of GL2 that can't be initialised."
+    new "这个游戏需要使用GL2，无法初始化"
+
+    # renpy/common/00gltest.rpy:256
+    old "More details on how to fix this can be found in the {a=[url]}documentation{/a}."
+    new "更多细节可以在{a=[url]}文档{/a}中找到"
+
+    # renpy/common/00gltest.rpy:273
+    old "Change render options"
+    new "改变渲染器选项"

--- a/tutorial/game/tl/schinese/indepth_character.rpy
+++ b/tutorial/game/tl/schinese/indepth_character.rpy
@@ -1,0 +1,211 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_character.rpy:11
+translate schinese demo_character_e7e1b1bb:
+
+    # e "We've already seen how to define a Character in Ren'Py. But I want to go into a bit more detail as to what a Character is."
+    e "我们已经看过如何在Ren'Py中定义一个角色（Character）。但我想更详细地谈谈什么是Character。"
+
+# game/indepth_character.rpy:17
+translate schinese demo_character_d7908a94:
+
+    # e "Here are couple of additional characters."
+    e "这里还有一些其他的角色。"
+
+# game/indepth_character.rpy:19
+translate schinese demo_character_275ef8b9:
+
+    # e "Each statement creates a Character object, and gives it a single argument, a name. If the name is None, no name is displayed."
+    e "每个语句创建一个Character对象，并给它一个参数，名字。如果名字为None，则不显示名称。"
+
+# game/indepth_character.rpy:21
+translate schinese demo_character_a63aea0c:
+
+    # e "This can be followed by named arguments that set properties of the character. A named argument is a property name, an equals sign, and a value."
+    e "后面可以是设置字符属性的命名参数。命名参数由属性名、等号和值组成。"
+
+# game/indepth_character.rpy:23
+translate schinese demo_character_636a502e:
+
+    # e "Multiple arguments should be separated with commas, like they are here. Let's see those characters in action."
+    e "多个参数应该用逗号分隔，就像它们在这里一样。让我们看看那些角色的动作。"
+
+# game/indepth_character.rpy:27
+translate schinese demo_character_44b54e1d:
+
+    # e_shout "I can shout!"
+    e_shout "我能大喊大叫！"
+
+# game/indepth_character.rpy:29
+translate schinese demo_character_a9646dd8:
+
+    # e_whisper "And I can speak in a whisper."
+    e_whisper "也能小声逼逼。"
+
+# game/indepth_character.rpy:31
+translate schinese demo_character_79793208:
+
+    # e "This example shows how the name Character is a bit of a misnomer. Here, we have multiple Characters in use, but you see it as me speaking."
+    e "这个例子显示Character有点用词不当。在这里，我们有多个Character在使用，但你看到只有我说话。"
+
+# game/indepth_character.rpy:33
+translate schinese demo_character_5d5d7482:
+
+    # e "It's best to think of a Character as repesenting a name and style, rather than a single person."
+    e "最好把一个Character当作展示一个名字和样式，而不是一个人。"
+
+# game/indepth_character.rpy:37
+translate schinese demo_character_66d08d98:
+
+    # e "There are a lot of properties that can be given to Characters, most of them prefixed styles."
+    e "有很多属性可以赋予Character，大多数都是前缀样式。"
+
+# game/indepth_character.rpy:39
+translate schinese demo_character_7e0d75aa:
+
+    # e "Properties beginning with window apply to the textbox, those with what apply to the the dialogue, and those with who to the name of Character speaking."
+    e "以window开头的属性应用于文本框，以what开头的属性应用于对话，以who开头的属性应用于Character的名字。"
+
+# game/indepth_character.rpy:41
+translate schinese demo_character_56703784:
+
+    # e "If you leave a prefix out, the style customizes the name of the speaker."
+    e "如果不使用前缀，则样式将定义说话者的名字。"
+
+# game/indepth_character.rpy:43
+translate schinese demo_character_b456f0a9:
+
+    # e "There are quite a few different properties that can be set this way. Here are some of the most useful."
+    e "有很多不同的属性可以这样设置。以下是一些最有用的。"
+
+# game/indepth_character.rpy:48
+translate schinese demo_character_31ace18e:
+
+    # e1 "The window_background property sets the image that's used for the background of the textbox, which should be the same size as the default in gui/textbox.png."
+    e1 "window_background属性设置用于文本框背景的图像，其大小应与 gui/textbox.png 中的默认大小相同。"
+
+# game/indepth_character.rpy:54
+translate schinese demo_character_18ba073d:
+
+    # e1a "If it's set to None, the textbox has no background window."
+    e1a "如果设置为None，则文本框没有背景窗口。"
+
+# game/indepth_character.rpy:59
+translate schinese demo_character_5a26445c:
+
+    # e2 "The who_color and what_color properties set the color of the character's name and dialogue text, respectively."
+    e2 "who_color和what_color属性分别设置人物名字和对话文本的颜色。"
+
+# game/indepth_character.rpy:61
+translate schinese demo_character_88a18c32:
+
+    # e2 "The colors are strings containing rgb hex codes, the same sort of colors understood by a web browser."
+    e2 "这些颜色是包含RGB十六进制代码的字符串，与网页浏览器所理解的颜色类型相同。"
+
+# game/indepth_character.rpy:67
+translate schinese demo_character_ed690751:
+
+    # e3 "Similarly, the who_font and what_font properties set the font used by the different kinds of text."
+    e3 "类似的，who_font和what_font属性设置不同文本使用的字体。"
+
+# game/indepth_character.rpy:74
+translate schinese demo_character_8dfa6426:
+
+    # e4 "Setting the who_bold, what_italic, and what_size properties makes the name bold, and the dialogue text italic at a size of 20 pixels."
+    e4 "设置who_bold、what_italic和what_size属性可使姓名变为粗体，对话文本变为20像素大小的斜体。"
+
+# game/indepth_character.rpy:76
+translate schinese demo_character_20e83c32:
+
+    # e4 "Of course, the what_bold, who_italic and who_size properties also exist, even if they're not used here."
+    e4 "当然，what_bold、who_italic和who_size属性也存在，即使它们不在这里使用。"
+
+# game/indepth_character.rpy:83
+translate schinese demo_character_e4cbb1f2:
+
+    # e5 "The what_outlines property puts an outline around the text."
+    e5 "what_outlines属性在文本周围放置轮廓。"
+
+# game/indepth_character.rpy:85
+translate schinese demo_character_71535ecf:
+
+    # e5 "It's a little complicated since it takes a list with a tuple in it, with the tuple being four things in parenthesis, and the list the square brackets around them."
+    e5 "这有点复杂，因为它需要一个列表（list），里面是一个元组（tuple），元组是括号中的四个东西，列表由方括号包围。"
+
+# game/indepth_character.rpy:87
+translate schinese demo_character_e9ac7482:
+
+    # e5 "The first number is the size of the outline, in pixels. That's followed by a string giving the hex-code of the color of the outline, and the x and y offsets."
+    e5 "第一个数字是轮廓的粗细，以像素为单位。后面是一个字符串，给出轮廓颜色的十六进制代码，以及X和Y偏移量。"
+
+# game/indepth_character.rpy:93
+translate schinese demo_character_ea72d988:
+
+    # e6 "When the outline size is 0 and the offsets are given, what_outlines can also act as a drop-shadow behind the text."
+    e6 "当轮廓大小为0且给定偏移量时，what_outlines也可以充当文本后面的阴影。"
+
+# game/indepth_character.rpy:99
+translate schinese demo_character_8d35ebcd:
+
+    # e7 "The what_xalign and what_textalign properties control the alignment of text, with 0.0 being left, 0.5 being center, and 1.0 being right."
+    e7 "what_xalign和what_textalign属性控制文本的对齐，0.0为左，0.5为中，1.0为右。"
+
+# game/indepth_character.rpy:101
+translate schinese demo_character_7c75906c:
+
+    # e7 "The what_xalign property controls where all the text itself is placed within the textbox, while what_textalign controls where rows of text are placed relative to each other."
+    e7 "what_xalign属性控制所有文本本身放置在文本框中的位置，what_textalign属性控制文本行相对放置的位置。"
+
+# game/indepth_character.rpy:103
+translate schinese demo_character_e2811c1c:
+
+    # e7 "Generally you'll want to to set them both what_xalign and what_textalign to the same value."
+    e7 "通常，您需要将what_xalign和what_textalign设置为相同的值。"
+
+# game/indepth_character.rpy:105
+translate schinese demo_character_baa52234:
+
+    # e7 "Setting what_layout to 'subtitle' puts Ren'Py in subtitle mode, which tries to even out the length of every line of text in a block."
+    e7 "将what_layout设置为“subtitle”将使Ren'Py进入subtitle模式，该模式尝试平衡块中每行文本的长度。"
+
+# game/indepth_character.rpy:110
+translate schinese demo_character_41190f01:
+
+    # e8 "These properties can be combined to achieve many different effects."
+    e8 "这些特性可以组合起来达到许多不同的效果。"
+
+# game/indepth_character.rpy:124
+translate schinese demo_character_aa12d9ca:
+
+    # e8 "This example hides the background and shows dialogue centered and outlined, as if the game is being subtitled."
+    e8 "这个例子隐藏了背景，显示居中并加上轮廓的对话，就好像游戏有字幕一样。"
+
+# game/indepth_character.rpy:133
+translate schinese demo_character_a7f243e5:
+
+    # e9 "There are two interesting non-style properties, what_prefix and what_suffix. These can put text at the start and end of a line of dialogue."
+    e9 "有两个有趣的非样式属性：what_prefix和what_suffix。它们可以将文本放在一行对话的开头和结尾。"
+
+# game/indepth_character.rpy:139
+translate schinese demo_character_f9b0052f:
+
+    # e "By using kind, you can copy properties from one character to another, changing only what you need to."
+    e "通过使用kind，可以将属性从一个角色复制到另一个角色，只需更改所需的内容。"
+
+# game/indepth_character.rpy:148
+translate schinese demo_character_6dfce4b7:
+
+    # l8 "Like this! Finally I get some more dialogue around here."
+    l8 "像这样！最后我在这里找到更多的对话。"
+
+# game/indepth_character.rpy:157
+translate schinese demo_character_68d9e46c:
+
+    # e "The last thing you have to know is that there's a special character, narrator, that speaks narration. Got it?"
+    e "最后你要知道的是，有一个特殊的角色，旁白，负责念旁白。懂了？"
+
+# game/indepth_character.rpy:159
+translate schinese demo_character_0c8f314a:
+
+    # "I think I do."
+    "我想我明白了。"

--- a/tutorial/game/tl/schinese/indepth_displayables.rpy
+++ b/tutorial/game/tl/schinese/indepth_displayables.rpy
@@ -1,0 +1,109 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_displayables.rpy:15
+translate schinese simple_displayables_db46fd25:
+
+    # e "Ren'Py has the concept of a displayable, which is something like an image that can be shown and hidden."
+    e "Ren'Py有一个可视组件的概念，它类似于一个可以显示和隐藏的图像。"
+
+# game/indepth_displayables.rpy:22
+translate schinese simple_displayables_bfe78cb7:
+
+    # e "The image statement is used to give an image name to a displayable. The easy way is to simply give an image filename."
+    e "image语句用于为可视组件提供图像名。简单的方法是直接赋予图像文件名。"
+
+# game/indepth_displayables.rpy:29
+translate schinese simple_displayables_cef4598b:
+
+    # e "But that's not the only thing that an image can refer to. When the string doesn't have a dot in it, Ren'Py interprets that as a reference to a second image."
+    e "但这并不是一个图像唯一可以参考的东西。当字符串中没有“.”时，Ren'Py将其解释为对第二个图像的引用。"
+
+# game/indepth_displayables.rpy:41
+translate schinese simple_displayables_a661fb63:
+
+    # e "The string can also contain a color code, consisting of hexadecimal digits, just like the colors used by web browsers."
+    e "字符串还可以包含一个颜色代码，由十六进制数字组成，就像网页浏览器使用的颜色一样。"
+
+# game/indepth_displayables.rpy:43
+translate schinese simple_displayables_7f2efb23:
+
+    # e "Three or six digit colors are opaque, containing red, green, and blue values. The four and eight digit versions append alpha, allowing translucent colors."
+    e "三位或六位数字的颜色是不透明的，包含红色、绿色和蓝色值。四位数和八位数的版本附加了alpha，允许半透明的颜色。"
+
+# game/indepth_displayables.rpy:53
+translate schinese simple_displayables_9cd108c6:
+
+    # e "The Transform displayable takes a displayable and can apply transform properties to it."
+    e "Transform可视组件使用一个可视组件并可以应用变换属性。"
+
+# game/indepth_displayables.rpy:55
+translate schinese simple_displayables_f8e1ba3f:
+
+    # e "Notice how, since it takes a displayable, it can take another image. In fact, it can take any displayable defined here."
+    e "注意，因为它使用一个可视组件，可以是另一个图像。实际上，它可以接受这里定义的任何可视组件。"
+
+# game/indepth_displayables.rpy:63
+translate schinese simple_displayables_c6e39078:
+
+    # e "There's a more complete form of Solid, that can take style properties. This lets us change the size of the Solid, where normally it fills the screen."
+    e "有一种更完整的Solid形式，可以使用样式属性。这允许我们更改Solid的大小，通常它会填充屏幕。"
+
+# game/indepth_displayables.rpy:72
+translate schinese simple_displayables_b102a029:
+
+    # e "The Text displayable lets Ren'Py treat text as if it was an image."
+    e "Text可视组件让Ren'Py把文本当作一个图像。"
+
+# game/indepth_displayables.rpy:80
+translate schinese simple_displayables_0befbee0:
+
+    # e "This means that we can apply other displayables, like Transform, to Text in the same way we do to images."
+    e "这意味着我们可以像对图像一样，将其他可视组件，如Transform，应用于文本。"
+
+# game/indepth_displayables.rpy:91
+translate schinese simple_displayables_fcf2325f:
+
+    # e "The Composite displayable lets us group multiple displayables together into a single one, from bottom to top."
+    e "Composite可视组件允许我们将多个可视组件组合成一个单一的可视组件，从底层到顶层。"
+
+# game/indepth_displayables.rpy:101
+translate schinese simple_displayables_3dc0050e:
+
+    # e "Some displayables are often used to customize the Ren'Py interface, with the Frame displayable being one of them. The frame displayable takes another displayable, and the size of the left, top, right, and bottom borders."
+    e "一些可视组件经常被用来定制Ren'Py界面，其中一个就是Frame可视组件。Frame可视组件采用另一个可视组件，以及左、上、右、下边界的大小。"
+
+# game/indepth_displayables.rpy:111
+translate schinese simple_displayables_801b7910:
+
+    # e "The Frame displayable expands or shrinks to fit the area available to it. It does this by scaling the center in two dimensions and the sides in one, while keeping the corners the same size."
+    e "Frame可视组件将放大或缩小以适合其可用的区域。它通过在二维上缩放中心和在一维上缩放边来实现，同时保持角的大小不变。"
+
+# game/indepth_displayables.rpy:118
+translate schinese simple_displayables_00603985:
+
+    # e "A Frame can also tile sections of the displayable supplied to it, rather than scaling."
+    e "Frame还可以平铺提供给它的可视组件，而不是缩放。"
+
+# game/indepth_displayables.rpy:126
+translate schinese simple_displayables_d8b23480:
+
+    # e "Frames might look a little weird in the abstract, but when used with a texture, you can see how we create scalable interface components."
+    e "抽象的Frame可能看起来有点奇怪，但是当与纹理一起使用时，您可以看到我们如何创建可伸缩的界面组件。"
+
+# game/indepth_displayables.rpy:132
+translate schinese simple_displayables_ae3f35f5:
+
+    # e "These are just the simplest displayables, the ones you'll use directly the most often."
+    e "这些只是最简单的可视组件，是您最常直接使用的内容。"
+
+# game/indepth_displayables.rpy:134
+translate schinese simple_displayables_de555a92:
+
+    # e "You can even write custom displayables for minigames, if you're proficient at Python. But for many visual novels, these will be all you'll need."
+    e "如果你精通Python，你甚至可以为小游戏编写自定义的可视组件。但对于许多视觉小说，这些就是你所需要的全部了。"
+
+translate schinese strings:
+
+    # game/indepth_displayables.rpy:67
+    old "This is a text displayable."
+    new "这是一个文本可视组件。"

--- a/tutorial/game/tl/schinese/indepth_minigame.rpy
+++ b/tutorial/game/tl/schinese/indepth_minigame.rpy
@@ -1,0 +1,103 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_minigame.rpy:220
+translate schinese demo_minigame_8f14835c:
+
+    # e "You may want to mix Ren'Py with other forms of gameplay. There are a couple of ways to do this."
+    e "你可能想把Ren'Py和其他形式的游戏结合起来。有几种方法可以做到这一点。"
+
+# game/indepth_minigame.rpy:222
+translate schinese demo_minigame_9b01503e:
+
+    # e "The first is with the screen system, which can be used to display data and create button and menu based interfaces."
+    e "第一种是界面系统，它可以用来显示数据和创建基于按钮和菜单的界面。"
+
+# game/indepth_minigame.rpy:224
+translate schinese demo_minigame_3e601161:
+
+    # e "Screens will work for many simulation-style games and RPGs."
+    e "界面将适用于许多模拟风格的游戏和RPG。"
+
+# game/indepth_minigame.rpy:226
+translate schinese demo_minigame_a92baa6b:
+
+    # e "When screens are not enough you can write a creator-defined displayable to extend Ren'Py itself. A Creator-defined displayables can process raw events and draw to the screen."
+    e "当界面不够用时，你可以编写一个创作者定义的可视组件来扩展Ren'Py本身。创建者定义可视组件可以处理原始事件并绘制到界面。"
+
+# game/indepth_minigame.rpy:228
+translate schinese demo_minigame_a07dbae0:
+
+    # e "That makes it possible to create all kinds of minigames. Would you like to play some pong?"
+    e "这使得创造各种迷你游戏成为可能。你想打乒乓球吗？"
+
+# game/indepth_minigame.rpy:245
+translate schinese play_pong_ce00ff63:
+
+    # e "I win!"
+    e "我赢了！"
+
+# game/indepth_minigame.rpy:249
+translate schinese play_pong_68c82e98:
+
+    # e "You won! Congratulations."
+    e "你赢了！恭喜。"
+
+# game/indepth_minigame.rpy:255
+translate schinese pong_done_dde7e31a:
+
+    # e "Would you like to play again?" nointeract
+    e "你想再玩一次吗？" nointeract
+
+# game/indepth_minigame.rpy:268
+translate schinese pong_done_a21abf38:
+
+    # e "Here's the source code for the minigame. It's very complex, and assumes you understand Python well."
+    e "这是小游戏的源代码。它非常复杂，需要你很好地理解Python。"
+
+# game/indepth_minigame.rpy:270
+translate schinese pong_done_750092ed:
+
+    # e "I won't go over it in detail here. You can read more about it in the {a=https://www.renpy.org/doc/html/udd.html}Creator-Defined Displayable documentation{/a}."
+    e "我不会在这里详细讨论的。你可以在{a=https://www.renpy.org/doc/html/udd.html}创作者定义的可视组件{/a}文档中阅读更多关于它的信息。（{a=https://renpy.cn/doc/udd.html}中文文档{/a}）"
+
+# game/indepth_minigame.rpy:274
+translate schinese pong_done_5781d902:
+
+    # e "Minigames can spice up your visual novel, but be careful – not every visual novel player wants to be good at arcade games."
+    e "迷你游戏可以为你的视觉小说增添情趣，但要小心——不是每个视觉小说玩家都想擅长街机游戏。"
+
+# game/indepth_minigame.rpy:276
+translate schinese pong_done_631325c8:
+
+    # e "Part of the reason Ren'Py works well is that it's meant for certain types of games, like visual novels and life simulations."
+    e "Ren'Py之所以能很好地工作，部分原因在于它是为某些类型的游戏设计的，比如视觉小说和生活模拟。"
+
+# game/indepth_minigame.rpy:278
+translate schinese pong_done_61d60761:
+
+    # e "The further afield you get from those games, the more you'll find yourself fighting Ren'Py. At some point, it makes sense to consider other engines."
+    e "离那些游戏越远，你越会发现Ren'Py难以使用。在某些时候，不妨考虑其他引擎。"
+
+# game/indepth_minigame.rpy:282
+translate schinese pong_done_715c7b12:
+
+    # e "And that's fine with us. We'll always be here for you when you're making visual novels."
+    e "我们没关系。当你制作视觉小说的时候，我们会一直在你身边。"
+
+translate schinese strings:
+
+    # game/indepth_minigame.rpy:198
+    old "Player"
+    new "玩家"
+
+    # game/indepth_minigame.rpy:211
+    old "Click to Begin"
+    new "点击开始"
+
+    # game/indepth_minigame.rpy:255
+    old "Sure."
+    new "好啊。"
+
+    # game/indepth_minigame.rpy:255
+    old "No thanks."
+    new "不，谢谢。"

--- a/tutorial/game/tl/schinese/indepth_style.rpy
+++ b/tutorial/game/tl/schinese/indepth_style.rpy
@@ -1,0 +1,809 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_style.rpy:40
+translate schinese new_gui_17a0326e:
+
+    # e "When you create a new project, Ren'Py will automatically create a GUI - a Graphical User Interface - for it."
+    e "创建新项目时，Ren'Py会自动为它创建一个图形用户界面（GUI）。"
+
+# game/indepth_style.rpy:42
+translate schinese new_gui_12c814ed:
+
+    # e "It defines the look of both in-game interface, like this text box, and out-of-game interface like the main and game menus."
+    e "它定义了游戏内界面（像是这个文本框）和游戏外界面（如主菜单和游戏菜单）的外观。"
+
+# game/indepth_style.rpy:44
+translate schinese new_gui_0a2a73bb:
+
+    # e "The default GUI is meant to be nice enough for a simple project. With a few small changes, it's what you're seeing in this game."
+    e "默认的GUI对于一个简单的项目来说已经足够好了。加上一些小的改变，就是你在这个游戏中看到的。"
+
+# game/indepth_style.rpy:46
+translate schinese new_gui_22adf68e:
+
+    # e "The GUI is also meant to be easy for an intermediate creator to customize. Customizing the GUI consists of changing the image files in the gui directory, and changing variables in gui.rpy."
+    e "GUI对中间创建者来说很容易定制。自定义GUI包括更改GUI目录中的图像文件，以及更改 gui.rpy 中的变量。"
+
+# game/indepth_style.rpy:48
+translate schinese new_gui_da21de30:
+
+    # e "At the same time, even when customized, the default GUI might be too recognizable for an extremely polished game. That's why we've made it easy to totally replace."
+    e "同时，即使是定制的，默认的GUI对于一个追求极致的游戏来说也太容易识别了。这就是为什么我们让它易于替换。"
+
+# game/indepth_style.rpy:50
+translate schinese new_gui_45765574:
+
+    # e "We've put an extensive guide to customizing the GUI on the Ren'Py website. So if you want to learn more, visit the {a=https://www.renpy.org/doc/html/gui.html}GUI customization guide{/a}."
+    e "我们在Ren'Py网站上提供了一个关于定制GUI的拓展指南。因此，如果您想了解更多信息，请访问{a=https://www.renpy.org/doc/html/gui.html}GUI定制指南{/a}。（{a=https://renpy.cn/doc/gui.html}中文文档{/a}）"
+
+# game/indepth_style.rpy:58
+translate schinese styles_fa345a38:
+
+    # e "Ren'Py has a powerful style system that controls what displayables look like."
+    e "Ren'Py有一个强大的样式系统，可以控制可视组件的外观。"
+
+# game/indepth_style.rpy:60
+translate schinese styles_6189ee12:
+
+    # e "While the default GUI uses variables to provide styles with sensible defaults, if you're replacing the GUI or creating your own screens, you'll need to learn about styles yourself."
+    e "虽然默认的GUI使用变量为样式提供合理的默认值，但如果要替换GUI或创建自己的界面，则需要自己学习样式。"
+
+# game/indepth_style.rpy:66
+translate schinese styles_menu_a4a6913e:
+
+    # e "What would you like to know about styles?" nointeract
+    e "关于样式，你想了解什么？" nointeract
+
+# game/indepth_style.rpy:98
+translate schinese style_basics_9a79ef89:
+
+    # e "Styles let a displayable look different from game to game, or even inside the same game."
+    e "样式让可视组件在不同的游戏、甚至同一个游戏内看起来不同。"
+
+# game/indepth_style.rpy:103
+translate schinese style_basics_48777f2c:
+
+    # e "Both of these buttons use the same displayables. But since different styles have been applied, the buttons look different from each other."
+    e "这两个按钮使用相同的可视组件。但由于应用了不同的样式，按钮看起来彼此不同。"
+
+# game/indepth_style.rpy:108
+translate schinese style_basics_57704d8c:
+
+    # e "Styles are a combination of information from four different places."
+    e "样式是来自四个不同地方的信息的组合。"
+
+# game/indepth_style.rpy:121
+translate schinese style_basics_144731f6:
+
+    # e "The first place Ren'Py can get style information from is part of a screen. Each displayable created by a screen can take a style name and style properties."
+    e "Ren'Py首先可以从界面的一部分得到样式信息。由界面创建的每个可视组件都可以采用样式名和样式属性。"
+
+# game/indepth_style.rpy:138
+translate schinese style_basics_67e48162:
+
+    # e "When a screen displayable contains text, style properties prefixed with text_ apply to that text."
+    e "当界面可视组件包含文本时，以text_为前缀的样式属性可用于该文本。"
+
+# game/indepth_style.rpy:151
+translate schinese style_basics_03516b4a:
+
+    # e "The next is as part of a displayable created in an image statement. Style properties are just arguments to the displayable."
+    e "下一个是作为在image语句中创建的可视组件的一部分。样式属性只是可视组件的参数。"
+
+# game/indepth_style.rpy:160
+translate schinese style_basics_ccc0d1ca:
+
+    # egreen "Style properties can also be given as arguments when defining a character."
+    egreen "定义人物时，样式属性也可以作为参数。"
+
+# game/indepth_style.rpy:162
+translate schinese style_basics_013ab314:
+
+    # egreen "Arguments beginning with who_ are style properties applied to the character's name, while those beginning with what_ are applied to the character's dialogue."
+    egreen "以who_开头的参数是应用于人物名的样式属性，而以what_开头的参数则应用于人物的对话。"
+
+# game/indepth_style.rpy:164
+translate schinese style_basics_dbe80939:
+
+    # egreen "Style properties that don't have a prefix are also applied to the character's name."
+    egreen "没有前缀的样式特性也应用于人物的名字。"
+
+# game/indepth_style.rpy:174
+translate schinese style_basics_ac6a8414:
+
+    # e "Finally, there is the the style statement, which creates or changes a named style. By giving Text the style argument, we tell it to use the blue_text style."
+    e "最后是样式语句，它创建或更改命名样式。通过给Text指定样式参数，我们告诉它使用blue_text样式。"
+
+# game/indepth_style.rpy:180
+translate schinese style_basics_3d9bdff7:
+
+    # e "A style property can inherit from a parent. If a style property is not given in a style, it comes from the parent of that style."
+    e "样式属性可以继承自父样式。如果样式属性没有在样式中指定，它就来自父样式。"
+
+# game/indepth_style.rpy:182
+translate schinese style_basics_49c5fbfe:
+
+    # e "By default the parent of the style has the same name, with the prefix up to the the first underscore removed. If the style does not have an underscore in its name, 'default' is used."
+    e "默认情况下，父样式具有相同的名称，只是删除了第一个下划线之前的前缀。如果样式名中没有下划线，则使用“default”。"
+
+# game/indepth_style.rpy:184
+translate schinese style_basics_6ab170a3:
+
+    # e "For example, blue_text inherits from text, which in turn inherits from default. The default style defines all properties, so it doesn't inherit from anything."
+    e "例如，blue_text继承自text，而text又继承自default。default样式定义了所有属性，因此它不继承任何内容。"
+
+# game/indepth_style.rpy:190
+translate schinese style_basics_f78117a7:
+
+    # e "The parent can be explicitly changed by giving the style statement an 'is' clause. In this case, we're explictly setting the style to the parent of text."
+    e "通过给样式语句一个“is”从句，可以显式地更改父样式。在本例中，我们明确地将样式设置为text的父类。"
+
+# game/indepth_style.rpy:194
+translate schinese style_basics_6007040b:
+
+    # e "Each displayable has a default style name. By default, it's usually the lower-case displayable name, like 'text' for Text, or 'button' for buttons."
+    e "每个可视组件都有一个默认样式名。默认情况下，它通常是小写的可视组件名，如Text的“text”，或按钮的“button”。"
+
+# game/indepth_style.rpy:196
+translate schinese style_basics_35db9a05:
+
+    # e "In a screen, a displayable can be given the style_prefix property to give a prefix for that displayable and it's children."
+    e "在界面中，可视组件的样式前缀（style_prefix）属性，赋予该可视组件及其子组件一个前缀。"
+
+# game/indepth_style.rpy:198
+translate schinese style_basics_422a87f7:
+
+    # e "For example, a text displayable with a style_prefix of 'help' will be given the style 'help_text'."
+    e "例如，文本可视组件有着“help”的style_prefix，会被赋予样式“help_text”。"
+
+# game/indepth_style.rpy:200
+translate schinese style_basics_bad2e207:
+
+    # e "Lastly, when a displayable is a button, or inside a button, it can take style prefixes."
+    e "最后，当可视组件是按钮，或者在按钮内部时，它可以使用样式前缀。"
+
+# game/indepth_style.rpy:202
+translate schinese style_basics_22ed20a1:
+
+    # e "The prefixes idle_, hover_, and insensitive_ are used when the button is unfocused, focused, and unfocusable."
+    e "当按钮未聚焦、聚焦和不可聚焦时，将使用前缀idle_、hover_和insensitive_。"
+
+# game/indepth_style.rpy:204
+translate schinese style_basics_7a58037e:
+
+    # e "These can be preceded by selected_ to change how the button looks when it represents a selected value or screen."
+    e "前面可以加上selected_，以更改按钮外观，当展示选定的值或界面时。"
+
+# game/indepth_style.rpy:233
+translate schinese style_basics_0cdcb8c3:
+
+    # e "This screen shows the style prefixes in action. You can click on a button to select it, or click outside to advance."
+    e "此界面显示正在运行的样式前缀。您可以单击一个按钮来选择它，或者单击其他部分来前进。"
+
+# game/indepth_style.rpy:240
+translate schinese style_basics_aed05094:
+
+    # e "Those are the basics of styles. If GUI customization isn't enough for you, styles let you customize just about everything in Ren'Py."
+    e "这些是样式的基础。如果GUI定制还不够，样式可以让您定制Ren'Py中的几乎所有内容。"
+
+# game/indepth_style.rpy:253
+translate schinese style_general_81f3c8ff:
+
+    # e "The first group of style properties that we'll go over are the general style properties. These work with every displayable, or at least many different ones."
+    e "我们将讨论的第一组样式属性是常规样式属性。它们适用于许多不同的可视组件。"
+
+# game/indepth_style.rpy:264
+translate schinese style_general_a8d99699:
+
+    # e "Every displayable takes the position properties, which control where it can be placed on screen. Since I've already mentioned them, I won't repeat them here."
+    e "每个可视组件都有位置属性，这些属性控制它在界面上的位置。前面已经提到，我就不在这里重复了。"
+
+# game/indepth_style.rpy:275
+translate schinese style_general_58d4a18f:
+
+    # e "The xmaximum and ymaximum properties set the maximum width and height of the displayable, respectively. This will cause Ren'Py to shrink things, if possible."
+    e "xmaximum和ymaximum属性分别设置可视组件的最大宽度和高度。可能，这会使Ren'Py缩小内容。"
+
+# game/indepth_style.rpy:277
+translate schinese style_general_cae9a39f:
+
+    # e "Sometimes, the shrunken size will be smaller than the size given by xmaximum and ymaximum."
+    e "有时，缩小后大小将小于xmaximum和ymaximum给定的大小。"
+
+# game/indepth_style.rpy:279
+translate schinese style_general_5928c24e:
+
+    # e "Similarly, the xminimum and yminimum properties set the minimum width and height. If the displayable is smaller, Ren'Py will try to make it bigger."
+    e "类似地，xminimum和yminimum属性设置最小宽度和高度。如果可视组件更小，Ren'Py会尝试放大。"
+
+# game/indepth_style.rpy:289
+translate schinese style_general_35a8ee5e:
+
+    # e "The xsize and ysize properties set the minimum and maximum size to the same value, fixing the size."
+    e "xsize和ysize属性将最小和最大设置为相同的值，从而固定大小。"
+
+# game/indepth_style.rpy:291
+translate schinese style_general_fcfb0640:
+
+    # e "These only works for displayables than can be resized. Some displayables, like images, can't be made bigger or smaller."
+    e "这些只适用于能调整大小可视组件。有些可视组件，比如图像，不能放大或缩小。"
+
+# game/indepth_style.rpy:299
+translate schinese style_general_cd5cc97c:
+
+    # e "The area property takes a tuple - a parenthesis bounded list of four items. The first two give the position, and the second two the size."
+    e "area属性接受一个元组——以圆括号为界的四项列表。前两个给出位置，后两个给出大小。"
+
+# game/indepth_style.rpy:308
+translate schinese style_general_e5a58f0b:
+
+    # e "Finally, the alt property changes the text used by self-voicing for the hearing impaired."
+    e "最后，alt属性改变给听障者的自动语音文本。"
+
+# game/indepth_style.rpy:335
+translate schinese style_text_fe457b8f:
+
+    # e "The text style properties apply to text and input displayables."
+    e "文本样式属性应用于文本和输入可视组件。"
+
+# game/indepth_style.rpy:337
+translate schinese style_text_7ab53f03:
+
+    # e "Text displayables can be created implicitly or explicitly. For example, a textbutton creates a text displayable with a style ending in button_text."
+    e "Text可视组件可以隐式或显式创建。例如，textbutton创建的文本可视组件，其样式以button_text结尾。"
+
+# game/indepth_style.rpy:339
+translate schinese style_text_6dd42a57:
+
+    # e "These can also be set in gui.rpy by changing or defining variables with names like gui.button_text_size."
+    e "也可以在 gui.rpy 中通过更改或定义变量，如gui.button_text_size，来设置这些值。"
+
+# game/indepth_style.rpy:347
+translate schinese style_text_c689130e:
+
+    # e "The bold style property makes the text bold. This can be done using an algorithm, rather than a different version of the font."
+    e "bold样式属性使文本变粗体。这可以使用算法来完成，而不是使用不同版本的字体。"
+
+# game/indepth_style.rpy:355
+translate schinese style_text_3420bfe4:
+
+    # e "The color property changes the color of the text. It takes hex color codes, just like everything else in Ren'Py."
+    e "color属性更改文本的颜色。它需要十六进制的颜色代码，就像Ren'Py的其他东西一样。"
+
+# game/indepth_style.rpy:363
+translate schinese style_text_14bd6327:
+
+    # e "The first_indent style property determines how far the first line is indented."
+    e "first_indent样式属性确定第一行缩进的距离。"
+
+# game/indepth_style.rpy:371
+translate schinese style_text_779ac517:
+
+    # e "The font style property changes the font the text uses. Ren'Py takes TrueType and OpenType fonts, and you'll have to include the font file as part of your visual novel."
+    e "font样式属性更改文本使用的字体。Ren'Py采用TrueType和OpenType字体，您必须将字体文件放进视觉小说。"
+
+# game/indepth_style.rpy:379
+translate schinese style_text_917e2bca:
+
+    # e "The size property changes the size of the text."
+    e "size属性更改文本的大小。"
+
+# game/indepth_style.rpy:388
+translate schinese style_text_1a46cd43:
+
+    # e "The italic property makes the text italic. Again, this is better done with a font, but for short amounts of text Ren'Py can do it for you."
+    e "italic属性使文本变为斜体。同样，用字体做这个更好，但是对于短文本，Ren'Py也可以。"
+
+# game/indepth_style.rpy:397
+translate schinese style_text_472f382d:
+
+    # e "The justify property makes the text justified, lining all but the last line up on the left and the right side."
+    e "justify属性使文本对齐，将除最后一行外的所有行在左侧和右侧对齐。"
+
+# game/indepth_style.rpy:405
+translate schinese style_text_87b075f8:
+
+    # e "The kerning property kerns the text. When it's negative, characters are closer together. When positive, characters are farther apart."
+    e "kerning属性调整文本间距。当它是负数时，字符之间的距离更近。当为正时，字符之间的距离更大。"
+
+# game/indepth_style.rpy:415
+translate schinese style_text_fe7dec14:
+
+    # e "The line_leading and line_spacing properties put spacing before each line, and between lines, respectively."
+    e "line_leading和line_spacing属性分别每行缩进和行距。"
+
+# game/indepth_style.rpy:424
+translate schinese style_text_aee9277a:
+
+    # e "The outlines property puts outlines around text. This takes a list of tuples, which is a bit complicated."
+    e "outlines属性在文本周围放置轮廓。这需要一个元组列表，这有点复杂。"
+
+# game/indepth_style.rpy:426
+translate schinese style_text_b4c5190f:
+
+    # e "But if you ignore the brackets and parenthesis, you have the width of the outline, the color, and then horizontal and vertical offsets."
+    e "但如果忽略所有括号，就是轮廓的宽度、颜色，以及水平和垂直偏移。"
+
+# game/indepth_style.rpy:434
+translate schinese style_text_5a0c2c02:
+
+    # e "The rest_indent property controls the indentation of lines after the first one."
+    e "rest_indent属性控制首行之外的缩进。"
+
+# game/indepth_style.rpy:443
+translate schinese style_text_430c1959:
+
+    # e "The text_align property controls the positioning of multiple lines of text inside the text displayable. For example, 0.5 means centered."
+    e "text_align属性控制文本可视组件中多行文本的位置。例如，0.5表示居中。"
+
+# game/indepth_style.rpy:445
+translate schinese style_text_19aa0833:
+
+    # e "It doesn't change the position of the text displayable itself. For that, you'll often want to set the text_align and xalign to the same value."
+    e "它不会改变文本可视组件本身的位置。为此，通常需要将text_align和xalign设置为相同的值。"
+
+# game/indepth_style.rpy:455
+translate schinese style_text_efc3c392:
+
+    # e "When both text_align and xalign are set to 1.0, the text is properly right-justified."
+    e "当text_align和xalign都设置为1.0时，文本将正确右对齐。"
+
+# game/indepth_style.rpy:464
+translate schinese style_text_43be63b9:
+
+    # e "The underline property underlines the text."
+    e "underline属性为文本加下划线。"
+
+# game/indepth_style.rpy:471
+translate schinese style_text_343f6d34:
+
+    # e "Those are the most common text style properties, but not the only ones. Here are a few more that you might need in special circumstances."
+    e "这些是最常见的文本样式属性，但不是全部。这里还有一些在特殊情况下你可能需要的。"
+
+# game/indepth_style.rpy:479
+translate schinese style_text_e7204a95:
+
+    # e "By default, text in Ren'Py is antialiased, to smooth the edges. The antialias property can turn that off, and make the text a little more jagged."
+    e "默认情况下，Ren'Py中的文本是抗锯齿的，以平滑边缘。antialias属性可以将其关闭，并使文本稍微锯齿化。"
+
+# game/indepth_style.rpy:487
+translate schinese style_text_a5316e4c:
+
+    # e "The adjust_spacing property is a very subtle one, that only matters when a player resizes the window. When True, characters will be shifted a bit so the Text has the same relative spacing."
+    e "adjust_spacing属性非常微妙，它只在玩家调整窗口大小时才起作用。如果为True，字符将移动一点，使文本具有相同的相对间距。"
+
+# game/indepth_style.rpy:496
+translate schinese style_text_605d4e4a:
+
+    # e "When False, the text won't jump around as much. But it can be a little wider or narrower based on screen size."
+    e "如果为False，则文本不会跳来跳去。但根据界面大小，它可以更宽或更窄一些。"
+
+# game/indepth_style.rpy:505
+translate schinese style_text_acf8a0e1:
+
+    # e "The layout property has a few special values that control where lines are broken. The 'nobreak' value disables line breaks entirely, making the text wider."
+    e "layout属性有一些特殊值，用于控制换行的位置。“nobreak”值完全禁用换行符，使文本变宽。"
+
+# game/indepth_style.rpy:516
+translate schinese style_text_785729cf:
+
+    # e "When the layout property is set to 'subtitle', the line breaking algorithm is changed to try to make all lines even in length, as subtitles usually are."
+    e "当layout属性设置为“subtitle”时，断行算法将被更改，以尝试使所有行的长度均匀，因为字幕通常是这样的。"
+
+# game/indepth_style.rpy:524
+translate schinese style_text_9c26f218:
+
+    # e "The strikethrough property draws a line through the text. It seems pretty unlikely you'd want to use this one."
+    e "删除线属性在文本中绘制一条线。你似乎不太可能用这个。"
+
+# game/indepth_style.rpy:534
+translate schinese style_text_c7229243:
+
+    # e "The vertical style property places text in a vertical layout. It's meant for Asian languages with special fonts."
+    e "vertical属性将文本放置在垂直布局中。用于亚洲语言的特殊字体。"
+
+# game/indepth_style.rpy:540
+translate schinese style_text_724bd5e0:
+
+    # e "And those are the text style properties. There might be a lot of them, but we want to give you a lot of control over how you present text to your players."
+    e "这些都是文本样式属性。可能有点多，但我们想让你自由地将文本呈现给玩家。"
+
+# game/indepth_style.rpy:580
+translate schinese style_button_300b6af5:
+
+    # e "Next up, we have the window and button style properties. These apply to windows like the text window at the bottom of this screen and frames like the ones we show examples in."
+    e "接下来是窗口和按钮样式的属性。这些应用于窗口像是当前界面底部的文本框，以及框架像是示例中那样。"
+
+# game/indepth_style.rpy:582
+translate schinese style_button_255a18e4:
+
+    # e "These properties also apply to buttons, in-game and out-of-game. To Ren'Py, a button is a window you can click."
+    e "这些属性也适用于游戏内和游戏外的按钮。对Ren'Py来说，按钮是一个可以点击的窗口。"
+
+# game/indepth_style.rpy:593
+translate schinese style_button_9b53ce93:
+
+    # e "I'll start off with this style, which everything will inherit from. To make our lives easier, it inherits from the default style, rather than the customizes buttons in this game's GUI."
+    e "我将从这种样式开始，一切继承于此。为了让我们更轻松，它继承了默认样式，而不是这个游戏的GUI中的自定义按钮。"
+
+# game/indepth_style.rpy:595
+translate schinese style_button_aece4a8c:
+
+    # e "The first style property is the background property. It adds a background to the a button or window. Since this is a button, idle and hover variants choose different backgrounds when focused."
+    e "第一个样式属性是background。它为按钮或窗口添加背景。由于这是一个按钮，指针空闲和悬停时选择不同的背景。"
+
+# game/indepth_style.rpy:597
+translate schinese style_button_b969f04a:
+
+    # e "We also center the two buttons, using the xalign position property."
+    e "我们还使用xalign位置属性将两个按钮居中。"
+
+# game/indepth_style.rpy:601
+translate schinese style_button_269ae069:
+
+    # e "We've also customized the style of the button's text, using this style. It centers the text and makes it change color when hovered."
+    e "我们还使用这种样式定制了按钮文本的样式。它使文本居中，并在指针指向时改变颜色。"
+
+# game/indepth_style.rpy:612
+translate schinese style_button_1009f3e1:
+
+    # e "Without any padding around the text, the button looks odd. Ren'Py has padding properties that add space inside the button's background."
+    e "文本周围没有任何填充，按钮看起来很奇怪。Ren'Py有内边距属性，可以在按钮的背景内部添加间距。"
+
+# game/indepth_style.rpy:621
+translate schinese style_button_5bdfa45a:
+
+    # e "More commonly used are the xpadding and ypadding style properties, which add the same padding to the left and right, or the top and bottom, respectively."
+    e "更常用的是xpadding和ypadding样式属性，它们分别在左侧和右侧、顶部和底部添加相同的填充。"
+
+# game/indepth_style.rpy:629
+translate schinese style_button_81283d42:
+
+    # e "The margin style properties work the same way, except they add space outside the background. The full set exists: left_margin, right_margin, top_margin, bottom_margin, xmargin, and ymargin."
+    e "外边距样式属性的工作方式相同，除了在背景之外增加间距。全套包括：left_margin、right_margin、top_margin、bottom_margin、xmargin和ymargin。"
+
+# game/indepth_style.rpy:638
+translate schinese style_button_0b7aca6b:
+
+    # e "The size_group style property takes a string. Ren'Py will make sure that all the windows or buttons with the same size_group string are the same size."
+    e "size_group样式属性采用字符串。Ren'Py将确保具有相同size_group的所有窗口或按钮的大小相同。"
+
+# game/indepth_style.rpy:647
+translate schinese style_button_4c6da7d9:
+
+    # e "Alternatively, the xfill and yfill style properties make a button take up all available space in the horizontal or vertical directions."
+    e "或者，xfill和yfill样式属性使按钮占据水平或垂直方向上的所有可用空间。"
+
+# game/indepth_style.rpy:657
+translate schinese style_button_fd5338b2:
+
+    # e "The foreground property gives a displayable that is placed on top of the contents and background of the window or button."
+    e "foreground属性使可视组件位于窗口或按钮的内容和背景之上。"
+
+# game/indepth_style.rpy:659
+translate schinese style_button_b8af697c:
+
+    # e "One way to use it is to provide extra decorations to a button that's serving as a checkbox. Another would be to use it with a Frame to provide a glossy shine that overlays the button's contents."
+    e "使用它的一种方法是为复选框按钮提供额外的装饰。另一种方法是将其与Frame一起使用，以提供覆盖按钮内容的光泽。"
+
+# game/indepth_style.rpy:668
+translate schinese style_button_c0b1b62e:
+
+    # e "There are also a few style properties that only apply to buttons. The hover_sound and activate_sound properties play sound files when a button is focused and activated, respectively."
+    e "还有一些样式特性仅适用于按钮。hover_sound和activate_sound属性分别在按钮聚焦和激活时播放声音文件。"
+
+# game/indepth_style.rpy:677
+translate schinese style_button_02fa647e:
+
+    # e "Finally, the focus_mask property applies to partially transparent buttons. When it's set to True, only areas of the button that aren't transparent cause a button to focus."
+    e "最后，focus_mask属性应用于部分透明的按钮。当设置为True时，只有按钮上不透明的区域才会使按钮聚焦。"
+
+# game/indepth_style.rpy:757
+translate schinese style_bar_414d454a:
+
+    # e "To demonstrate styles, let me first show two of the images we'll be using. This is the image we're using for parts of the bar that are empty."
+    e "为了演示样式，让我首先展示两个我们将使用的图像。这是我们在bar空着的地方使用的图像。"
+
+# game/indepth_style.rpy:761
+translate schinese style_bar_9422b7b0:
+
+    # e "And here's what we use for parts of the bar that are full."
+    e "这是我们用在bar满的部分的。"
+
+# game/indepth_style.rpy:773
+translate schinese style_bar_8ae6a14b:
+
+    # e "The left_bar and right_bar style properties, and their hover variants, give displayables for the left and right side of the bar. By default, the value is shown on the left."
+    e "left_bar和riht_bar样式属性，以及鼠标指向时使用的变体，给bar的左侧和右侧提供可视组件。默认该值显示在左侧。"
+
+# game/indepth_style.rpy:775
+translate schinese style_bar_7f0f50e5:
+
+    # e "Also by default, both the left and right displayables are rendered at the full width of the bar, and then cropped to the appropriate size."
+    e "此外，默认情况下，左右可视组件在bar的全宽上渲染，然后剪切为适当的大小。"
+
+# game/indepth_style.rpy:777
+translate schinese style_bar_9ef4f62f:
+
+    # e "We give the bar the ysize property to set how tall it is. We could also give it xsize to choose how wide, but here it's limited by the width of the frame it's in."
+    e "我们给bar设置ysize属性来设置它的高度。我们也可以给它xsize来选择宽度，但这里它受所在框的宽度限制。"
+
+# game/indepth_style.rpy:790
+translate schinese style_bar_d4c29710:
+
+    # e "When the bar_invert style property is True, the bar value is displayed on the right side of the bar. The left_bar and right_bar displayables might also need to be swapped."
+    e "当bar_invert属性为True时，bar的值将显示在右侧。left_bar和right_bar可视组件也可能需要交换。"
+
+# game/indepth_style.rpy:804
+translate schinese style_bar_cca67222:
+
+    # e "The bar_resizing style property causes the bar images to be resized to represent the value, rather than being rendered at full size and cropped."
+    e "bar_resizing样式属性使bar图像的大小调整为对应的值，而不是全尺寸渲染后裁剪。"
+
+# game/indepth_style.rpy:817
+translate schinese style_bar_7d361bac:
+
+    # e "The thumb style property gives a thumb image, that's placed based on the bars value. In the case of a scrollbar, it's resized if possible."
+    e "thumb样式属性提供一个缩略图，基于bar值。对于进度条，如果可能，大小会调整。"
+
+# game/indepth_style.rpy:819
+translate schinese style_bar_b6dfb61b:
+
+    # e "Here, we use it with the base_bar style property, which sets both bar images to the same displayable."
+    e "在这里，我们将其与base_bar样式属性一起使用，从而将两个bar图像设置为相同的可视组件。"
+
+# game/indepth_style.rpy:834
+translate schinese style_bar_996466ad:
+
+    # e "The left_gutter and right_gutter properties set a gutter on the left or right size of the bar. The gutter is space the bar can't be dragged into, that can be used for borders."
+    e "left_gutter和right_gutter属性在bar的左侧或右侧大小上设置一个gutter。gutter是bar不能拖进去的空间，可以用于边界。"
+
+# game/indepth_style.rpy:849
+translate schinese style_bar_fa41a83c:
+
+    # e "The bar_vertical style property displays a vertically oriented bar. All of the other properties change names - left_bar becomes top_bar, while right_bar becomes bottom_bar."
+    e "bar_vertical样式属性显示垂直方向的bar。所有其他属性都会更改名称——left_bar变为top_bar，right_bar变为bottom_bar。"
+
+# game/indepth_style.rpy:854
+translate schinese style_bar_5d33c5dc:
+
+    # e "Finally, there's one style we can't show here, and it's unscrollable. It controls what happens when a scrollbar can't be moved at all."
+    e "最后，有一种样式我们无法在这里展示，它是unscrollable。它控制当进度条完全不能移动时发生的事情。"
+
+# game/indepth_style.rpy:856
+translate schinese style_bar_e8e32280:
+
+    # e "By default, it's shown. But if unscrollable is 'insensitive', the bar becomes insensitive. If it's 'hide', the bar is hidden, but still takes up space."
+    e "默认显示。但如果unscrollable是“insensitive”的，那么bar就会变得不敏感。如果是“hide”，则bar是隐藏的，但仍占用空间。"
+
+# game/indepth_style.rpy:860
+translate schinese style_bar_f1292000:
+
+    # e "That's it for the bar properties. By using them, a creator can customize bars, scrollbars, and sliders."
+    e "这是bar的属性。通过使用它们，创作者可以定制条、滚动条和滑块。"
+
+# game/indepth_style.rpy:959
+translate schinese style_box_5fd535f4:
+
+    # e "The hbox displayable is used to lay its children out horizontally. By default, there's no spacing between children, so they run together."
+    e "hbox可视组件用于水平放置其子组件。默认子组件之间没有间隔，因此它们一起运行。"
+
+# game/indepth_style.rpy:965
+translate schinese style_box_0111e5dc:
+
+    # e "Similarly, the vbox displayable is used to lay its children out vertically. Both support style properties that control placement."
+    e "类似地，vbox可视组件用于垂直布局其子组件。两者都支持控制放置的样式特性。"
+
+# game/indepth_style.rpy:970
+translate schinese style_box_5a44717b:
+
+    # e "To make the size of the box displayable obvious, I'll add a highlight to the box itself, and not the frame containing it."
+    e "为了使box可视组件的大小显示，我将高亮box本身，而不是包含它的框架。"
+
+# game/indepth_style.rpy:978
+translate schinese style_box_239e7a8f:
+
+    # e "Boxes support the xfill and yfill style properties. These properties make a box expand to fill the available space, rather than the space of the largest child."
+    e "box支持xfill和yfill样式属性。这些属性使box拉伸以填充可用空间，而不是最大子组件的空间。"
+
+# game/indepth_style.rpy:988
+translate schinese style_box_e513c946:
+
+    # e "The spacing style property takes a value in pixels, and adds that much spacing between each child of the box."
+    e "spacing样式属性以像素为单位获取值，并在box的每个子组件之间添加这么大的间距。"
+
+# game/indepth_style.rpy:998
+translate schinese style_box_6ae4f94d:
+
+    # e "The first_spacing style property is similar, but it only adds space between the first and second children. This is useful when the first child is a title that needs different spacing."
+    e "first_spacing样式属性类似，但它只在第一个子组件和第二个之间添加间距。当第一个子组件是标题，需要不同的间距时，这很有用。"
+
+# game/indepth_style.rpy:1008
+translate schinese style_box_0c518d9f:
+
+    # e "The box_reverse style property reverses the order of entries in the box."
+    e "box_reverse样式属性反转框中条目的顺序。"
+
+# game/indepth_style.rpy:1021
+translate schinese style_box_f73c1422:
+
+    # e "We'll switch back to a horizontal box for our next example."
+    e "我们将在下一个示例中换回水平box。"
+
+# game/indepth_style.rpy:1031
+translate schinese style_box_285592bb:
+
+    # e "The box_wrap style property fills the box with children until it's full, then starts again on the next line."
+    e "box_wrap样式属性用子组件填充box，直到填满，然后在下一行重新开始。"
+
+# game/indepth_style.rpy:1044
+translate schinese style_box_a7637552:
+
+    # e "Grids bring with them two more style properties. The xspacing and yspacing properties control spacing in the horizontal and vertical directions, respectively."
+    e "Grid还带来两个样式特性。xspacing和yspacing属性分别控制水平和垂直方向的间距。"
+
+# game/indepth_style.rpy:1051
+translate schinese style_box_4006f74b:
+
+    # e "Lastly, we have the fixed layout. The fixed layout usually expands to fill all space, and shows its children from back to front."
+    e "最后，我们有固定的布局。固定布局通常扩展以填满所有空间，并从后到前显示其子组件。"
+
+# game/indepth_style.rpy:1053
+translate schinese style_box_4a2866f0:
+
+    # e "But of course, we have some style properties that can change that."
+    e "当然，我们有一些样式属性可以改变这种情况。"
+
+# game/indepth_style.rpy:1062
+translate schinese style_box_66e042c4:
+
+    # e "When the xfit style property is True, the fixed lays out all its children as if it was full size, and then shrinks in width to fit them. The yfit style works the same way, but in height."
+    e "当xfit样式属性为True时，fixed会所有子组件以全尺寸平铺，然后缩小宽度以适合它们。yfit样式以同样的方式作用在高度上。"
+
+# game/indepth_style.rpy:1070
+translate schinese style_box_6a593b10:
+
+    # e "The order_reverse style property changes the order in which the children are shown. Instead of back-to-front, they're displayed front-to-back."
+    e "order_reverse样式属性更改子组件的显示顺序。不再是从后向前，而是从前到后。"
+
+# game/indepth_style.rpy:1082
+translate schinese style_inspector_21bc0709:
+
+    # e "Sometimes it's hard to figure out what style is being used for a particular displayable. The displayable inspector can help with that."
+    e "有时很难弄清楚某个特定的可视组件使用了什么样式。可视组件检查器可以帮助实现这一点。"
+
+# game/indepth_style.rpy:1084
+translate schinese style_inspector_243c50f0:
+
+    # e "To use it, place the mouse over a portion of the Ren'Py user interface, and hit shift+I. That's I for inspector."
+    e "要使用它，请将鼠标放在Ren'Py用户界面的一部分上，然后按 shift+I 。检查器中按 I 。"
+
+# game/indepth_style.rpy:1086
+translate schinese style_inspector_bcbdc396:
+
+    # e "Ren'Py will pop up a list of displayables the mouse is over. Next to each is the name of the style that displayable uses."
+    e "Ren'Py会在鼠标指向的位置弹出可视组件列表，每一项可视组件使用的样式的名称。"
+
+# game/indepth_style.rpy:1088
+translate schinese style_inspector_d981e5c8:
+
+    # e "You can click on the name of the style to see where it gets its properties from."
+    e "您可以单击样式名以查看其属性的来源。"
+
+# game/indepth_style.rpy:1090
+translate schinese style_inspector_ef46b86d:
+
+    # e "By default, the inspector only shows interface elements like screens, and not images. Type shift+alt+I if you'd like to see images as well."
+    e "默认情况下，检查器只显示界面元素（如界面），而不显示图像。如果您还想查看图像，请按下 shift+alt+I 。"
+
+# game/indepth_style.rpy:1092
+translate schinese style_inspector_b59c6b69:
+
+    # e "You can try the inspector right now, by hovering this text and hitting shift+I."
+    e "你现在就可以尝试检查器，将鼠标悬停在这段文字上并按下 shift+I 。"
+
+translate schinese strings:
+
+    # game/indepth_style.rpy:20
+    old "Button 1"
+    new "Button 1"
+
+    # game/indepth_style.rpy:22
+    old "Button 2"
+    new "Button 2"
+
+    # game/indepth_style.rpy:66
+    old "Style basics."
+    new "样式基础。"
+
+    # game/indepth_style.rpy:66
+    old "General style properties."
+    new "常规样式属性。"
+
+    # game/indepth_style.rpy:66
+    old "Text style properties."
+    new "Text样式属性。"
+
+    # game/indepth_style.rpy:66
+    old "Window and Button style properties."
+    new "window和button样式属性。"
+
+    # game/indepth_style.rpy:66
+    old "Bar style properties."
+    new "bar样式属性。"
+
+    # game/indepth_style.rpy:66
+    old "Box, Grid, and Fixed style properties."
+    new "box、grid和fixed样式属性。"
+
+    # game/indepth_style.rpy:66
+    old "The Displayable Inspector."
+    new "可视组件检查器。"
+
+    # game/indepth_style.rpy:66
+    old "That's all I want to know."
+    new "我只想知道这些。"
+
+    # game/indepth_style.rpy:112
+    old "This text is colored green."
+    new "这段文字是绿色的。"
+
+    # game/indepth_style.rpy:126
+    old "Danger"
+    new "危险"
+
+    # game/indepth_style.rpy:142
+    old "This text is colored red."
+    new "这段文字是红色的。"
+
+    # game/indepth_style.rpy:170
+    old "This text is colored blue."
+    new "这段文字是蓝色的。"
+
+    # game/indepth_style.rpy:248
+    old "Orbiting Earth in the spaceship, I saw how beautiful our planet is.\n–Yuri Gagarin"
+    new "当我乘坐飞船在地球轨道上运行时,我为地球的美丽而惊奇。\n——尤里·加加林"
+
+    # game/indepth_style.rpy:303
+    old "\"Orbiting Earth in the spaceship, I saw how beautiful our planet is.\" Said by Yuri Gagarin."
+    new "“当我乘坐飞船在地球轨道上运行时,我为地球的美丽而惊奇。”尤里·加加林说。"
+
+    # game/indepth_style.rpy:326
+    old "Vertical"
+    new "垂直"
+
+    # game/indepth_style.rpy:329
+    old "Far better it is to dare mighty things, to win glorious triumphs, even though checkered by failure, than to rank with those poor spirits who neither enjoy nor suffer much, because they live in the gray twilight that knows not victory nor defeat.\n\n–Theodore Roosevelt"
+    new "敢于做伟大的事情，赢得光荣的胜利，尽管会遭受挫败，也比那些精神贫乏的人强得多，他们既不会享受生活，也不会吃太多苦头，因为他们生活在不知胜利和失败的混沌时节。\n\n——西奥多·罗斯福"
+
+    # game/indepth_style.rpy:561
+    old "Top Choice"
+    new "顶部选择"
+
+    # game/indepth_style.rpy:566
+    old "Bottom Choice"
+    new "底部选择"
+
+    # game/indepth_style.rpy:877
+    old "First Child"
+    new "第一个子组件"
+
+    # game/indepth_style.rpy:878
+    old "Second Child"
+    new "第二个子组件"
+
+    # game/indepth_style.rpy:879
+    old "Third Child"
+    new "第三个子组件"
+
+    # game/indepth_style.rpy:882
+    old "Fourth Child"
+    new "第四个子组件"
+
+    # game/indepth_style.rpy:883
+    old "Fifth Child"
+    new "第五个子组件"
+
+    # game/indepth_style.rpy:884
+    old "Sixth Child"
+    new "第六个子组件"

--- a/tutorial/game/tl/schinese/indepth_text.rpy
+++ b/tutorial/game/tl/schinese/indepth_text.rpy
@@ -1,0 +1,179 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_text.rpy:22
+translate schinese a_label_8d79d234:
+
+    # e "You just clicked to jump to a label."
+    e "你刚刚点击了跳转到一个label。"
+
+# game/indepth_text.rpy:28
+translate schinese text_578c4060:
+
+    # e "Sometimes, when showing text, we'll want to change the way some of the text is displayed."
+    e "有时，在显示文本时，我们会希望更改某些文本的显示方式。"
+
+# game/indepth_text.rpy:31
+translate schinese text_60750345:
+
+    # e "For example, we might want to have text that is {b}bold{/b}, {i}italic{/i}, {s}struckthrough{/s}, or {u}underlined{/u}."
+    e "例如，我们可能希望文本是{b}粗体{/b}、{i}斜体{/i}、{s}删除线{/s}，或者{u}下划线{/u}。"
+
+# game/indepth_text.rpy:33
+translate schinese text_5e1a6ee8:
+
+    # e "That's what text tags are for."
+    e "这就是文本标签的用途。"
+
+# game/indepth_text.rpy:37
+translate schinese text_38c63ec8:
+
+    # e "Text tags are contained in braces, like the {{b} tag above. When a text tag takes a closing tag, the closing tag begins with a slash, like {{/b} does."
+    e "文本标签包含在大括号中，如上面的{{b}标记。当文本标记接受结束标记时，结束标记以斜线开头，就像{{/b}那样。"
+
+# game/indepth_text.rpy:39
+translate schinese text_1760f9c8:
+
+    # e "We've already seen the b, i, s, and u tags, but there are lot more than those. I'll show you the rest of them."
+    e "我们已经看到了b、i、s和u等标签，但还有很多其他标签。接下来我将展示给你。"
+
+# game/indepth_text.rpy:43
+translate schinese text_a620251f:
+
+    # e "The a text tag can {a=https://www.renpy.org}link to a website{/a} or {a=jump:a_label}jump to a label{/a}."
+    e "a文本标签可以{a=https://www.renpy.org}链接网址{/a}或{a=jump:a_label}跳转到一个标签{/a}。"
+
+# game/indepth_text.rpy:49
+translate schinese after_a_label_d22d5f4a:
+
+    # e "The alpha text tag makes text {alpha=.5}translucent{/alpha}."
+    e "alpha文本标签使文本{alpha=.5}半透明{/alpha}。"
+
+# game/indepth_text.rpy:53
+translate schinese after_a_label_7c2c3cd2:
+
+    # e "The color text tag changes the {color=#0080c0}color{/color} of the text."
+    e "color文本标签更改文本的{color=#0080c0}颜色{/color}。"
+
+# game/indepth_text.rpy:57
+translate schinese after_a_label_3f81fe7b:
+
+    # e "The cps text tag {cps=25}makes text type itself out slowly{/cps}, even if slow text is off."
+    e "cps文本标签{cps=25}使文本缓慢地打出{/cps}，即使慢速文本处于关闭状态。"
+
+# game/indepth_text.rpy:59
+translate schinese after_a_label_b102941f:
+
+    # e "The cps tag can also be relative to the default speed, {cps=*2}doubling{/cps} or {cps=*0.5}halving{/cps} it."
+    e "cps还可以相对于默认速度{cps=*2}加倍{/cps}或{cps=*0.5}减半{/cps}。"
+
+# game/indepth_text.rpy:64
+translate schinese after_a_label_22c4339a:
+
+    # e "The font tag changes the font, for example to {font=DejaVuSans-Bold.ttf}DejaVuSans-Bold.ttf{/font}."
+    e "font更改字体，例如{font=DejaVuSans-Bold.ttf}DejaVuSans-Bold.ttf{/font}。"
+
+# game/indepth_text.rpy:66
+translate schinese after_a_label_d43417d7:
+
+    # e "Sometimes, changing to a bold font looks better than using the {{b} tag."
+    e "有时，更改为粗体字体比使用{{b}更好。"
+
+# game/indepth_text.rpy:71
+translate schinese after_a_label_f24052f9:
+
+    # e "The k tag changes kerning. It can space the letters of a word {k=-.5}closer together{/k} or {k=.5}farther apart{/k}."
+    e "k改变了字体间距。它可以使单词的字母间距{k=-.5}更近{/k}或{k=.5}更远{/k}。（译者注：看上去对中文字体不起作用）"
+
+# game/indepth_text.rpy:76
+translate schinese after_a_label_2310b922:
+
+    # e "The size tag changes the size of text. It can make text {size=+10}bigger{/size} or {size=-10}smaller{/size}, or set it to a {size=30}fixed size{/size}."
+    e "size更改文本的大小。它可以使文本{size=+10}变大{/size}或{size=-10}变小{/size}，或者将其设置为{size=30}固定大小{/size}。"
+
+# game/indepth_text.rpy:81
+translate schinese after_a_label_f566abf2:
+
+    # e "The space tag {space=30} adds horizontal space in text.{vspace=30}The vspace tag adds vertical space between lines."
+    e "space{space=30}在文本中添加水平空格。{vspace=30}vspace在行之间添加垂直空格。"
+
+# game/indepth_text.rpy:85
+translate schinese after_a_label_054b9ffa:
+
+    # e "There are a few text tags that only makes sense in dialogue."
+    e "有一些文本标签只有在对话中才有意义。"
+
+# game/indepth_text.rpy:89
+translate schinese after_a_label_86efc45b:
+
+    # e "The p tag breaks a paragraph,{p}and waits for the player to click."
+    e "p会打断一个段落，{p}并等待玩家单击。"
+
+# game/indepth_text.rpy:91
+translate schinese after_a_label_3ece2387:
+
+    # e "If it is given a number as an argument,{p=1.5}it waits that many seconds."
+    e "如果给它一个数字作为参数，{p=1.5}它会等待那么多秒。"
+
+# game/indepth_text.rpy:95
+translate schinese after_a_label_3881f72d:
+
+    # e "The w tag also waits for a click,{w} except it doesn't break lines,{w=.5} the way p does."
+    e "w也会等待一次点击，{w}除了不换行，{w=.5}不像p那样。"
+
+# game/indepth_text.rpy:100
+translate schinese after_a_label_e5321e79:
+
+    # eslow "The nw tag causes Ren'Py to continue past slow text,{nw}"
+    eslow "nw使Ren'Py慢速显示文本，{nw}"
+
+# game/indepth_text.rpy:102
+translate schinese after_a_label_1f2697ba:
+
+    # extend " to the next statement."
+    extend "到下一个语句。"
+
+# game/indepth_text.rpy:106
+translate schinese after_a_label_dbfca166:
+
+    # e "To break a line without pausing,\none can write \\n. \\' and \\\" include quotes in the text."
+    e "若要在不暂停的情况下换行，\n可以在文本中写入\\n。\\'和\\\"在文本中加入引号。"
+
+# game/indepth_text.rpy:111
+translate schinese after_a_label_ffdf7e76:
+
+    # e "The interpolation feature takes a variable name in square brackets, and inserts it into text."
+    e "插值功能采用方括号中的变量名，并将其插入到文本中。"
+
+# game/indepth_text.rpy:117
+translate schinese after_a_label_fc99fcbf:
+
+    # e "For example, this displays the [variable!t]."
+    e "例如，这里显示[variable]。"
+
+# game/indepth_text.rpy:121
+translate schinese after_a_label_c84d9087:
+
+    # e "When the variable name is followed by !q, special characters are quoted. This displays the raw [variable!q!t], including the italics tags."
+    e "当变量名后面跟着!q，特殊字符会被引用。这里显示原始的[variable!q]，包括斜体标签。"
+
+# game/indepth_text.rpy:126
+translate schinese after_a_label_c90f24a8:
+
+    # e "When the variable name is followed by !t, it is translated to [variable!t]. It could be something else in a different language."
+    e "当变量名后面跟着!t，它被转换成[variable!t]。这可能是另一种语言。"
+
+# game/indepth_text.rpy:129
+translate schinese after_a_label_fb106a95:
+
+    # e "Finally, certain characters are special. [[, {{, and \\ need to be doubled if included in text. The %% character should be doubled if used in dialogue."
+    e "最后，某些字符是特殊的。如果包含在文本中， [[ 、 {{ 和 \\ 需要两个。如果在对话中使用， %% 字符也要两个。"
+
+translate schinese strings:
+
+    # game/indepth_text.rpy:115
+    old "{i}variable value{/i}"
+    new "{i}变量值{/i}"
+
+    # game/indepth_text.rpy:124
+    old "translatable text"
+    new "可翻译文本"

--- a/tutorial/game/tl/schinese/indepth_transitions.rpy
+++ b/tutorial/game/tl/schinese/indepth_transitions.rpy
@@ -1,0 +1,523 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_transitions.rpy:56
+translate schinese demo_transitions_5bbc72fe:
+
+    # e "Ren'Py ships with a large number of built-in transitions, and also includes classes that let you define your own."
+    e "Ren'Py提供了大量的内置转场，还有让您自己定义的类。"
+
+# game/indepth_transitions.rpy:58
+translate schinese demo_transitions_menu_3caf78d3:
+
+    # e "What kind of transitions would you like demonstrated?" nointeract
+    e "您希望演示什么样的转场？" nointeract
+
+# game/indepth_transitions.rpy:95
+translate schinese demo_simple_transitions_2b4fbae3:
+
+    # e "Okay, I can tell you about simple transitions. We call them simple because they don't take much in the way of configuration."
+    e "好，我介绍一些简单的转场。之所以说简单，是因为它们不太需要配置。"
+
+# game/indepth_transitions.rpy:97
+translate schinese demo_simple_transitions_4b235ac2:
+
+    # e "But don't let that get you down, since they're the transitions you'll probably use the most in a game."
+    e "但是不要失望，因为它们很可能是你在游戏中使用最多的转场。"
+
+# game/indepth_transitions.rpy:103
+translate schinese demo_simple_transitions_af0431ac:
+
+    # e "The 'dissolve' transition is probably the most useful, blending one scene into another."
+    e "“溶解（dissolve）”转场将一个场景混合到另一个中，可能是最有用的，。"
+
+# game/indepth_transitions.rpy:109
+translate schinese demo_simple_transitions_5b9f711f:
+
+    # e "The 'Dissolve' function lets you create your own dissolves, taking a different amount of time."
+    e "“Dissolve”函数允许您创建自己的溶解，使用不同的时长。"
+
+# game/indepth_transitions.rpy:116
+translate schinese demo_simple_transitions_79816523:
+
+    # e "The 'fade' transition fades to black, and then fades back in to the new scene."
+    e "“淡出淡入（fade）”转场淡出为黑色，然后淡入新场景。"
+
+# game/indepth_transitions.rpy:118
+translate schinese demo_simple_transitions_141bb95d:
+
+    # e "If you're going to stay at a black screen, you'll probably want to use 'dissolve' rather than 'fade'."
+    e "如果你想保持黑屏上，你可能会想用“溶解”而不是“淡入”。"
+
+# game/indepth_transitions.rpy:123
+translate schinese demo_simple_transitions_f059f4ae:
+
+    # e "You can use 'Fade' to define your own fades. By changing the timing and the color faded to, you can use this for special effects, like flashbulbs."
+    e "你可以用“Fade”来定义你自己的淡入。通过改变淡入的时间和颜色，可以实现一些特殊效果，如闪光灯。"
+
+# game/indepth_transitions.rpy:129
+translate schinese demo_simple_transitions_e948905b:
+
+    # e "The 'pixellate' transition pixellates out the old scene, switches to the new scene, and then unpixellates that."
+    e "“像素化（pixellate）”转场像素化旧场景，切换到新场景，然后取消像素化。"
+
+# game/indepth_transitions.rpy:131
+translate schinese demo_simple_transitions_6a1ae05f:
+
+    # e "It's probably not appropriate for most games, but we think it's kind of neat."
+    e "它可能不适合大多数游戏，但我们认为这比较整洁。"
+
+# game/indepth_transitions.rpy:134
+translate schinese demo_simple_transitions_bdfcd85a:
+
+    # e "You can use 'Pixellate' to change the details of the pixellation."
+    e "您可以使用“Pixellate”来改变像素化的细节。"
+
+# game/indepth_transitions.rpy:136
+translate schinese demo_simple_transitions_432f7224:
+
+    # e "Motions can also be used as transitions."
+    e "运动也可以用作转场。"
+
+# game/indepth_transitions.rpy:138
+translate schinese demo_simple_transitions_a20cefa7:
+
+    # "..."
+    "..."
+
+# game/indepth_transitions.rpy:140
+translate schinese demo_simple_transitions_0fd4d656:
+
+    # "......"
+    "......"
+
+# game/indepth_transitions.rpy:146
+translate schinese demo_simple_transitions_fbf11906:
+
+    # e "Hey! Pay attention."
+    e "嘿！注意。"
+
+# game/indepth_transitions.rpy:148
+translate schinese demo_simple_transitions_51c1c5b8:
+
+    # e "I was about to demonstrate 'vpunch'... well, I guess I just did."
+    e "我正要演示“vpunch”……好吧，我想我刚刚演示了。"
+
+# game/indepth_transitions.rpy:154
+translate schinese demo_simple_transitions_57f19473:
+
+    # e "We can also shake the screen horizontally, with 'hpunch'. These were defined using the 'Move' function."
+    e "我们也可以水平晃动界面，用“hpunch”。这些是使用“Move”函数定义的。"
+
+# game/indepth_transitions.rpy:156
+translate schinese demo_simple_transitions_fce83e12:
+
+    # e "There's also the 'move' transition, which is confusingly enough defined using the 'MoveTransition' function."
+    e "还有一个“move”转场，使用“MoveTransition”函数定义，这非常令人困惑。"
+
+# game/indepth_transitions.rpy:164
+translate schinese demo_simple_transitions_1050b6a4:
+
+    # e "The 'move' transition finds images that have changed placement, and slides them to their new place. It's an easy way to get motion in your game."
+    e "“move”转场将改变位置的图像，滑动到新位置。在你的游戏中，这是一个很简单的方法实现运动。"
+
+# game/indepth_transitions.rpy:168
+translate schinese demo_simple_transitions_dc776e59:
+
+    # e "That's it for the simple transitions."
+    e "这就是简单转场。"
+
+# game/indepth_transitions.rpy:175
+translate schinese demo_imagedissolve_transitions_2db67018:
+
+    # e "Perhaps the most flexible kind of transition is the ImageDissolve, which lets you use an image to control a dissolve."
+    e "也许最灵活的一种转场是Imagesolve，它允许你使用图像来控制溶解。"
+
+# game/indepth_transitions.rpy:177
+translate schinese demo_imagedissolve_transitions_429f8d03:
+
+    # e "This lets us specify very complex transitions, fairly simply. Let's try some, and then I'll show you how they work."
+    e "这使得我们可以非常简单地指定非常复杂的转换。先看一些示例，然后我告诉你该怎么做。。"
+
+# game/indepth_transitions.rpy:179
+translate schinese demo_imagedissolve_transitions_1ce501b0:
+
+    # e "There are two ImageDissolve transitions built into Ren'Py."
+    e "Ren'Py中内置了两个Imagesolve转场。"
+
+# game/indepth_transitions.rpy:191
+translate schinese demo_imagedissolve_transitions_ea0413be:
+
+    # e "The 'blinds' transition opens and closes what looks like vertical blinds."
+    e "“blinds”转场像垂直百叶窗一样打开和关闭。"
+
+# game/indepth_transitions.rpy:201
+translate schinese demo_imagedissolve_transitions_12e2e0d0:
+
+    # e "The 'squares' transition uses these squares to show things."
+    e "“squares”转场使用这些方块来显示。"
+
+# game/indepth_transitions.rpy:203
+translate schinese demo_imagedissolve_transitions_bbf73d1c:
+
+    # e "I'm not sure why anyone would want to use it, but it was used in some translated games, so we added it."
+    e "我不知道为什么有人会想用它，但一些翻译的游戏中用过，所以我们加上了它。"
+
+# game/indepth_transitions.rpy:207
+translate schinese demo_imagedissolve_transitions_0ab2902d:
+
+    # e "The most interesting transitions aren't in the standard library."
+    e "最有趣的转场不在标准库中。"
+
+# game/indepth_transitions.rpy:209
+translate schinese demo_imagedissolve_transitions_54aa9bf9:
+
+    # e "These ones require an image the size of the screen, and so we couldn't include them as the size of the screen can change from game to game."
+    e "它们需要和界面等大的图像，而不同游戏的界面尺寸可能也是不同的，因此我们不能将其包括在内。"
+
+# game/indepth_transitions.rpy:215
+translate schinese demo_imagedissolve_transitions_ca316184:
+
+    # e "We can hide things with a 'circleirisin'..."
+    e "我们可以用“circleirisin”来隐藏东西……"
+
+# game/indepth_transitions.rpy:221
+translate schinese demo_imagedissolve_transitions_b8fdf2b6:
+
+    # e "... and show them again with a 'circleirisout'."
+    e "……然后再用“circleirisout”显示。"
+
+# game/indepth_transitions.rpy:227
+translate schinese demo_imagedissolve_transitions_ee427486:
+
+    # e "The 'circlewipe' transitions changes screens using a circular wipe effect."
+    e "“circlewipe”转场使用圆形擦除效果改变界面。"
+
+# game/indepth_transitions.rpy:233
+translate schinese demo_imagedissolve_transitions_6f089276:
+
+    # e "The 'dream' transition does this weird wavy dissolve, and does it relatively slowly."
+    e "“dream”转场是一种奇怪的波浪状溶解，并且相对缓慢。"
+
+# game/indepth_transitions.rpy:239
+translate schinese demo_imagedissolve_transitions_c0b9d74d:
+
+    # e "The 'teleport' transition reveals the new scene one line at a time."
+    e "“teleport”转场一行行地显示新场景。"
+
+# game/indepth_transitions.rpy:246
+translate schinese demo_imagedissolve_transitions_72ba11d4:
+
+    # e "This is the background picture used with the circleirisout transition."
+    e "这是使用circleirisout转场的背景图片。"
+
+# game/indepth_transitions.rpy:248
+translate schinese demo_imagedissolve_transitions_fc3b3339:
+
+    # e "When we use an ImageDissolve, the white will dissolve in first, followed by progressively darker colors. Let's try it."
+    e "当我们使用ImageResolve时，白色将首先溶解，然后更暗的颜色。来看看吧。"
+
+# game/indepth_transitions.rpy:255
+translate schinese demo_imagedissolve_transitions_4327dca2:
+
+    # e "If we give ImageDissolve the 'reverse' parameter, black areas will dissolve in first."
+    e "如果我们给ImageResolve “reverse”参数，黑色区域将首先溶解。"
+
+# game/indepth_transitions.rpy:260
+translate schinese demo_imagedissolve_transitions_3a401ee7:
+
+    # e "This lets circleirisin and circleirisout use the same image."
+    e "这使得circleirsin和circleirisout使用相同的图像。"
+
+# game/indepth_transitions.rpy:267
+translate schinese demo_imagedissolve_transitions_20d9cf6c:
+
+    # e "The teleport transition uses a different image, one that dissolves things in one line at a time."
+    e "teleport转场使用不同的图像，一次溶解一行。"
+
+# game/indepth_transitions.rpy:272
+translate schinese demo_imagedissolve_transitions_906f7800:
+
+    # e "A dissolve only seems to affect parts of the scene that have changed..."
+    e "溶解似乎只影响场景中已经改变的部分……"
+
+# game/indepth_transitions.rpy:277
+translate schinese demo_imagedissolve_transitions_4b557a29:
+
+    # e "... which is how we apply the teleport effect to a single character."
+    e "……这就是我们如何将teleport效果应用于单个角色。"
+
+# game/indepth_transitions.rpy:285
+translate schinese demo_cropmove_transitions_1711a91e:
+
+    # e "The CropMove transition class provides a wide range of transition effects. It's not used very much in practice, though."
+    e "CropMove转场类提供了广泛的转场效果。不过，在实践中没有太多的使用。"
+
+# game/indepth_transitions.rpy:290
+translate schinese demo_cropmove_transitions_6d82cfd7:
+
+    # e "I'll stand offscreen, so you can see some of its modes. I'll read out the mode name after each transition."
+    e "我站在界面外，这样你就能看到它的一些模式。每次转场后我都会读出模式名。"
+
+# game/indepth_transitions.rpy:296
+translate schinese demo_cropmove_transitions_4427c78c:
+
+    # e "We first have wiperight..."
+    e "首先是向右擦除（wiperight）……"
+
+# game/indepth_transitions.rpy:302
+translate schinese demo_cropmove_transitions_6d1810a1:
+
+    # e "...followed by wipeleft... "
+    e "然后是向左擦除（wipeleft）……"
+
+# game/indepth_transitions.rpy:308
+translate schinese demo_cropmove_transitions_1dd1c6a1:
+
+    # e "...wipeup..."
+    e "向上擦除（wipeup）……"
+
+# game/indepth_transitions.rpy:314
+translate schinese demo_cropmove_transitions_0ea0fa83:
+
+    # e "...and wipedown."
+    e "向下擦除（wipedown）。"
+
+# game/indepth_transitions.rpy:316
+translate schinese demo_cropmove_transitions_c7cb4c16:
+
+    # e "Next, the slides."
+    e "接着，滑入。"
+
+# game/indepth_transitions.rpy:322
+translate schinese demo_cropmove_transitions_462a442f:
+
+    # e "Slideright..."
+    e "向右滑入（slideright）……"
+
+# game/indepth_transitions.rpy:328
+translate schinese demo_cropmove_transitions_f9a2e523:
+
+    # e "...slideleft..."
+    e "向左滑入（slideleft）……"
+
+# game/indepth_transitions.rpy:334
+translate schinese demo_cropmove_transitions_20ce3e9c:
+
+    # e "...slideup..."
+    e "向上滑入（slideup）……"
+
+# game/indepth_transitions.rpy:340
+translate schinese demo_cropmove_transitions_9e00a7a6:
+
+    # e "and slidedown."
+    e "和向下滑入（slidedown）。"
+
+# game/indepth_transitions.rpy:342
+translate schinese demo_cropmove_transitions_b8a710c1:
+
+    # e "While the slide transitions slide in the new scene, the slideaways slide out the old scene."
+    e "slide转场滑入新场景，而slideaway滑出旧场景。"
+
+# game/indepth_transitions.rpy:349
+translate schinese demo_cropmove_transitions_1efb4cd0:
+
+    # e "Slideawayright..."
+    e "向右滑出（slideawayright）……"
+
+# game/indepth_transitions.rpy:355
+translate schinese demo_cropmove_transitions_bfb5dfd7:
+
+    # e "...slideawayleft..."
+    e "向左滑出（slideawayleft）……"
+
+# game/indepth_transitions.rpy:361
+translate schinese demo_cropmove_transitions_6c1a4a6f:
+
+    # e "...slideawayup..."
+    e "向上滑出（slideawayup）……"
+
+# game/indepth_transitions.rpy:367
+translate schinese demo_cropmove_transitions_1f994a7b:
+
+    # e "and slideawaydown."
+    e "和向下滑出（slideawaydown）……"
+
+# game/indepth_transitions.rpy:369
+translate schinese demo_cropmove_transitions_025ef723:
+
+    # e "We also have a couple of transitions that use a rectangular iris."
+    e "我们也有一些使用矩形虹膜的转场。"
+
+# game/indepth_transitions.rpy:376
+translate schinese demo_cropmove_transitions_d00d505e:
+
+    # e "There's irisout..."
+    e "有irisout……"
+
+# game/indepth_transitions.rpy:383
+translate schinese demo_cropmove_transitions_016a1e0a:
+
+    # e "... and irisin."
+    e "……和irisin。"
+
+# game/indepth_transitions.rpy:387
+translate schinese demo_cropmove_transitions_08d753ed:
+
+    # e "It's enough to make you feel a bit dizzy."
+    e "这足以让你感到有点头晕。"
+
+# game/indepth_transitions.rpy:393
+translate schinese demo_pushmove_transitions_003e506d:
+
+    # e "The PushMove transitions use the new scene to push the old one out. Let's take a look."
+    e "PushMove转场用新场景将旧场景推走。让我们看看。"
+
+# game/indepth_transitions.rpy:401
+translate schinese demo_pushmove_transitions_124f375d:
+
+    # "There's pushright..."
+    "有向右推（pushright）……"
+
+# game/indepth_transitions.rpy:408
+translate schinese demo_pushmove_transitions_ce380ccb:
+
+    # "...pushleft..."
+    "向左推（pushleft）……"
+
+# game/indepth_transitions.rpy:416
+translate schinese demo_pushmove_transitions_77629638:
+
+    # "...pushdown..."
+    "向下推（pushdown）……"
+
+# game/indepth_transitions.rpy:424
+translate schinese demo_pushmove_transitions_b7f33c95:
+
+    # "... and pushup. And that's it the for the PushMove-based transitions."
+    "……和向上推（pushup）。这就是基于PushMove的转场。"
+
+# game/indepth_transitions.rpy:434
+translate schinese demo_movetransition_14df0e34:
+
+    # e "The most common MoveTransition is move, which slides around images that have changed position on the screen."
+    e "最常见的MoveTransition是move，界面上它可以在改变位置的图像周围滑动。"
+
+# game/indepth_transitions.rpy:442
+translate schinese demo_movetransition_84e40422:
+
+    # e "Just like that."
+    e "就像这样。"
+
+# game/indepth_transitions.rpy:446
+translate schinese demo_movetransition_098ee9f1:
+
+    # e "There are also the moveout and movein transitions."
+    e "还有moveout和movein转场。"
+
+# game/indepth_transitions.rpy:448
+translate schinese demo_movetransition_09748f81:
+
+    # e "The moveout transitions (moveoutleft, moveoutright, moveouttop, and moveoutbottom) slide hidden images off the appropriate side of the screen."
+    e "moveout转场（moveoutleft、moveoutright、moveouttop和moveoutbottom）将隐藏图像沿对应方向滑出界面。"
+
+# game/indepth_transitions.rpy:450
+translate schinese demo_movetransition_5edf6007:
+
+    # e "The movein transitions (moveinleft, moveinright, moveintop, and moveinbottom) slide in new images."
+    e "movein转场（moveinleft、moveinright、moveintop和moveinbottom）滑入新图像。"
+
+# game/indepth_transitions.rpy:452
+translate schinese demo_movetransition_20946d36:
+
+    # e "Let's see them all in action."
+    e "让我们看看实际效果。"
+
+# game/indepth_transitions.rpy:487
+translate schinese demo_movetransition_569952e3:
+
+    # e "That's it for the moveins and moveouts."
+    e "这就是movein和moveout。"
+
+# game/indepth_transitions.rpy:489
+translate schinese demo_movetransition_bbb75540:
+
+    # e "Finally, there are the zoomin and zoomout transitions, which show and hide things using a zoom."
+    e "最后，还有zoomin和zoomout转场，它们使用缩放显示和隐藏内容。"
+
+# game/indepth_transitions.rpy:499
+translate schinese demo_movetransition_dc5ccd54:
+
+    # e "And that's all there is."
+    e "就这些了。"
+
+# game/indepth_transitions.rpy:508
+translate schinese demo_alphadissolve_51613c02:
+
+    # e "The AlphaDissolve transition lets you use one displayable to combine two others. Click, and I'll show you an example."
+    e "AlphaResolve转场允许你把一个可视组件与另外两个组合起来。点击，我给你看一个例子。"
+
+# game/indepth_transitions.rpy:518
+translate schinese demo_alphadissolve_7c08cf8b:
+
+    # e "The AlphaDissolve displayable takes a control displayable, usually an ATL transform."
+    e "AlphaDissolve可视组件接受一个可视组件作为控件，通常是ATL变换。"
+
+# game/indepth_transitions.rpy:523
+translate schinese demo_alphadissolve_068e3e98:
+
+    # e "To be useful, the control displayable should be partially transparent."
+    e "为了有用，可视控件应该是部分透明的。"
+
+# game/indepth_transitions.rpy:525
+translate schinese demo_alphadissolve_6a1b6203:
+
+    # e "During an AlphaDissolve, the old screen is used to fill the transparent areas of the image, while the new screen fills the opaque areas."
+    e "在AlphaDissolve中，旧界面用于填充图像的透明区域，而新界面填充不透明区域。"
+
+# game/indepth_transitions.rpy:529
+translate schinese demo_alphadissolve_80a728b6:
+
+    # e "For our spotlight example, the old screen is this all-black image."
+    e "这个例子，旧界面是这张全黑的图像。"
+
+# game/indepth_transitions.rpy:534
+translate schinese demo_alphadissolve_ce4380eb:
+
+    # e "The new screen is me just standing here."
+    e "新界面是我站在这里。"
+
+# game/indepth_transitions.rpy:542
+translate schinese demo_alphadissolve_2e95917b:
+
+    # e "By combining them using AlphaDissolve, we can build a complicated effect out of simpler parts."
+    e "加上AlphaDissolve，我们可以用简单的部分构建复杂的效果。"
+
+translate schinese strings:
+
+    # game/indepth_transitions.rpy:58
+    old "Simple Transitions"
+    new "简单转场"
+
+    # game/indepth_transitions.rpy:58
+    old "ImageDissolve Transitions"
+    new "ImageDissolve转场"
+
+    # game/indepth_transitions.rpy:58
+    old "MoveTransition Transitions"
+    new "MoveTransition转场"
+
+    # game/indepth_transitions.rpy:58
+    old "CropMove Transitions"
+    new "CropMove转场"
+
+    # game/indepth_transitions.rpy:58
+    old "PushMove Transitions"
+    new "PushMove转场"
+
+    # game/indepth_transitions.rpy:58
+    old "AlphaDissolve Transitions"
+    new "AlphaDissolve转场"
+
+    # game/indepth_transitions.rpy:58
+    old "How about something else?"
+    new "要看别的吗？"

--- a/tutorial/game/tl/schinese/indepth_translations.rpy
+++ b/tutorial/game/tl/schinese/indepth_translations.rpy
@@ -1,0 +1,109 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/indepth_translations.rpy:12
+translate schinese translations_c4ef181f:
+
+    # e "Ren'Py includes support for translating your game into languages other than the one it was originally written in."
+    e "Ren'Py支持将游戏翻译成不同于最初编写的语言。"
+
+# game/indepth_translations.rpy:14
+translate schinese translations_20b9a600:
+
+    # e "This includes the translation of every string in the game, including dialogue, menu choice, and interface strings, and of images and other assets."
+    e "这包括对游戏中的每个字符串的翻译，包括对话、菜单选项和界面字符串，以及对图像和其他资源的翻译。"
+
+# game/indepth_translations.rpy:16
+translate schinese translations_07c7643c:
+
+    # e "While Ren'Py can find dialogue and menu choice strings for you, you'll have to indicate which other strings need translation."
+    e "Ren'Py可以帮你找到对话和菜单选项的字符串，但是其他需要翻译的字符串要你来指出。"
+
+# game/indepth_translations.rpy:20
+translate schinese translations_317d73e5:
+
+    # e "For example, here is how we define a character and her name."
+    e "例如，我们如何定义一个角色和她的名字。"
+
+# game/indepth_translations.rpy:24
+translate schinese translations_ab0f3c94:
+
+    # e "To mark Lucy's name as translatable, we surround it by parentheses preceded by a single underscore."
+    e "为了将Lucy的名字标记为可翻译，我们在它周围加上下划线。"
+
+# game/indepth_translations.rpy:26
+translate schinese translations_c81acfc7:
+
+    # e "Notice how we don't translate the reddish color that we use for her name. That stays the same for all languages."
+    e "注意我们没有翻译她名字的红色。在所有语言都是一样的。"
+
+# game/indepth_translations.rpy:33
+translate schinese translations_8272a0ef:
+
+    # e "Once that's done, you can generate the translation files. That's done by going to the launcher, and clicking translate."
+    e "完成后，就可以生成翻译文件。打开启动器，点击“生成翻译文件”。"
+
+# game/indepth_translations.rpy:35
+translate schinese translations_fde34832:
+
+    # e "After you type in the name of the language you'll be translating to, choosing Generate Translations will scan your game and create translation files."
+    e "输入要翻译的语言名称后，选择“生成翻译文件”将扫描游戏并创建翻译文件。"
+
+# game/indepth_translations.rpy:37
+translate schinese translations_e2ebb4af:
+
+    # e "The files will be generated in game/tl/language, where language is the name of the language you typed in."
+    e "文件将在 game/tl/language 目录下生成， language 是您键入的语言的名称。"
+
+# game/indepth_translations.rpy:39
+translate schinese translations_28ec40b9:
+
+    # e "You'll need to edit those files to include translations for everything in your game."
+    e "你需要编辑这些文件来实现对游戏内容的翻译。"
+
+# game/indepth_translations.rpy:41
+translate schinese translations_f6d3fd2d:
+
+    # e "If you want to localize image files, you can also place them in game/tl/language."
+    e "如果要本地化图像文件，也可以将它们放在 game/tl/language 中。"
+
+# game/indepth_translations.rpy:48
+translate schinese translations_71bf6e72:
+
+    # e "If the default fonts used by the game do not support the language you are translating to, you will have to change them."
+    e "如果游戏使用的默认字体不支持您要翻译的语言，您必须换一个。"
+
+# game/indepth_translations.rpy:50
+translate schinese translations_82c9748e:
+
+    # e "The translate python statement can be used to set the values of gui variables to change the font."
+    e "translate语句可用于设置gui变量的值以更改字体。"
+
+# game/indepth_translations.rpy:52
+translate schinese translations_a0042025:
+
+    # e "The translate style statement sets style properties more directly."
+    e "translate style语句更直接地设置样式属性。"
+
+# game/indepth_translations.rpy:54
+translate schinese translations_b10990ce:
+
+    # e "If you need to add new files, such as font files, you can place them into the game/tl/language directory where Ren'Py will find them."
+    e "如果需要添加新文件，例如字体文件，可以将它们放入 game/tl/language 目录，Ren'Py会找到它们。"
+
+# game/indepth_translations.rpy:58
+translate schinese translations_01fcacc2:
+
+    # e "Finally, you'll have to add support for picking the language of the game. That usually goes into the preferences screen, found in screens.rpy."
+    e "最后，您必须添加多语言支持的选项。一般可以在 screens.rpy 的首选项（preferences）界面找到。"
+
+# game/indepth_translations.rpy:60
+translate schinese translations_a91befcc:
+
+    # e "Here's an excerpt of the preferences screen of this tutorial. The Language action tells Ren'Py to change the language. It takes a string giving a language name, or None."
+    e "这是本教程的首选项界面的节选。Language动作让Ren'Py改变语言。它需要语言名称的字符串，或者None。"
+
+# game/indepth_translations.rpy:62
+translate schinese translations_9b7d6401:
+
+    # e "The None language is special, as it's the default language that the visual novel was written in. Since this tutorial was written in English, Language(None) selects English."
+    e "None语言是特殊的，它是视觉小说的默认语言。由于本教程是用英语写的，Language(None)选择英语。"

--- a/tutorial/game/tl/schinese/options.rpy
+++ b/tutorial/game/tl/schinese/options.rpy
@@ -1,0 +1,7 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+translate schinese strings:
+
+    # game/options.rpy:15
+    old "Ren'Py Tutorial Game"
+    new "Ren'Py 教程"

--- a/tutorial/game/tl/schinese/screens.rpy
+++ b/tutorial/game/tl/schinese/screens.rpy
@@ -1,0 +1,327 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+translate schinese strings:
+
+    # game/screens.rpy:261
+    old "Back"
+    new "后退"
+
+    # game/screens.rpy:262
+    old "History"
+    new "历史"
+
+    # game/screens.rpy:263
+    old "Skip"
+    new "跳过"
+
+    # game/screens.rpy:264
+    old "Auto"
+    new "自动"
+
+    # game/screens.rpy:265
+    old "Save"
+    new "保存"
+
+    # game/screens.rpy:266
+    old "Q.Save"
+    new "快速保存"
+
+    # game/screens.rpy:267
+    old "Q.Load"
+    new "快速读取"
+
+    # game/screens.rpy:268
+    old "Prefs"
+    new "首选项"
+
+    # game/screens.rpy:309
+    old "Start"
+    new "开始"
+
+    # game/screens.rpy:317
+    old "Load"
+    new "读取"
+
+    # game/screens.rpy:319
+    old "Preferences"
+    new "首选项"
+
+    # game/screens.rpy:323
+    old "End Replay"
+    new "结束回想"
+
+    # game/screens.rpy:327
+    old "Main Menu"
+    new "主菜单"
+
+    # game/screens.rpy:329
+    old "About"
+    new "关于"
+
+    # game/screens.rpy:334
+    old "Help"
+    new "帮助"
+
+    # game/screens.rpy:339
+    old "Quit"
+    new "退出"
+
+    # game/screens.rpy:482
+    old "Return"
+    new "返回"
+
+    # game/screens.rpy:566
+    old "Version [config.version!t]\n"
+    new "版本 [config.version!t]\n"
+
+    # game/screens.rpy:572
+    old "Made with {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
+    new "由{a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only]制作。\n\n[renpy.license!t]"
+
+    # game/screens.rpy:612
+    old "Page {}"
+    new "第 {} 页"
+
+    # game/screens.rpy:612
+    old "Automatic saves"
+    new "自动保存"
+
+    # game/screens.rpy:612
+    old "Quick saves"
+    new "快速保存"
+
+    # game/screens.rpy:654
+    old "{#file_time}%A, %B %d %Y, %H:%M"
+    new "{#file_time}%Y年%B%d日%A %H:%M"
+
+    # game/screens.rpy:654
+    old "empty slot"
+    new "无存档"
+
+    # game/screens.rpy:671
+    old "<"
+    new "<"
+
+    # game/screens.rpy:674
+    old "{#auto_page}A"
+    new "{#auto_page}自动"
+
+    # game/screens.rpy:677
+    old "{#quick_page}Q"
+    new "{#quick_page}快速"
+
+    # game/screens.rpy:683
+    old ">"
+    new ">"
+
+    # game/screens.rpy:745
+    old "Display"
+    new "显示"
+
+    # game/screens.rpy:746
+    old "Window"
+    new "窗口"
+
+    # game/screens.rpy:747
+    old "Fullscreen"
+    new "全屏"
+
+    # game/screens.rpy:759
+    old "Unseen Text"
+    new "未读文本"
+
+    # game/screens.rpy:760
+    old "After Choices"
+    new "选择后"
+
+    # game/screens.rpy:766
+    old "Examples"
+    new "示例"
+
+    # game/screens.rpy:775
+    old "Language"
+    new "语言"
+
+    # game/screens.rpy:798
+    old "Text Speed"
+    new "文本速度"
+
+    # game/screens.rpy:802
+    old "Auto-Forward Time"
+    new "自动推进时间"
+
+    # game/screens.rpy:809
+    old "Music Volume"
+    new "音乐"
+
+    # game/screens.rpy:816
+    old "Sound Volume"
+    new "音效"
+
+    # game/screens.rpy:822
+    old "Test"
+    new "测试"
+
+    # game/screens.rpy:826
+    old "Voice Volume"
+    new "语音"
+
+    # game/screens.rpy:837
+    old "Mute All"
+    new "静音"
+
+    # game/screens.rpy:956
+    old "The dialogue history is empty."
+    new "对话历史为空。"
+
+    # game/screens.rpy:1022
+    old "Keyboard"
+    new "键盘"
+
+    # game/screens.rpy:1023
+    old "Mouse"
+    new "鼠标"
+
+    # game/screens.rpy:1026
+    old "Gamepad"
+    new "游戏手柄"
+
+    # game/screens.rpy:1039
+    old "Enter"
+    new "回车"
+
+    # game/screens.rpy:1040
+    old "Advances dialogue and activates the interface."
+    new "推进对话并激活界面。"
+
+    # game/screens.rpy:1043
+    old "Space"
+    new "空格"
+
+    # game/screens.rpy:1044
+    old "Advances dialogue without selecting choices."
+    new "在没有选项的情况下推进对话。"
+
+    # game/screens.rpy:1047
+    old "Arrow Keys"
+    new "方向键"
+
+    # game/screens.rpy:1048
+    old "Navigate the interface."
+    new "导航界面。"
+
+    # game/screens.rpy:1051
+    old "Escape"
+    new "Esc"
+
+    # game/screens.rpy:1052
+    old "Accesses the game menu."
+    new "进入游戏菜单。"
+
+    # game/screens.rpy:1055
+    old "Ctrl"
+    new "Ctrl"
+
+    # game/screens.rpy:1056
+    old "Skips dialogue while held down."
+    new "按住时跳过对话。"
+
+    # game/screens.rpy:1059
+    old "Tab"
+    new "Tab"
+
+    # game/screens.rpy:1060
+    old "Toggles dialogue skipping."
+    new "切换对话跳过。"
+
+    # game/screens.rpy:1063
+    old "Page Up"
+    new "Page Up"
+
+    # game/screens.rpy:1064
+    old "Rolls back to earlier dialogue."
+    new "回到前面的对话。"
+
+    # game/screens.rpy:1067
+    old "Page Down"
+    new "Page Down"
+
+    # game/screens.rpy:1068
+    old "Rolls forward to later dialogue."
+    new "转到后面的对话。"
+
+    # game/screens.rpy:1072
+    old "Hides the user interface."
+    new "隐藏用户界面。"
+
+    # game/screens.rpy:1076
+    old "Takes a screenshot."
+    new "截图。"
+
+    # game/screens.rpy:1080
+    old "Toggles assistive {a=https://www.renpy.org/l/voicing}self-voicing{/a}."
+    new "切换无障碍{a=https://www.renpy.org/l/voicing}自动语音{/a}。（{a=https://renpy.cn/doc/self_voicing.html}中文文档{/a}）"
+
+    # game/screens.rpy:1086
+    old "Left Click"
+    new "左键"
+
+    # game/screens.rpy:1090
+    old "Middle Click"
+    new "中键"
+
+    # game/screens.rpy:1094
+    old "Right Click"
+    new "右键"
+
+    # game/screens.rpy:1098
+    old "Mouse Wheel Up\nClick Rollback Side"
+    new "鼠标滚轮向上\n单击 Rollback Side"
+
+    # game/screens.rpy:1102
+    old "Mouse Wheel Down"
+    new "鼠标滚轮向下"
+
+    # game/screens.rpy:1109
+    old "Right Trigger\nA/Bottom Button"
+    new "右触发器\nA/下 键"
+
+    # game/screens.rpy:1113
+    old "Left Trigger\nLeft Shoulder"
+    new "左触发器\n左肩"
+
+    # game/screens.rpy:1117
+    old "Right Shoulder"
+    new "右肩"
+
+    # game/screens.rpy:1121
+    old "D-Pad, Sticks"
+    new "D-Pad, Sticks"
+
+    # game/screens.rpy:1125
+    old "Start, Guide"
+    new "Start, Guide"
+
+    # game/screens.rpy:1129
+    old "Y/Top Button"
+    new "Y/上 键"
+
+    # game/screens.rpy:1132
+    old "Calibrate"
+    new "校准"
+
+    # game/screens.rpy:1197
+    old "Yes"
+    new "是"
+
+    # game/screens.rpy:1198
+    old "No"
+    new "否"
+
+    # game/screens.rpy:1244
+    old "Skipping"
+    new "跳过"
+
+    # game/screens.rpy:1465
+    old "Menu"
+    new "菜单"

--- a/tutorial/game/tl/schinese/script.rpy
+++ b/tutorial/game/tl/schinese/script.rpy
@@ -1,0 +1,179 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/script.rpy:156
+translate schinese start_0e6a5bb4:
+
+    # e "Hi! My name is Eileen, and I'd like to welcome you to the Ren'Py tutorial."
+    e "嗨！我的名字是艾琳，欢迎你来到Ren'Py的教程。"
+
+# game/script.rpy:160
+translate schinese start_d3abb53c:
+
+    # e "In this tutorial, we'll teach you the basics of Ren'Py, so you can make games of your own. We'll also demonstrate many features, so you can see what Ren'Py is capable of."
+    e "在本教程中，我们将教你Ren'Py的基本知识，这样你就可以自己制作游戏了。我们还将演示许多特性，这样您就可以看到Ren'Py的能力了。"
+
+# game/script.rpy:205
+translate schinese end_b2482727:
+
+    # e "Thank you for viewing this tutorial."
+    e "感谢您观看本教程。"
+
+# game/script.rpy:207
+translate schinese end_38362e36:
+
+    # e "If you'd like to see a full Ren'Py game, select \"The Question\" in the launcher."
+    e "如果你想看一个完整的游戏，在启动器中选择“The Question”。"
+
+# game/script.rpy:209
+translate schinese end_02527d05:
+
+    # e "You can download new versions of Ren'Py from {a=https://www.renpy.org/}https://www.renpy.org/{/a}. For help and discussion, check out the {a=https://lemmasoft.renai.us/forums/}Lemma Soft Forums{/a}."
+    e "你可以从{a=https://www.renpy.org/}https://www.renpy.org/{/a}下载新版本的Ren'Py。有关帮助和讨论，请查看{a=https://lemmasoft.renai.us/forums/}Lemma Soft Forums{/a}。"
+
+# game/script.rpy:211
+translate schinese end_c9d03136:
+
+    # e "We'd like to thank Piroshki for contributing my sprites; Mugenjohncel for Lucy, the band, and drawn backgrounds; and Jake for the magic circle."
+    e "我们要感谢Piroshki给我提供了灵感；感谢Mugenjohncel贡献了露西、乐队和绘画背景；感谢Jake的魔法圈（magic circle）。"
+
+# game/script.rpy:213
+translate schinese end_762dc07a:
+
+    # e "The background music is \"Sunflower Slow Drag\", by Scott Joplin and Scott Hayden, performed by the United States Marine Band. The concert music is by Alessio."
+    e "背景音乐是Scott Joplin和Scott Hayden的《Sunflower Slow Drag》，由美国海军乐队表演。音乐会音乐是Alessio的。"
+
+# game/script.rpy:217
+translate schinese end_a634d396:
+
+    # e "We look forward to seeing what you create with Ren'Py. Have fun!"
+    e "我们期待着看到你用Ren'Py进行创作。玩得高兴！"
+
+translate schinese strings:
+
+    # game/script.rpy:11
+    old "Eileen"
+    new "艾琳"
+
+    # game/script.rpy:56
+    old "Quickstart"
+    new "快速入门"
+
+    # game/script.rpy:58
+    old "Player Experience"
+    new "玩家体验"
+
+    # game/script.rpy:59
+    old "Creating a New Game"
+    new "创建新游戏"
+
+    # game/script.rpy:60
+    old "Writing Dialogue"
+    new "写对话"
+
+    # game/script.rpy:61
+    old "Adding Images"
+    new "加图片"
+
+    # game/script.rpy:62
+    old "Positioning Images"
+    new "改变图像位置"
+
+    # game/script.rpy:63
+    old "Transitions"
+    new "转场"
+
+    # game/script.rpy:64
+    old "Music and Sound Effects"
+    new "音乐和音效"
+
+    # game/script.rpy:65
+    old "Choices and Python"
+    new "选项和Python"
+
+    # game/script.rpy:66
+    old "Input and Interpolation"
+    new "输入和插值"
+
+    # game/script.rpy:67
+    old "Video Playback"
+    new "视频回放"
+
+    # game/script.rpy:68
+    old "NVL Mode"
+    new "NVL模式"
+
+    # game/script.rpy:69
+    old "Tools and the Interactive Director"
+    new "工具和交互控制器"
+
+    # game/script.rpy:70
+    old "Building Distributions"
+    new "发布"
+
+    # game/script.rpy:72
+    old "In Depth"
+    new "进阶"
+
+    # game/script.rpy:74
+    old "Text Tags, Escapes, and Interpolation"
+    new "文本标签、转义和插值"
+
+    # game/script.rpy:75
+    old "Character Objects"
+    new "角色（Character）对象"
+
+    # game/script.rpy:76
+    old "Simple Displayables"
+    new "简单的可视组件"
+
+    # game/script.rpy:77
+    old "Transition Gallery"
+    new "转场画廊"
+
+    # game/script.rpy:80
+    old "Position Properties"
+    new "位置属性"
+
+    # game/script.rpy:83
+    old "Transforms and Animation"
+    new "变换和动画"
+
+    # game/script.rpy:84
+    old "Transform Properties"
+    new "变换属性"
+
+    # game/script.rpy:86
+    old "GUI Customization"
+    new "图形用户界面（GUI）定制"
+
+    # game/script.rpy:87
+    old "Styles and Style Properties"
+    new "样式和样式属性"
+
+    # game/script.rpy:88
+    old "Screen Basics"
+    new "界面基础"
+
+    # game/script.rpy:89
+    old "Screen Displayables"
+    new "界面可视组件"
+
+    # game/script.rpy:91
+    old "Minigames and CDDs"
+    new "小游戏和CDD"
+
+    # game/script.rpy:92
+    old "Translations"
+    new "多语言支持"
+
+    # game/script.rpy:129
+    old "That's enough for now."
+    new "暂时够了。"
+
+    # game/script.rpy:168
+    old "What would you like to see?"
+    new "你想看什么？"
+
+    # game/script.rpy:170
+    old "Is there anything else you'd like to see?"
+    new "你还有什么想看的吗？"

--- a/tutorial/game/tl/schinese/style.rpy
+++ b/tutorial/game/tl/schinese/style.rpy
@@ -1,0 +1,2 @@
+translate schinese python:
+    gui.system_font = gui.main_font = gui.text_font = gui.name_text_font = gui.interface_text_font = gui.button_text_font = gui.choice_button_text_font = "../../launcher/game/fonts/SourceHanSansLite.ttf"

--- a/tutorial/game/tl/schinese/tutorial_atl.rpy
+++ b/tutorial/game/tl/schinese/tutorial_atl.rpy
@@ -1,0 +1,651 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_atl.rpy:205
+translate schinese tutorial_positions_a09a3fd1:
+
+    # e "In this tutorial, I'll teach you how Ren'Py positions things on the screen. But before that, let's learn a little bit about how Python handles numbers."
+    e "在本教程中，我会教你Ren'Py如何在界面上定位。在此之前，让我们了解一下Python如何处理数字。"
+
+# game/tutorial_atl.rpy:207
+translate schinese tutorial_positions_ba39aabc:
+
+    # e "There are two main kinds of numbers in Python: integers and floating point numbers. An integer consists entirely of digits, while a floating point number has a decimal point."
+    e "Python中主要有两种数字：整数和浮点数。整数完全由数字组成，而浮点数有小数点。"
+
+# game/tutorial_atl.rpy:209
+translate schinese tutorial_positions_a60b775d:
+
+    # e "For example, 100 is an integer, while 0.5 is a floating point number, or float for short. In this system, there are two zeros: 0 is an integer, and 0.0 is a float."
+    e "例如，100是整数，而0.5是浮点数。在这个系统中，有两种零：0是整数，而0.0是浮点数。"
+
+# game/tutorial_atl.rpy:211
+translate schinese tutorial_positions_7f1a560c:
+
+    # e "Ren'Py uses integers to represent absolute coordinates, and floats to represent fractions of an area with known size."
+    e "Ren'Py使用整数表示绝对坐标，而float表示已知大小区域的比例。"
+
+# game/tutorial_atl.rpy:213
+translate schinese tutorial_positions_8e7d3e52:
+
+    # e "When we're positioning something, the area is usually the entire screen."
+    e "当我们定位某个东西时，这个区域通常是整个界面。"
+
+# game/tutorial_atl.rpy:215
+translate schinese tutorial_positions_fdcf9d8b:
+
+    # e "Let me get out of the way, and I'll show you where some positions are."
+    e "我先让开，给你看一些位置。"
+
+# game/tutorial_atl.rpy:229
+translate schinese tutorial_positions_76d7a5bf:
+
+    # e "The origin is the upper-left corner of the screen. That's where the x position (xpos) and the y position (ypos) are both zero."
+    e "原点是界面的左上角。那里x坐标（xpos）和y坐标（ypos）都是0。"
+
+# game/tutorial_atl.rpy:235
+translate schinese tutorial_positions_be14c7c3:
+
+    # e "When we increase xpos, we move to the right. So here's an xpos of .5, meaning half the width across the screen."
+    e "增加xpos，则向右移动。xpos为.5，意味着界面宽度的一半。"
+
+# game/tutorial_atl.rpy:240
+translate schinese tutorial_positions_9b91be6c:
+
+    # e "Increasing xpos to 1.0 moves us to the right-hand border of the screen."
+    e "xpos增加到1.0，则移动到界面的右边界。"
+
+# game/tutorial_atl.rpy:246
+translate schinese tutorial_positions_2b293304:
+
+    # e "We can also use an absolute xpos, which is given in an absolute number of pixels from the left side of the screen. For example, since this window is 1280 pixels across, using an xpos of 640 will return the target to the center of the top row."
+    e "我们也可以使用绝对的xpos，它是以距离界面左侧的像素数的绝对值。例如，由于此窗口的宽度为1280像素，因此使用640的xpo将使目标位于顶行的中心。"
+
+# game/tutorial_atl.rpy:248
+translate schinese tutorial_positions_c4d18c0a:
+
+    # e "The y-axis position, or ypos works the same way. Right now, we have a ypos of 0.0."
+    e "y轴位置，即ypos，以同样的方式起作用。现在，我们的ypos为0.0。"
+
+# game/tutorial_atl.rpy:254
+translate schinese tutorial_positions_16933a61:
+
+    # e "Here's a ypos of 0.5."
+    e "ypos为0.5。"
+
+# game/tutorial_atl.rpy:259
+translate schinese tutorial_positions_6eb36777:
+
+    # e "A ypos of 1.0 specifies a position at the bottom of the screen. If you look carefully, you can see the position indicator spinning below the text window."
+    e "若ypos为1.0，则位于界面底部。仔细看，位置指示器在文本窗口下面旋转。"
+
+# game/tutorial_atl.rpy:261
+translate schinese tutorial_positions_a423050f:
+
+    # e "Like xpos, ypos can also be an integer. In this case, ypos would give the total number of pixels from the top of the screen."
+    e "与xpos一样，ypos也可以是整数。在本例中，ypos是距离界面顶部的像素总数。"
+
+# game/tutorial_atl.rpy:267
+translate schinese tutorial_positions_bc7a809a:
+
+    # e "Can you guess where this position is, relative to the screen?" nointeract
+    e "你能猜出这个位置相对于界面的位置吗？" nointeract
+
+# game/tutorial_atl.rpy:273
+translate schinese tutorial_positions_6f926e18:
+
+    # e "Sorry, that's wrong. The xpos is .75, and the ypos is .25."
+    e "对不起，那是错的。xpos是.75，ypos是.25。"
+
+# game/tutorial_atl.rpy:275
+translate schinese tutorial_positions_5d5feb98:
+
+    # e "In other words, it's 75%% of the way from the left side, and 25%% of the way from the top."
+    e "换言之，距离左侧75%%的距离，距离顶部25%%的距离。"
+
+# game/tutorial_atl.rpy:279
+translate schinese tutorial_positions_77b45218:
+
+    # e "Good job! You got that position right."
+    e "干得好！你选择了正确的位置。"
+
+# game/tutorial_atl.rpy:283
+translate schinese tutorial_positions_6f926e18_1:
+
+    # e "Sorry, that's wrong. The xpos is .75, and the ypos is .25."
+    e "对不起，那是错的。xpos是.75，ypos是.25。"
+
+# game/tutorial_atl.rpy:285
+translate schinese tutorial_positions_5d5feb98_1:
+
+    # e "In other words, it's 75%% of the way from the left side, and 25%% of the way from the top."
+    e "换言之，距离左侧75%%的距离，距离顶部25%%的距离。"
+
+# game/tutorial_atl.rpy:299
+translate schinese tutorial_positions_e4380a83:
+
+    # e "The second position we care about is the anchor. The anchor is a spot on the thing being positioned."
+    e "我们关心的第二个位置是锚点（anchor）。锚点是被定位物体上的一个点。"
+
+# game/tutorial_atl.rpy:301
+translate schinese tutorial_positions_d1db1246:
+
+    # e "For example, here we have an xanchor of 0.0 and a yanchor of 0.0. It's in the upper-left corner of the logo image."
+    e "例如，这里的xanchor为0.0，yanchor为0.0。它在logo图像的左上角。"
+
+# game/tutorial_atl.rpy:306
+translate schinese tutorial_positions_6056873f:
+
+    # e "When we increase the xanchor to 1.0, the anchor moves to the right corner of the image."
+    e "当xanchor增加到1.0时，锚点移动到图像的右上角。"
+
+# game/tutorial_atl.rpy:311
+translate schinese tutorial_positions_7cdb8dcc:
+
+    # e "Similarly, when both xanchor and yanchor are 1.0, the anchor is the bottom-right corner."
+    e "类似的，当xanchor和yanchor都为1.0时，锚点位于右下角。"
+
+# game/tutorial_atl.rpy:318
+translate schinese tutorial_positions_03a07da8:
+
+    # e "To place an image on the screen, we need both the position and the anchor."
+    e "要在界面上放置图像，位置和锚点都需要。"
+
+# game/tutorial_atl.rpy:326
+translate schinese tutorial_positions_8945054f:
+
+    # e "We then line them up, so that both the position and anchor are at the same point on the screen."
+    e "如果我们把它们对齐，这样位置和锚点都在界面上同一点。"
+
+# game/tutorial_atl.rpy:336
+translate schinese tutorial_positions_2b184a93:
+
+    # e "When we place both in the upper-left corner, the image moves to the upper-left corner of the screen."
+    e "当我们把两者都放在左上角时，图像会移到界面的左上角。"
+
+# game/tutorial_atl.rpy:345
+translate schinese tutorial_positions_5aac4f3f:
+
+    # e "With the right combination of position and anchor, any place on the screen can be specified, without even knowing the size of the image."
+    e "位置和锚点的正确组合，可以指定界面上的任意位置，甚至不需要知道图像的大小。"
+
+# game/tutorial_atl.rpy:357
+translate schinese tutorial_positions_3b59b797:
+
+    # e "It's often useful to set xpos and xanchor to the same value. We call that xalign, and it gives a fractional position on the screen."
+    e "通常，将xpos和xanchor设置为相同的值非常有用。我们称之为xalign，可以指定界面上的相对位置。"
+
+# game/tutorial_atl.rpy:362
+translate schinese tutorial_positions_b8ebf9fe:
+
+    # e "For example, when we set xalign to 0.0, things are aligned to the left side of the screen."
+    e "例如，当我们将xalign设置为0.0时，物体将与界面左侧对齐。"
+
+# game/tutorial_atl.rpy:367
+translate schinese tutorial_positions_8ce35d52:
+
+    # e "When we set it to 1.0, then we're aligned to the right side of the screen."
+    e "当我们将其设置为1.0时，物体将与界面的右侧对齐。"
+
+# game/tutorial_atl.rpy:372
+translate schinese tutorial_positions_6745825f:
+
+    # e "And when we set it to 0.5, we're back to the center of the screen."
+    e "当我们把它设置为0.5时，物体回到界面的中心。"
+
+# game/tutorial_atl.rpy:374
+translate schinese tutorial_positions_64428a07:
+
+    # e "Setting yalign is similar, except along the y-axis."
+    e "设置yalign与此类似，只不过是沿y轴。"
+
+# game/tutorial_atl.rpy:376
+translate schinese tutorial_positions_cfb77d42:
+
+    # e "Remember that xalign is just setting xpos and xanchor to the same value, and yalign is just setting ypos and yanchor to the same value."
+    e "记住，xalign只是将xpos和xanchor设置为相同的值，yallign只是将ypos和yanchor设置为相同的值。"
+
+# game/tutorial_atl.rpy:381
+translate schinese tutorial_positions_cfc1723e:
+
+    # e "The xcenter and ycenter properties position the center of the image. Here, with xcenter set to .75, the center of the image is three-quarters of the way to the right side of the screen."
+    e "xcenter和ycenter属性定位图像的中心。这里，将xcenter设置为.75，图像的中心在到界面右侧的路上的四分之三。"
+
+# game/tutorial_atl.rpy:386
+translate schinese tutorial_positions_7728dbf9:
+
+    # e "The difference between xalign and xcenter is more obvious when xcenter is 1.0, and the image is halfway off the right side of the screen."
+    e "当xcenter为1.0时，xalign和xcenter之间的差异更为明显，图像有一般超出离右边界。"
+
+# game/tutorial_atl.rpy:394
+translate schinese tutorial_positions_1b1cedc6:
+
+    # e "There are the xoffset and yoffset properties, which are applied after everything else, and offset things to the right or bottom, respectively."
+    e "xoffset和yoffset属性，应用于所有其他属性之后，分别让物体向右或向下偏移。"
+
+# game/tutorial_atl.rpy:399
+translate schinese tutorial_positions_e6da2798:
+
+    # e "Of course, you can use negative numbers to offset things to the left and top."
+    e "当然，你可以用负数来让物体向左或向上偏移。"
+
+# game/tutorial_atl.rpy:404
+translate schinese tutorial_positions_e0fe2d81:
+
+    # e "Lastly, I'll mention that there are combined properties like align, pos, anchor, and center. Align takes a pair of numbers, and sets xalign to the first and yalign to the second. The others are similar."
+    e "最后，我会提到一些组合属性，如align、pos、anchor和center。align接受一对数字，并将xalign的值设置为第一个，yalign设置为第二个。其他的也差不多。"
+
+# game/tutorial_atl.rpy:411
+translate schinese tutorial_positions_0f4ca2b6:
+
+    # e "Once you understand positions, you can use transformations to move things around the Ren'Py screen."
+    e "一旦你理解位置，就可以使变换在Ren'Py界面上移动物体。"
+
+# game/tutorial_atl.rpy:418
+translate schinese tutorial_atl_d5d6b62a:
+
+    # e "Ren'Py uses transforms to animate, manipulate, and place images. We've already seen the very simplest of transforms in use:"
+    e "Ren'Py使用变换来设置动画、操作和放置图像。我们已经在使用中见过最简单的变换："
+
+# game/tutorial_atl.rpy:425
+translate schinese tutorial_atl_7e853c9d:
+
+    # e "Transforms can be very simple affairs that place the image somewhere on the screen, like the right transform."
+    e "变换可以是将图像放在界面上某个地方这样非常简单的事情，像是右边的变换。"
+
+# game/tutorial_atl.rpy:429
+translate schinese tutorial_atl_87a6ecbd:
+
+    # e "But transforms can also be far more complicated affairs, that introduce animation and effects into the mix. To demonstrate, let's have a Gratuitous Rock Concert!"
+    e "但是变换也可以是远比这复杂的事情，将动画和特效引入并混合。为了演示，让我们来个免费的摇滚音乐会吧！"
+
+# game/tutorial_atl.rpy:437
+translate schinese tutorial_atl_65badef3:
+
+    # e "But first, let's have... a Gratuitous Rock Concert!"
+    e "但首先，让我们来个……免费的摇滚音乐会！"
+
+# game/tutorial_atl.rpy:445
+translate schinese tutorial_atl_e0d3c5ec:
+
+    # e "That was a lot of work, but it was built out of small parts."
+    e "这是一个大工程，但它是由小部分组成的。"
+
+# game/tutorial_atl.rpy:447
+translate schinese tutorial_atl_f2407514:
+
+    # e "Most transforms in Ren'Py are built using the Animation and Transform Language, or ATL for short."
+    e "Ren'Py中的大多数变换都是使用动画和变换语言（Animation and Transform Language, ATL）构建的。"
+
+# game/tutorial_atl.rpy:449
+translate schinese tutorial_atl_1f22f875:
+
+    # e "There are currently three places where ATL can be used in Ren'Py."
+    e "目前Ren'Py中有三个地方可以使用ATL。"
+
+# game/tutorial_atl.rpy:454
+translate schinese tutorial_atl_fd036bdf:
+
+    # e "The first place ATL can be used is as part of an image statement. Instead of a displayable, an image may be defined as a block of ATL code."
+    e "ATL的第一个用处是作为image语句的一部分。图像可以定义为ATL代码块，而不是可视组件。"
+
+# game/tutorial_atl.rpy:456
+translate schinese tutorial_atl_7cad2ab9:
+
+    # e "When used in this way, we have to be sure that ATL includes one or more displayables to actually show."
+    e "当以这种方式使用时，我们必须确保ATL包含一个或多个实际显示的可视组件。"
+
+# game/tutorial_atl.rpy:461
+translate schinese tutorial_atl_c78b2a1e:
+
+    # e "The second way is through the use of the transform statement. This assigns the ATL block to a python variable, allowing it to be used in at clauses and inside other transforms."
+    e "第二种方式是使用transform语句。将ATL块赋予python变量，允许用于at从句和其他变换内部。"
+
+# game/tutorial_atl.rpy:473
+translate schinese tutorial_atl_da7a7759:
+
+    # e "Finally, an ATL block can be used as part of a show statement, instead of the at clause."
+    e "最后，ATL块可以用作show语句的一部分，而不是at从句。"
+
+# game/tutorial_atl.rpy:480
+translate schinese tutorial_atl_1dd345c6:
+
+    # e "When ATL is used as part of a show statement, values of properties exist even when the transform is changed. So even though a click your click stopped the motion, the image remains in the same place."
+    e "当ATL用作show语句的一部分时，即使变换已更改，属性值也存在。所以即使你用点击停止图像的运动，它仍然保持在原来的位置。"
+
+# game/tutorial_atl.rpy:488
+translate schinese tutorial_atl_98047789:
+
+    # e "The key to ATL is what we call composability. ATL is made up of relatively simple commands, which can be combined together to create complicated transforms."
+    e "ATL的关键是我们称为可组合性的东西。ATL由相对简单的命令组成，这些命令可以组合在一起以创建复杂的变换。"
+
+# game/tutorial_atl.rpy:490
+translate schinese tutorial_atl_ed82983f:
+
+    # e "Before I explain how ATL works, let me explain what animation and transformation are."
+    e "在我解释ATL如何工作之前，让我解释一下什么是动画和变换。"
+
+# game/tutorial_atl.rpy:495
+translate schinese tutorial_atl_2807adff:
+
+    # e "Animation is when the displayable being shown changes. For example, right now I am changing my expression."
+    e "动画是可视组件正在显示变化。例如，现在我正在改变我的表情。"
+
+# game/tutorial_atl.rpy:522
+translate schinese tutorial_atl_3eec202b:
+
+    # e "Transformation involves moving or distorting an image. This includes placing it on the screen, zooming it in and out, rotating it, and changing its opacity."
+    e "变换包括移动或扭曲图像。这包括放置、缩放、旋转和改变不透明度。"
+
+# game/tutorial_atl.rpy:530
+translate schinese tutorial_atl_fbc9bf83:
+
+    # e "To introduce ATL, let's start by looking at at a simple animation. Here's one that consists of five lines of ATL code, contained within an image statement."
+    e "为了介绍ATL，让我们先看一个简单的动画。这有五行ATL代码，包含在一个image语句中。"
+
+# game/tutorial_atl.rpy:532
+translate schinese tutorial_atl_bf92d973:
+
+    # e "To change a displayable, simply mention it on a line of ATL. Here, we're switching back and forth between two images."
+    e "要更改一个可视组件，只需在一行ATL中提到它。这里，我们在两个图像之间来回切换。"
+
+# game/tutorial_atl.rpy:534
+translate schinese tutorial_atl_51a41db4:
+
+    # e "Since we're defining an image, the first line of ATL must give a displayable. Otherwise, there would be nothing to show."
+    e "因为我们要定义一个图像，ATL的第一行必须给出可视组件。否则，就没有什么可显示。"
+
+# game/tutorial_atl.rpy:536
+translate schinese tutorial_atl_3d065074:
+
+    # e "The second and fourth lines are pause statements, which cause ATL to wait half a second each before continuing. That's how we give the delay between images."
+    e "第二行和第四行是pause语句，它们使ATL在继续之前各等待半秒。这就是如何在图像之间设置延迟。"
+
+# game/tutorial_atl.rpy:538
+translate schinese tutorial_atl_60f2a5e8:
+
+    # e "The final line is a repeat statement. This causes the current block of ATL to be restarted. You can only have one repeat statement per block."
+    e "最后一行是repeat语句。这使当前的ATL块重新启动。每一块只能有一个repeat语句。"
+
+# game/tutorial_atl.rpy:543
+translate schinese tutorial_atl_146cf4c4:
+
+    # e "If we were to write repeat 2 instead, the animation would loop twice, then stop."
+    e "如果我们改为repeat 2，动画将循环两次，然后停止。"
+
+# game/tutorial_atl.rpy:548
+translate schinese tutorial_atl_d90b1838:
+
+    # e "Omitting the repeat statement means that the animation stops once we reach the end of the block of ATL code."
+    e "省略repeat语句意味着，当ATL代码运行到块的末尾，动画就会停止。"
+
+# game/tutorial_atl.rpy:554
+translate schinese tutorial_atl_e5872360:
+
+    # e "By default, displayables are replaced instantaneously. We can also use a with clause to give a transition between displayables."
+    e "可视组件默认立即替换。我们也可以使用with从句在可视组件之间进行转场。"
+
+# game/tutorial_atl.rpy:561
+translate schinese tutorial_atl_2e9d63ea:
+
+    # e "With animation done, we'll see how we can use ATL to transform images, starting with positioning an image on the screen."
+    e "动画完成后，我们将了解如何使用ATL来变换图像，从在界面上定位图像开始。"
+
+# game/tutorial_atl.rpy:570
+translate schinese tutorial_atl_ddc55039:
+
+    # e "The simplest thing we can to is to statically position an image. This is done by giving the names of the position properties, followed by the property values."
+    e "我们能做的最简单的事情就是静态定位图像。先给出位置属性的名称，然后是属性值。"
+
+# game/tutorial_atl.rpy:575
+translate schinese tutorial_atl_43516492:
+
+    # e "With a few more statements, we can move things around on the screen."
+    e "再加上一些语句，我们就可以在界面上移动物体。"
+
+# game/tutorial_atl.rpy:577
+translate schinese tutorial_atl_fb979287:
+
+    # e "This example starts the image off at the top-right of the screen, and waits a second. It then moves it to the left side, waits another second, and repeats."
+    e "本例图像开始在界面右上角，等待一秒。然后将它移到左边，再等一秒，重复。"
+
+# game/tutorial_atl.rpy:579
+translate schinese tutorial_atl_7650ec09:
+
+    # e "The pause and repeat statements are the same statements we used in our animations. They work throughout ATL code."
+    e "pause和repeat语句与我们在动画中使用的相同。它们贯穿ATL代码。"
+
+# game/tutorial_atl.rpy:584
+translate schinese tutorial_atl_d3416d4f:
+
+    # e "Having the image jump around on the screen isn't all that useful. That's why ATL has the interpolation statement."
+    e "让图像在界面上跳来跳去并没有那么有用。这就是为什么ATL有插值（interpolation）语句。"
+
+# game/tutorial_atl.rpy:586
+translate schinese tutorial_atl_4e7512ec:
+
+    # e "The interpolation statement allows you to smoothly vary the value of a transform property, from an old to a new value."
+    e "插值语句允许您将属性值平滑地从旧的变成新的。"
+
+# game/tutorial_atl.rpy:588
+translate schinese tutorial_atl_685eeeaa:
+
+    # e "Here, we have an interpolation statement on the second ATL line. It starts off with the name of a time function, in this case linear."
+    e "这里，我们在第二行ATL有一个插值语句。以时间函数名开始，在本例中是linear。"
+
+# game/tutorial_atl.rpy:590
+translate schinese tutorial_atl_c5cb49de:
+
+    # e "That's followed by an amount of time, in this case three seconds. It ends with a list of properties, each followed by its new value."
+    e "后面是时长，在本例中是三秒。以属性列表结束，每个属性后面都是新的值。"
+
+# game/tutorial_atl.rpy:592
+translate schinese tutorial_atl_04b8bc1d:
+
+    # e "The value of each property is interpolated from its value when the statement starts to the value at the end of the statement. This is done once per frame, allowing smooth animation."
+    e "每个属性的插值从语句开始时的值到语句末尾的值。每帧执行一次，以实现平滑动画。"
+
+# game/tutorial_atl.rpy:603
+translate schinese tutorial_atl_2958f397:
+
+    # e "ATL supports more complicated move types, like circle and spline motion. But I won't be showing those here."
+    e "ATL支持更复杂的移动类型，如圆和螺旋线运动。但我不会在这里展示。"
+
+# game/tutorial_atl.rpy:607
+translate schinese tutorial_atl_d08fe8d9:
+
+    # e "Apart from displayables, pause, interpolation, and repeat, there are a few other statements we can use as part of ATL."
+    e "除了可视组件、pause、插值和repeat之外，还有一些其他语句可以用作ATL的一部分。"
+
+# game/tutorial_atl.rpy:619
+translate schinese tutorial_atl_84b22ac0:
+
+    # e "ATL transforms created using the statement become ATL statements themselves. Since the default positions are also transforms, this means that we can use left, right, and center inside of an ATL block."
+    e "使用该语句创建的ATL变换本身成为ATL语句。由于默认位置也是变换，所以我们可以在ATL块内部使用左（left）、右（right）和中心（center）。"
+
+# game/tutorial_atl.rpy:635
+translate schinese tutorial_atl_331126c1:
+
+    # e "Here, we have two new statements. The block statement allows you to include a block of ATL code. Since the repeat statement applies to blocks, this lets you repeat only part of an ATL transform."
+    e "这里，我们有两个新的语句。block语句允许包含ATL代码块。由于repeat语句应用于块，所以允许只重复ATL变换的一部分。"
+
+# game/tutorial_atl.rpy:637
+translate schinese tutorial_atl_24f67b67:
+
+    # e "We also have the time statement, which runs after the given number of seconds have elapsed from the start of the block. It will run even if another statement is running, stopping the other statement."
+    e "我们还有time语句，它在给定的秒数之后开始运行块。即使另一个语句正在运行，它也会运行，而那个语句停止。"
+
+# game/tutorial_atl.rpy:639
+translate schinese tutorial_atl_b7709507:
+
+    # e "So this example bounces the image back and forth for eleven and a half seconds, and then moves it to the right side of the screen."
+    e "这个例子在11.5秒的时间里来回反射图像，然后将其移动到界面的右侧。"
+
+# game/tutorial_atl.rpy:653
+translate schinese tutorial_atl_f903bc3b:
+
+    # e "The parallel statement lets us run two blocks of ATL code at the same time."
+    e "parallel语句允许我们同时运行两个ATL代码块。"
+
+# game/tutorial_atl.rpy:655
+translate schinese tutorial_atl_5d0f8f9d:
+
+    # e "Here, the top block move the image in the horizontal direction, and the bottom block moves it in the vertical direction. Since they're moving at different speeds, it looks like the image is bouncing on the screen."
+    e "在这里，顶部块沿水平方向移动图像，底部块在垂直方向移动图像。因为它们以不同的速度移动，所以看起来像是在界面上反弹。"
+
+# game/tutorial_atl.rpy:669
+translate schinese tutorial_atl_28a7d27e:
+
+    # e "Finally, the choice statement makes Ren'Py randomly pick a block of ATL code. This allows you to add some variation as to what Ren'Py shows."
+    e "最后，choice语句使Ren'Py随机选择一个ATL代码块。这允许您给Ren'Py显示内容增加一些变化。"
+
+# game/tutorial_atl.rpy:675
+translate schinese tutorial_atl_2265254b:
+
+    # e "This tutorial game has only scratched the surface of what you can do with ATL. For example, we haven't even covered the on and event statements. For more information, you might want to check out {a=https://renpy.org/doc/html/atl.html}the ATL chapter in the reference manual{/a}."
+    e "关于ATL可以做什么，这个教程游戏只触及表面。例如，我们甚至没有讨论on和event语句。更多信息，请查看{a=https://renpy.org/doc/html/atl.html}参考手册中的ATL章节{/a}。（{a=https://renpy.cn/doc/atl.html}中文文档{/a}）"
+
+# game/tutorial_atl.rpy:684
+translate schinese transform_properties_391169cf:
+
+    # e "Ren'Py has quite a few transform properties that can be used with ATL, the Transform displayable, and the add Screen Language statement."
+    e "Ren'Py有不少可以与ATL、Transform可视组件和add界面语言语句一起使用的变换属性。"
+
+# game/tutorial_atl.rpy:685
+translate schinese transform_properties_fc895a1f:
+
+    # e "Here, we'll show them off so you can see them in action and get used to what each does."
+    e "这里，我们将展示它们，这样你就可以看到它们的实际效果，并习惯每一个的作用。"
+
+# game/tutorial_atl.rpy:701
+translate schinese transform_properties_88daf990:
+
+    # e "First off, all of the position properties are also transform properties. These include the pos, anchor, align, center, and offset properties."
+    e "首先，所有位置属性也是变换属性。这些包括pos、anchor、align、center和offset属性。"
+
+# game/tutorial_atl.rpy:719
+translate schinese transform_properties_d7a487f1:
+
+    # e "The position properties can also be used to pan over a displayable larger than the screen, by giving xpos and ypos negative values."
+    e "position属性还可以通过赋予xpos和ypos负值，在比界面更大的可视组件上平移。"
+
+# game/tutorial_atl.rpy:729
+translate schinese transform_properties_89e0d7c2:
+
+    # "The subpixel property controls how things are lined up with the screen. When False, images can be pixel-perfect, but there can be pixel jumping."
+    "subpixel属性控制图像如何与界面对齐。如果为False，图像可以是像素完美的，但也可能存在像素跳跃。"
+
+# game/tutorial_atl.rpy:736
+translate schinese transform_properties_4194527e:
+
+    # "When it's set to True, movement is smoother at the cost of blurring images a little."
+    "当设置为True时，移动更平滑，但图像会模糊一点。"
+
+# game/tutorial_atl.rpy:755
+translate schinese transform_properties_35934e77:
+
+    # e "Transforms also support polar coordinates. The around property sets the center of the coordinate system to coordinates given in pixels."
+    e "变换也支持极坐标。around属性将坐标系的中心设置为以像素为单位的坐标。"
+
+# game/tutorial_atl.rpy:763
+translate schinese transform_properties_605ebd0c:
+
+    # e "The angle property gives the angle in degrees. Angles run clockwise, with the zero angle at the top of the screen."
+    e "angle属性以度（degree）表示角度。角度按顺时针计算，零度在界面顶部。"
+
+# game/tutorial_atl.rpy:772
+translate schinese transform_properties_6d4555ed:
+
+    # e "The radius property gives the distance in pixels from the anchor of the displayable to the center of the coordinate system."
+    e "radius属性给出从可视组件的锚点到坐标系中心的像素距离。"
+
+# game/tutorial_atl.rpy:786
+translate schinese transform_properties_7af037a5:
+
+    # e "There are several ways to resize a displayable. The zoom property lets us scale a displayable by a factor, making it bigger and smaller."
+    e "有几种方法可以调整可视组件的大小。zoom属性允许按倍数缩放可视组件，使其变大变小。"
+
+# game/tutorial_atl.rpy:799
+translate schinese transform_properties_b6527546:
+
+    # e "The xzoom and yzoom properties allow the displayable to be scaled in the X and Y directions independently."
+    e "xzoom和yzoom属性允许可视组件独立地在X和Y方向上缩放。"
+
+# game/tutorial_atl.rpy:809
+translate schinese transform_properties_b98b780b:
+
+    # e "By making xzoom or yzoom a negative number, we can flip the image horizontally or vertically."
+    e "通过将xzoom或yzoom设为负数，我们可以水平或垂直翻转图像。"
+
+# game/tutorial_atl.rpy:819
+translate schinese transform_properties_74d542ff:
+
+    # e "Instead of zooming by a scale factor, the size transform property can be used to scale a displayable to a size in pixels."
+    e "与按比例倍数缩放不同，size变换属性可用于将可视组件缩放缩放到指定的像素大小。"
+
+# game/tutorial_atl.rpy:834
+translate schinese transform_properties_438ed776:
+
+    # e "The alpha property is used to change the opacity of a displayable. This can make it appear and disappear."
+    e "alpha属性用于更改可视组件的不透明度。这可以使图像出现和消失。"
+
+# game/tutorial_atl.rpy:847
+translate schinese transform_properties_aee19f86:
+
+    # e "The rotate property rotates a displayable."
+    e "rotate属性旋转可视组件。"
+
+# game/tutorial_atl.rpy:858
+translate schinese transform_properties_57b3235a:
+
+    # e "By default, when a displayable is rotated, Ren'Py will include extra space on all four sides, so the size doesn't change as it rotates. Here, you can see the extra space on the left and top, and it's also there on the right and bottom."
+    e "默认情况下，可视组件旋转时，Ren'Py会在全部四个边上包含额外的空间，因此旋转时大小不会改变。这里，你能看到左侧和顶部的额外空间，以及右侧和底部也有。"
+
+# game/tutorial_atl.rpy:870
+translate schinese transform_properties_66d29ee8:
+
+    # e "By setting rotate_pad to False, we can get rid of the space, at the cost of the size of the displayable changing as it rotates."
+    e "通过将rotate_pad设置为False，我们可以去除空间，但代价是可视组件的大小随着旋转而改变。"
+
+# game/tutorial_atl.rpy:881
+translate schinese transform_properties_7f32e8ad:
+
+    # e "The tile transform properties, xtile and ytile, repeat the displayable multiple times."
+    e "tile变换属性，xtile和ytile，重复可视组件数次。"
+
+# game/tutorial_atl.rpy:891
+translate schinese transform_properties_207b7fc8:
+
+    # e "The crop property crops a rectangle out of a displayable, showing only part of it."
+    e "crop属性从可视组件中裁剪一个矩形，仅显示一部分。"
+
+# game/tutorial_atl.rpy:905
+translate schinese transform_properties_e7e22d28:
+
+    # e "When used together, crop and size can be used to focus in on specific parts of an image."
+    e "当crop和size一起使用时，可用于聚焦图像的特定部分。"
+
+# game/tutorial_atl.rpy:917
+translate schinese transform_properties_f34abd82:
+
+    # e "The xpan and ypan properties can be used to pan over a displayable, given an angle in degrees, with 0 being the center."
+    e "xpan和ypan属性可用于在给定角度（以度为单位）上平移可视组件，0为中心。"
+
+# game/tutorial_atl.rpy:924
+translate schinese transform_properties_bfa3b139:
+
+    # e "Those are all the transform properties we have to work with. By putting them together in the right order, you can create complex things."
+    e "这些都是我们必须知道的变换属性。把它们按正确的顺序放在一起，你就能创造出复杂的东西。"
+
+translate schinese strings:
+
+    # game/tutorial_atl.rpy:267
+    old "xpos 1.0 ypos .5"
+    new "xpos 1.0 ypos .5"
+
+    # game/tutorial_atl.rpy:267
+    old "xpos .75 ypos .25"
+    new "xpos .75 ypos .25"
+
+    # game/tutorial_atl.rpy:267
+    old "xpos .25 ypos .33"
+    new "xpos .25 ypos .33"

--- a/tutorial/game/tl/schinese/tutorial_director.rpy
+++ b/tutorial/game/tl/schinese/tutorial_director.rpy
@@ -1,0 +1,127 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_director.rpy:5
+translate schinese director_e4543d9b:
+
+    # e "There are a few tools you can access by pressing the right commands on the keyboard."
+    e "键盘上的正确命令可以使用一些工具。"
+
+# game/tutorial_director.rpy:7
+translate schinese director_ebf40500:
+
+    # e "Typing Shift+R turns on autoreload mode. When it's enabled, your game will automatically reload when you edit a script file."
+    e "Shift+R 打开自动重新加载模式。启用后，当脚本文件发生改变，游戏将自动重新加载。"
+
+# game/tutorial_director.rpy:9
+translate schinese director_6f3d1bea:
+
+    # e "Shift+O brings you to the console, which lets you enter Ren'Py and Python commands to try them out."
+    e "Shift+O 启动控制台，可以输入Ren'Py和Python命令。"
+
+# game/tutorial_director.rpy:11
+translate schinese director_70a61c1c:
+
+    # e "Shift+D pops up a developer menu with access to these and other functions."
+    e "Shift+D 弹出一个开发者菜单，可以使用这些及其他功能。"
+
+# game/tutorial_director.rpy:13
+translate schinese director_43504744:
+
+    # e "The most powerful tool is the interactive director that lets you add images, music, and voice lines to your game from inside Ren'Py."
+    e "最强大的工具是交互式编导器，它让你在Ren'Py内部将图像、音乐和语音添加到游戏。"
+
+# game/tutorial_director.rpy:15
+translate schinese director_32f8695e:
+
+    # e "The idea is that you can use an editor to write the script and logic of your visual novel, and then interactively add images in the right places."
+    e "这个想法是，你可以使用一个编辑器来编写你的视觉小说的脚本和逻辑，然后在正确的地方交互式地添加图像。"
+
+# game/tutorial_director.rpy:21
+translate schinese director_62734181:
+
+    # e "It looks like Ren'Py is installed read-only on your system, so you won't be able to try out the interactive director now."
+    e "看起来Ren'Py是以只读方式安装在您的系统上的，因此您现在无法试用交互式编导器。"
+
+# game/tutorial_director.rpy:23
+translate schinese director_aec4c7d4:
+
+    # e "You'll need to make your own project, and try it out there. But I can tell you how to use it."
+    e "你需要在你自己的工程中尝试。但我可以告诉你如何使用它。"
+
+# game/tutorial_director.rpy:29
+translate schinese director_453d4d67:
+
+    # e "You can try the interactive director out right now, by using it to change this tutorial game."
+    e "你现在可以试用交互式编导器，用它来改变这个教程游戏。"
+
+# game/tutorial_director.rpy:31
+translate schinese director_c35284d1:
+
+    # e "Be sure to click my dialogue at the bottom of the screen to advance the tutorial."
+    e "请点击界面底部的我的对话以推进教程。"
+
+# game/tutorial_director.rpy:33
+translate schinese director_e253e03b:
+
+    # e "If something goes wrong, don't worry. Quitting and restarting this tutorial will remove your changes and bring everything back to normal."
+    e "如果出错，别担心。退出并重新启动本教程将删除您的更改并使一切恢复正常。"
+
+# game/tutorial_director.rpy:42
+translate schinese director_1cd735bc:
+
+    # e "To get started, let's go back to a blank slate, with no images on the screen."
+    e "首先，让我们回到没有图像的空白界面。"
+
+# game/tutorial_director.rpy:44
+translate schinese director_c7a18979:
+
+    # e "You can show the director at any time by pressing the 'D' key on your keyboard. Ren'Py will reload, and you'll come back here. Try it now."
+    e "你可以随时按键盘上的“D”键来显示编导器。Ren'Py会重新加载，并回到这里。现在就试试吧。"
+
+# game/tutorial_director.rpy:46
+translate schinese director_3dcc4362:
+
+    # e "Let's add a background. Click the '+' to pick where to add it, then the 'scene' statement and 'washington' for the image. Finally, click 'Add' to add it."
+    e "让我们添加一个背景。单击“+”选择添加位置，然后单击“scene”语句和“washington”图像。最后，单击“添加”来添加它。"
+
+# game/tutorial_director.rpy:48
+translate schinese director_292d58b5:
+
+    # e "Next, add a sprite. Click '+', then 'show', 'eileen', 'happy', and 'Add'. Once you've added it, dissolve it in by clicking the second '+', then 'with', 'dissolve', and 'Add'."
+    e "接下来，添加一个精灵（sprite）。单击“+”，然后单击“show”、“eileen”、“happy”和“Add”。添加完后，单击第二个“+”，然后单击“with”、“dissolve”和“Add”使其溶解。"
+
+# game/tutorial_director.rpy:52
+translate schinese director_c875c1a7:
+
+    # e "You can edit or remove statements with the pencil icon. You can move me to the right by editing the show statement, then clicking '(transform)', 'right', and 'Change'."
+    e "您可以点击铅笔图标来编辑或删除语句。您可以通过编辑show语句，然后单击“(transform)”、“right”和“Change”将我移到右侧。"
+
+# game/tutorial_director.rpy:54
+translate schinese director_4e04a74e:
+
+    # e "Finally, you can use the play, queue, stop, and voice statements to manage audio. Try adding 'play', 'music', 'sunflower-slow-drag.ogg'."
+    e "最后，您可以使用play、queue、stop和voice语句来管理音频。尝试添加“play”、“music”、“sunflower-slow-drag.ogg”。"
+
+# game/tutorial_director.rpy:61
+translate schinese director_1364b336:
+
+    # l "Finally, I get some more screen time!"
+    l "最后，我有更多的界面时间！"
+
+# game/tutorial_director.rpy:69
+translate schinese director_c6dd0c81:
+
+    # e "The changes you make with the director are permanent. They're saved to the script, and you can rollback or repeat this section to see them."
+    e "你用编导器所做的改变是永久性的。它们被保存到脚本中，您可以回滚或重复此部分来查看它们。"
+
+# game/tutorial_director.rpy:71
+translate schinese director_9d03b14b:
+
+    # e "However, we reset this tutorial when the game restarts, so you can try again from a clean slate. That won't happen with your own visual novel."
+    e "不过，当游戏重新启动时，我们会重置此教程，以便您可以从头再来。这不会发生在你自己的视觉小说里。"
+
+# game/tutorial_director.rpy:73
+translate schinese director_dbfa07b2:
+
+    # e "I hope these tools make developing your visual novel that much easier."
+    e "我希望这些工具能让你的视觉小说开发变得更容易。"

--- a/tutorial/game/tl/schinese/tutorial_distribute.rpy
+++ b/tutorial/game/tl/schinese/tutorial_distribute.rpy
@@ -1,0 +1,73 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_distribute.rpy:3
+translate schinese distribute_7db9b042:
+
+    # e "One thing Ren'Py makes easy is building distributions of your visual novel so you can give it to players."
+    e "Ren'Py让构建你的视觉小说的发行版变得简单，你可以轻松地发给玩家。"
+
+# game/tutorial_distribute.rpy:5
+translate schinese distribute_d373903b:
+
+    # e "Before you build distributions, you should use the Lint command to check your game for problems."
+    e "在生成分发版之前，你应该使用“检查脚本并分析统计（Lint）”来检查游戏是否存在问题。"
+
+# game/tutorial_distribute.rpy:7
+translate schinese distribute_2f970565:
+
+    # e "While not every potential problem lint reports is a real issue, they generally are, and you should try to understand what might be wrong."
+    e "虽然并非每个lint报告的潜在问题都是真正的问题，但通常是，您应该尝试了解可能出了什么问题。"
+
+# game/tutorial_distribute.rpy:12
+translate schinese distribute_29aea017:
+
+    # e "After lint has finished, you can choose Build Distributions to build the Windows, Linux, and Mac distributions of your game."
+    e "lint完成后，您可以选择生成分发版来构建游戏的Windows、Linux和Mac发行版。"
+
+# game/tutorial_distribute.rpy:14
+translate schinese distribute_821be97b:
+
+    # e "This can be as simple as clicking the Build button, when you're not on a Mac."
+    e "简单到只要点击生成按钮，即使你不在用Mac。"
+
+# game/tutorial_distribute.rpy:16
+translate schinese distribute_638f964a:
+
+    # e "If you are on a Macintosh, you can have Ren'Py sign the Mac application, which makes it easier for players to run. To enable this, you need to set build.mac_identity in options.rpy."
+    e "如果你在用麦金塔（译者注：这里指苹果的个人电脑），你可以让Ren'Py给Mac应用签名，这使玩家更容易运行游戏。要启用此功能，您需要在在 options.rpy 中设置 build.mac_identity 。"
+
+# game/tutorial_distribute.rpy:21
+translate schinese distribute_dd1af4dd:
+
+    # e "Ren'Py supports the mobile platforms, Android and iOS. We also support ChromeOS, through its ability to run Android apps."
+    e "Ren'Py支持移动平台，安卓和iOS。我们还支持ChromeOS，借助它运行Android应用的能力。"
+
+# game/tutorial_distribute.rpy:23
+translate schinese distribute_0b547b7b:
+
+    # e "These mobile platforms can be a bit more complicated. While Android apps can be built everywhere, iOS requires a Mac."
+    e "这些移动平台可能更复杂一些。Android应用可以在任何地方构建，但是iOS需要Mac。"
+
+# game/tutorial_distribute.rpy:25
+translate schinese distribute_50a57bcf:
+
+    # e "Mobile platforms might also require you to change your visual novel a little, due to the smaller limited devices. For example, buttons need to be made large enough for a person to touch."
+    e "鉴于小型设备的限制，你可能也需要稍微改变你的视觉小说以适应移动平台。例如，按钮需要做得足够大，让人可以触摸。"
+
+# game/tutorial_distribute.rpy:27
+translate schinese distribute_a9a2149f:
+
+    # e "Rather than cover mobile here, I'll point you to the {a=https://www.renpy.org/doc/html/android.html}Android{/a} and {a=https://www.renpy.org/doc/html/ios.html}iOS{/a} documentation, where you can read more."
+    e "与其在这里讲移动版，我会给你指出{a=https://www.renpy.org/doc/html/android.html}Android{/a}和{a=https://www.renpy.org/doc/html/ios.html}iOS{/a}文档，您可以在这里阅读更多。（{a=https://renpy.cn/doc/android.html}Android{/a}和{a=https://renpy.cn/doc/ios.html}iOS{/a}中文文档）"
+
+# game/tutorial_distribute.rpy:29
+translate schinese distribute_f1cbc9d0:
+
+    # e "Thanks to the distribution tools Ren'Py ships with, there are thousands of visual novels available."
+    e "Ren'Py附带的发行工具产生了成千上万的视觉小说。"
+
+# game/tutorial_distribute.rpy:33
+translate schinese distribute_500b3e7f:
+
+    # e "I hope that soon, yours will be one of them!"
+    e "我希望不久，你的游戏也会成为其中一员！"

--- a/tutorial/game/tl/schinese/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/schinese/tutorial_nvlmode.rpy
@@ -1,0 +1,107 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_nvlmode.rpy:17
+translate schinese tutorial_nvlmode_76b2fe88:
+
+    # nvl clear
+    nvl clear
+
+# game/tutorial_nvlmode.rpy:20
+translate schinese tutorial_nvlmode_ac125210:
+
+    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    nvle "NVL风格的游戏用文本覆盖整个界面，而不是将其放在界面底部的窗口中。像这样。"
+
+# game/tutorial_nvlmode.rpy:24
+translate schinese tutorial_nvlmode_e7030787:
+
+    # nvle "To use NVL-mode, you need to define Characters with a kind=nvl."
+    nvle "要使用NVL模式，需要定义带有kind=NVL的角色（Character）。"
+
+# game/tutorial_nvlmode.rpy:28
+translate schinese tutorial_nvlmode_c9a35125:
+
+    # nvle "Then just use that character in a say statement."
+    nvle "然后在say语句中使用那个角色。"
+
+# game/tutorial_nvlmode.rpy:30
+translate schinese tutorial_nvlmode_130610c2:
+
+    # nvl clear
+    # nvle "You use 'nvl clear' to clear the screen when that becomes necessary."
+    nvl clear
+    nvle "必要时，可以使用“nvl clear”来清空界面。"
+
+# game/tutorial_nvlmode.rpy:37
+translate schinese tutorial_nvlmode_390a4eb1:
+
+    # nvle "The 'nvl show' and 'nvl hide' statements use transitions to show and hide the NVL window."
+    nvle "“nvl show”和“nvl hide”语句使用转场来显示和隐藏NVL窗口。"
+
+# game/tutorial_nvlmode.rpy:48
+translate schinese tutorial_nvlmode_05956e33:
+
+    # nvle "NVL-mode also supports showing menus to the player, providing it's the last thing on the screen. Understand?" nointeract
+    nvle "NVL模式还支持向玩家显示菜单，前提是它是界面上的最后一件事。明白吗？" nointeract
+
+# game/tutorial_nvlmode.rpy:54
+translate schinese tutorial_nvlmode_0f2b7d59:
+
+    # nvl clear
+    # nvle "Good!"
+    nvl clear
+    nvle "好！"
+
+# game/tutorial_nvlmode.rpy:60
+translate schinese tutorial_nvlmode_f3a79c09:
+
+    # nvl clear
+    # nvle "Well, hopefully the code below makes it a little more clear."
+    nvl clear
+    nvle "希望下面的代码能让它更清楚一点。"
+
+# game/tutorial_nvlmode.rpy:69
+translate schinese after_nvl_menu_cb560cd2:
+
+    # nvle "Games can mix NVL-mode and the normal ADV-mode by having some characters that have kind=nvl, and some that do not."
+    nvle "游戏可以将NVL模式和普通ADV模式混合使用，通过让一些角色有kind=NVL，而一些没有。"
+
+# game/tutorial_nvlmode.rpy:71
+translate schinese after_nvl_menu_10a6e85a:
+
+    # e "You can specify transitions that occur when going from NVL-mode to ADV-mode."
+    e "您可以指定从NVL模式到ADV模式时发生的转场。"
+
+# game/tutorial_nvlmode.rpy:73
+translate schinese after_nvl_menu_d43b28d1:
+
+    # nvle "As well as when going from ADV-mode to NVL-mode."
+    nvle "以及从ADV模式到NVL模式。"
+
+# game/tutorial_nvlmode.rpy:75
+translate schinese after_nvl_menu_f056c7ad:
+
+    # nvle "Text tags like {{w}{w} work in NVL-mode."
+    nvle "文本标签像{{w}{w}在NVL模式中起作用。"
+
+# game/tutorial_nvlmode.rpy:77
+translate schinese after_nvl_menu_750cd9a1:
+
+    # extend " As does the \"extend\" special character."
+    extend "特殊角色“extend”也有效。"
+
+# game/tutorial_nvlmode.rpy:79
+translate schinese after_nvl_menu_146d840b:
+
+    # nvle "And that's it for NVL-mode."
+    nvle "这就是NVL模式。"
+
+translate schinese strings:
+
+    # game/tutorial_nvlmode.rpy:48
+    old "Yes."
+    new "是。"
+
+    # game/tutorial_nvlmode.rpy:48
+    old "No."
+    new "不。"

--- a/tutorial/game/tl/schinese/tutorial_playing.rpy
+++ b/tutorial/game/tl/schinese/tutorial_playing.rpy
@@ -1,0 +1,193 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_playing.rpy:11
+translate schinese tutorial_playing_2985ab86:
+
+    # e "As someone who has played more than a few visual novels, there are many features that I expect all games to have."
+    e "作为一个玩过不少视觉小说的人，有很多特性我希望所有的游戏都有。"
+
+# game/tutorial_playing.rpy:13
+translate schinese tutorial_playing_ca4769bb:
+
+    # e "Features like saving, loading, changing preferences, and so on."
+    e "像是保存、读取、改变首选项等等。"
+
+# game/tutorial_playing.rpy:15
+translate schinese tutorial_playing_f30f1979:
+
+    # e "One of the nice things about Ren'Py is that the engine provides many of these features for you. You can spend your time creating your game, and let us provide these things."
+    e "Ren'Py的一个优点是引擎为您提供了许多特性。你可以把时间花在创造游戏上，而我们来提供这些东西。"
+
+# game/tutorial_playing.rpy:17
+translate schinese tutorial_playing_afa743e7:
+
+    # e "While you're in the game, you can access the game menu by right clicking or hitting the escape key."
+    e "在游戏中，您可以通过右击或按Esc键来打开游戏菜单。"
+
+# game/tutorial_playing.rpy:19
+translate schinese tutorial_playing_1a6c8296:
+
+    # e "You can also access the game menu through some of the quick menu buttons at the bottom of this screen."
+    e "你也可以通过这个界面底部的一些快速菜单按钮进入游戏菜单。"
+
+# game/tutorial_playing.rpy:25
+translate schinese tutorial_playing_8360224a:
+
+    # e "When you first enter the game menu, you'll see the save screen. Clicking on a numbered slot will save the game."
+    e "当你第一次进入游戏菜单，你会看到保存界面。点击一个编号槽将保存游戏。"
+
+# game/tutorial_playing.rpy:27
+translate schinese tutorial_playing_edea14ff:
+
+    # e "Unlike other engines, Ren'Py doesn't limit the number of save slots that you can use. You can keep hitting next until you reach the page you want."
+    e "与其他引擎不同，Ren'Py不限制你可以使用的保存槽的数量。你可以一直点击“>”，直到抵达你想要的页面。"
+
+# game/tutorial_playing.rpy:29
+translate schinese tutorial_playing_900ce396:
+
+    # e "Clicking on the title of the page allows you to start typing to change the page name."
+    e "单击页面标题允许您开始输入以更改页面名称。"
+
+# game/tutorial_playing.rpy:31
+translate schinese tutorial_playing_fea05c6b:
+
+    # e "The load screen looks quite similar to the save screen, and lets you load a game from a save slot."
+    e "读取界面看起来与保存界面非常相似，允许您从保存槽加载游戏。"
+
+# game/tutorial_playing.rpy:33
+translate schinese tutorial_playing_8e7e83a8:
+
+    # e "It also lets you load one of the auto-saves that Ren'Py makes for you."
+    e "它还允许你加载Ren'Py的自动保存。"
+
+# game/tutorial_playing.rpy:38
+translate schinese tutorial_playing_4b21f071:
+
+    # e "The game menu also has the preferences screen."
+    e "游戏菜单也有首选项界面。"
+
+# game/tutorial_playing.rpy:40
+translate schinese tutorial_playing_eaac8ba9:
+
+    # e "This screen lets you decide how Ren'Py displays, pick what Ren'Py skips, control text speed and auto-click speed, and adjust sound, music, and voice volumes."
+    e "此界面让您决定Ren'Py的显示方式，选择Ren'Py跳过的内容，控制文本速度和自动点击速度，以及调整音效、音乐和语音的音量。"
+
+# game/tutorial_playing.rpy:42
+translate schinese tutorial_playing_b1562a34:
+
+    # e "The game menu also lets you end the game and return to the main menu, or quit Ren'Py entirely."
+    e "游戏菜单还允许您结束游戏并返回主菜单，或者完全退出Ren'Py。"
+
+# game/tutorial_playing.rpy:47
+translate schinese tutorial_playing_790f9dc7:
+
+    # e "While the default game menus look a bit generic, with a little work they can be customized or even entirely replaced, allowing you to create menus as unique as your game."
+    e "虽然默认的游戏菜单看起来有点普通，但是只要稍加修改，就可以定制甚至完全替换它们，这样你就可以创建和你的游戏一样独特的菜单。"
+
+# game/tutorial_playing.rpy:53
+translate schinese tutorial_playing_bc29822e:
+
+    # e "While inside the game, there are a few more things you can do."
+    e "在游戏中，你可以做更多的事情。"
+
+# game/tutorial_playing.rpy:55
+translate schinese tutorial_playing_dc0f9cf7:
+
+    # e "When I'm liking a visual novel, I want to see all the endings. Ren'Py's skip function lets me easily do this, by skipping text that I've already seen."
+    e "当遇到我喜欢的视觉小说，我想看到所有的结局。Ren'Py的skip函数让我可以跳过我已经看过的文本，从而轻松地做到这一点。"
+
+# game/tutorial_playing.rpy:57
+translate schinese tutorial_playing_93f7b8f9:
+
+    # e "I can skip a few lines by holding down Control, or I can toggle skip mode by clicking the skip button at the bottom of the screen."
+    e "我可以按住Ctrl键跳过几行，或者单击界面底部的跳过按钮来切换skip模式。"
+
+# game/tutorial_playing.rpy:59
+translate schinese tutorial_playing_d3553fbe:
+
+    # e "By default, we only skip read text, so this won't do anything the first time through the game."
+    e "默认情况下，我们只跳过阅读文本，所以第一次游戏时不会有任何跳过。"
+
+# game/tutorial_playing.rpy:61
+translate schinese tutorial_playing_fc0cac03:
+
+    # e "Clicking the auto button toggles auto-forward mode, which makes the game advance without you clicking."
+    e "点击自动按钮启动自动前进模式，让游戏在你不点击的情况下自动前进。"
+
+# game/tutorial_playing.rpy:63
+translate schinese tutorial_playing_14e1c854:
+
+    # e "The Q.Save and Q.Load buttons provide a single-click way to make a save, and a fast way to load that save again."
+    e "快速保存和快速读取按钮提供点一下就可以保存，和快速读取那个存档的方式。"
+
+# game/tutorial_playing.rpy:65
+translate schinese tutorial_playing_5d6e4c0f:
+
+    # e "Pressing the 's' key saves a screenshot to disk, so I can upload pictures of the game to websites like {a=https://www.renpy.org}renpy.org{/a}."
+    e "按“S”键会把截图保存到硬盘，这样我就可以把游戏的图片上传到网站，例如 {a=https://www.renpy.org}renpy.org{/a} 。"
+
+# game/tutorial_playing.rpy:67
+translate schinese tutorial_playing_73f3cfec:
+
+    # e "The history button displays a history of read text - but you can also use rollback, which is usually better."
+    e "历史按钮显示已读文本的历史。不过你也可以使用回滚，这通常更好。"
+
+# game/tutorial_playing.rpy:69
+translate schinese tutorial_playing_f065a34c:
+
+    # e "Would you like to hear about rollback?" nointeract
+    e "您想听听回滚（rollback）吗？" nointeract
+
+# game/tutorial_playing.rpy:84
+translate schinese tutorial_rollback_a520091b:
+
+    # e "You can invoke a rollback by clicking the 'Back' button, scrolling the mouse wheel up, or by pushing the page up key. That'll bring you back to the previous screen."
+    e "您可以通过单击“后退”按钮、向上滚动鼠标滚轮或按page up键来调用回滚。这会让你回到之前的界面。"
+
+# game/tutorial_playing.rpy:86
+translate schinese tutorial_rollback_041be71b:
+
+    # e "While at a previous screen, you can roll forward by scrolling the mouse wheel down, or pushing the page down key."
+    e "在前面的界面，您可以通过向下滚动鼠标滚轮或按page down键向后滚动。"
+
+# game/tutorial_playing.rpy:88
+translate schinese tutorial_rollback_4b903465:
+
+    # e "Rolling forward through a menu will make the same choice you did last time. But you don't have to do that - Ren'Py's rollback system allows you to make a different choice."
+    e "通过菜单向前滚动将做出与上次相同的选择。但你不必这么做——Ren'Py的回滚系统允许你做出不同的选择。"
+
+# game/tutorial_playing.rpy:90
+translate schinese tutorial_rollback_a4633f53:
+
+    # e "You can try it by rolling back through the last menu, and saying 'No'."
+    e "你可以试着回到上一个菜单，然后说“不”。"
+
+# game/tutorial_playing.rpy:92
+translate schinese tutorial_rollback_5b73f822:
+
+    # e "Click back a few times, press page up, or scroll up the mouse wheel."
+    e "单击几次后退，按page up，或向上滚动鼠标滚轮。"
+
+# game/tutorial_playing.rpy:96
+translate schinese tutorial_rollback_de0b6f5a:
+
+    # e "Well, are you going to try it?"
+    e "好吧，你要试试吗？"
+
+# game/tutorial_playing.rpy:98
+translate schinese tutorial_rollback_6bbdedaa:
+
+    # e "Your loss."
+    e "你的损失。"
+
+# game/tutorial_playing.rpy:100
+translate schinese tutorial_rollback_dce979d4:
+
+    # e "Moving on."
+    e "继续。"
+
+# game/tutorial_playing.rpy:106
+translate schinese tutorial_rollback_done_6564cd32:
+
+    # e "By allowing Ren'Py to take care of out-of-game issues like loading and saving, you can focus on making your game, while still giving players the experience they've come to expect when playing visual novels."
+    e "让Ren'Py处理游戏外的问题，比如读取和保存，你就可以在专注于制作游戏的同时，保证玩家得到玩视觉小说时所期待的体验。"

--- a/tutorial/game/tl/schinese/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/schinese/tutorial_quickstart.rpy
@@ -1,0 +1,871 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_quickstart.rpy:28
+translate schinese tutorial_create_27048c11:
+
+    # e "When you're ready to use Ren'Py to create your visual novel, the first step is to create a new project."
+    e "当你准备好使用Ren'Py来创建你的视觉小说时，第一步就是创建一个新的工程。"
+
+# game/tutorial_quickstart.rpy:30
+translate schinese tutorial_create_bae6289c:
+
+    # e "You can create a new project by clicking 'Create New Project' on the front screen of the launcher."
+    e "您可以通过单击启动器头版界面上的“创建新工程”来创建新工程。"
+
+# game/tutorial_quickstart.rpy:32
+translate schinese tutorial_create_45915fcb:
+
+    # e "If this is your first time using Ren'Py, it'll ask you for the place you want to keep your projects. The best place is always somewhere that's frequently backed up."
+    e "如果这是你第一次使用Ren'Py，它会询问你保存工程的位置。最好是经常备份的地方。"
+
+# game/tutorial_quickstart.rpy:36
+translate schinese tutorial_create_55e30cb5:
+
+    # e "After that, Ren'Py will ask for a name for your project. You'll have to stick to English letters and numbers, as zip files can't handle anything more than that."
+    e "之后，Ren'Py会问你工程的名称，只能使用英文字母和数字，因为zip文件不能处理更多的东西。"
+
+# game/tutorial_quickstart.rpy:40
+translate schinese tutorial_create_dea3e5c2:
+
+    # e "The next thing Ren'Py will ask for is the resolution the visual novel will run at. This controls how large or small you'll have to make your game's artwork."
+    e "接下来Ren'Py会询问视觉小说的分辨率。这将控制你的游戏艺术作品的大小。"
+
+# game/tutorial_quickstart.rpy:44
+translate schinese tutorial_create_3289ea75:
+
+    # e "Finally, Ren'Py will ask you to select a color scheme. You can change this after the game has been created, so just pick a color that's pleasing."
+    e "最后，Ren'Py会要求你选择一个配色方案。你可以在游戏创建后改变这个，所以只需选择一个令人愉悦的颜色。"
+
+# game/tutorial_quickstart.rpy:48
+translate schinese tutorial_create_6b9e3b96:
+
+    # e "Once that's done, Ren'Py will work for a bit and return you to the main menu with the new project selected. Now, when you click Launch, Ren'Py will start your new game."
+    e "完成后，Ren'Py将工作一段时间，并返回到主菜单，选择新工程。现在，当你点击启动工程时，Ren'Py将开始你的新游戏。"
+
+# game/tutorial_quickstart.rpy:50
+translate schinese tutorial_create_bdf94f9b:
+
+    # e "To get back here, you can choose 'Tutorial' to switch to this tutorial game."
+    e "要回到这里，你可以选择“教程”切换到这个教程游戏。"
+
+# game/tutorial_quickstart.rpy:52
+translate schinese tutorial_create_22f516df:
+
+    # e "You'll also need to edit the games script to make changes. To do that, click 'script.rpy' on the front page of the launcher."
+    e "您还需要编辑游戏脚本来进行更改。要执行此操作，请单击启动器头版上的“script.rpy”。"
+
+# game/tutorial_quickstart.rpy:54
+translate schinese tutorial_create_18cd1d9d:
+
+    # e "If it's your first time doing so, Ren'Py will ask you to select a text editor. Editra might be a safe choice, but read the descriptions to be sure."
+    e "如果这是你第一次这么做，Ren'Py会要求你选择一个文本编辑器。Editra可能是一个安全的选择，但请阅读说明以确定。"
+
+# game/tutorial_quickstart.rpy:56
+translate schinese tutorial_create_bfbd6220:
+
+    # e "After the text editor is downloaded, the script will open up and you can start to change what characters are saying."
+    e "文本编辑器下载完成后，脚本将打开，您可以开始更改角色所说的内容。"
+
+# game/tutorial_quickstart.rpy:69
+translate schinese tutorial_dialogue_112ff505:
+
+    # e "Probably the most common thing a creator does with Ren'Py is to write dialogue for the player to read."
+    e "也许一个创作者最常用Ren'Py做的事情就是编写对话供玩家阅读。"
+
+# game/tutorial_quickstart.rpy:71
+translate schinese tutorial_dialogue_be2be31a:
+
+    # e "But before I can show you how to write dialogue, let me show you how we present script examples."
+    e "但是在我教你如何写对话之前，让我先给你演示一下我们如何呈现脚本示例。"
+
+# game/tutorial_quickstart.rpy:74
+translate schinese tutorial_dialogue_7b6be28e:
+
+    # "Eileen" "Examples will show up in a window like the one above. You'll need to click outside of the example window in order to advance the tutorial."
+    "艾琳" "示例将显示在像上面这样的窗口中。您需要在示例窗口外单击，才能继续本教程。"
+
+# game/tutorial_quickstart.rpy:76
+translate schinese tutorial_dialogue_5269d005:
+
+    # "Eileen" "When an example is bigger than the screen, you can scroll around in it using the mouse wheel or by simply dragging the mouse."
+    "艾琳" "当一个示例比界面大时，你可以用鼠标滚轮或简单地拖动鼠标。"
+
+# game/tutorial_quickstart.rpy:78
+translate schinese tutorial_dialogue_241c0c74:
+
+    # "Eileen" "Script might seem scary at first, but if you look you'll see it's easy to match it up to what I'm saying."
+    "艾琳" "脚本一开始可能看起来很吓人，但如果你仔细看，你会发现它很容易与我说的相对应。"
+
+# game/tutorial_quickstart.rpy:82
+translate schinese tutorial_dialogue_f0d66410:
+
+    # e "Let's see the simplest possible Ren'Py game."
+    e "让我们看看可能是最简单的Ren'Py游戏。"
+
+# game/tutorial_quickstart.rpy:89
+translate schinese tutorial_dialogue_3e6b0068:
+
+    # "Wow, It's really really dark in here."
+    "哇，这里真的很黑。"
+
+# game/tutorial_quickstart.rpy:91
+translate schinese tutorial_dialogue_5072a404:
+
+    # "Lucy" "Better watch out. You don't want to be eaten by a Grue."
+    "露西" "最好小心点。你不想被咕噜吃掉（译者注：源于Zork，最早的互动式小说游戏之一）。"
+
+# game/tutorial_quickstart.rpy:99
+translate schinese tutorial_dialogue_d39d1b2b:
+
+    # e "I'll show you the script of that example."
+    e "我将向您展示该示例的脚本。"
+
+# game/tutorial_quickstart.rpy:101
+translate schinese tutorial_dialogue_f51ecf1f:
+
+    # e "This script demonstrates two kinds of Ren'Py statements, labels and say statements."
+    e "这个脚本演示了两种Ren'Py语句，label和say。"
+
+# game/tutorial_quickstart.rpy:103
+translate schinese tutorial_dialogue_bc7ec147:
+
+    # e "The first line is a label statement. The label statement is used to give a name to a place in the program."
+    e "第一行是标签（label）语句。label语句用于为程序中的某个位置指定名称。"
+
+# game/tutorial_quickstart.rpy:105
+translate schinese tutorial_dialogue_b20db833:
+
+    # e "In this case, we're naming a place \"start\". The start label is special, as it marks the place a game begins running."
+    e "在本例中，我们将一个地方命名为“start”。start标签很特别，因为它标志着游戏开始运行的地方。"
+
+# game/tutorial_quickstart.rpy:107
+translate schinese tutorial_dialogue_b0afbe96:
+
+    # e "The next line is a simple say statement. It consists of a string beginning with a double-quote, and ending at the next double-quote."
+    e "下一行是一个简单的say语句。它由一个以双引号开头、在下一个双引号结束的字符串组成。"
+
+# game/tutorial_quickstart.rpy:109
+translate schinese tutorial_dialogue_628c9e4c:
+
+    # e "Special characters in strings can be escaped with a backslash. To include \" in a string, we have to write \\\"."
+    e "字符串中的特殊字符可以用反斜杠转义。要在字符串中包含\"，我们必须写\\\"。"
+
+# game/tutorial_quickstart.rpy:116
+translate schinese tutorial_dialogue_3e6b0068_1:
+
+    # "Wow, It's really really dark in here."
+    "哇，这里真的很黑。"
+
+# game/tutorial_quickstart.rpy:125
+translate schinese tutorial_dialogue_d7f0b5b7:
+
+    # e "When Ren'Py sees a single string on a line by itself, it uses the narrator to say that string. So a single string can be used to express a character's thoughts."
+    e "当Ren'Py在一行中看到一个单独的字符串时，它使用旁白来说出该字符串。所以单个字符串可以用来表达一个角色的思想。"
+
+# game/tutorial_quickstart.rpy:131
+translate schinese tutorial_dialogue_5072a404_1:
+
+    # "Lucy" "Better watch out. You don't want to be eaten by a Grue."
+    "露西" "最好小心点。你不想被咕噜吃掉（译者注：源于Zork，最早的互动式小说游戏之一）。"
+
+# game/tutorial_quickstart.rpy:139
+translate schinese tutorial_dialogue_9dd2d543:
+
+    # e "When we have two strings separated by a space, the first is used as the character's name, and the second is what the character is saying."
+    e "当我们有两个字符串、由空格隔开时，第一个字符串用作角色的名称，第二个字符串是角色说的内容。"
+
+# game/tutorial_quickstart.rpy:141
+translate schinese tutorial_dialogue_64ffe685:
+
+    # e "This two-argument form of the say statement is used for dialogue, where a character is speaking out loud."
+    e "say语句的这种双参数形式用于对话，即角色大声说出来。"
+
+# game/tutorial_quickstart.rpy:143
+translate schinese tutorial_dialogue_97a33275:
+
+    # e "If you'd like, you can run this game yourself by erasing everything in your project's script.rpy file, and replacing it with the code in the box above."
+    e "如果你愿意的话，你可以通过删除工程的script.rpy文件中的所有内容，替换为上面框里的代码，然后运行这个游戏。"
+
+# game/tutorial_quickstart.rpy:145
+translate schinese tutorial_dialogue_c5e70d7e:
+
+    # e "Be sure to preserve the spacing before lines. That's known as indentation, and it's used to help Ren'Py group lines of script into blocks."
+    e "一定要保留行前空间。这就是所谓的缩进，用于帮助Ren'Py将脚本行组成块。"
+
+# game/tutorial_quickstart.rpy:149
+translate schinese tutorial_dialogue_90719f73:
+
+    # e "Using a string for a character's name is inconvenient, for two reasons."
+    e "使用字符串作为角色名是不方便的，有两个原因。"
+
+# game/tutorial_quickstart.rpy:151
+translate schinese tutorial_dialogue_910f286a:
+
+    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    e "首先是有点冗长。虽然输入“露西”不是很糟糕，但是想象一下，如果你不得不输入数千次“艾琳·理查森”。"
+
+# game/tutorial_quickstart.rpy:153
+translate schinese tutorial_dialogue_9c9d59c2:
+
+    # e "The second is that it doesn't leave any place to put styling, which can change the look of a character."
+    e "第二，它没有留下任何地方来放置样式，样式可以改变角色的外观。"
+
+# game/tutorial_quickstart.rpy:155
+translate schinese tutorial_dialogue_2a2d1e51:
+
+    # e "To solve these problems, Ren'Py lets you define Characters."
+    e "为了解决这些问题，Ren'Py允许您定义角色（Character）。"
+
+# game/tutorial_quickstart.rpy:159
+translate schinese tutorial_dialogue_16e8c5fd:
+
+    # e "Here's an example Character definition. It begins with the word \"define\". That tells Ren'Py that we are defining something."
+    e "下面是一个Character定义的示例。它以单词“define”开头。这告诉Ren'Py我们正在定义一些东西。"
+
+# game/tutorial_quickstart.rpy:161
+translate schinese tutorial_dialogue_34fe5aa0:
+
+    # e "Define is followed by a short name for the character, like \"l\". We'll be able to use that short name when writing dialogue."
+    e "define后面跟角色的简称，如“l”。我们在写对话的时候可以用这个简称。"
+
+# game/tutorial_quickstart.rpy:163
+translate schinese tutorial_dialogue_67f90201:
+
+    # e "This is followed by an equals sign, and the thing that we're defining. In this case, it's a Character."
+    e "后面跟着一个等号，还有我们要定义的东西。在这种情况下，它是Character。"
+
+# game/tutorial_quickstart.rpy:165
+translate schinese tutorial_dialogue_4e454a89:
+
+    # e "On the first line, the character's name is given to be \"Lucy\", and her name will be drawn a reddish color."
+    e "在第一行，角色的名字被指定为“露西”，她的名字将被画成红色。"
+
+# game/tutorial_quickstart.rpy:167
+translate schinese tutorial_dialogue_db11f026:
+
+    # e "These short names are case-sensitive. Capital L is a different name from lower-case l, so you'll need to be careful about that."
+    e "这些简称区分大小写。大写字母L与小写字母l不同，你需要注意。"
+
+# game/tutorial_quickstart.rpy:171
+translate schinese tutorial_dialogue_1d161320:
+
+    # e "Now that we have a character defined, we can use it to say dialogue."
+    e "既然我们已经定义了一个角色，我们就可以用它进行对话。"
+
+# game/tutorial_quickstart.rpy:178
+translate schinese tutorial_dialogue_3710169c:
+
+    # l "Why are you trying to put words into my mouth? And who are you calling \"it\"?"
+    l "为什么你把话放到我的嘴里？你说的“它”是谁？"
+
+# game/tutorial_quickstart.rpy:180
+translate schinese tutorial_dialogue_6d463776:
+
+    # l "What's more, what are you going to do about the Grue problem? Are you just going to leave me here?"
+    l "还有，你打算怎么解决咕噜问题？你要把我留在这里吗？"
+
+# game/tutorial_quickstart.rpy:188
+translate schinese tutorial_dialogue_023bcd31:
+
+    # e "Here's the full game, including the two new lines of dialogue, both of which use the Character we defined to say dialogue."
+    e "这是完整的游戏，包括两个新行新的对话，它们都使用我们定义的Character来进行对话。"
+
+# game/tutorial_quickstart.rpy:190
+translate schinese tutorial_dialogue_48bb9547:
+
+    # e "The one-argument form of the say statement is unchanged, but in the two-argument form, instead of the first string we can use a short name."
+    e "say语句的单参数形式不变，但在双参数形式中，我们可以使用一个简称来代替第一个字符串。"
+
+# game/tutorial_quickstart.rpy:192
+translate schinese tutorial_dialogue_56a9936f:
+
+    # e "When this say statement is run, Ren'Py will look up the short name, which is really a Python variable. It will then use the associated Character to show the dialogue."
+    e "运行say语句时，Ren'Py将查找简称，它实际上是一个Python变量。然后它将使用关联的Character来显示对话。"
+
+# game/tutorial_quickstart.rpy:194
+translate schinese tutorial_dialogue_d5984a21:
+
+    # e "The Character object controls who is speaking, the color of their name, and many other properties of the dialogue."
+    e "Character对象控制说话者、他们姓名的颜色以及对话的许多其他属性。"
+
+# game/tutorial_quickstart.rpy:198
+translate schinese tutorial_dialogue_a5bcac8b:
+
+    # e "Since the bulk of a visual novel is dialogue, we've tried to make it as easy to write as possible."
+    e "因为视觉小说的主体是对话，所以我们尽量让它更容易写。"
+
+# game/tutorial_quickstart.rpy:200
+translate schinese tutorial_dialogue_6b9a42d0:
+
+    # e "Hopefully, by allowing the use of short names for characters, we've succeeded."
+    e "希望通过允许角色使用简称，我们已经成功了。"
+
+# game/tutorial_quickstart.rpy:206
+translate schinese tutorial_images_e09ac970:
+
+    # e "A visual novel isn't much without images. So let's add some images to our little game."
+    e "没有图像的视觉小说不多。所以让我们在我们的小游戏中添加一些图片。"
+
+# game/tutorial_quickstart.rpy:208
+translate schinese tutorial_images_40140793:
+
+    # e "Before we can show images, we must first choose image names, then place the image files into the images directory."
+    e "在显示图像之前，必须先选择图像名，然后将图像文件放入 images 目录。"
+
+# game/tutorial_quickstart.rpy:210
+translate schinese tutorial_images_d73388f8:
+
+    # e "An image name is something like 'bg cave' or 'lucy happy', with one or more parts separated by spaces."
+    e "图像名是“bg cave”或“lucy happy”之类，其中一个或多个部分用空格隔开。"
+
+# game/tutorial_quickstart.rpy:212
+translate schinese tutorial_images_2d5596d4:
+
+    # e "Each part should start with a lower-case letter, and then contain lower-case letters, numbers, and underscores."
+    e "每个部分应该以小写字母开头，后面包含小写字母、数字和下划线。"
+
+# game/tutorial_quickstart.rpy:214
+translate schinese tutorial_images_e02c0c82:
+
+    # e "The first part of an image is called the tag. For 'bg cave' the tag is 'bg', while for 'lucy happy' the tag is 'lucy'."
+    e "图像的第一部分叫做标签。“bg cave”的标签是“bg”，而“lucy happy”的标签是“lucy”。"
+
+# game/tutorial_quickstart.rpy:216
+translate schinese tutorial_images_d5eafcf2:
+
+    # e "You can open the images directory by clicking the appropriate button in the Ren'Py launcher."
+    e "您可以通过单击Ren'Py启动器中的相应按钮打开 images 目录。"
+
+# game/tutorial_quickstart.rpy:218
+translate schinese tutorial_images_e4b12fb6:
+
+    # e "The files in the images directory should have the same name as the image, followed by an extension like .jpg, .png, or .webp."
+    e "images 目录中的文件应该与图像同名，后面跟一个扩展名，比如 .jpg 、 .png 或 .webp 。"
+
+# game/tutorial_quickstart.rpy:220
+translate schinese tutorial_images_a3bd89b2:
+
+    # e "Our example uses 'bg cave.jpg', 'lucy happy.png', and 'lucy mad.png'."
+    e "我们的示例使用“bg cave.jpg”、“lucy happy.png”和“lucy mad.png”。"
+
+# game/tutorial_quickstart.rpy:224
+translate schinese tutorial_images_76b954de:
+
+    # e "Let's see what those look like in the game."
+    e "让我们看看这些在游戏中是什么样子。"
+
+# game/tutorial_quickstart.rpy:230
+translate schinese tutorial_images_f04e72ea:
+
+    # l "Now that the lights are on, we don't have to worry about Grues anymore."
+    l "现在亮堂了，我们再也不用担心咕噜了。"
+
+# game/tutorial_quickstart.rpy:234
+translate schinese tutorial_images_d77ffa1c:
+
+    # l "But what's the deal with me being in a cave? Eileen gets to be out in the sun, and I'm stuck here!"
+    l "但是为什么我在山洞里？艾琳在外面晒太阳，而我被困在这里了！"
+
+# game/tutorial_quickstart.rpy:242
+translate schinese tutorial_images_6c0c938b:
+
+    # e "Here's the script for that scene. Notice how it includes two new statements, the scene and show statement."
+    e "这是那个场景的脚本。请注意它包含的两个新语句：scene和show。"
+
+# game/tutorial_quickstart.rpy:244
+translate schinese tutorial_images_1a4660b9:
+
+    # e "The scene statement clears the screen, and then adds a background image."
+    e "scene语句清空界面，然后添加背景图像。"
+
+# game/tutorial_quickstart.rpy:246
+translate schinese tutorial_images_672c8cb8:
+
+    # e "The show statement adds a background image on top of all the other images on the screen."
+    e "show语句在界面上的所有其他图像顶层添加背景图像。"
+
+# game/tutorial_quickstart.rpy:248
+translate schinese tutorial_images_2fc7baee:
+
+    # e "If there was already an image with the same tag, the new image is used to replace the old one."
+    e "如果已经有标签相同的图像，则新图像将替换旧图像。"
+
+# game/tutorial_quickstart.rpy:250
+translate schinese tutorial_images_802825f2:
+
+    # e "Changes to the list of shown images take place instantly, so in the example, the user won't see the background by itself."
+    e "对所显示图像列表的更改会立即发生，因此在本例中，用户不会自己看到背景。"
+
+# game/tutorial_quickstart.rpy:252
+translate schinese tutorial_images_b246dfdd:
+
+    # e "The second show statement has an at clause, which gives a location on the screen. Common locations are left, right, and center, but you can define many more."
+    e "第二个show语句有一个at从句，它给出了界面上的位置。常见的位置有左（left）、右（right）和中（center），但您可以定义更多。"
+
+# game/tutorial_quickstart.rpy:257
+translate schinese tutorial_images_82fceeb8:
+
+    # e "In this example, we show an image named logo base, and we show it at a creator-defined position, rightish."
+    e "在这个例子中，我们展示了一个名为logo base的图像，并将其显示在创建者定义的位置rightish。"
+
+# game/tutorial_quickstart.rpy:259
+translate schinese tutorial_images_9defda43:
+
+    # e "We also specify that it should be shown behind another image, in this case eileen. That's me."
+    e "我们也指定它位于另一个图像后面（behind），本例中是eileen，也就是我。"
+
+# game/tutorial_quickstart.rpy:264
+translate schinese tutorial_images_73d331f7:
+
+    # e "Finally, there's the hide statement, which hides the image with the given tag."
+    e "最后，还有hide语句，它隐藏带有给定标签的图像。"
+
+# game/tutorial_quickstart.rpy:266
+translate schinese tutorial_images_f34f62d5:
+
+    # e "Since the show statement replaces an image, and the scene statement clears the scene, it's pretty rare to hide an image."
+    e "由于show语句替换图像，而scene语句则清空场景，所以很少隐藏图像。"
+
+# game/tutorial_quickstart.rpy:268
+translate schinese tutorial_images_e06fa53a:
+
+    # e "The main use is for when a character or prop leaves before the scene is over."
+    e "主要用于角色或道具在场景结束前离开。"
+
+# game/tutorial_quickstart.rpy:282
+translate schinese tutorial_simple_positions_b492e793:
+
+    # e "When the standard positions that come with Ren'Py aren't enough for you, you can create your own. Here, I'll show you the easy way to do it."
+    e "当Ren'Py提供的标准位置对你来说还不够时，你可以创建自己的位置。这里，我会告诉你如何简单地做到。"
+
+# game/tutorial_quickstart.rpy:291
+translate schinese tutorial_simple_positions_04e3bc44:
+
+    # e "The first way to do it is to show an image followed by a colon. Then indented on the next couple of lines are the xalign and yalign transform properties."
+    e "第一种方法是在显示图像后面加上英文冒号。后面缩进的几行是xalign和yalign变换属性。"
+
+# game/tutorial_quickstart.rpy:293
+translate schinese tutorial_simple_positions_3ecad5f8:
+
+    # e "Each of the transform properties is a name followed by a value. For xalign and yalign, the values are numbers."
+    e "每个变换属性都是一个名称后跟一个值。对于xalign和yalign，值是数字。"
+
+# game/tutorial_quickstart.rpy:295
+translate schinese tutorial_simple_positions_61c1b124:
+
+    # e "The xalign transform property is the important one, as it controls where the image is placed horizontally on the screen."
+    e "xalign变换属性非常重要，因为它控制图像在界面上水平放置的位置。"
+
+# game/tutorial_quickstart.rpy:305
+translate schinese tutorial_simple_positions_67ebea97:
+
+    # e "An xalign of 0.0 is the left side."
+    e "xalign为0.0在左侧。"
+
+# game/tutorial_quickstart.rpy:315
+translate schinese tutorial_simple_positions_bd4f56d8:
+
+    # e "0.5 is the center."
+    e "0.5在中间"
+
+# game/tutorial_quickstart.rpy:324
+translate schinese tutorial_simple_positions_fb2c48f2:
+
+    # e "And 1.0 is the right. The decimal place is important and has to be there. Just 1 by itself won't work the same."
+    e "1.0在右侧。小数位很重要，必须在那里。只有1本身效果就不一样了。"
+
+# game/tutorial_quickstart.rpy:333
+translate schinese tutorial_simple_positions_8eebc9a7:
+
+    # e "Of course, you can pick any position in between."
+    e "当然，你可以选择两者之间的任意位置。"
+
+# game/tutorial_quickstart.rpy:335
+translate schinese tutorial_simple_positions_4cd917f6:
+
+    # e "The yalign property is the same way, with 0.0 being the top of the screen and 1.0 being the bottom. Since most sprites stick to the bottom, it's almost always 1.0."
+    e "yalign属性也是这样，0.0是界面的顶部，1.0是底部。因为大多数精灵都在底部，所以它几乎总是1.0。"
+
+# game/tutorial_quickstart.rpy:341
+translate schinese tutorial_simple_positions_fbd1a3eb:
+
+    # e "While being able to write positions like this is useful, having to repeatedly do so isn't. So Ren'Py lets you define a transform once, and reuse it."
+    e "虽然能够这样写位置是有用的，但是必须重复这样做就不是了，所以Ren'Py允许你定义变换，然后重复使用它。"
+
+# game/tutorial_quickstart.rpy:345
+translate schinese tutorial_simple_positions_2377e3b3:
+
+    # e "Usually transforms are defined at the top of a file, right after the characters. But it doesn't matter to Ren'Py where you define them."
+    e "通常，变换定义在文件的开头，角色之后。但对Ren'Py来说，你在哪里定义它们并不重要。"
+
+# game/tutorial_quickstart.rpy:347
+translate schinese tutorial_simple_positions_3ce7e367:
+
+    # e "The transform is given a name, slightleft, and then the xalign and yalign properties."
+    e "这个变换被命名为slimleft，加上xalign和yalign属性。"
+
+# game/tutorial_quickstart.rpy:355
+translate schinese tutorial_simple_positions_82d640d9:
+
+    # e "Once a transform has been defined, you can use it in the at clause of the show statement."
+    e "一旦变换被定义，就可以在show语句的at从句中使用它。"
+
+# game/tutorial_quickstart.rpy:360
+translate schinese tutorial_simple_positions_16b66785:
+
+    # e "Transforms are sticky. If you replace an image without using a transform, Ren'Py will keep the same transforms it had been using."
+    e "变换有粘性。如果在不使用变换的情况下替换图像，Ren'Py将保持它一直使用的变换。"
+
+# game/tutorial_quickstart.rpy:364
+translate schinese tutorial_simple_positions_5d5e0cfd:
+
+    # e "Of course, there's a lot more to transforms than this. If you want to learn more, you can read the sections on Position Properties, Transforms and Animation, and Transform Properties."
+    e "当然，还有比这多得多的变换。想更多信息，你可以阅读有关位置属性、变换和动画以及变换属性的部分。"
+
+# game/tutorial_quickstart.rpy:366
+translate schinese tutorial_simple_positions_e65da9bf:
+
+    # e "But for many visual novels, xalign and yalign are the only properties that matter."
+    e "但是对于许多视觉小说来说，xalign和yallign是唯一重要的属性。"
+
+# game/tutorial_quickstart.rpy:381
+translate schinese tutorial_transitions_9b8c714c:
+
+    # e "It can be somewhat jarring for the game to jump from place to place."
+    e "游戏从一个地方跳到另一个地方可能令人烦躁。"
+
+# game/tutorial_quickstart.rpy:388
+translate schinese tutorial_transitions_3e290ea8:
+
+    # e "To help take some of edge off a change in scene, Ren'Py supports the use of transitions. Let's try that scene change again, but this time we'll use transitions."
+    e "为了帮助消除场景变化中的一些边缘，Ren'Py支持使用转场。让我们再次尝试改变场景，但这次我们将使用转场。"
+
+# game/tutorial_quickstart.rpy:402
+translate schinese tutorial_transitions_9c0a86c4:
+
+    # e "That's much smoother. Here's some example code showing how we include transitions in our game."
+    e "丝滑多了。下面是一些示例代码，演示如何在游戏中加入转场。"
+
+# game/tutorial_quickstart.rpy:404
+translate schinese tutorial_transitions_3e490d40:
+
+    # e "It uses the with statement. The with statement causes the scene to transition from the last things shown to the things currently being shown."
+    e "使用with语句。with语句使场景从之前显示的内容过渡到当前显示的内容。"
+
+# game/tutorial_quickstart.rpy:406
+translate schinese tutorial_transitions_a43847df:
+
+    # e "It takes a transition as an argument. In this case, we're using the Dissolve transition. This transition takes as an argument the amount of time the dissolve should take."
+    e "with使用转场作为参数。本例中，我们用Dissolve转场。这个转场使用溶解需要的时长作为参数。"
+
+# game/tutorial_quickstart.rpy:408
+translate schinese tutorial_transitions_6fcee414:
+
+    # e "In this case, each transition takes half a second."
+    e "本例中，每次转场需要半秒钟。"
+
+# game/tutorial_quickstart.rpy:412
+translate schinese tutorial_transitions_033042cc:
+
+    # e "We can define a short name for a transition, using the define statement. Here, we're defining slowdissolve to be a dissolve that takes a whole second."
+    e "我们可以使用define语句为转场定义简称。这里，我们将slowdissolve定义为需要一整秒的溶解。"
+
+# game/tutorial_quickstart.rpy:427
+translate schinese tutorial_transitions_0ba82f00:
+
+    # e "Once a transition has been given a short name, we can use it in our game."
+    e "一旦一个转场被赋予了一个简称，我们就可以在我们的游戏中使用它。"
+
+# game/tutorial_quickstart.rpy:431
+translate schinese tutorial_transitions_51ff9600:
+
+    # e "Ren'Py defines some transitions for you, like dissolve, fade, and move. For more complex or customized transitions, you'll have to define your own."
+    e "Ren'Py为您定义了一些转场，如溶解（dissolve）、淡出淡入（fade）和移动（move）。更复杂或定制的转换，您必须自己定义。"
+
+# game/tutorial_quickstart.rpy:433
+translate schinese tutorial_transitions_1528f73f:
+
+    # e "If you're interested, check out the Transitions Gallery section of this tutorial."
+    e "如果您感兴趣，请查看本教程的转场画廊部分。"
+
+# game/tutorial_quickstart.rpy:439
+translate schinese tutorial_music_8b92efb7:
+
+    # e "Another important part of a visual novel or simulation game is the soundtrack."
+    e "视觉小说或模拟游戏的另一个重要部分是配音。"
+
+# game/tutorial_quickstart.rpy:441
+translate schinese tutorial_music_53910317:
+
+    # e "Ren'Py breaks sound up into channels. The channel a sound is played on determines if the sound loops, and if it is saved and restored with the game."
+    e "Ren'Py把声音分到不同频道。播放声音的频道决定声音是否循环，以及是否在游戏中保存和恢复。"
+
+# game/tutorial_quickstart.rpy:443
+translate schinese tutorial_music_a1e37712:
+
+    # e "When a sound is played on the music channel, it is looped, and it is saved when the game is saved."
+    e "当一个声音在音乐（music）频道上播放时，它会循环播放，当游戏被保存时，它就会被保存。"
+
+# game/tutorial_quickstart.rpy:445
+translate schinese tutorial_music_d9086d22:
+
+    # e "When the channel named sound is used, the sound is played once and then stopped. It isn't saved."
+    e "当使用音效（sound）频道时，声音播放一次，然后停止播放。它没有被保存。"
+
+# game/tutorial_quickstart.rpy:447
+translate schinese tutorial_music_3555b640:
+
+    # e "The sounds themselves are stored in audio files. Ren'Py supports the Opus, Ogg Vorbis, and mp3 formats."
+    e "声音本身存储在音频文件中。Ren'Py支持Opus、Ogg Vorbis和mp3格式。"
+
+# game/tutorial_quickstart.rpy:449
+translate schinese tutorial_music_a2ffbe9b:
+
+    # e "Let's check out some of the commands that can affect the music channel."
+    e "让我们来看看影响音乐频道的一些命令。"
+
+# game/tutorial_quickstart.rpy:454
+translate schinese tutorial_music_8b606a55:
+
+    # e "The play music command replaces the currently playing music, and replaces it with the named filename."
+    e "play music命令将当前正在播放的音乐替换为命名的文件名。"
+
+# game/tutorial_quickstart.rpy:456
+translate schinese tutorial_music_18650fe7:
+
+    # e "If you specify the currently-playing song, it will restart it."
+    e "如果指定当前正在播放的歌曲，它会从头播放。"
+
+# game/tutorial_quickstart.rpy:458
+translate schinese tutorial_music_413d91fc:
+
+    # e "If the optional fadeout clause is given, it will fade out the currently playing music before starting the new music."
+    e "如果给出了可选的fadeout从句，它将在开始新音乐之前使当前正在播放的音乐淡出。"
+
+# game/tutorial_quickstart.rpy:463
+translate schinese tutorial_music_a282a0e3:
+
+    # e "The queue statement also adds music to the named channel, but it waits until the currently-playing song is finished before playing the new music."
+    e "queue语句将音乐添加到命名频道，但等到当前歌曲播放完之后才播放新音乐。"
+
+# game/tutorial_quickstart.rpy:468
+translate schinese tutorial_music_01ca6bad:
+
+    # e "The third statement is the stop statement. It stops the music playing on a channel. It too takes the fadeout clause."
+    e "第三个是stop语句。停止频道里播放的音乐，也接受fadeout从句。"
+
+# game/tutorial_quickstart.rpy:473
+translate schinese tutorial_music_384937da:
+
+    # e "Unlike the music channel, playing a sound on the sound channel causes it to play only once."
+    e "与音乐频道不同，在音效频道上播放的声音只播放一次。"
+
+# game/tutorial_quickstart.rpy:480
+translate schinese tutorial_music_1d3e9fd2:
+
+    # e "You can queue up multiple sounds on the sound channel, but the sounds will only play one at a time."
+    e "您可以在音效频道上对多个声音进行排队，但一次只能播放一个声音。"
+
+# game/tutorial_quickstart.rpy:486
+translate schinese tutorial_music_aa01c19d:
+
+    # e "Ren'Py has separate mixers for sound, music, and voices, so the player can adjust them as they like."
+    e "Ren'Py有单独的混音器，用于音效、音乐和语音，因此玩家可以根据需要进行调节。"
+
+# game/tutorial_quickstart.rpy:492
+translate schinese tutorial_menus_0426904b:
+
+    # e "Many visual novels require the player to make choices from in-game menus. These choices can add some challenge to the game, or adjust it to the player's preferences."
+    e "许多视觉小说要求玩家在游戏菜单中做出选择。这些选择可以给游戏增加一些挑战，或者根据玩家的喜好进行调整。"
+
+# game/tutorial_quickstart.rpy:494
+translate schinese tutorial_menus_431eeff0:
+
+    # e "Do you like to play visual novels with choices in them?"
+    e "你喜欢玩有选项的视觉小说吗？"
+
+# game/tutorial_quickstart.rpy:509
+translate schinese choice1_yes_f6d95df8:
+
+    # e "While creating a multi-path visual novel can be a bit more work, it can yield a unique experience."
+    e "虽然创作一部多路线的视觉小说可能需要更多的工作，但它可以产生一种独特的体验。"
+
+# game/tutorial_quickstart.rpy:517
+translate schinese choice1_no_72958b50:
+
+    # e "Games without menus are called kinetic novels, and there are dozens of them available to play."
+    e "没有菜单的游戏被称为动态小说，有几十种可以玩。"
+
+# game/tutorial_quickstart.rpy:528
+translate schinese choice1_done_acba9504:
+
+    # e "Here, you can see the code for that menu. If you scroll down, you can see the code we run after the menu."
+    e "这里，你可以看到那个菜单的代码。如果向下翻，你可以看到菜单之后运行的代码。"
+
+# game/tutorial_quickstart.rpy:530
+translate schinese choice1_done_f9fa6889:
+
+    # e "Menus are introduced by the menu statement. The menu statement takes an indented block, in which there can be one line of dialogue and multiple choices."
+    e "菜单由menu语句引入。menu语句使用缩进块，其中可以有一行对话和多个选择。"
+
+# game/tutorial_quickstart.rpy:532
+translate schinese choice1_done_ebb2db38:
+
+    # e "Each choice must end with a colon, as each choice has its own block of Ren'Py code, that is run when that choice is selected."
+    e "每个选项必须以冒号结尾，因为每个选项都有自己的Ren'Py代码块，在选中该项时运行。"
+
+# game/tutorial_quickstart.rpy:534
+translate schinese choice1_done_59cac95d:
+
+    # e "Here, each block jumps to a label. While you could put small amounts of Ren'Py code inside a menu label, it's probably good practice to usually jump to a bigger block of code."
+    e "这里，每个块跳转到一个标签。虽然可以在菜单标签中放入少量的Ren'Py代码，但通常跳转到更大的代码块可能是一个好的做法。"
+
+# game/tutorial_quickstart.rpy:536
+translate schinese choice1_done_2851a313:
+
+    # e "Scrolling down past the menu, you can see the labels that the menu jumps to. There are three labels here, named choice1_yes, choice1_no, and choice1_done."
+    e "向下翻过菜单，可以看到菜单跳转到的标签。这里有三个标签，名为choice1_yes、choice1_no和choice1_done。"
+
+# game/tutorial_quickstart.rpy:538
+translate schinese choice1_done_ff761b03:
+
+    # e "When the first menu choice is picked, we jump to the choice1_yes, which runs two lines of script before jumping to choice1_done."
+    e "当第一个菜单选项被选中时，我们跳转到choice1_yes，它在跳到choice1_done之前运行两行脚本。"
+
+# game/tutorial_quickstart.rpy:540
+translate schinese choice1_done_664fe702:
+
+    # e "Similarly, picking the second choice jumps us to choice1_no, which also runs two lines of script."
+    e "类似的，选择第二个选项会跳转到choice1_no，它也运行两行脚本。"
+
+# game/tutorial_quickstart.rpy:542
+translate schinese choice1_done_31d12b1e:
+
+    # e "The lines beginning with the dollar sign are lines of python code, which are used to set a flag based on the user's choice."
+    e "以美元符号开头的行是python代码行，用于根据用户的选择设置标识（flag）。"
+
+# game/tutorial_quickstart.rpy:544
+translate schinese choice1_done_88398d3e:
+
+    # e "The flag is named menu_flag, and it's set to True or False based on the user's choice. The if statement can be used to test a flag, so the game can remember the user's choices."
+    e "该标识名为menu_flag，根据用户的选择将其设置为True或False。if语句可用于测试标识，这样游戏可以记住用户的选择。"
+
+# game/tutorial_quickstart.rpy:549
+translate schinese choice1_done_2828dbfc:
+
+    # e "For example, I remember that you plan to use menus in your game."
+    e "例如，我记得你计划在游戏中使用菜单。"
+
+# game/tutorial_quickstart.rpy:553
+translate schinese choice1_done_503786e4:
+
+    # e "For example, I remember that you're planning to make a kinetic novel, without menus."
+    e "例如，我记得你打算写一部没有菜单的动态小说。"
+
+# game/tutorial_quickstart.rpy:555
+translate schinese choice1_done_819e234a:
+
+    # e "Here's an example that shows how we can test a flag, and do different things if it is true or not."
+    e "下面是一个例子，展示了我们如何测试标识，并在真假两种情况下，我们可以做不同的事情。"
+
+# game/tutorial_quickstart.rpy:559
+translate schinese choice1_done_461e6a59:
+
+    # e "Finally, this shows how you can show dialogue and menus at the same time. Understand?" nointeract
+    e "最后，这展示如何同时显示对话框和菜单。明白吗？" nointeract
+
+# game/tutorial_quickstart.rpy:564
+translate schinese choice1_done_a32e30fd:
+
+    # e "Great."
+    e "好极了。"
+
+# game/tutorial_quickstart.rpy:568
+translate schinese choice1_done_fbd1dbc1:
+
+    # e "If you look at the example, before the first choice, there's an indented say statement."
+    e "看这个例子，在第一个选项之前，有一个缩进的say语句。"
+
+# game/tutorial_quickstart.rpy:574
+translate schinese menu3_done_47fa2268:
+
+    # e "Although we won't demonstrate it here, Ren'Py supports making decisions based on a combinations of points, flags, and other factors."
+    e "虽然我们没有演示，但是Ren'Py支持基于点、标识和其他因素的组合来做出决策。"
+
+# game/tutorial_quickstart.rpy:576
+translate schinese menu3_done_826a600b:
+
+    # e "One of Ren'Py's big advantages is the flexibility using a scripting language like Python provides us. It lets us easily scale from kinetic novels to complex simulation games."
+    e "Ren'Py的一大优势是Python之类的脚本语言提供的灵活性。这让我们很容易从动态小说扩展到复杂的模拟游戏。"
+
+# game/tutorial_quickstart.rpy:585
+translate schinese tutorial_input_066611c5:
+
+    # e "Some games might prompt the player for input."
+    e "有些游戏可能会提示玩家输入。"
+
+# game/tutorial_quickstart.rpy:599
+translate schinese tutorial_input_dc3b4560:
+
+    # e "That's done with Python, and especially the renpy.input function. The first line of this example prompts the player for some texts, and sticks it in the name variable."
+    e "这是用Python做的，尤其是renpy.input函数。本例的第一行提示玩家输入一些文本，并将其粘贴到name变量中。"
+
+# game/tutorial_quickstart.rpy:601
+translate schinese tutorial_input_c88b3f4e:
+
+    # e "Often times, you'll want to clean the name up before you use it. The last line does that, by calling the strip method to remove whitespace, and replacing the name with a default if it's missing."
+    e "很多时候，你想在使用之前把name清空。最后一行调用strip方法删除空白，并在缺少名称时用默认值替换。"
+
+# game/tutorial_quickstart.rpy:605
+translate schinese tutorial_input_1236e9da:
+
+    # e "To interpolate a variable, write it in square brackets. Isn't that right, [name]?"
+    e "要插入一个变量值，请将其写在方括号中。不对吗，[name]？"
+
+# game/tutorial_quickstart.rpy:609
+translate schinese tutorial_input_c1f7a808:
+
+    # e "Variable names can also be shown in character names. To do that, just include the variable in square brackets in the character's name. Got it?"
+    e "变量名也可以在角色名中显示。为此，只需用在角色名中的方括号包含变量。明白了吗？"
+
+# game/tutorial_quickstart.rpy:612
+translate schinese tutorial_input_f7757a8e:
+
+    # g "I think I do."
+    g "我想我明白了。"
+
+# game/tutorial_quickstart.rpy:619
+translate schinese tutorial_input_0548d3e2:
+
+    # e "Variable interpolation also works with other variables. Here, the answer is [answer] and the flag is [flag]."
+    e "变量插值也可以是其他变量。这里，答案是[answer]，标识是[flag]。"
+
+translate schinese strings:
+
+    # game/tutorial_quickstart.rpy:2
+    old "Lucy"
+    new "露西"
+
+    # game/tutorial_quickstart.rpy:497
+    old "Yes, I do."
+    new "是的。"
+
+    # game/tutorial_quickstart.rpy:497
+    old "No, I don't."
+    new "不。"
+
+    # game/tutorial_quickstart.rpy:589
+    old "What's your name?"
+    new "你的名字是什么？"
+
+    # game/tutorial_quickstart.rpy:591
+    old "Guy Shy"
+    new "害 羞 小 伙"
+
+# TODO: Translation updated at 2020-11-01 00:00
+
+# game/tutorial_quickstart.rpy:54
+translate schinese tutorial_create_9151025b:
+
+    # e "If it's your first time doing so, Ren'Py will ask you to select a text editor. Atom might be a safe choice, but read the descriptions to be sure."
+    e "如果这是你第一次这么做，Ren'Py会要求你选择一个文本编辑器。Atom可能是一个安全的选择，但请阅读描述以确定。"

--- a/tutorial/game/tl/schinese/tutorial_screen_displayables.rpy
+++ b/tutorial/game/tl/schinese/tutorial_screen_displayables.rpy
@@ -1,0 +1,765 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_screen_displayables.rpy:3
+translate schinese screen_displayables_7c897a6d:
+
+    # e "There are quite a few screen displayables. Here, I'll tell you about some of the most important ones."
+    e "有相当多的界面可视组件（displayable）。这里，我将告诉你一些最重要的。"
+
+# game/tutorial_screen_displayables.rpy:9
+translate schinese screen_displayables_menu_fef7b441:
+
+    # e "What would you like to know about?" nointeract
+    e "你想知道什么？" nointeract
+
+# game/tutorial_screen_displayables.rpy:49
+translate schinese screen_displayable_properties_76c5639a:
+
+    # e "There are a few properties that every screen language displayable shares. Here, I'll demonstrate them for you."
+    e "有一些属性是每个界面语言可视组件共享的。这里，我给你演示一下。"
+
+# game/tutorial_screen_displayables.rpy:57
+translate schinese screen_displayable_properties_527d4b4e:
+
+    # e "First off, every screen language displayable supports the position properties. When the container a displayable is in supports it, you can use properties like align, anchor, pos, and so so on."
+    e "首先，每个界面语言可视组件都支持位置属性。当可视组件所在的容器支持时，可以使用align、anchor、pos等属性。"
+
+# game/tutorial_screen_displayables.rpy:69
+translate schinese screen_displayable_properties_8aff26dd:
+
+    # e "The at property applies a transform to the displayable, the same way the at clause in the show statement does."
+    e "at属性对可视组件应用变换，用法与show语句中at从句相同。"
+
+# game/tutorial_screen_displayables.rpy:106
+translate schinese screen_displayable_properties_2ed40a70:
+
+    # e "The id property is mostly used with the say screen, which is used to show dialogue. Outside of the say screen, it isn't used much."
+    e "id属性主要用于say界面，say界面用于显示对话。在say界面之外，它不常用。"
+
+# game/tutorial_screen_displayables.rpy:108
+translate schinese screen_displayable_properties_da5733d1:
+
+    # e "It tells Ren'Py which displayables are the background window, 'who' is speaking, and 'what' is being said. This used to apply per-Character styles, and help with auto-forward mode."
+    e "它告诉Ren'Py哪个可视组件是背景窗口，“who”在说话，“what”被说出来。这应用于每个Character样式，并帮助自动前进模式。"
+
+# game/tutorial_screen_displayables.rpy:123
+translate schinese screen_displayable_properties_cc09fade:
+
+    # e "The style property lets you specify the style of a single displayable."
+    e "style属性允许您指定单个可视组件的样式。"
+
+# game/tutorial_screen_displayables.rpy:144
+translate schinese screen_displayable_properties_a7f4e25c:
+
+    # e "The style_prefix property sets the prefix of the style that's used for a displayable and its children."
+    e "style_prefix属性设置可视组件及其子组件使用的样式的前缀。"
+
+# game/tutorial_screen_displayables.rpy:146
+translate schinese screen_displayable_properties_6bdb0723:
+
+    # e "For example, when the style_prefix property is 'green', the vbox has the 'green_vbox' style, and the text in it has the 'green_text' style."
+    e "例如，当style_prefix属性为“green”时，vbox具有“green_vbox”样式，其中的文本具有“green_text”样式。"
+
+# game/tutorial_screen_displayables.rpy:150
+translate schinese screen_displayable_properties_8a3a8635:
+
+    # e "There are a few more properties than these, and you can find the rest in the documentation. But these are the ones you can expect to see in your game, in the default screens."
+    e "此外还有一些属性，你可以在文档中找到。但是这些是你在游戏中可以看到的，在默认界面上。"
+
+# game/tutorial_screen_displayables.rpy:156
+translate schinese add_displayable_ec121c5c:
+
+    # e "Sometimes you'll have a displayable, like an image, that you want to add to a screen."
+    e "有时你会有一个可视组件，像一个图像，想添加到界面上。"
+
+# game/tutorial_screen_displayables.rpy:165
+translate schinese add_displayable_7ec3e2b0:
+
+    # e "This can be done using the add statement, which adds an image or other displayable to the screen."
+    e "这可以使用add语句，向界面添加图像或其他可视组件。"
+
+# game/tutorial_screen_displayables.rpy:167
+translate schinese add_displayable_7112a377:
+
+    # e "There are a few ways to refer to the image. If it's in the images directory or defined with the image statement, you can just put the name inside a quoted string."
+    e "有几种方法可以引用图像。如果它在images目录中或是用image语句定义的，那么只需将名称放入带引号的字符串中。"
+
+# game/tutorial_screen_displayables.rpy:176
+translate schinese add_displayable_8ba81c26:
+
+    # e "An image can also be referred to by it's filename, relative to the game directory."
+    e "图像也可以通过文件名引用，相对于game目录。"
+
+# game/tutorial_screen_displayables.rpy:185
+translate schinese add_displayable_1f5571e3:
+
+    # e "Other displayables can also be added using the add statement. Here, we add the Solid displayable, showing a solid block of color."
+    e "其他可视组件也可以使用add语句添加。这里，我们添加了Solid可视组件，显示一个实体块的颜色。"
+
+# game/tutorial_screen_displayables.rpy:195
+translate schinese add_displayable_0213ffa2:
+
+    # e "In addition to the displayable, the add statement can be given transform properties. These can place or otherwise transform the displayable being added."
+    e "除了可视组件之外，add语句还可以用于变换属性。这些可以放置或变换加入的可视组件。"
+
+# game/tutorial_screen_displayables.rpy:207
+translate schinese add_displayable_3a56a464:
+
+    # e "Of course, the add statement can also take the at property, letting you give it a more complex transform."
+    e "当然，add语句也可以使用at属性，进行更复杂的变换。"
+
+# game/tutorial_screen_displayables.rpy:222
+translate schinese text_displayable_96f88225:
+
+    # e "The screen language text statement adds a text displayable to the screen. It takes one argument, the text to be displayed."
+    e "界面语言text语句向界面添加文本可视组件。它需要一个参数，即要显示的文本。"
+
+# game/tutorial_screen_displayables.rpy:224
+translate schinese text_displayable_1ed1a8c2:
+
+    # e "In addition to the common properties that all displayables take, text takes the text style properties. For example, size sets the size of the text."
+    e "除了所有可视组件都有的常见属性外，文本还有文本样式属性。例如，size设置文本的大小。"
+
+# game/tutorial_screen_displayables.rpy:234
+translate schinese text_displayable_9351d9dd:
+
+    # e "The text displayable can also interpolate values enclosed in square brackets."
+    e "文本可视组件还可以插入方括号中的值。"
+
+# game/tutorial_screen_displayables.rpy:236
+translate schinese text_displayable_32d76ccb:
+
+    # e "When text is displayed in a screen using the text statement variables defined in the screen take precedence over those defined outside it."
+    e "当使用text语句在界面中显示文本时，在界面中定义的变量优先于外部定义的变量。"
+
+# game/tutorial_screen_displayables.rpy:238
+translate schinese text_displayable_7e84a5d1:
+
+    # e "Those variables may be parameters given to the screen, defined with the default or python statements, or set using the SetScreenVariable action."
+    e "那些变量也许是界面的参数，用默认或python语句定义，或者用SetScreenVariable动作设置。"
+
+# game/tutorial_screen_displayables.rpy:247
+translate schinese text_displayable_8bc866c4:
+
+    # e "There's not much more to say about text in screens, as it works the same way as all other text in Ren'Py."
+    e "关于界面中的文本没有更多要说的，它与Ren'Py中所有其他文本的作用方式相同。"
+
+# game/tutorial_screen_displayables.rpy:255
+translate schinese layout_displayables_d75efbae:
+
+    # e "The layout displayables take other displayables and lay them out on the screen."
+    e "布局可视组件获取其他可视组件并将其铺设在界面上。"
+
+# game/tutorial_screen_displayables.rpy:269
+translate schinese layout_displayables_9a15144d:
+
+    # e "For example, the hbox displayable takes its children and lays them out horizontally."
+    e "例如，hbox可视组件会将其子组件水平排列。"
+
+# game/tutorial_screen_displayables.rpy:284
+translate schinese layout_displayables_48eff197:
+
+    # e "The vbox displayable is similar, except it takes its children and arranges them vertically."
+    e "vbox可视组件与之类似，只不过它将子组件竖直排列。"
+
+# game/tutorial_screen_displayables.rpy:286
+translate schinese layout_displayables_74de8a66:
+
+    # e "Both of the boxes take the box style properties, the most useful of which is spacing, the amount of space to leave between children."
+    e "这两个框（box）都采用了框样式属性，其中最有用的是间距（spacing），即子组件之间留出的空间量。"
+
+# game/tutorial_screen_displayables.rpy:301
+translate schinese layout_displayables_a156591f:
+
+    # e "The grid displayable displays its children in a grid of equally-sized cells. It takes two arguments, the number of columns and the number of rows."
+    e "网格（grid）可视组件在大小相等的单元格网格中显示其子组件。它需要两个参数，列数和行数。"
+
+# game/tutorial_screen_displayables.rpy:303
+translate schinese layout_displayables_126f5816:
+
+    # e "The grid has to be full, or Ren'Py will produce an error. Notice how in this example, the empty cell is filled with a null."
+    e "网格必须填满，否则Ren'Py将产生错误。注意在这个例子中，空单元格是如何用null填充的。"
+
+# game/tutorial_screen_displayables.rpy:305
+translate schinese layout_displayables_bfaaaf9b:
+
+    # e "Like the boxes, grid uses the spacing property to specify the space between cells."
+    e "与框一样，grid使用spacing属性指定单元格之间的距离。"
+
+# game/tutorial_screen_displayables.rpy:321
+translate schinese layout_displayables_3e931106:
+
+    # e "Grid also takes the transpose property, to make it fill top-to-bottom before it fills left-to-right."
+    e "grid还接受transpose属性，使其先从上到下、再从左到右填充。"
+
+# game/tutorial_screen_displayables.rpy:338
+translate schinese layout_displayables_afdc1b11:
+
+    # e "And just to demonstrate that all cells are equally-sized, here's what happens when once child is bigger than the others."
+    e "为了展示所有单元格的大小是相等的，这里是当一个子组件比其他子组件大时发生的事情。"
+
+# game/tutorial_screen_displayables.rpy:353
+translate schinese layout_displayables_a23e2826:
+
+    # e "The fixed displayable displays the children using Ren'Py's normal placement algorithm. This lets you place displayables anywhere in the screen."
+    e "fixed可视组件使用Ren'Py正常的放置算法显示子组件。你可以将可视组件放在界面的任意位置。"
+
+# game/tutorial_screen_displayables.rpy:355
+translate schinese layout_displayables_fd3926ca:
+
+    # e "By default, the layout expands to fill all the space available to it. To prevent that, we use the xsize and ysize properties to set its size in advance."
+    e "默认情况下，布局会扩展以填充所有可用空间。为了避免这种情况，我们使用xsize和ysize属性预先设置其大小。"
+
+# game/tutorial_screen_displayables.rpy:369
+translate schinese layout_displayables_eff42786:
+
+    # e "When a non-layout displayable is given two or more children, it's not necessary to create a fixed. A fixed is automatically added, and the children are added to it."
+    e "当一个无布局的可视组件被赋予两个以上子组件时，不需要创建fixed。fixed将自动创建，并将子对象添加到其中。"
+
+# game/tutorial_screen_displayables.rpy:384
+translate schinese layout_displayables_c32324a7:
+
+    # e "Finally, there's one convenience to save space. When many displayables are nested, adding a layout to each could cause crazy indent levels."
+    e "最后，还有节省空间的便利。当许多可视组件嵌套时，为每一项添加布局可能会导致令人抓狂的缩进级别。"
+
+# game/tutorial_screen_displayables.rpy:386
+translate schinese layout_displayables_d7fa0f28:
+
+    # e "The has statement creates a layout, and then adds all further children of its parent to that layout. It's just a convenience to make screens more readable."
+    e "has语句创建一个布局，然后将其父组件的所有子组件添加到其中。这只是为了让界面便于阅读。"
+
+# game/tutorial_screen_displayables.rpy:395
+translate schinese window_displayables_14beb786:
+
+    # e "In the default GUI that Ren'Py creates for a game, most user interface elements expect some sort of background."
+    e "在Ren'Py为游戏创建的默认GUI中，大多数用户界面元素都需要某种背景。"
+
+# game/tutorial_screen_displayables.rpy:405
+translate schinese window_displayables_495d332b:
+
+    # e "Without the background, text can be hard to read. While a frame isn't strictly required, many screens have one or more of them."
+    e "没有背景，文本可能很难阅读。虽然frame不是严格需要的，但许多界面都有一个以上。"
+
+# game/tutorial_screen_displayables.rpy:417
+translate schinese window_displayables_2c0565ab:
+
+    # e "But when I add a background, it's much easier. That's why there are two displayables that are intended to give backgrounds to user interface elements."
+    e "但当我加上背景的时候，就容易多了。这就是为什么有两个可视组件是用来给用户界面元素提供背景的。"
+
+# game/tutorial_screen_displayables.rpy:419
+translate schinese window_displayables_c7d0968c:
+
+    # e "The two displayables are frame and window. Frame is the one we use above, and it's designed to provide a background for arbitrary parts of the user interface."
+    e "两个可视组件是框架（frame）和窗口（window）。frame是我们在上面使用的，它被设计来为用户界面的任意部分提供背景。"
+
+# game/tutorial_screen_displayables.rpy:423
+translate schinese window_displayables_7d843f62:
+
+    # e "On the other hand, the window displayable is very specific. It's used to provide the text window. If you're reading what I'm saying, you're looking at the text window right now."
+    e "另一方面，window可视组件非常具体。它用于提供文本窗口。如果你正在读我说的话，你就在看文本窗口。"
+
+# game/tutorial_screen_displayables.rpy:425
+translate schinese window_displayables_de5963e4:
+
+    # e "Both frames and windows can be given window style properties, allowing you to change things like the background, margins, and padding around the window."
+    e "frame和window都可以指定窗口样式属性，允许您更改背景（background）、窗口周围的外边距（margin）和内边距（padding）。"
+
+# game/tutorial_screen_displayables.rpy:433
+translate schinese button_displayables_ea626553:
+
+    # e "One of the most flexible displayables is the button displayable, and its textbutton and imagebutton variants."
+    e "最灵活的可视组件之一是按钮（button）可视组件，以及文本按钮（textbutton）和图像按钮（imagebutton）变体。"
+
+# game/tutorial_screen_displayables.rpy:443
+translate schinese button_displayables_372dcc0f:
+
+    # e "A button is a displayable that when selected runs an action. Buttons can be selected by clicking with the mouse, by touch, or with the keyboard and controller."
+    e "按钮是被选中时运行动作（action）的可视组件。按钮可以用鼠标单击、触摸或键盘和控制器来选择。"
+
+# game/tutorial_screen_displayables.rpy:445
+translate schinese button_displayables_a6b270ff:
+
+    # e "Actions can do many things, like setting variables, showing screens, jumping to a label, or returning a value. There are many {a=https://www.renpy.org/doc/html/screen_actions.html}actions in the Ren'Py documentation{/a}, and you can also write your own."
+    e "动作可以做很多事情，比如设置变量、显示界面、跳转到标签或返回值。有很多{a=https://www.renpy.org/doc/html/screen_actions.html}Ren'Py文档中的动作{/a}，您也可以自己编写。（{a=https://renpy.cn/doc/screen_actions.html}中文文档{/a}）"
+
+# game/tutorial_screen_displayables.rpy:458
+translate schinese button_displayables_4c600d20:
+
+    # e "It's also possible to run actions when a button gains and loses focus."
+    e "当按钮获得或失去焦点时，也可以运行动作。"
+
+# game/tutorial_screen_displayables.rpy:473
+translate schinese button_displayables_47af4bb9:
+
+    # e "A button takes another displayable as children. Since that child can be a layout, it can takes as many children as you want."
+    e "按钮将另一个可视组件作为子组件。因为子组件可以是布局，所以按钮可以包含任意数量的子组件。"
+
+# game/tutorial_screen_displayables.rpy:483
+translate schinese button_displayables_d01adde3:
+
+    # e "In many cases, buttons will be given text. To make that easier, there's the textbutton displayable that takes the text as an argument."
+    e "许多情况下，按钮会被赋予文本。更简单的，这里有使用文本作为参数的textbutton可视组件。"
+
+# game/tutorial_screen_displayables.rpy:485
+translate schinese button_displayables_01c551b3:
+
+    # e "Since the textbutton displayable manages the style of the button text for you, it's the kind of button that's used most often in the default GUI."
+    e "由于textbutton可视组件为您管理按钮文本的样式，因此它是默认GUI中最常用的一种按钮。"
+
+# game/tutorial_screen_displayables.rpy:498
+translate schinese button_displayables_6911fb9b:
+
+    # e "There's also the imagebutton, which takes displayables, one for each state the button can be in, and displays them as the button."
+    e "还有imagebutton，它需要一系列可视组件，每个对应一个按钮状态，并作为按钮显示。"
+
+# game/tutorial_screen_displayables.rpy:500
+translate schinese button_displayables_49720fa6:
+
+    # e "An imagebutton gives you the most control over what a button looks like, but is harder to translate and won't look as good if the game window is resized."
+    e "imagebutton可以让你最大程度地控制按钮的外观，但是很难翻译，而且如果游戏窗口大小改变了，效果也不太好。"
+
+# game/tutorial_screen_displayables.rpy:522
+translate schinese button_displayables_e8d40fc8:
+
+    # e "Buttons take Window style properties, that are used to specify the background, margins, and padding. They also take Button-specific properties, like a sound to play on hover."
+    e "按钮使用窗口样式属性，用于指定背景、外边距和内边距。它们还使用特定的按钮属性，例如悬停时播放的音效。"
+
+# game/tutorial_screen_displayables.rpy:524
+translate schinese button_displayables_1e40e311:
+
+    # e "When used with a button, style properties can be given prefixes like idle and hover to make the property change with the button state."
+    e "与按钮一起使用时，样式属性可以加上像idle和hover之类的前缀，使属性随按钮状态而改变。"
+
+# game/tutorial_screen_displayables.rpy:526
+translate schinese button_displayables_220b020d:
+
+    # e "A text button also takes Text style properties, prefixed with text. These are applied to the text displayable it creates internally."
+    e "文本按钮也使用文本样式属性，只要加上text前缀。这些应用于它在内部创建的文本可视组件。"
+
+# game/tutorial_screen_displayables.rpy:558
+translate schinese button_displayables_b89d12aa:
+
+    # e "Of course, it's prety rare we'd ever customize a button in a screen like that. Instead, we'd create custom styles and tell Ren'Py to use them."
+    e "当然，我们很少在界面里定制按钮。相反，我们会创建自定义样式并让Ren'Py使用。"
+
+# game/tutorial_screen_displayables.rpy:577
+translate schinese bar_displayables_946746c2:
+
+    # e "The bar and vbar displayables are flexible displayables that show bars representing a value. The value can be static, animated, or adjustable by the player."
+    e "bar和vbar可视组件灵活地显示代表值的条。该值可以是静态的、动画的或由玩家调整的。"
+
+# game/tutorial_screen_displayables.rpy:579
+translate schinese bar_displayables_af3a51b8:
+
+    # e "The value property gives a BarValue, which is an object that determines the bar's value and range. Here, a StaticValue sets the range to 100 and the value to 66, making a bar that's two thirds full."
+    e "value属性提供BarValue，它是确定条的值和范围的对象。这里，StaticValue将范围设置为100、值为66，从而使条三分之二满。"
+
+# game/tutorial_screen_displayables.rpy:581
+translate schinese bar_displayables_62f8b0ab:
+
+    # e "A list of all the BarValues that can be used is found {a=https://www.renpy.org/doc/html/screen_actions.html#bar-values}in the Ren'Py documentation{/a}."
+    e "所有可用Barvalue的列表见{a=https://www.renpy.org/doc/html/screen_actions.html#bar-values}Ren'Py文档{/a}。（{a=https://renpy.cn/doc/screen_actions.html#bar}中文文档{/a}）"
+
+# game/tutorial_screen_displayables.rpy:583
+translate schinese bar_displayables_5212eb0a:
+
+    # e "In this example, we give the frame the xsize property. If we didn't do that, the bar would expand to fill all available horizontal space."
+    e "在本例中，我们给frame设定了xsize属性。如果我们不这样做，这个条会扩展以填充所有可用的水平空间。"
+
+# game/tutorial_screen_displayables.rpy:600
+translate schinese bar_displayables_67295018:
+
+    # e "There are a few different bar styles that are defined in the default GUI. The styles are selected by the style property, with the default selected by the value."
+    e "默认GUI定义了几种不同的条样式。样式由样式特性选择，默认根据值选择。"
+
+# game/tutorial_screen_displayables.rpy:602
+translate schinese bar_displayables_1b037b21:
+
+    # e "The top style is the 'bar' style. It's used to display values that the player can't adjust, like a life or progress bar."
+    e "顶部样式是“条（bar）”样式。它用来显示玩家无法调整的值，比如生命或进度条。"
+
+# game/tutorial_screen_displayables.rpy:604
+translate schinese bar_displayables_c2aa4725:
+
+    # e "The middle stye is the 'slider' value. It's used for values the player is expected to adjust, like a volume preference."
+    e "中间的样式是“滑块（slider）”值。它用于玩家想调整的值，例如音量首选项。"
+
+# game/tutorial_screen_displayables.rpy:606
+translate schinese bar_displayables_2fc44226:
+
+    # e "Finally, the bottom style is the 'scrollbar' style, which is used for horizontal scrollbars. When used as a scrollbar, the thumb in the center changes size to reflect the visible area of a viewport."
+    e "最后，底部样式是“滚动条（scrollbar）”样式，用于水平滚动条。当用作滚动条时，中间的小方块改变大小以反映视口的可见区域。"
+
+# game/tutorial_screen_displayables.rpy:623
+translate schinese bar_displayables_26eb88bf:
+
+    # e "The vbar displayable is similar to the bar displayable, except it uses vertical styles - 'vbar', 'vslider', and 'vscrollbar' - by default."
+    e "vbar可视组件与bar可视组件类似，不过它默认使用垂直样式如“vbar”、“vslider”和“vscrollbar”。"
+
+# game/tutorial_screen_displayables.rpy:626
+translate schinese bar_displayables_11cf8af2:
+
+    # e "Bars take the Bar style properties, which can customize the look and feel greatly. Just look at the difference between the bar, slider, and scrollbar styles."
+    e "条使用条样式属性，可以对外观进行很大的定制。看看条、滑块和滚动条样式之间的区别就知道了。"
+
+# game/tutorial_screen_displayables.rpy:635
+translate schinese imagemap_displayables_d62fad02:
+
+    # e "Imagemaps use two or more images to show buttons and bars. Let me start by showing you an example of an imagemap in action."
+    e "图像映射（imagemap）使用两个或多个图像来显示按钮和栏。首先让我向您展示一个imagemap的实际应用示例。"
+
+# game/tutorial_screen_displayables.rpy:657
+translate schinese swimming_405542a5:
+
+    # e "You chose swimming."
+    e "你选了游泳。"
+
+# game/tutorial_screen_displayables.rpy:659
+translate schinese swimming_264b5873:
+
+    # e "Swimming seems like a lot of fun, but I didn't bring my bathing suit with me."
+    e "游泳看起来很有趣，但我没有带泳衣。"
+
+# game/tutorial_screen_displayables.rpy:665
+translate schinese science_83e5c0cc:
+
+    # e "You chose science."
+    e "你选了科学。"
+
+# game/tutorial_screen_displayables.rpy:667
+translate schinese science_319cdf4b:
+
+    # e "I've heard that some schools have a competitive science team, but to me research is something that can't be rushed."
+    e "我听说有些学校有一支很有竞争力的科学团队，但对我来说，研究是一件不能急于求成的事情。"
+
+# game/tutorial_screen_displayables.rpy:672
+translate schinese art_d2a94440:
+
+    # e "You chose art."
+    e "你选了艺术。"
+
+# game/tutorial_screen_displayables.rpy:674
+translate schinese art_e6af6f1d:
+
+    # e "Really good background art is hard to make, which is why so many games use filtered photographs. Maybe you can change that."
+    e "真正好的背景图很难创作，这就是为什么这么多游戏使用带滤镜的照片。也许你可以改变。"
+
+# game/tutorial_screen_displayables.rpy:680
+translate schinese home_373ea9a5:
+
+    # e "You chose to go home."
+    e "你选择回家。"
+
+# game/tutorial_screen_displayables.rpy:686
+translate schinese imagemap_done_48eca0a4:
+
+    # e "Anyway..."
+    e "好吧……"
+
+# game/tutorial_screen_displayables.rpy:691
+translate schinese imagemap_done_a60635a1:
+
+    # e "To demonstrate how imagemaps are put together, I'll show you the five images that make up a smaller imagemap."
+    e "为了演示imagemap是如何组合在一起的，我将向您展示组成较小imagemap的五个图像。"
+
+# game/tutorial_screen_displayables.rpy:697
+translate schinese imagemap_done_ac9631ef:
+
+    # e "The idle image is used for the background of the imagemap, for hotspot buttons that aren't focused or selected, and for the empty part of an unfocused bar."
+    e "idle图像用于imagemap的背景、未聚焦或未选中的热点按钮以及未聚焦条的空白部分。"
+
+# game/tutorial_screen_displayables.rpy:703
+translate schinese imagemap_done_123b5924:
+
+    # e "The hover image is used for hotspots that are focused but not selected, and for the empty part of a focused bar."
+    e "hover图像用于聚集但未选中的热点以及聚焦条的空白部分。"
+
+# game/tutorial_screen_displayables.rpy:705
+translate schinese imagemap_done_37f538dc:
+
+    # e "Notice how both the bar and button are highlighted in this image. When we display them as part of a screen, only one of them will show up as focused."
+    e "注意此图中的条和按钮是如何高亮的。当我们将它们作为界面的一部分显示时，只有其中一个会显示为已聚焦。"
+
+# game/tutorial_screen_displayables.rpy:711
+translate schinese imagemap_done_c76b072d:
+
+    # e "Selected images like this selected_idle image are used for parts of the bar that are filled, and for selected buttons, like the current screen and a checked checkbox."
+    e "selected图像，像这个selected_idle图像，用于条的填充部分，以及选中按钮如当前界面和勾选的选择框。"
+
+# game/tutorial_screen_displayables.rpy:717
+translate schinese imagemap_done_241a4112:
+
+    # e "Here's the selected_hover image. The button here will never be shown, since it will never be marked as selected."
+    e "这有selected_hover图像。这里的按钮永远不会显示，因为它永远不会被标记为选中。"
+
+# game/tutorial_screen_displayables.rpy:723
+translate schinese imagemap_done_3d8f454c:
+
+    # e "Finally, an insensitive image can be given, which is used when a hotspot can't be interacted with."
+    e "最后，可以给出一个insensitive图像，当热点不能交互时使用。"
+
+# game/tutorial_screen_displayables.rpy:728
+translate schinese imagemap_done_ca286729:
+
+    # e "Imagemaps aren't limited to just images. Any displayable can be used where an image is expected."
+    e "imagemap不限于图像。任何可视组件都可以在需要图像的地方使用。"
+
+# game/tutorial_screen_displayables.rpy:743
+translate schinese imagemap_done_6060b17f:
+
+    # e "Here's an imagemap built using those five images. Now that it's an imagemap, you can interact with it if you want to."
+    e "这有用这五个图像构建的imagemap。现在它是imagemap，你可以与它交互。"
+
+# game/tutorial_screen_displayables.rpy:755
+translate schinese imagemap_done_c817794d:
+
+    # e "To make this a little more concise, we can replace the five images with the auto property, which replaces '%%s' with 'idle', 'hover', 'selected_idle', 'selected_hover', or 'insensitive' as appropriate."
+    e "为了更简洁一点，我们可以用auto属性替换这五个图像，它将视情况替换“%%s”为“idle”、“hover”、“selected_idle”、“selected_hover”或“insensitive”。"
+
+# game/tutorial_screen_displayables.rpy:757
+translate schinese imagemap_done_c1ed91b8:
+
+    # e "Feel free to omit the selected and insensitive images if your game doesn't need them. Ren'Py will use the idle or hover images to replace them."
+    e "如果你的游戏不需要的话，你可以随意省略selected和insensitive图像。Ren'Py将使用idle或hover图像来替换它们。"
+
+# game/tutorial_screen_displayables.rpy:759
+translate schinese imagemap_done_166f75db:
+
+    # e "The hotspot and hotbar statements describe areas of the imagemap that should act as buttons or bars, respectively."
+    e "hotspot和hotbar语句分别描述imagemap中应该充当按钮或条的区域。"
+
+# game/tutorial_screen_displayables.rpy:761
+translate schinese imagemap_done_becb9688:
+
+    # e "Both take the coordinates of the area, in (x, y, width, height) format."
+    e "两者都采用 (横坐标, 纵坐标, 宽度, 高度) 格式的区域坐标。"
+
+# game/tutorial_screen_displayables.rpy:763
+translate schinese imagemap_done_fd56baa2:
+
+    # e "A hotspot takes an action that is run when the hotspot is activated. It can also take actions that are run when it's hovered and unhovered, just like a button can."
+    e "hotspot需要当热点激活时运行的动作。它也可以接受悬停和未发现时运行的动作，就像按钮一样。"
+
+# game/tutorial_screen_displayables.rpy:765
+translate schinese imagemap_done_5660a6a2:
+
+    # e "A hotbar takes a BarValue object that describes how full the bar is, and the range of values the bar should display, just like a bar and vbar does."
+    e "hotbar接受一个BarValue对象，描述条的填充程度、应该显示的值的范围，就像bar和vbar一样。"
+
+# game/tutorial_screen_displayables.rpy:772
+translate schinese imagemap_done_10496a29:
+
+    # e "A useful pattern is to define a screen with an imagemap that has hotspots that jump to labels, and call that using the call screen statement."
+    e "一个有用的模式是用imagemap定义一个具有跳转到标签的热点的界面，并使用call screen语句调用它。"
+
+# game/tutorial_screen_displayables.rpy:774
+translate schinese imagemap_done_dcb45224:
+
+    # e "That's what we did in the school example I showed before. Here's the script for it. It's long, but the imagemap itself is fairly simple."
+    e "在我之前展示的学校例子中，我们就是这样做的。这是脚本。它很长，但imagemap本身相当简单。"
+
+# game/tutorial_screen_displayables.rpy:778
+translate schinese imagemap_done_5b5bc5e5:
+
+    # e "Imagemaps have pluses and minuses. On one hand, they are easy for a designer to create, and can look very good. At the same time, they can be hard to translate, and text baked into images may be blurry when the window is scaled."
+    e "imagemap有优点和缺点。一方面，它们对于设计师来说很容易创作，而且看起来非常好。同时，它们可能很难翻译，而且图像中的文本可能因缩放而变得模糊。"
+
+# game/tutorial_screen_displayables.rpy:780
+translate schinese imagemap_done_b6cebf2b:
+
+    # e "It's up to you and your team to decide if imagemaps are right for your project."
+    e "由您和您的团队来决定imagemap是否适合您的项目。"
+
+# game/tutorial_screen_displayables.rpy:787
+translate schinese viewport_displayables_e509d50d:
+
+    # e "Sometimes, you'll want to display something bigger than the screen. That's what the viewport displayable is for."
+    e "有时候，你会想显示比界面更大的东西。这就是视口（viewport）可视组件的用途。"
+
+# game/tutorial_screen_displayables.rpy:803
+translate schinese viewport_displayables_9853b0e3:
+
+    # e "Here's an example of a simple viewport, used to display a single image that's far bigger than the screen. Since the viewport will expand to the size of the screen, we use the xysize property to make it smaller."
+    e "下面是一个简单视口的示例，用于显示远大于界面的单个图像。由于视口会扩展到界面大小，因此我们使用xysize属性缩小它。"
+
+# game/tutorial_screen_displayables.rpy:805
+translate schinese viewport_displayables_778668c8:
+
+    # e "By default the viewport can't be moved, so we give the draggable, mousewheel, and arrowkeys properties to allow it to be moved in multiple ways."
+    e "默认情况下，视口不能移动，因此我们提供了draggable、mouseweel和arrowkeys属性，从而允许以多种方式移动。"
+
+# game/tutorial_screen_displayables.rpy:820
+translate schinese viewport_displayables_bbd63377:
+
+    # e "When I give the viewport the edgescroll property, the viewport automatically scrolls when the mouse is near its edges. The two numbers are the size of the edges, and the speed in pixels per second."
+    e "如果我给视口edgescroll属性，当鼠标靠近边缘时，视口会自动滚动。这两个数字是边缘的大小和滚动速度（像素/秒）。"
+
+# game/tutorial_screen_displayables.rpy:839
+translate schinese viewport_displayables_7c4678ee:
+
+    # e "Giving the viewport the scrollbars property surrounds it with scrollbars. The scrollbars property can take 'both', 'horizontal', and 'vertical' as values."
+    e "给视口scrollbars属性，则视口被scrollbars包围。scrollbars属性可以将“both”、“horizontal”和“vertical”作为值。"
+
+# game/tutorial_screen_displayables.rpy:841
+translate schinese viewport_displayables_197953b5:
+
+    # e "The spacing property controls the space between the viewport and its scrollbars, in pixels."
+    e "spacing属性控制视口与滚动条之间的距离（单位：像素）。"
+
+# game/tutorial_screen_displayables.rpy:864
+translate schinese viewport_displayables_54dd6e7b:
+
+    # e "The xinitial and yinitial properties set the initial amount of scrolling, as a fraction of the amount that can be scrolled."
+    e "xinitial和yinitial属性设置滚动的初始量，作为可滚动量的一小部分。"
+
+# game/tutorial_screen_displayables.rpy:885
+translate schinese viewport_displayables_c047efb5:
+
+    # e "Finally, there's the child_size property. To explain what it does, I first have to show you what happens when we don't have it."
+    e "最后，还有child_size属性。为了解释它的作用，我首先要告诉你，没有它时会发生什么。"
+
+# game/tutorial_screen_displayables.rpy:887
+translate schinese viewport_displayables_c563019f:
+
+    # e "As you can see, the text wraps. That's because Ren'Py is offering it space that isn't big enough."
+    e "如您所见，文本换行。这是因为Ren'Py提供的空间不够大。"
+
+# game/tutorial_screen_displayables.rpy:909
+translate schinese viewport_displayables_4bcf0ad0:
+
+    # e "When we give the screen a child_size, it offers more space to its children, allowing scrolling. It takes a horizontal and vertical size. If one component is None, it takes the size of the viewport."
+    e "如果我们给界面一个child_size时，它就给子组件提供了更多的空间，允许滚动。它需要水平和垂直大小。如果一个组分为None，则使用视区的大小。"
+
+# game/tutorial_screen_displayables.rpy:936
+translate schinese viewport_displayables_ae4ff821:
+
+    # e "Finally, there's the vpgrid displayable. It combines a viewport and a grid into a single displayable, except it's more efficient than either, since it doesn't have to draw every child."
+    e "最后，还有vpgrid可视组件。它将一个视口和一个网格组合成一个可视组件，不过它比任一都更有效，因为它不必绘制每个子组件。"
+
+# game/tutorial_screen_displayables.rpy:938
+translate schinese viewport_displayables_71fa0b8f:
+
+    # e "It takes the cols and rows properties, which give the number of rows and columns of children. If one is omitted, Ren'Py figures it out from the other and the number of children."
+    e "它接受cols和rows属性，分别给出提供子组件的列数和行数。如果其中一个省略了，Ren'Py会根据另一个以及子组件的数量计算出来。"
+
+translate schinese strings:
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Common properties all displayables share."
+    new "所有可视组件共享的常见属性。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Adding images and other displayables."
+    new "添加图像和其他可视组件。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Text."
+    new "文本。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Boxes and other layouts."
+    new "框和其他布局。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Windows and frames."
+    new "窗口和框架。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Buttons."
+    new "按钮。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Bars."
+    new "条。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Viewports."
+    new "视口。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "Imagemaps."
+    new "图像映射。"
+
+    # game/tutorial_screen_displayables.rpy:9
+    old "That's all for now."
+    new "目前就这些。"
+
+    # game/tutorial_screen_displayables.rpy:55
+    old "This uses position properties."
+    new "这使用位置属性。"
+
+    # game/tutorial_screen_displayables.rpy:63
+    old "And the world turned upside down..."
+    new "世界颠倒了……"
+
+    # game/tutorial_screen_displayables.rpy:115
+    old "Flight pressure in tanks."
+    new "平衡飞行压力。"
+
+    # game/tutorial_screen_displayables.rpy:116
+    old "On internal power."
+    new "切换内部动力。"
+
+    # game/tutorial_screen_displayables.rpy:117
+    old "Launch enabled."
+    new "发射就位。"
+
+    # game/tutorial_screen_displayables.rpy:118
+    old "Liftoff!"
+    new "发射！"
+
+    # game/tutorial_screen_displayables.rpy:232
+    old "The answer is [answer]."
+    new "答案是[answer]。"
+
+    # game/tutorial_screen_displayables.rpy:244
+    old "Text tags {color=#c8ffc8}work{/color} in screens."
+    new "文本标签在界面中{color=#c8ffc8}作用{/color}。"
+
+    # game/tutorial_screen_displayables.rpy:336
+    old "Bigger"
+    new "更大"
+
+    # game/tutorial_screen_displayables.rpy:401
+    old "This is a screen."
+    new "这是一个界面。"
+
+    # game/tutorial_screen_displayables.rpy:402
+    old "Okay"
+    new "确定"
+
+    # game/tutorial_screen_displayables.rpy:440
+    old "You clicked the button."
+    new "你点击了按钮。"
+
+    # game/tutorial_screen_displayables.rpy:441
+    old "Click me."
+    new "点我。"
+
+    # game/tutorial_screen_displayables.rpy:453
+    old "You hovered the button."
+    new "你悬停在按钮上。"
+
+    # game/tutorial_screen_displayables.rpy:454
+    old "You unhovered the button."
+    new "你离开了按钮。"
+
+    # game/tutorial_screen_displayables.rpy:470
+    old "Heal"
+    new "治愈"
+
+    # game/tutorial_screen_displayables.rpy:479
+    old "This is a textbutton."
+    new "这是一个文本按钮。"
+
+    # game/tutorial_screen_displayables.rpy:539
+    old "Or me."
+    new "或者我。"
+
+    # game/tutorial_screen_displayables.rpy:541
+    old "You clicked the other button."
+    new "你点击了另一个按钮。"
+
+    # game/tutorial_screen_displayables.rpy:880
+    old "This text is wider than the viewport."
+    new "这段文本比视口更宽。"

--- a/tutorial/game/tl/schinese/tutorial_screens.rpy
+++ b/tutorial/game/tl/schinese/tutorial_screens.rpy
@@ -1,0 +1,593 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_screens.rpy:165
+translate schinese tutorial_screens_2faa22e5:
+
+    # e "Screens are the most powerful part of Ren'Py. Screens let you customize the out-of-game interface, and create new in-game interface components."
+    e "界面是Ren'Py最强大的部分。界面允许您自定义游戏外界面，并创建新的游戏内界面组件。"
+
+# game/tutorial_screens.rpy:171
+translate schinese screens_menu_7f31d730:
+
+    # e "What would you like to know about screens?" nointeract
+    e "你想知道关于界面的什么？" nointeract
+
+# game/tutorial_screens.rpy:201
+translate schinese screens_demo_115a4b8f:
+
+    # e "Screens are how we create the user interface in Ren'Py. With the exception of images and transitions, everything you see comes from a screen."
+    e "界面是我们在Ren'Py中创建用户界面的方式。除了图像和转场，你看到的一切都来自界面。"
+
+# game/tutorial_screens.rpy:203
+translate schinese screens_demo_ce100e07:
+
+    # e "When I'm speaking to you, I'm using the 'say' screen. It's responsible for taking dialogue and presenting it to the player."
+    e "我对你说话时，正在使用“say”界面。它负责进行对话并将其呈现给玩家。"
+
+# game/tutorial_screens.rpy:205
+translate schinese screens_demo_1bdfb4bd:
+
+    # e "And when the menu statement displays an in-game choice, the 'choice' screen is used. Got it?" nointeract
+    e "当菜单语句显示游戏中的选项时，将使用“选项”界面。懂？" nointeract
+
+# game/tutorial_screens.rpy:215
+translate schinese screens_demo_31a20e24:
+
+    # e "Text input uses the 'input' screen, NVL mode uses the 'nvl' screen, and so on."
+    e "文本输入使用“输入”界面，NVL模式使用“NVL”界面，依此类推。"
+
+# game/tutorial_screens.rpy:217
+translate schinese screens_demo_5a5aa2d5:
+
+    # e "More than one screen can be displayed at once. For example, the buttons at the bottom - Back, History, Skip, and so on - are all displayed by a quick_menu screen that's shown all of the time."
+    e "可同时显示多个界面。例如，底部的按钮——后退、历史记录、跳过等等——都是通过一直显示的快速菜单（quick_menu）界面显示的。"
+
+# game/tutorial_screens.rpy:219
+translate schinese screens_demo_58d48fde:
+
+    # e "There are a lot of special screens, like 'main_menu', 'load', 'save', and 'preferences'. Rather than list them all here, I'll {a=https://www.renpy.org/doc/html/screen_special.html}send you to the documentation{/a}."
+    e "有很多特殊的界面，如“主菜单”、“读取”、“保存”和“首选项”。与其把它们都列在这里，我会给你{a=https://www.renpy.org/doc/html/screen_special.html}文档链接{/a}（{a=https://renpy.cn/doc/screen_special.html}中文文档链接{/a}）。"
+
+# game/tutorial_screens.rpy:221
+translate schinese screens_demo_27476d11:
+
+    # e "In a newly created project, all these screens live in screens.rpy. You can edit that file in order to change them."
+    e "在一个新创建的工程中，所有这些界面都位于 screens.rpy 。您可以编辑该文件以更改它们。"
+
+# game/tutorial_screens.rpy:223
+translate schinese screens_demo_a699b1cb:
+
+    # e "You aren't limited to these screens either. In Ren'Py, you can make your own screens, and use them for your game's interface."
+    e "你也不局限于这些界面。在Ren'Py中，你可以制作自己的界面，并将其用于游戏界面。"
+
+# game/tutorial_screens.rpy:230
+translate schinese screens_demo_a136e191:
+
+    # e "For example, in an RPG like visual novel, a screen can display the player's statistics."
+    e "例如，在类似RPG的视觉小说中，界面可以显示玩家的统计信息。"
+
+# game/tutorial_screens.rpy:234
+translate schinese screens_demo_1f50f3d3:
+
+    # e "Which reminds me, I should probably heal you."
+    e "这提醒我，我应该治疗你。"
+
+# game/tutorial_screens.rpy:241
+translate schinese screens_demo_8a54de7a:
+
+    # e "Complex screens can be the basis of whole game mechanics. A stats screen like this can be the basis of dating and life-sims."
+    e "复杂的界面可以成为整个游戏机制的基础。像这样的统计界面可以作为约会和模拟人生的基础。"
+
+# game/tutorial_screens.rpy:246
+translate schinese screens_demo_62c184f8:
+
+    # e "While screens might be complex, they're really just the result of a lot of simple parts working together to make something larger than all of them."
+    e "虽然界面可能很复杂，但它们实际上只是许多简单部分协同工作的结果，使得一些东西比所有部分都大。"
+
+# game/tutorial_screens.rpy:265
+translate schinese screens_showing_1b51e9a4:
+
+    # e "Here's an example of a very simple screen. The screen statement is used to tell Ren'Py this is a screen, and it's name is simple_screen."
+    e "下面是一个非常简单的界面示例。screen语句用于告诉Ren'Py这是一个界面，它的名称是simple_screen。"
+
+# game/tutorial_screens.rpy:267
+translate schinese screens_showing_5a6bbad0:
+
+    # e "Inside the screen statement, lines introduces displayables such as frame, vbox, text, and textbutton; or properties like action, xalign, and ypos."
+    e "在screen语句中，行引入可视组件，如frame、vbox、text和textbutton；或诸如action、xalign和ypos之类的属性。"
+
+# game/tutorial_screens.rpy:272
+translate schinese screens_showing_ae40755c:
+
+    # e "I'll work from the inside out to describe the statements. But first, I'll show the screen so you can see it in action."
+    e "我将从内到外介绍这些语句。但首先，我将显示界面以便您可以看到它的实际操作。"
+
+# game/tutorial_screens.rpy:274
+translate schinese screens_showing_bc320819:
+
+    # e "The text statement is used to display the text provided."
+    e "text语句用于显示提供的文本。"
+
+# game/tutorial_screens.rpy:276
+translate schinese screens_showing_64f23380:
+
+    # e "The textbutton statement introduces a button that can be clicked. When the button is clicked, the provided action is run."
+    e "textbutton语句引入了一个可以单击的按钮。单击按钮时，提供的动作将运行。"
+
+# game/tutorial_screens.rpy:278
+translate schinese screens_showing_e8f68c08:
+
+    # e "Both are inside a vbox, which means vertical box, statement - that places the text on top of the button."
+    e "两者都在一个垂直框（vbox）语句中，这意味着文本被放在按钮的上面。"
+
+# game/tutorial_screens.rpy:280
+translate schinese screens_showing_7e48fc22:
+
+    # e "And that is inside a frame that provides the background and borders. The frame has an at property that takes a transform giving its position."
+    e "以上都在提供背景和边框的frame内。frame有一个at属性，该属性接受一个给定其位置的变换。"
+
+# game/tutorial_screens.rpy:286
+translate schinese screens_showing_80425bf3:
+
+    # e "There are a trio of statements that are used to display screens."
+    e "有三种语句用于显示界面。"
+
+# game/tutorial_screens.rpy:291
+translate schinese screens_showing_7d2deb37:
+
+    # e "The first is the show screen statement, which displays a screen and lets Ren'Py keep going."
+    e "第一个是show screen语句，它显示一个界面并让Ren'Py继续运行。"
+
+# game/tutorial_screens.rpy:293
+translate schinese screens_showing_7626dc8b:
+
+    # e "The screen will stay shown until it is hidden."
+    e "界面将一直显示直到隐藏。"
+
+# game/tutorial_screens.rpy:297
+translate schinese screens_showing_c79038a4:
+
+    # e "Hiding a screen is done with the hide screen statement."
+    e "隐藏界面是用hide screen语句完成的。"
+
+# game/tutorial_screens.rpy:301
+translate schinese screens_showing_8f78a97d:
+
+    # e "The call screen statement stops Ren'Py from executing script until the screen either returns a value, or jumps the script somewhere else."
+    e "call screen语句使Ren'Py中止执行脚本，直到界面返回值或将脚本跳转到其他位置。"
+
+# game/tutorial_screens.rpy:303
+translate schinese screens_showing_b52e420c:
+
+    # e "Since we can't display dialogue at the same time, you'll have to click 'Okay' to continue."
+    e "由于无法同时显示对话，您必须单击“确定”继续。"
+
+# game/tutorial_screens.rpy:310
+translate schinese screens_showing_c5ca730f:
+
+    # e "When a call screen statement ends, the screen is automatically hidden."
+    e "当call screen语句结束时，界面将自动隐藏。"
+
+# game/tutorial_screens.rpy:312
+translate schinese screens_showing_a38d1702:
+
+    # e "Generally, you use show screen to show overlays that are up all the time, and call screen to show screens the player interacts with for a little while."
+    e "通常，您使用show screen来显示一直处于开启状态的覆盖，而用call screen来显示与玩家短暂交互的界面。"
+
+# game/tutorial_screens.rpy:335
+translate schinese screens_parameters_0666043d:
+
+    # e "Here's an example of a screen that takes three parameters. The message parameter is a message to show, while the okay and cancel actions are run when the appropriate button is chosen."
+    e "下面是一个包含三个参数的界面示例。message参数是一条要显示的消息，而okay和cancel动作在按下对应按钮时运行。"
+
+# game/tutorial_screens.rpy:337
+translate schinese screens_parameters_cf95b914:
+
+    # e "While the message parameter always has to be supplied, the okay and cancel parameters have default values that are used if no argument is given."
+    e "虽然必须始终提供message参数，但是okay和cancel参数具有默认值，如果没有给定参数，则使用这些值。"
+
+# game/tutorial_screens.rpy:339
+translate schinese screens_parameters_4ce03111:
+
+    # e "Each parameter is a variable that is defined inside the screen. Inside the screen, these variables take priority over those used in the rest of Ren'Py."
+    e "每个参数都是在界面内定义的变量。在界面中，这些变量优先于那些在Ren'Py其他部分中使用的变量。"
+
+# game/tutorial_screens.rpy:343
+translate schinese screens_parameters_106c2a04:
+
+    # e "When a screen is shown, arguments can be supplied for each of the parameters. Arguments can be given by position or by name."
+    e "当显示界面时，可以为每个形参提供实参。实参可以按位置或名称给定。（译者注：不必在意形参和实参的定义，都当成参数就好）"
+
+# game/tutorial_screens.rpy:350
+translate schinese screens_parameters_12ac92d4:
+
+    # e "Parameters let us change what a screen displays, simply by re-showing it with different arguments."
+    e "形参允许我们改变界面显示的内容，只需要改变实参、重新显示。"
+
+# game/tutorial_screens.rpy:357
+translate schinese screens_parameters_d143a994:
+
+    # e "The call screen statement can also take arguments, much like show screen does."
+    e "call screen语句也可以接受参数，就像show screen一样。"
+
+# game/tutorial_screens.rpy:369
+translate schinese screens_properties_423246a2:
+
+    # e "There are a few properties that can be applied to a screen itself."
+    e "有几个属性可以应用于界面本身。"
+
+# game/tutorial_screens.rpy:380
+translate schinese screens_properties_4fde164e:
+
+    # e "When the modal property is true, you can't interact with things beneath the screen. You'll have to click 'Close This Screen' before you can continue."
+    e "当modal属性为true时，不能与界面下的内容交互。您必须单击“关闭此界面”才能继续。"
+
+# game/tutorial_screens.rpy:398
+translate schinese screens_properties_550c0bea:
+
+    # e "When a screen has the tag property, it's treated like the tag part of an image name. Here, I'm showing a_tag_screen."
+    e "当界面具有tag属性时，它像图像名的标签部分一样处理。这里，我显示a_tag_screen界面。"
+
+# game/tutorial_screens.rpy:402
+translate schinese screens_properties_4fcf8af8:
+
+    # e "When I show b_tag_screen, it replaces a_tag_screen."
+    e "当我显示b_tag_screen时，它会替换a_tag_screen。"
+
+# game/tutorial_screens.rpy:404
+translate schinese screens_properties_7ed5a791:
+
+    # e "This is useful in the game and main menus, where you want the load screen to replace the preferences screen. By default, all those screens have tag menu."
+    e "这在游戏和主菜单中非常有用，您希望用读取界面替换首选项界面。默认情况下，所有这些界面都有标签menu。"
+
+# game/tutorial_screens.rpy:408
+translate schinese screens_properties_5d51bd1e:
+
+    # e "For some reason, tag takes a name, and not an expression. It's too late to change it."
+    e "出于某种原因，tag使用一个名称，而不是一个表达式。现在改变已经太晚了。"
+
+# game/tutorial_screens.rpy:432
+translate schinese screens_properties_6706e266:
+
+    # e "The zorder property controls the order in which screens overlap each other. The larger the zorder number, the closer the screen is to the player."
+    e "zorder属性控制界面彼此重叠的顺序。zorder数字越大，界面离玩家越近。"
+
+# game/tutorial_screens.rpy:434
+translate schinese screens_properties_f7a2c73d:
+
+    # e "By default, a screen has a zorder of 0. When two screens have the same zorder number, the screen that is shown second is closer to the player."
+    e "默认情况下，界面的zorder为0。当两个界面具有相同的zorder编号时，第二个显示的界面更靠近玩家。"
+
+# game/tutorial_screens.rpy:454
+translate schinese screens_properties_78433eb8:
+
+    # e "The variant property selects a screen based on the properties of the device it's running on."
+    e "variant属性根据正在运行的设备的属性选择界面。"
+
+# game/tutorial_screens.rpy:456
+translate schinese screens_properties_e6db6d02:
+
+    # e "In this example, the first screen will be used for small devices like telephones, and the other screen will be used for tablets and computers."
+    e "在本例中，第一个界面将用于电话等小型设备，另一个界面将用于平板电脑和计算机。"
+
+# game/tutorial_screens.rpy:475
+translate schinese screens_properties_d21b5500:
+
+    # e "Finally, the style_prefix property specifies a prefix that's applied to the styles in the screen."
+    e "最后，style_prefix属性指定应用于界面的样式的前缀。"
+
+# game/tutorial_screens.rpy:477
+translate schinese screens_properties_560ca08a:
+
+    # e "When the 'red' prefix is given, the frame gets the 'red_frame' style, and the text gets the 'red_text' style."
+    e "当给定“red”前缀时，frame使用“red_frame”样式，而文本使用“red_text”样式。"
+
+# game/tutorial_screens.rpy:479
+translate schinese screens_properties_c7ad3a8e:
+
+    # e "This can save a lot of typing when styling screens with many displayables in them."
+    e "这可以在设计包含许多可视组件的界面时节省大量的输入。"
+
+# game/tutorial_screens.rpy:491
+translate schinese screens_control_4a1d8d7c:
+
+    # e "The screen language has a few statements that do things other than show displayables. If you haven't seen the section on {a=jump:warp_screen_displayables}Screen Displayables{/a} yet, you might want to check it out, then come back here."
+    e "界面语言有一些语句还可以做显示可视组件之外的事情。如果你还没有看{a=jump:warp_screen_displayables}界面可视组件{/a}部分，你可能想看一看，再回来这里。"
+
+# game/tutorial_screens.rpy:503
+translate schinese screens_control_0e939050:
+
+    # e "The python statement works just about the same way it does in the script. A single line of Python is introduced with a dollar sign. This line is run each time the screen updates."
+    e "python语句的工作方式与脚本中的基本相同。单行Python用美元符号引入。每次界面更新时都会运行此行。"
+
+# game/tutorial_screens.rpy:518
+translate schinese screens_control_6334650a:
+
+    # e "Similarly, the python statement introduces an indented block of python statements. But there is one big difference in Python in screens and Python in scripts."
+    e "类似地，python语句引入多行python的缩进块。但是界面里的Python和脚本中的Python有一个很大的区别。"
+
+# game/tutorial_screens.rpy:520
+translate schinese screens_control_ba8f5f13:
+
+    # e "The Python you use in screens isn't allowed to have side effects. That means that it can't do things like change the value of a variable."
+    e "界面中使用的Python不允许有副作用。这意味着它不能改变变量的值。"
+
+# game/tutorial_screens.rpy:522
+translate schinese screens_control_f75fa254:
+
+    # e "The reason for this is that Ren'Py will run a screen, and the Python in it, during screen prediction."
+    e "原因是Ren'Py会运行界面，和里面的Python，在界面预测期间。"
+
+# game/tutorial_screens.rpy:536
+translate schinese screens_control_40c12afa:
+
+    # e "The default statement lets you set the value of a screen variable the first time the screen runs. This value can be changed with the SetScreenVariable and ToggleScreenVariable actions."
+    e "default语句允许您在界面第一次运行时设置界面变量的值。可以使用SetScreenVariable和ToggleScreenVariable动作更改此值。"
+
+# game/tutorial_screens.rpy:538
+translate schinese screens_control_39e0f7e6:
+
+    # e "The default statement differs from the Python statement in that it is only run once. Python runs each time the screen updates, and hence the variable would never change value."
+    e "default语句与Python语句的不同之处在于它只运行一次。每次界面更新时Python都会运行，因此变量永远不会改变值。"
+
+# game/tutorial_screens.rpy:557
+translate schinese screens_control_87a75fe7:
+
+    # e "The if statement works like it does in script, running one block if the condition is true and another if the condition is false."
+    e "if语句的工作方式与脚本中类似，如果条件为true，则运行一个块；如果条件为false，则运行另一个块。"
+
+# game/tutorial_screens.rpy:572
+translate schinese screens_control_6a8c07f6:
+
+    # e "The for statement takes a list of values, and iterates through them, running the block inside the for loop with the variable bound to each list item."
+    e "for语句获取一个值列表，并遍历它们，在for循环中运行块，并将变量绑定到每个列表项。"
+
+# game/tutorial_screens.rpy:588
+translate schinese screens_control_f7b755fa:
+
+    # e "The on and key statements probably only make sense at the top level of the screen."
+    e "on和key语句可能只在界面的顶层才有意义。"
+
+# game/tutorial_screens.rpy:590
+translate schinese screens_control_328b0676:
+
+    # e "The on statement makes the screen run an action when an event occurs. The 'show' event happens when the screen is first shown, and the 'hide' event happens when it is hidden."
+    e "on语句使界面在事件发生时运行动作。“show”事件在界面第一次显示时发生，而“hide”事件在它被隐藏时发生。"
+
+# game/tutorial_screens.rpy:592
+translate schinese screens_control_6768768b:
+
+    # e "The key event runs an event when a key is pressed."
+    e "key事件在按键时运行事件。"
+
+# game/tutorial_screens.rpy:600
+translate schinese screen_use_c6a20a16:
+
+    # e "The screen language use statement lets you include a screen inside another. This can be useful to prevent duplication inside screens."
+    e "界面语言use语句允许您在另一个界面中包含一个界面。这有助于防止界面内的重复。"
+
+# game/tutorial_screens.rpy:616
+translate schinese screen_use_95a34d3a:
+
+    # e "Take for example this screen, which shows two stat entries. There's already a lot of duplication there, and if we had more stats, there would be more."
+    e "以这个界面为例，它显示两个状态（stat）条目。那已经有很多重复，如果我们有更多的状态，重复会更多。"
+
+# game/tutorial_screens.rpy:633
+translate schinese screen_use_e2c673d9:
+
+    # e "Here, we moved the statements that show the text and bar into a second screen, and the use statement includes that screen in the first one."
+    e "这里，我们将显示文本和条的语句移到第二个界面中，而use语句将该界面加入第一个界面。"
+
+# game/tutorial_screens.rpy:635
+translate schinese screen_use_2efdd2ff:
+
+    # e "The name and amount of the stat are passed in as arguments to the screen, just as is done in the call screen statement."
+    e "状态的名称和数值作为参数传递给界面，就像在call screen语句中所做的那样。"
+
+# game/tutorial_screens.rpy:637
+translate schinese screen_use_f8d1bf9d:
+
+    # e "By doing it this way, we control the amount of duplication, and can change the stat in one place."
+    e "通过这样做，我们可以控制重复的数量，并且可以在一个地方更改状态。"
+
+# game/tutorial_screens.rpy:653
+translate schinese screen_use_4e22c25e:
+
+    # e "The transclude statement goes one step further, by letting the use statement take a block of screen language statements."
+    e "transclude语句更进一步，让use语句获取界面语言的语句块。"
+
+# game/tutorial_screens.rpy:655
+translate schinese screen_use_c83b97e3:
+
+    # e "When the included screen reaches the transclude statement it is replaced with the block from the use statement."
+    e "当包含的界面到达transclude语句时，它将被来自use语句的块替换。"
+
+# game/tutorial_screens.rpy:657
+translate schinese screen_use_1ad1f358:
+
+    # e "The boilerplate screen is included in the first one, and the text from the first screen is transcluded into the boilerplate screen."
+    e "boilerplate界面被包含在第一个界面中，来自第一个界面的文本被嵌入boilerplate界面中。"
+
+# game/tutorial_screens.rpy:659
+translate schinese screen_use_f74fab6e:
+
+    # e "Use and transclude are complex, but very powerful. If you think about it, 'use boilerplate' is only one step removed from writing your own Screen Language statement."
+    e "use和transclude复杂，但非常强大。仔细想想，“使用样板”只是移除写你自己的界面语言语句的一步。"
+
+translate schinese strings:
+
+    # game/tutorial_screens.rpy:26
+    old " Lv. [lv]"
+    new " Lv. [lv]"
+
+    # game/tutorial_screens.rpy:29
+    old "HP"
+    new "HP"
+
+    # game/tutorial_screens.rpy:58
+    old "Morning"
+    new "早晨"
+
+    # game/tutorial_screens.rpy:58
+    old "Afternoon"
+    new "下午"
+
+    # game/tutorial_screens.rpy:58
+    old "Evening"
+    new "傍晚"
+
+    # game/tutorial_screens.rpy:61
+    old "Study"
+    new "学习"
+
+    # game/tutorial_screens.rpy:61
+    old "Exercise"
+    new "锻炼"
+
+    # game/tutorial_screens.rpy:61
+    old "Eat"
+    new "吃"
+
+    # game/tutorial_screens.rpy:61
+    old "Drink"
+    new "喝"
+
+    # game/tutorial_screens.rpy:61
+    old "Be Merry"
+    new "开心"
+
+    # game/tutorial_screens.rpy:107
+    old "Strength"
+    new "力量"
+
+    # game/tutorial_screens.rpy:111
+    old "Intelligence"
+    new "智力"
+
+    # game/tutorial_screens.rpy:115
+    old "Moxie"
+    new "勇气"
+
+    # game/tutorial_screens.rpy:119
+    old "Chutzpah"
+    new "狂妄"
+
+    # game/tutorial_screens.rpy:171
+    old "What screens can do."
+    new "界面能做什么。"
+
+    # game/tutorial_screens.rpy:171
+    old "How to show screens."
+    new "如何显示界面。"
+
+    # game/tutorial_screens.rpy:171
+    old "Passing parameters to screens."
+    new "传递参数给界面。"
+
+    # game/tutorial_screens.rpy:171
+    old "Screen properties."
+    new "界面属性。"
+
+    # game/tutorial_screens.rpy:171
+    old "Special screen statements."
+    new "特殊界面语句。"
+
+    # game/tutorial_screens.rpy:171
+    old "Using other screens."
+    new "使用其他界面。"
+
+    # game/tutorial_screens.rpy:171
+    old "That's it."
+    new "就这些。"
+
+    # game/tutorial_screens.rpy:205
+    old "I do."
+    new "我懂。"
+
+    # game/tutorial_screens.rpy:331
+    old "Hello, world."
+    new "Hello, world."
+
+    # game/tutorial_screens.rpy:331
+    old "You can't cancel this."
+    new "你不能取消这个。"
+
+    # game/tutorial_screens.rpy:346
+    old "Shiro was here."
+    new "西罗刚才在这里。"
+
+    # game/tutorial_screens.rpy:362
+    old "Click either button to continue."
+    new "单击任一按钮继续。"
+
+    # game/tutorial_screens.rpy:377
+    old "Close This Screen"
+    new "关闭此界面"
+
+    # game/tutorial_screens.rpy:388
+    old "A Tag Screen"
+    new "A标签界面"
+
+    # game/tutorial_screens.rpy:395
+    old "B Tag Screen"
+    new "B标签界面"
+
+    # game/tutorial_screens.rpy:447
+    old "You're on a small device."
+    new "你在使用小型设备。"
+
+    # game/tutorial_screens.rpy:452
+    old "You're not on a small device."
+    new "你不在使用小型设备。"
+
+    # game/tutorial_screens.rpy:466
+    old "This text is red."
+    new "这段文字是红色。"
+
+    # game/tutorial_screens.rpy:496
+    old "Hello, World."
+    new "Hello, World."
+
+    # game/tutorial_screens.rpy:510
+    old "It's good to meet you."
+    new "很高兴认识你。"
+
+    # game/tutorial_screens.rpy:534
+    old "Increase"
+    new "增加"
+
+    # game/tutorial_screens.rpy:563
+    old "Earth"
+    new "地球"
+
+    # game/tutorial_screens.rpy:563
+    old "Moon"
+    new "月球"
+
+    # game/tutorial_screens.rpy:563
+    old "Mars"
+    new "火星"
+
+    # game/tutorial_screens.rpy:581
+    old "Now press 'a'."
+    new "现在按下“A”。"
+
+    # game/tutorial_screens.rpy:583
+    old "The screen was just shown."
+    new "界面刚才显示了。"
+
+    # game/tutorial_screens.rpy:585
+    old "You pressed the 'a' key."
+    new "你按了“A”键。"
+
+    # game/tutorial_screens.rpy:608
+    old "Health"
+    new "体力"
+
+    # game/tutorial_screens.rpy:613
+    old "Magic"
+    new "魔力"
+
+    # game/tutorial_screens.rpy:644
+    old "There's not much left to see."
+    new "没什么可看的了。"

--- a/tutorial/game/tl/schinese/tutorial_video.rpy
+++ b/tutorial/game/tl/schinese/tutorial_video.rpy
@@ -1,0 +1,43 @@
+﻿# TODO: Translation updated at 2020-04-12 22:59
+
+# game/tutorial_video.rpy:10
+translate schinese tutorial_video_f34a17f5:
+
+    # e "Ren'Py supports playing movies. There are two ways of doing this."
+    e "Ren'Py支持播放电影。有两种方法。"
+
+# game/tutorial_video.rpy:12
+translate schinese tutorial_video_4aefd413:
+
+    # e "The first way allows you to show a movie as an image, along with every other image that's displayed on the screen."
+    e "第一种方法允许您将电影作为图像显示，和所有其他图像一起显示在界面上。"
+
+# game/tutorial_video.rpy:16
+translate schinese tutorial_video_b56ccf19:
+
+    # e "To do this, we first have to define an image to be a Movie displayable. Movie displayables take a movie to play, and can be given position properties."
+    e "为此，我们首先必须定义一个图像为Movie可视组件。Movie可视组件接受一部要播放的电影，并且可以指定位置属性。"
+
+# game/tutorial_video.rpy:25
+translate schinese tutorial_video_fbaa71e4:
+
+    # e "Then, we can show the movie displayable, which starts the movie playing."
+    e "然后，我们可以显示电影可视组件，开始播放电影。"
+
+# game/tutorial_video.rpy:30
+translate schinese tutorial_video_bbbb242d:
+
+    # e "When we no longer want to play the movie, we can hide it."
+    e "当我们不想播放这部电影时，我们可以把它隐藏起来。"
+
+# game/tutorial_video.rpy:34
+translate schinese tutorial_video_a66b154c:
+
+    # e "The other way to show a movie is with the renpy.movie_cutscene python function. This shows the movie fullscreen, either until it ends or until the user clicks."
+    e "另一种显示电影的方式是用python函数renpy.movie_cutscene。电影会全屏显示，直到结束或用户单击为止。"
+
+# game/tutorial_video.rpy:41
+translate schinese tutorial_video_63e75209:
+
+    # e "A Movie displayable can also take a mask with an alpha channel, which lets you make movie sprites. But that's more complicated, so I'll stop here for now."
+    e "Movie可视组件也可以使用一个带有alpha通道的蒙版，它可以让你制作电影精灵。但那更复杂，所以我就到此为止。"


### PR DESCRIPTION
Though [Chinese documentation](https://renpy.cn/doc/) of Ren'py has already been complete, I think the tutorial game is more intuitive. Starters can see how it works in action. So I spent some time translating it into Chinese.

I name the translation as "schinese". And I add an appropriate option in Language preference screen. I also try to keep technical terms in the tutorial consistent with the Chinese documentation while translating. I hope these would be helpful.

---

By the way, have you thought about changing the font for Chinese, Japanese and Korean? In my view, SourceHanSansLite.tff is too limited, and sometimes not beautiful in Chinese. I suggest [Noto Sans CJK](http://www.google.com/get/noto/help/cjk/) from Google, covering Simplified Chinese, Traditional Chinese, Japanese, and Korean in a unified font family. All Noto fonts are published under the SIL Open Font License, Version 1.1. It may be as large as 23 MB, but that's not a problem for modern PC.