### PR TITLE
Improve small gui

### DIFF
--- a/gui/game/gui.rpy
+++ b/gui/game/gui.rpy
@@ -442,6 +442,7 @@ init python:
         gui.slider_size = gui.scale(36)
 
         gui.choice_button_width = gui.scale(1240)
+        gui.choice_button_text_size = gui.scale(30)
 
         gui.navigation_spacing = gui.scale(20)
         gui.pref_button_spacing = gui.scale(10)

--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -1505,10 +1505,10 @@ style vslider:
     base_bar Frame("gui/phone/slider/vertical_[prefix_]bar.png", gui.vslider_borders, tile=gui.slider_tile)
     thumb "gui/phone/slider/vertical_[prefix_]thumb.png"
 
-style slider_pref_vbox:
+style slider_vbox:
     variant "small"
     xsize None
 
-style slider_pref_slider:
+style slider_slider:
     variant "small"
     xsize gui.scale(600)


### PR DESCRIPTION
I have made two small tweaks to the default GUI so that it'll work more nicely on small-screen devices right out of the box.

One is adding a small variant for the text size of choice button texts, since unlike other text with specified text sizes choice button text didn't already have that and thus didn't change size on small-screen devices.

The other is changing two of the small variant styles, slider_pref_vbox and slider_pref_slider, to slider_vbox and slider_slider, since slider_pref_vbox and slider_pref_slider are unused styles.