### PR TITLE
Add a getter for the achievement progress

### DIFF
--- a/renpy/common/00achievement.rpy
+++ b/renpy/common/00achievement.rpy
@@ -320,6 +320,17 @@ init -1500 python in achievement:
         for i in backends:
             i.clear_all()
 
+    def get_progress(name):
+        """
+        :doc: achievement
+
+        Returns the current progress towards the achievement identified
+        with `name`, or 0 if no progress has been registered for it or if
+        the achievement is not known.
+        """
+
+        return persistent._achievement_progress.get(name, 0)
+
     def progress(name, complete, total=None):
         """
         :doc: achievement


### PR DESCRIPTION
In addition to the setter already in place (the `achievement.progress` function), there's now a getter to display to the user inside ren'py, giving a use to the non-steam achievement progress tracking.

I directly used the persistent's implementation, since the steam's implementation of the `progress` function uses it directly, but if in the future several ways to store progress emerge, a `get_progress` method could be added to all subclasses of Backend, and the function could be a foreach loop like the others.