### PR TITLE
Fixes for Live2D

### DIFF
--- a/renpy/gl2/live2d.py
+++ b/renpy/gl2/live2d.py
@@ -692,8 +692,14 @@ class Live2D(renpy.display.core.Displayable):
         # True if the motion should be faded out.
         do_fade_out = True
 
+        # True if the motion stays on last frame.
+        last_frame = False
+
         for m in self.motions:
             motion = common.motions.get(m, None)
+
+            if motion is None:
+                continue
 
             if motion.duration > st:
 
@@ -705,16 +711,17 @@ class Live2D(renpy.display.core.Displayable):
             st -= motion.duration
 
         else:
+            if motion is None:
+                return None
+
             if self.loop:
                 do_fade_in = not common.is_seamless(m)
                 do_fade_out = not common.is_seamless(m)
             else:
                 st = motion.duration
+                last_frame = True
 
-        if motion is None:
-            return None
-
-        motion_data = motion.get(st, st_fade, do_fade_in, do_fade_out)
+        motion_data, wait = motion.update(st, st_fade, do_fade_in, do_fade_out)
 
         for k, v in motion_data.items():
 
@@ -728,7 +735,7 @@ class Live2D(renpy.display.core.Displayable):
             elif kind == "Model":
                 common.model.set_parameter(key, value, factor)
 
-        return motion.wait(st, st_fade, do_fade_in, do_fade_out)
+        return None if last_frame else wait
 
     def update_expressions(self, st):
 

--- a/renpy/gl2/live2dmotion.py
+++ b/renpy/gl2/live2dmotion.py
@@ -172,10 +172,11 @@ class Motion(object):
                 curve.get("FadeOutTime", fadeout),
                 )
 
-    def get(self, st, fade_st, do_fade_in, do_fade_out):
+    def update(self, st, fade_st, do_fade_in, do_fade_out):
         """
-        Returns a dictionary where the keys are the type of parameter and the
-        parameter name, and the values are the blend factor and value.
+        Returns a tuple of dictionary where the keys are the type of parameter
+        and the parameter name, and the values are the blend factor and value, and
+        number how much time should pass until this displayable needs to be redrawn.
         """
 
         if st == self.duration:
@@ -183,7 +184,9 @@ class Motion(object):
         else:
             st = st % self.duration
 
-        rv = { }
+        data = { }
+
+        wait = 86400.0
 
         for k, segments in self.curves.items():
 
@@ -214,61 +217,21 @@ class Motion(object):
             t = st
 
             for i in segments:
-                if t <= i.duration:
-                    rv[k] = (factor, i.get(t))
+                if t <= i.duration or i is segments[-1]:
+
+                    if factor > 0.0:
+                        wait = min(wait, i.wait(t))
+
+                    data[k] = (factor, i.get(t))
 
                     break
 
                 t -= i.duration
 
-        return rv
+        if wait == 86400.0:
+            wait = None
 
-    def wait(self, st, fade_st, do_fade_in, do_fade_out):
-        """
-        Returns how much time should pass until this displayable needs to be
-        redrawn.
-        """
-
-        st = st % self.duration
-
-        rv = 86400.0
-
-        for k, segments in self.curves.items():
-
-            fadeout = self.fades[k][1]
-
-            if not do_fade_out:
-                fadeout = 0
-
-            factor = 1.0
-
-            if st > self.duration - fadeout:
-                factor = min(factor, 1.0 - (st - (self.duration - fadeout)) / fadeout)
-
-            if fade_st is not None:
-                if fadeout > 0:
-                    factor = min(factor, 1.0 - fade_st / fadeout)
-                else:
-                    factor = 0.0
-
-            factor = max(factor, 0.0)
-
-            if factor == 0.0:
-                continue
-
-            t = st
-
-            for i in segments:
-                if t < i.duration:
-                    rv = min(rv, i.wait(t))
-                    break
-
-                t -= i.duration
-
-        if rv == 86400.0:
-            rv = None
-
-        return rv
+        return data, wait
 
 
 class NullMotion(object):
@@ -278,8 +241,5 @@ class NullMotion(object):
 
     duration = 1.0
 
-    def get(self, st, fade_st, do_fade_in, do_fade_out):
-        return { }
-
-    def wait(self, st, fade_st, do_fade_in, do_fade_out):
-        return max(1.0 - st, 0)
+    def update(self, st, fade_st, do_fade_in, do_fade_out):
+        return { }, max(1.0 - st, 0)


### PR DESCRIPTION
1. Combined get and wait methods of Motion class, as they called only from the Live2D.update function and do almost the same.
2. Fixed the issue that "hold on last frame" feature caused redrawing with 0 seconds instead of stop redrawing.
3. Fixed the issue when if curves total duration less than motion duration this used the default value of the parameter instead of the value from the last curve.