### PR TITLE
Make screen main_menu() easier to customize

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -356,13 +356,11 @@ screen main_menu():
     ## This ensures that any other menu screen is replaced.
     tag menu
 
-    style_prefix "main_menu"
-
     add gui.main_menu_background
 
     ## This empty frame darkens the main menu.
     frame:
-        pass
+        style "main_menu_frame"
 
     ## The use statement includes another screen inside this one. The actual
     ## contents of the main menu are in the navigation screen.
@@ -371,6 +369,8 @@ screen main_menu():
     if gui.show_name:
 
         vbox:
+            style "main_menu_vbox"
+
             text "[config.name!t]":
                 style "main_menu_title"
 


### PR DESCRIPTION
`screen main_menu()` is probably the most customized of all built-in screens.

Currently styles in `screen main_menu` are applied to one `frame` and one `vbox` from `style_prefix`. This way, any time a developer adds a `frame` or a `vbox` to customize their `main_menu` they will inherit some unexpected properties (like `xsize`, `yfill`, `xalign`, `yalign`, a very specific `background`...).

Actually: `style_prefix` is useful to reuse the same properties in different children of the same type. But current properties defined in `style main_menu_frame` and `style main_menu_vbox` will hardly be reused.

My proposal is not to use `style_prefix` in the main menu, but apply directly those two styles to the two unique children that will use them.

This way, if developers add more `vbox` or `frame` to their `main_menu`, they will behave as expected with default properties.