### PR TITLE
Make threading function names consistent to snake_case

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -115,7 +115,7 @@ class Cache(object):
 
         # The preload thread.
         self.preload_thread = threading.Thread(target=self.preload_thread_main, name="preloader")
-        self.preload_thread.setDaemon(True)
+        self.preload_thread.daemon = True
         self.preload_thread.start()
 
         # Have we been added this tick?
@@ -169,7 +169,7 @@ class Cache(object):
             self.cache_limit = int(renpy.config.image_cache_size_mb * 1024 * 1024 // 4)
 
     def quit(self): # @ReservedAssignment
-        if not self.preload_thread.isAlive():
+        if not self.preload_thread.is_alive():
             return
 
         with self.preload_lock:

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -184,7 +184,7 @@ def save_dump(roots, log):
     with f:
         visit(roots, "roots")
         visit(log, "log")
-    
+
 def find_bad_reduction(roots, log):
     """
     Finds objects that can't be reduced properly.
@@ -483,7 +483,7 @@ def autosave():
         return
 
     # That is, autosave is running.
-    if not autosave_not_running.isSet():
+    if not autosave_not_running.is_set():
         return
 
     if renpy.config.skipping:
@@ -527,7 +527,7 @@ def force_autosave(take_screenshot=False, block=False):
         return
 
     # That is, autosave is running.
-    if not autosave_not_running.isSet():
+    if not autosave_not_running.is_set():
         return
 
     # Join the autosave thread to clear resources.

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -535,7 +535,7 @@ def quit():  # @ReservedAssignment
 
     with scan_thread_condition:
         quit_scan_thread = True
-        scan_thread_condition.notifyAll()
+        scan_thread_condition.notify_all()
 
     scan_thread.join()
 


### PR DESCRIPTION
Old camelCase names still exists in Python 3, but now all the names in the code follow the snake_case scheme.