### PR TITLE
Gamepad vibrate support

### DIFF
--- a/renpy/display/controller.py
+++ b/renpy/display/controller.py
@@ -156,6 +156,13 @@ def start(index):
 
     renpy.exports.restart_interaction()
 
+def rumble(duration):
+    """
+    Rumbles all controllers for `duration` ms.
+    """
+
+    for controller in controllers.values():
+        controller.rumble(0x2222, 0x2222, duration)
 
 class PadEvent(object):
     """

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3161,6 +3161,8 @@ def vibrate(duration):
         import android # @UnresolvedImport
         android.vibrate(duration)
 
+    renpy.display.controller.vibrate(int(duration * 1000))
+
 
 def get_say_attributes():
     """


### PR DESCRIPTION
Allows gamepad vibrate from `renpy.exports.vibrate`.

Depends on https://github.com/renpy/pygame_sdl2/pull/130

**Untested code.**