### PR TITLE
doc: clarify video library used

### DIFF
--- a/sphinx/source/movie.rst
+++ b/sphinx/source/movie.rst
@@ -3,7 +3,7 @@
 Movie
 =====
 
-Ren'Py is capable of using libav (included) to play movies using the
+Ren'Py is capable of using FFmpeg (included) to play movies using the
 video codecs:
 
 * VP9


### PR DESCRIPTION
Hi. I got contacted by a dev who wondered about poor video performances and blamed Ren'Py usage of a defunc library (libav.org).
I answered that there was probably confusion between the libav* libraries provided by FFmpeg and the old libav fork.
Nonetheless, the current documentation has an ambiguous usage of "libav" and I figured we could clarify.