### PR TITLE
Make mouse area stay unhovered when keyboard focus being used

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2181,13 +2181,17 @@ class MouseArea(renpy.display.core.Displayable):
         if renpy.display.focus.get_grab():
             return
 
-        if self.style.focus_mask is not None:
-            crend = renpy.display.render.render(self.style.focus_mask, self.width, self.height, st, self.at_st_offset + st)
-            is_hovered = crend.is_pixel_opaque(x, y)
-        elif 0 <= x < self.width and 0 <= y < self.height:
-            is_hovered = True
-        else:
+        if renpy.display.focus.focus_type == 'keyboard':
             is_hovered = False
+
+        else:
+            if self.style.focus_mask is not None:
+                crend = renpy.display.render.render(self.style.focus_mask, self.width, self.height, st, self.at_st_offset + st)
+                is_hovered = crend.is_pixel_opaque(x, y)
+            elif 0 <= x < self.width and 0 <= y < self.height:
+                is_hovered = True
+            else:
+                is_hovered = False
 
         if is_hovered and not self.is_hovered:
             self.is_hovered = True

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2181,7 +2181,7 @@ class MouseArea(renpy.display.core.Displayable):
         if renpy.display.focus.get_grab():
             return
 
-        if renpy.display.focus.focus_type == 'keyboard':
+        if renpy.display.focus.pending_focus_type == 'keyboard':
             is_hovered = False
 
         else:


### PR DESCRIPTION
I am of the opinion that when a player is using the keyboard to navigate the interface the location of the mouse should be ignored to avoid potentially confusing the player, but the mouse area displayable doesn't follow this principle. Ideally a mouse area would be able to tell if the keyboard-focused displayable overlaps with it and remain hovered then and only then, so it can be used to style/animate menus of buttons with built in keyboard support, but I have made the mouse area always unhovered when using the keyboard to navigate the interface as a simple solution in the meantime.