### PR TITLE
Avoid unknown attributes warning in layeredimage

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -658,11 +658,14 @@ python early in layeredimage:
             if self.attribute_function:
                 attributes = set(self.attribute_function(attributes))
 
-                unknown = set(attributes)
+                unknown = set([i[1:] if i.startswith('-') else i for i in attributes])
 
                 for a in self.attributes:
 
                     unknown.discard(a.attribute)
+
+                    if a.variant:
+                        unknown.discard(a.variant)
 
             rv = Fixed(**self.fixed_args)
 


### PR DESCRIPTION
With renpy 7.4.3, when using attribute_function in layeredimage, `unknown attributes` warning are show in two cases:  
- `attribute_function`  returns `-attribute`, even if attribute is define in the layerimage defintion
- `attribute_function` returns a `variant` attribute
