### PR TITLE
Add frame background to default notify screen

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -665,7 +665,9 @@ init -1500:
     screen notify:
         zorder 100
 
-        text "[message!tq]" at _notify_transform
+        frame at _notify_transform:
+            background '#7777'
+            text "[message!tq]"
 
         # This controls how long it takes between when the screen is
         # first shown, and when it begins hiding.


### PR DESCRIPTION
Adds a grey transparent background to improve contrast and readability over any surface.
Comes from the fact that it appears over a white surface in the launcher, and could pose the same problem in games with white backdrops if the gui asset or the screens.rpy notify screen is missing.