### PR TITLE
Can now sync to channel when playing audio

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -353,6 +353,17 @@ class Channel(object):
             except:
                 raise exception("expected float, got {!r}.".format(v))
 
+        def expect_channel():
+            if not spec:
+                raise exception("expected channel at end.")
+
+            v = spec.pop(0)
+
+            try:
+                return renpy.audio.audio.get_channel(v)
+            except:
+                raise exception("expected channel, got {!r}.".format(v))
+
         m = re.match(r'<(.*)>(.*)', filename)
         if not m:
             return filename, 0, -1
@@ -373,6 +384,13 @@ class Channel(object):
                 start = expect_float()
             elif clause == "to":
                 end = expect_float()
+            elif clause == "sync":
+                sync_channel = expect_channel()
+                t = sync_channel.get_pos()
+                if not t or t < 0:
+                    pass
+                else:
+                    start = t / 1000.0
             elif clause == "loop":
                 loop = expect_float()
             elif clause == "silence":

--- a/sphinx/source/audio.rst
+++ b/sphinx/source/audio.rst
@@ -160,6 +160,25 @@ will play 10.5 seconds of waves.opus, starting at the 5 second mark. The stateme
 will play song.opus all the way through once, then loop back to the 6.333
 second mark before playing it again all the way through to the end.
 
+.. _sync-start:
+
+Sync Start Position
+-------------------
+
+The position in the file at which the clip begins playing can also be synced to
+another channel with a currently-playing track using a filename like
+"<sync channelname>track.opus", where channelname is the name of the channel,
+which could be music, sound, or any other registered channels.
+
+This can be used to sync multi-layered looping tracks together. For example::
+
+        play music_2 [ "<sync music_1>layer_2.opus", "layer_2.opus" ]
+
+Will play layer_2.opus with the start time synced to the current track in
+channel music_1 in the first iteration, before playing the whole track in
+subsequent iterations. (By default, the layer_2.opus start time will remain
+modified even in subsequent iterations in the loop.)
+
 .. _silence:
 
 Playing Silence


### PR DESCRIPTION
Ensures that we can sync the audio clip time of new music layer to a channel we specify. This will allow the music layers to remain in sync after save/load (\<from X\> doesn't sync after save/load, since X is at a different point after loading).

Usage:
Audio clip filename to play = "<sync [channel_name]>[audiofilename.ogg]"