### PR TITLE
Adjust Java Heap Size Limit in Ren'Py

### DIFF
--- a/launcher/game/android.rpy
+++ b/launcher/game/android.rpy
@@ -49,7 +49,7 @@ init python:
 
     DEBUG_TEXT = _("Selects the Debug build, which can be accessed through Android Studio. Changing between debug and release builds requires an uninstall from your device.")
     RELEASE_TEXT = _("Selects the Release build, which can be uploaded to stores. Changing between debug and release builds requires an uninstall from your device.")
-
+    HEAP_SIZE_TEXT = _("Opens {i}gradle.properties{/i} in a editor to change Java Heap Size in RAPT.\n\nUse this only if you recieve a {i}java.lang.OutOfMemory{/i} error while building.")
 
     import subprocess
     import re
@@ -419,6 +419,10 @@ screen android:
                             textbutton _("Logcat"):
                                 action AndroidIfState(state, ANDROID_NO_KEY, Jump("logcat"))
                                 hovered tt.Action(LOGCAT_TEXT)
+                                
+                            textbutton _("Change Java Heap Size"):
+                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties")
+                                hovered tt.Action(HEAP_SIZE_TEXT)
 
 
                 # Right side.

--- a/launcher/game/android.rpy
+++ b/launcher/game/android.rpy
@@ -49,7 +49,7 @@ init python:
 
     DEBUG_TEXT = _("Selects the Debug build, which can be accessed through Android Studio. Changing between debug and release builds requires an uninstall from your device.")
     RELEASE_TEXT = _("Selects the Release build, which can be uploaded to stores. Changing between debug and release builds requires an uninstall from your device.")
-    HEAP_SIZE_TEXT = _("Opens {i}gradle.properties{/i} in a editor to change Java Heap Size in RAPT.\n\nUse this only if you recieve a {i}java.lang.OutOfMemory{/i} error while building.")
+    HEAP_SIZE_TEXT = _("Opens \"gradle.properties\" in a editor in order to change the Java heap size limit in RAPT.\n\nUse this if you recieved a \"java.lang.OutOfMemory\" error while building.")
 
     import subprocess
     import re
@@ -421,7 +421,7 @@ screen android:
                                 hovered tt.Action(LOGCAT_TEXT)
                                 
                             textbutton _("Change Java Heap Size"):
-                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties")
+                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties"))
                                 hovered tt.Action(HEAP_SIZE_TEXT)
 
 

--- a/launcher/game/android.rpy
+++ b/launcher/game/android.rpy
@@ -49,7 +49,7 @@ init python:
 
     DEBUG_TEXT = _("Selects the Debug build, which can be accessed through Android Studio. Changing between debug and release builds requires an uninstall from your device.")
     RELEASE_TEXT = _("Selects the Release build, which can be uploaded to stores. Changing between debug and release builds requires an uninstall from your device.")
-    HEAP_SIZE_TEXT = _("Opens \"gradle.properties\" in a editor in order to change the Java heap size limit in RAPT.\n\nUse this if you recieved a \"java.lang.OutOfMemory\" error while building.")
+    HEAP_SIZE_TEXT = _("Opens \"gradle.properties\" in a editor in order to change the Java heap size limit in RAPT.\n\nUse this if you received a \"java.lang.OutOfMemory\" error while building.")
 
     import subprocess
     import re
@@ -421,7 +421,7 @@ screen android:
                                 hovered tt.Action(LOGCAT_TEXT)
                                 
                             textbutton _("Change Java Heap Size"):
-                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties"))
+                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties", check=True))
                                 hovered tt.Action(HEAP_SIZE_TEXT)
 
 

--- a/launcher/game/android.rpy
+++ b/launcher/game/android.rpy
@@ -49,7 +49,6 @@ init python:
 
     DEBUG_TEXT = _("Selects the Debug build, which can be accessed through Android Studio. Changing between debug and release builds requires an uninstall from your device.")
     RELEASE_TEXT = _("Selects the Release build, which can be uploaded to stores. Changing between debug and release builds requires an uninstall from your device.")
-    HEAP_SIZE_TEXT = _("Opens \"gradle.properties\" in a editor in order to change the Java heap size limit in RAPT.\n\nUse this if you received a \"java.lang.OutOfMemory\" error while building.")
 
     import subprocess
     import re
@@ -419,11 +418,6 @@ screen android:
                             textbutton _("Logcat"):
                                 action AndroidIfState(state, ANDROID_NO_KEY, Jump("logcat"))
                                 hovered tt.Action(LOGCAT_TEXT)
-                                
-                            textbutton _("Change Java Heap Size"):
-                                action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties", check=True))
-                                hovered tt.Action(HEAP_SIZE_TEXT)
-
 
                 # Right side.
                 frame:


### PR DESCRIPTION
## Issue
In some instances, when building a project on Android, you might get a `java.lang.OutOfMemory` error when Gradle attempts to package your project for release (Issue #1891). This is normally caused when a project is approximately >500 MB in size and will cause the current Java Allocation of 3 GB to be filled completely which causes the following issue.

## Versions Affected
Ren'Py Versions that use Gradle as of late with `-Xms3g` coded in *gradle.properties*

## Solution
This PR addresses this issue by making a button available to the user under **Other**, below _Logcat_ named __Change Java Heap Size__ with this description.
> Opens "gradle.properties" in a editor in order to change the Java heap size limit in RAPT. Use this if you received a "java.lang.OutOfMemory" error while building.

Button Code
```python
textbutton _("Change Java Heap Size"):
    action AndroidIfState(state, ANDROID_NO_CONFIG, editor.Edit(config.basedir + "/rapt/project/gradle.properties"))
    hovered tt.Action(HEAP_SIZE_TEXT)
```

This button will only be clickable once the Android SDK is installed to avoid any file does not exist errors.