### PR TITLE
Allow labels not to take colons

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -2335,9 +2335,7 @@ def label_statement(l, loc, init=False):
     else:
         hide = False
 
-    l.require(':')
-    l.expect_eol()
-
+    l.match(':')
     # Optional block here. It's empty if no block is associated with
     # this statement.
     block = parse_block(l.subblock_lexer(init))


### PR DESCRIPTION
I always thought it was weird that the label statement requires a colon, but indenting the following line (and giving it a block) is not mandatory. Imho, scripts would make a lot more sense imo if there was no indenting after labels, since labels have no scope like functions do.

So I disabled the requirement to have a colon ending a label's line.
It helps especially because most IDEs automatically indent a line following a colon.
It seems to work fine, after limited testing.

It could also be
```py
if l.match(':'):
    block = parse_block(l.subblock_lexer(init))
else:
    block = []
```
It would maybe save some execution time.