### PR TITLE
Update focus.py

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -422,6 +422,9 @@ def focus_extreme(xmul, ymul, wmul, hmul):
 
     for f in focus_list:
 
+        if not f.widget.style.keyboard_focus:
+            continue
+
         if f.x is None:
             continue
 


### PR DESCRIPTION
Made it so the focus_extreme function (used when arrow key is pressed if self voicing is off and no displayable on screen is currently focused) ignores displayables with keyboard_focus set to False.