### PR TITLE
Doc minor fixes

### DIFF
--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -25,7 +25,7 @@ five things that can be provided:
   where each component is an integer between 0 and 255. Colors are
   passed to :func:`Solid`.
 * An image name. Any other string is interpreted as a reference to an
-  image defined with the image statement.
+  image defined with the image statement, or if none exist, to a filename.
 * A list. If a list is provided, each item is expanded as described
   below, and checked to see if it matches a filename or image name.
   If so, expansion stops and the matched thing is then processed
@@ -207,7 +207,7 @@ An image manipulator can be used any place a displayable can, but not
 vice-versa. An :func:`Image` is a kind of image manipulator, so an
 Image can be used whenever an image manipulator is required.
 
-With the few exceptions listed below, the use of image manipulators is
+The use of image manipulators is
 historic. A number of image manipulators that had been documented in the
 past should no longer be used, as they suffer from inherent problems.
 In any case except for :func:`im.Data`, the :func:`Transform` displayable provides

--- a/sphinx/source/im.rst
+++ b/sphinx/source/im.rst
@@ -12,7 +12,7 @@ image manipulators as input.
 
 An image manipulator can be used any place a displayable can, but not
 vice-versa. An :func:`Image` is a kind of image manipulator, so an
-Image can e used whenever an image manipulator is required.
+Image can be used whenever an image manipulator is required.
 
 With the few exceptions listed below, the use of image manipulators is
 historic. A number of image manipulators that had been documented in the

--- a/sphinx/source/matrixcolor.rst
+++ b/sphinx/source/matrixcolor.rst
@@ -101,7 +101,7 @@ A ColorMatrix is a class that inherits from the ColorMatrix class, and
 implements a __call__ method. This method takes:
 
 * An old object to interpolate off of. This object may be of any class,
-  and may be None if the no old object exists.
+  and may be None if no old object exists.
 * A value betwee 0.0 and 1.0, representing the point to interpolate.
   0.0 is entirely the old object, and 1.0 is entirely the new object.
 

--- a/sphinx/source/save_load_rollback.rst
+++ b/sphinx/source/save_load_rollback.rst
@@ -58,7 +58,7 @@ What isn't Saved
 ================
 
 Python variables that are not changed after the game begins will not be
-saved. This can be a major problem if a variable that is saved and one that is
+saved. This can be a major problem if a variable that is not saved and one that is
 refer to the same object. (Alias the object.) In this example::
 
     init python:
@@ -374,7 +374,7 @@ Example::
             hotspot (8, 200, 78, 78) action ui.ChoiceJump("swimming", "go_swimming", block_all=False)
             hotspot (204, 50, 78, 78) action ui.ChoiceJump("science", "go_science_club", block_all=False)
             hotspot (452, 79, 78, 78) action ui.ChoiceJump("art", "go_art_lessons", block_all=False)
-            hotspot (602, 316, 78, 78) action uiChoiceJump("home", "go_home", block_all=False)
+            hotspot (602, 316, 78, 78) action ui.ChoiceJump("home", "go_home", block_all=False)
 
 Example::
 


### PR DESCRIPTION
Some typos, and the fact that strings not referring already-defined images work fine even if the extension is missing.