### PR TITLE
make hard pause undismissable

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1524,7 +1524,7 @@ def pause(delay=None, music=None, with_none=None, hard=False, checkpoint=None):
         afm = None
 
     if hard or not renpy.store._dismiss_pause:
-        renpy.ui.saybehavior(afm=afm, dismiss='dismiss_hard_pause')
+        renpy.ui.saybehavior(afm=afm, dismiss='dismiss_hard_pause', dismiss_unfocused=[])
     else:
         renpy.ui.saybehavior(afm=afm)
 


### PR DESCRIPTION
In projects where 'dismiss_unfocused' has been provided keys, these keys will also dismiss unfocused hard pauses. Generally this is undesirable, so this commit makes it so hard pauses use an empty list for the dismiss_unfocused parameter of the say behavior.