### PR TITLE
Fix issues that prevented #2653 from working.

### DIFF
--- a/renpy/text/ftfont.pyx
+++ b/renpy/text/ftfont.pyx
@@ -556,7 +556,12 @@ cdef class FTFont:
             if is_ucs2_surrogate(s[0]) != 1 and len_s > vs_offset and is_vs(s[vs_offset]):
                 vs = s[vs_offset]
                 next_index = FT_Face_GetCharVariantIndex(face, next_c, vs)
+                # Fallback to 0 if variation doesn't exist
+                if next_index == 0:
+                    vs = 0
+                    next_index = FT_Get_Char_Index(face, next_c)
             else:
+                vs = 0
                 next_index = FT_Get_Char_Index(face, next_c)
 
         for i from 0 <= i < len_s:
@@ -570,6 +575,7 @@ cdef class FTFont:
             gl = Glyph.__new__(Glyph)
 
             gl.character = c
+            gl.variation = vs
             gl.ascent = self.ascent
             gl.width = cache.width
             gl.line_spacing = self.lineskip
@@ -588,7 +594,12 @@ cdef class FTFont:
                 if is_ucs2_surrogate(s[i + 1]) != 1 and i < len_s - vs_offset and is_vs(s[i + vs_offset]):
                     vs = s[i + vs_offset]
                     next_index = FT_Face_GetCharVariantIndex(face, next_c, vs)
+                    # Fallback to 0 if variation doesn't exist
+                    if next_index == 0:
+                        vs = 0
+                        next_index = FT_Get_Char_Index(face, next_c)
                 else:
+                    vs = 0
                     next_index = FT_Get_Char_Index(face, next_c)
 
                 error = FT_Get_Kerning(face, index, next_index, FT_KERNING_DEFAULT, &kerning)
@@ -649,7 +660,10 @@ cdef class FTFont:
             if glyph.character == 0x200b:
                 continue
 
-            index = FT_Get_Char_Index(face, <FT_ULong> glyph.character)
+            if glyph.variation == 0:
+                index = FT_Get_Char_Index(face, glyph.character)
+            else:
+                index = FT_Face_GetCharVariantIndex(face, glyph.character, glyph.variation)
             cache = self.get_glyph(index)
 
             bmx = <int> (glyph.x + .5) + cache.bitmap_left
@@ -724,7 +738,10 @@ cdef class FTFont:
             underline_x = x - glyph.delta_x_offset
             underline_end = x + <int> glyph.advance + expand
 
-            index = FT_Get_Char_Index(face, <FT_ULong> glyph.character)
+            if glyph.variation == 0:
+                index = FT_Get_Char_Index(face, glyph.character)
+            else:
+                index = FT_Face_GetCharVariantIndex(face, glyph.character, glyph.variation)
             cache = self.get_glyph(index)
 
             # with nogil used to be here, but it slowed things down.

--- a/renpy/text/ftfont.pyx
+++ b/renpy/text/ftfont.pyx
@@ -556,6 +556,7 @@ cdef class FTFont:
             if is_ucs2_surrogate(s[0]) != 1 and len_s > vs_offset and is_vs(s[vs_offset]):
                 vs = s[vs_offset]
                 next_index = FT_Face_GetCharVariantIndex(face, next_c, vs)
+
                 # Fallback to 0 if variation doesn't exist
                 if next_index == 0:
                     vs = 0
@@ -582,6 +583,7 @@ cdef class FTFont:
             gl.draw = True
 
             if i < len_s - 1:
+
                 if i < len_s - 2 and is_ucs2_surrogate(s[i + 1]) == 2 and is_ucs2_surrogate(s[i + 2]) == 1:
                     next_c = ((<FT_ULong> s[i + 1]) & 0b1111111111) << 10
                     next_c |= (<FT_ULong> s[i + 2]) & 0b1111111111
@@ -594,6 +596,7 @@ cdef class FTFont:
                 if is_ucs2_surrogate(s[i + 1]) != 1 and i < len_s - vs_offset and is_vs(s[i + vs_offset]):
                     vs = s[i + vs_offset]
                     next_index = FT_Face_GetCharVariantIndex(face, next_c, vs)
+
                     # Fallback to 0 if variation doesn't exist
                     if next_index == 0:
                         vs = 0
@@ -664,6 +667,7 @@ cdef class FTFont:
                 index = FT_Get_Char_Index(face, glyph.character)
             else:
                 index = FT_Face_GetCharVariantIndex(face, glyph.character, glyph.variation)
+
             cache = self.get_glyph(index)
 
             bmx = <int> (glyph.x + .5) + cache.bitmap_left
@@ -742,6 +746,7 @@ cdef class FTFont:
                 index = FT_Get_Char_Index(face, glyph.character)
             else:
                 index = FT_Face_GetCharVariantIndex(face, glyph.character, glyph.variation)
+
             cache = self.get_glyph(index)
 
             # with nogil used to be here, but it slowed things down.

--- a/renpy/text/textsupport.pxd
+++ b/renpy/text/textsupport.pxd
@@ -44,6 +44,7 @@ cdef class Glyph:
 
         # The character we use.
         public unsigned int character
+        public unsigned int variation
 
         # Controls splitting of this glyph, based on where we are in the
         # the line.

--- a/renpy/text/textsupport.pyx
+++ b/renpy/text/textsupport.pyx
@@ -27,10 +27,14 @@ include "linebreak.pxi"
 cdef class Glyph:
 
     def __cinit__(self):
+        self.variation = 0
         self.delta_x_offset = 0
 
     def __repr__(self):
-        return "<Glyph {0!r} time={1}>".format(self.character, self.time)
+        if self.variation == 0:
+            return "<Glyph {0!r} time={1}>".format(self.character, self.time)
+        else:
+            return "<Glyph {0!r} vs={1} time={2}>".format(self.character, self.variation, self.time)
 
 cdef class Line:
 


### PR DESCRIPTION
Specifically:

- Explicitly cast the Unicode characters to FT_ULong before doing bit ops.
- Add the decoded value by 0x10000 to get the actual Unicode value.
- Change the rest of Py_UNICODE castings to FT_ULong so the Unicode values don't get casted back to 16-bit when rendering.
- Make the decode routine easier to read.

---

This is a followup to #2653, which properly closes #2642.