### PR TITLE
Character class callable for string type

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1047,7 +1047,10 @@ class ADVCharacter(object):
         who = self.name
 
         if self.dynamic:
-            who = renpy.python.py_eval(who)
+            if callable(who):
+                who = who()
+            else:
+                who = renpy.python.py_eval(who)
 
         return renpy.substitutions.substitute(who)[0]
 
@@ -1056,7 +1059,10 @@ class ADVCharacter(object):
         who = self.name
 
         if self.dynamic:
-            who = renpy.python.py_eval(who)
+            if callable(who):
+                who = who()
+            else:
+                who = renpy.python.py_eval(who)
 
         rv = renpy.substitutions.substitute(who)[0]
 


### PR DESCRIPTION
This fixes issue #2682 .
Adds the ability for the string type conversion to also "call" a callable "who". Currently, only __call__ will attempt a callable who conversion.



