### PR TITLE
Fix order tts reads children in

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -701,7 +701,7 @@ class Displayable(renpy.object.Object):
 
         rv = [ ]
 
-        for i in self.visit():
+        for i in self.visit()[::-1]:
             if i is not None:
                 speech = i._tts()
 


### PR DESCRIPTION
Fixed issue introduced by 3ee3794 where tts reads the children of containers in the wrong order.