### PR TITLE
Normalize game filename for unelide

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -171,6 +171,8 @@ def elide_filename(fn):
 
 
 def unelide_filename(fn):
+    fn = os.path.normpath(fn)
+
     fn1 = os.path.join(renpy.config.basedir, fn)
     if os.path.exists(fn1):
         return fn1


### PR DESCRIPTION
Fixes paths on Windows being returned with mixed separators.
Resolves relative paths in filename before joining to base directory.

This matches the behaviour change from #2527, but for opening files from a running game.