### PR TITLE
Refresh LayeredImageProxy when interpolation is performed on its name

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -1143,7 +1143,7 @@ python early in layeredimage:
 
                 def new_per_interact():
                     newchild = self._base_duplicate(args)
-                    if rv.child is not newchild:
+                    if rv.child != newchild:
                         rv.remove(rv.child)
                         rv.add(newchild)
                         renpy.display.render.redraw(rv, 0)

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -1122,13 +1122,35 @@ python early in layeredimage:
             return image
 
 
-        def _duplicate(self, args):
+        def _base_duplicate(self, args):
 
             rv = self.image._duplicate(args)
 
 
             for i in self.transform:
                 rv = i(rv)
+
+            return rv
+
+        def _duplicate(self, args):
+
+            rv = self._base_duplicate(args)
+
+            if "[" in self.name:
+                rv = Fixed(rv, fit_first=True)
+
+                per_interact_original = rv.per_interact
+
+                def new_per_interact():
+                    newchild = self._base_duplicate(args)
+                    if rv.child is not newchild:
+                        rv.remove(rv.child)
+                        rv.add(newchild)
+                        renpy.display.render.redraw(rv, 0)
+                        newchild.visit_all(lambda i : i.per_interact())
+                    return per_interact_original()
+
+                rv.per_interact = new_per_interact
 
             return rv
 


### PR DESCRIPTION
When the string given to the LayeredImageProxy has square brackets in it, the data it accesses can change while the image is displayed, but the changes won't be taken into account until another `show` instruction is performed on the LayeredImageProxy.

Now, only when there's interpolation (not to waste processing time), the displayable which would be returned by the `_duplicate` method to be displayed (which is basically a Fixed wrapped in Transforms) is wrapped in a Fixed whose `per_interact` method is overriden.
The new method, having a link to the LayeredImageProxy, recomputes the displayable, and if updated, replaces its child with it. (Actually it always replaces it, since Transforms and Fixed don't support equality.)

Therefore, when the underlying data updates, the image is refreshed.