### PR TITLE
Normalize project filename for unelide

### DIFF
--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -366,6 +366,8 @@ init python in project:
             Unelides the filename relative to the project base.
             """
 
+            fn = os.path.normpath(fn)
+
             fn1 = os.path.join(self.path, fn)
             if os.path.exists(fn1):
                 return fn1


### PR DESCRIPTION
Fixes paths on Windows being returned with mixed separators.
Resolves relative paths in filename before joining to base directory.

Example of first issue which this fixes:
```py
project.current.unelide_filename("game/script.rpy")
u'C:\\Users\\mwillcock\\Documents\\testgame\\game/script.rpy'
```
...this was potentially passed to external programs if using custom editor configurations.

I'm presuming that it would be by design for project files to always be within the project folder, I cannot find any obvious usage contrary to that and monitoring calls to the unelide function doesn't seem to show any part of the program using it that way.