### PR TITLE
Fixed awkward Korean Translations

### DIFF
--- a/tutorial/game/tl/korean/indepth_character.rpy
+++ b/tutorial/game/tl/korean/indepth_character.rpy
@@ -15,19 +15,19 @@ translate korean demo_character_d7908a94:
 translate korean demo_character_275ef8b9:
 
     # e "Each statement creates a Character object, and gives it a single argument, a name. If the name is None, no name is displayed."
-    e "각각의 구절은 캐릭터 객체를 생성하고 하나의 인자인 이름을 주는데, 이름이 None이면 표시되는 이름이 없게 돼."
+    e "각각의 구문은 캐릭터 객체를 생성하고 이름 인자 한 개를 전달하는데, 만약 이름이 None이면 표시되는 이름이 없게 돼."
 
 # game/indepth_character.rpy:21
 translate korean demo_character_a63aea0c:
 
     # e "This can be followed by named arguments that set properties of the character. A named argument is a property name, an equals sign, and a value."
-    e "이 다음에는 캐릭터의 속성을 설정하는 인수가 올 수 있어. 정의된 인수는 특성 이름과 등호, 값이야."
+    e "이 다음에는 캐릭터의 속성을 설정하는 인자가 올 수 있어. 정의된 인수는 특성 이름과 등호, 값이야."
 
 # game/indepth_character.rpy:23
 translate korean demo_character_636a502e:
 
     # e "Multiple arguments should be separated with commas, like they are here. Let's see those characters in action."
-    e "여러 개의 인수는 여기에 있는 것처럼 쉼표로 구분해야 해. 이제 행동하는 캐릭터를 보도록 하자."
+    e "여러 개의 인자는 여기에 있는 것처럼 쉼표로 구분해야 해. 이제 캐릭터의 행동을 보도록 하자."
 
 # game/indepth_character.rpy:27
 translate korean demo_character_44b54e1d:
@@ -45,7 +45,7 @@ translate korean demo_character_a9646dd8:
 translate korean demo_character_79793208:
 
     # e "This example shows how the name Character is a bit of a misnomer. Here, we have multiple Characters in use, but you see it as me speaking."
-    e "이 예제는 약간의 잘못된 캐릭터를 보여주고 있어. 여기서 우리는 여러 캐릭터를 사용하고 있지만, 네게는 단지 내가 말하는 것처럼 보였을 거야."
+    e "이 예제는 약간 잘못된 캐릭터를 보여주고 있어. 여기서 우리는 여러 캐릭터를 사용하고 있지만, 네게는 단지 내가 말하는 것처럼 보였을 거야."
 
 # game/indepth_character.rpy:33
 translate korean demo_character_5d5d7482:
@@ -195,13 +195,13 @@ translate korean demo_character_f9b0052f:
 translate korean demo_character_6dfce4b7:
 
     # l8 "Like this! Finally I get some more dialogue around here."
-    l8 "이처럼 말야! 마지막으로 여기에서 좀 더 대화를 나눴어."
+    l8 "이렇게 말야! 마지막으로 여기에서 좀 더 대화를 나눴어."
 
 # game/indepth_character.rpy:157
 translate korean demo_character_68d9e46c:
 
     # e "The last thing you have to know is that there's a special character, narrator, that speaks narration. Got it?"
-    e "마지막으로 알아야 할 것은 내레이션을 말하는 특수 캐릭터, 내레이터야. 알겟지?"
+    e "마지막으로 알아야 할 것은 내레이션을 말하는 특수 캐릭터, 내레이터야. 알겠지?"
 
 # game/indepth_character.rpy:159
 translate korean demo_character_0c8f314a:

--- a/tutorial/game/tl/korean/indepth_displayables.rpy
+++ b/tutorial/game/tl/korean/indepth_displayables.rpy
@@ -9,7 +9,7 @@ translate korean simple_displayables_db46fd25:
 translate korean simple_displayables_bfe78cb7:
 
     # e "The image statement is used to give an image name to a displayable. The easy way is to simply give an image filename."
-    e "이미지(image) 문은 디스플레이어블에 이미지 이름을 부여하는 데 사용돼. 간단하게는 이미지 파일을 지정하는 쉬운 방법이 있어."
+    e "이미지(image) 구문은 디스플레이어블에 이미지 이름을 부여하는 데 사용돼. 간단하게는 이미지 파일을 지정하는 쉬운 방법이 있어."
 
 # game/indepth_displayables.rpy:29
 translate korean simple_displayables_cef4598b:
@@ -27,7 +27,7 @@ translate korean simple_displayables_a661fb63:
 translate korean simple_displayables_7f2efb23:
 
     # e "Three or six digit colors are opaque, containing red, green, and blue values. The four and eight digit versions append alpha, allowing translucent colors."
-    e "3 또는 6자리 색상은 불투명하며 빨강, 초록 및 파랑 값을 포함해. 4자리 및 8자리 버전은 알파를 추가하여 반투명 색상을 허용하지."
+    e "3자리 또는 6자리 색상은 불투명하고, 빨강, 초록, 파랑 값을 포함해. 4자리 또는 8자리 색상은 알파 값을 포함해 반투명 색상을 허용하지."
 
 # game/indepth_displayables.rpy:53
 translate korean simple_displayables_9cd108c6:
@@ -99,7 +99,7 @@ translate korean simple_displayables_ae3f35f5:
 translate korean simple_displayables_de555a92:
 
     # e "You can even write custom displayables for minigames, if you're proficient at Python. But for many visual novels, these will be all you'll need."
-    e "파이썬을 능숙하게 사용한다면, 미니 게임용 커스텀 디스플레이어블을 작성할 수도 있어. 그러나 많은 시각 소설을 위해, 이것들은 네가 필요로 하는 모든 것이 될 거야."
+    e "파이썬을 능숙하게 사용한다면, 미니 게임용 커스텀 디스플레이어블을 작성할 수도 있어. 하지만 대부분의 비주얼 노벨에선, 여기까지가 너에게 필요한 내용 전부야."
 
 translate korean strings:
 

--- a/tutorial/game/tl/korean/indepth_minigame.rpy
+++ b/tutorial/game/tl/korean/indepth_minigame.rpy
@@ -3,31 +3,31 @@
 translate korean demo_minigame_8f14835c:
 
     # e "You may want to mix Ren'Py with other forms of gameplay. There are a couple of ways to do this."
-    e "렌파이를 다른 형태의 게임 플레이와 혼합하는 작업에는 몇 가지 방법이 있어."
+    e "렌파이를 다른 형태의 게임 플레이와 혼합하는 몇 가지 방법이 있어."
 
 # game/indepth_minigame.rpy:222
 translate korean demo_minigame_9b01503e:
 
     # e "The first is with the screen system, which can be used to display data and create button and menu based interfaces."
-    e "첫 번째는 화면 시스템으로 데이터를 표시하고 버튼 및 메뉴 기반 인터페이스를 만드는 데 사용하는 거야."
+    e "첫 번째는 화면 시스템으로, 데이터를 표시하고 버튼 및 메뉴 기반 인터페이스를 만드는 데 사용하는 거야."
 
 # game/indepth_minigame.rpy:224
 translate korean demo_minigame_3e601161:
 
     # e "Screens will work for many simulation-style games and RPGs."
-    e "스크린은 많은 시뮬레이션 스타일의 게임 및 RPG에서 작동해."
+    e "스크린(Screen)은 많은 시뮬레이션 스타일의 게임 및 RPG에서 작동해."
 
 # game/indepth_minigame.rpy:226
 translate korean demo_minigame_a92baa6b:
 
     # e "When screens are not enough you can write a creator-defined displayable to extend Ren'Py itself. A Creator-defined displayables can process raw events and draw to the screen."
-    e "스크린이 충분하지 않으면 렌파이 자체를 확장하기 위해 창작자-정의 디스플레이어블을 작성할 수 있어. 창작자-정의된 디스플레이어블은 그대로의 이벤트를 처리하고 스크린에 그릴 수 있지."
+    e "스크린이 충분하지 않으면 렌파이 자체를 확장하기 위해 창작자-정의 디스플레이어블을 작성할 수 있어. 창작자-정의 디스플레이어블은 그대로의 이벤트를 처리하고 스크린에 그릴 수 있지."
 
 # game/indepth_minigame.rpy:228
 translate korean demo_minigame_a07dbae0:
 
     # e "That makes it possible to create all kinds of minigames. Would you like to play some pong?"
-    e "그것은 모든 종류의 미니 게임을 만드는 것을 가능하게 해. 퐁을 플레이해볼래?"
+    e "어떤 종류의 미니 게임이든 만들어볼 수 있어. 퐁 한번 플레이해볼래?"
 
 # game/indepth_minigame.rpy:245
 translate korean play_pong_ce00ff63:
@@ -63,25 +63,25 @@ translate korean pong_done_750092ed:
 translate korean pong_done_5781d902:
 
     # e "Minigames can spice up your visual novel, but be careful – not every visual novel player wants to be good at arcade games."
-    e "미니게임은 시각 소설을 다채롭게 할 수 있지만 조심해야 해. 모든 시각 소설 플레이어가 아케이드 게임을 잘하고 싶어하는 것은 아니니까."
+    e "미니게임은 비주얼 노벨을 다채롭게 할 수 있지만 조심해야 해. 모든 비주얼 노벨 플레이어가 아케이드 게임을 잘하고 싶어하는 것은 아니니까."
 
 # game/indepth_minigame.rpy:276
 translate korean pong_done_631325c8:
 
     # e "Part of the reason Ren'Py works well is that it's meant for certain types of games, like visual novels and life simulations."
-    e "렌파이가 잘 작동하는 이유 중 하나는 그것이 시각 소설과 육성 시뮬레이션과 같은 특정 유형의 게임에 해당된다는 거야."
+    e "렌파이가 좋은 이유 중 하나는, 비주얼 노벨이나 육성 시뮬레이션 같은 특정 유형의 게임에 잘 어울린다는 점이야."
 
 # game/indepth_minigame.rpy:278
 translate korean pong_done_61d60761:
 
     # e "The further afield you get from those games, the more you'll find yourself fighting Ren'Py. At some point, it makes sense to consider other engines."
-    e "그러한 게임들을 만들다 보면 어느새 렌파이와 싸우고 있는 너를 발견하게 될 거야. 어떤 시점에서는, 다른 엔진을 고려하는 것이 좋아."
+    e "그런 것과 거리가 먼 게임을 만들다 보면, 어느새 렌파이와 싸우고 있는 너를 발견하게 될 거야. 이런 시점에서는, 다른 엔진을 고려해보는 게 좋아."
 
 # game/indepth_minigame.rpy:282
 translate korean pong_done_715c7b12:
 
     # e "And that's fine with us. We'll always be here for you when you're making visual novels."
-    e "그건 당연해. 그리고 우리는 네가 시각 소설을 만들 때 항상 여기에 있을 거야."
+    e "그래도 괜찮아. 우리는 네가 비주얼 노벨을 만들 때 항상 여기에 있을 테니까."
 
 translate korean strings:
 

--- a/tutorial/game/tl/korean/indepth_style.rpy
+++ b/tutorial/game/tl/korean/indepth_style.rpy
@@ -3,7 +3,7 @@
 translate korean new_gui_17a0326e:
 
     # e "When you create a new project, Ren'Py will automatically create a GUI - a Graphical User Interface - for it."
-    e "새로운 프로젝트를 만들 때, 렌파이는 프로젝트를 위한 GUI-그래픽 유저 인터페이스-를 자동으로 생성할 거야."
+    e "새로운 프로젝트를 만들 때, 렌파이는 프로젝트를 위한 GUI(그래픽 유저 인터페이스)를 자동으로 생성할 거야."
 
 # game/indepth_style.rpy:42
 translate korean new_gui_12c814ed:
@@ -15,19 +15,19 @@ translate korean new_gui_12c814ed:
 translate korean new_gui_0a2a73bb:
 
     # e "The default GUI is meant to be nice enough for a simple project. With a few small changes, it's what you're seeing in this game."
-    e "기본 GUI는 몇 가지 작은 변화와 함께 단순한 프로젝트에 사용하기 충분해. 네가 이 길라잡이에서 보고 있는 것도 GUI야."
+    e "기본 GUI는 몇 가지 작은 변화만 줘 가며, 단순한 프로젝트에 사용하기 충분해. 네가 이 길라잡이에서 보고 있는 것도 GUI야."
 
 # game/indepth_style.rpy:46
 translate korean new_gui_22adf68e:
 
     # e "The GUI is also meant to be easy for an intermediate creator to customize. Customizing the GUI consists of changing the image files in the gui directory, and changing variables in gui.rpy."
-    e "GUI는 제작자가 쉽게 사용자 정의할 수 있도록 제작됐어. GUI를 사용자 정의하는 작업은 gui 디렉토리의 이미지 파일을 변경하고 gui.rpy의 변수를 변경하는 것으로 가능해."
+    e "GUI는 제작자가 쉽게 사용자 정의할 수 있도록 제작됐어. GUI를 사용자 정의하려면 gui 디렉토리의 이미지 파일을 변경하고 gui.rpy의 변수를 변경하면 돼."
 
 # game/indepth_style.rpy:48
 translate korean new_gui_da21de30:
 
     # e "At the same time, even when customized, the default GUI might be too recognizable for an extremely polished game. That's why we've made it easy to totally replace."
-    e "동시에, 사용자 정의된 극도로 세련된 게임의 경우에도 기본 GUI가 잘 인식 될 수 있어. 그게 우리가 그것을 완전히 교체하기 쉽게 만든 이유야."
+    e "동시에, 엄청 커스텀된 세련된 게임에서도 기본 GUI는 잘 인식될 수 있어. 그게 우리가 그걸 완전히 교체하기 쉽게 만든 이유야."
 
 # game/indepth_style.rpy:50
 translate korean new_gui_45765574:
@@ -39,13 +39,13 @@ translate korean new_gui_45765574:
 translate korean styles_fa345a38:
 
     # e "Ren'Py has a powerful style system that controls what displayables look like."
-    e "렌파이는 디스플레이어블의 생김새를 제어하는 ​​강력한 스타일 시스템을 갖추고 있어."
+    e "렌파이는 디스플레이어블의 생김새를 제어하는 강력한 스타일 시스템을 갖추고 있어."
 
 # game/indepth_style.rpy:60
 translate korean styles_6189ee12:
 
     # e "While the default GUI uses variables to provide styles with sensible defaults, if you're replacing the GUI or creating your own screens, you'll need to learn about styles yourself."
-    e "기본 GUI가 스타일을 현명한 기본값으로 제공하기 위해 변수를 사용하지만, GUI를 바꾸거나 자신만의 스크린을 만들려면 스타일에 대해 알아야 해."
+    e "기본 GUI가 스타일을 괜찮은 기본값으로 제공하기 위해 변수를 사용하지만, GUI를 바꾸거나 자신만의 스크린을 만들려면 스타일에 대해 알아야 해."
 
 # game/indepth_style.rpy:66
 translate korean styles_menu_a4a6913e:
@@ -57,13 +57,13 @@ translate korean styles_menu_a4a6913e:
 translate korean style_basics_9a79ef89:
 
     # e "Styles let a displayable look different from game to game, or even inside the same game."
-    e "스타일을 통해 게임마다 또는 동일한 게임 내에서 보이는 디스플레이어블이 달라지게 돼."
+    e "스타일을 통해 게임마다, 또는 동일한 게임 내에서 보이는 디스플레이어블이 달라지게 돼."
 
 # game/indepth_style.rpy:103
 translate korean style_basics_48777f2c:
 
     # e "Both of these buttons use the same displayables. But since different styles have been applied, the buttons look different from each other."
-    e "이 두 버튼은 동일한 디스플레이어블을 사용해. 그러나 서로 다른 스타일이 적용되었기 때문에 버튼이 서로 다르게 보이지."
+    e "이 두 버튼은 동일한 디스플레이어블을 사용해. 하지만 서로 다른 스타일이 적용되었기 때문에 버튼이 서로 다르게 보이지."
 
 # game/indepth_style.rpy:108
 translate korean style_basics_57704d8c:
@@ -87,19 +87,19 @@ translate korean style_basics_67e48162:
 translate korean style_basics_03516b4a:
 
     # e "The next is as part of a displayable created in an image statement. Style properties are just arguments to the displayable."
-    e "다음은 이미지 문에서 생성된 디스플레이어블의 일부야. 스타일 속성은 디스플레이어블에 대한 인수일 뿐이야."
+    e "다음은 이미지 구문에서 생성된 디스플레이어블의 일부야. 스타일 속성은 디스플레이어블에 대한 인자일 뿐이야."
 
 # game/indepth_style.rpy:160
 translate korean style_basics_ccc0d1ca:
 
     # egreen "Style properties can also be given as arguments when defining a character."
-    egreen "스타일 속성은 캐릭터를 정의할 때 인수로 지정할 수도 있어."
+    egreen "스타일 속성은 캐릭터를 정의할 때 인자로 지정할 수도 있어."
 
 # game/indepth_style.rpy:162
 translate korean style_basics_013ab314:
 
     # egreen "Arguments beginning with who_ are style properties applied to the character's name, while those beginning with what_ are applied to the character's dialogue."
-    egreen "who_로 시작하는 인수는 캐릭터의 이름에 적용되는 스타일 속성이고 what_으로 시작하는 인수는 캐릭터의 대사에 적용돼."
+    egreen "who_로 시작하는 인수는 캐릭터의 이름에 적용되는 스타일 속성이고 what_으로 시작하는 인자는 캐릭터의 대사에 적용돼."
 
 # game/indepth_style.rpy:164
 translate korean style_basics_dbe80939:
@@ -195,7 +195,7 @@ translate korean style_general_81f3c8ff:
 translate korean style_general_a8d99699:
 
     # e "Every displayable takes the position properties, which control where it can be placed on screen. Since I've already mentioned them, I won't repeat them here."
-    e "모든 디스플레이어블은 화면에 배치할 수 있는 위치를 제어하는 ​​위치 속성을 사용해. 이미 언급했으니까 반복하지 않을게."
+    e "모든 디스플레이어블은 화면에 배치할 수 있는 위치를 제어하는 위치 속성을 사용해. 이미 언급했으니까 반복하지 않을게."
 
 # game/indepth_style.rpy:275
 translate korean style_general_58d4a18f:

--- a/tutorial/game/tl/korean/indepth_text.rpy
+++ b/tutorial/game/tl/korean/indepth_text.rpy
@@ -3,7 +3,7 @@
 translate korean a_label_8d79d234:
 
     # e "You just clicked to jump to a label."
-    e "조금 전의 클릭으로 레이블로 점프했어."
+    e "방금 전의 클릭으로 레이블로 점프했어."
 
 # game/indepth_text.rpy:28
 translate korean text_578c4060:
@@ -21,7 +21,7 @@ translate korean text_60750345:
 translate korean text_5e1a6ee8:
 
     # e "That's what text tags are for."
-    e "그럴 때 필요한 것이 바로 텍스트 태그(taxe tag)야."
+    e "그럴 때 필요한 것이 바로 텍스트 태그(text tag)야."
 
 # game/indepth_text.rpy:37
 translate korean text_38c63ec8:
@@ -39,7 +39,7 @@ translate korean text_1760f9c8:
 translate korean text_a620251f:
 
     # e "The a text tag can {a=https://www.renpy.org}link to a website{/a} or {a=jump:a_label}jump to a label{/a}."
-    e "글자 태그는 {a=https://www.renpy.org}누리집 이동{/a}이나 {a=jump:a_label}a 레이블로 점프{/a}가 될 수 있어."
+    e "글자 태그로 {a=https://www.renpy.org}웹사이트로 이동{/a}하거나 {a=jump:a_label}a 레이블로 점프{/a}할 수도 있어."
 
 # game/indepth_text.rpy:49
 translate korean after_a_label_d22d5f4a:
@@ -81,13 +81,13 @@ translate korean after_a_label_d43417d7:
 translate korean after_a_label_f24052f9:
 
     # e "The k tag changes kerning. It can space the letters of a word {k=-.5}closer together{/k} or {k=.5}farther apart{/k}."
-    e "k 태그는 자간을 변경해. 그것은 단어들을 {k=-.5}서로 가깝게 놓거나{/k} {k=1.5}멀리 떨어뜨려 놓을 수 있어{/k}."
+    e "k 태그는 자간을 변경해. 단어들을 {k=-.5}서로 가깝게 놓거나{/k} {k=1.5}멀리 떨어뜨려 놓을 수 있어{/k}."
 
 # game/indepth_text.rpy:76
 translate korean after_a_label_2310b922:
 
     # e "The size tag changes the size of text. It can make text {size=+10}bigger{/size} or {size=-10}smaller{/size}, or set it to a {size=30}fixed size{/size}."
-    e "크기(size) 태그는 글자의 크기를 바꿔. 그것은 글자를 {size=+10}크게 만들거나{/size} {size=-10}작게{/size}, 혹은 {size=30}고정된 크기{/size}로 만들 수 있지."
+    e "크기(size) 태그는 글자의 크기를 바꿔. 글자를 {size=+10}크게 만들거나{/size} {size=-10}작게{/size}, 혹은 {size=30}고정된 크기{/size}로 만들 수 있지."
 
 # game/indepth_text.rpy:81
 translate korean after_a_label_f566abf2:
@@ -165,7 +165,7 @@ translate korean after_a_label_c90f24a8:
 translate korean after_a_label_fb106a95:
 
     # e "Finally, certain characters are special. [[, {{, and \\ need to be doubled if included in text. The %% character should be doubled if used in dialogue."
-    e "마지막으로, 특수 문자는 특별해. [[, {{, 그리고 \\는 글자에 포함된 경우 두 번을 써야 해. %% 문자를 대사에 사용할 경우 두 번을 써야 하지."
+    e "마지막으로, 어떤 문자는 특별하게 다뤄져. [[, {{, 그리고 \\는 글자에 포함된 경우 두 번을 써야 해. %% 문자를 대사에 사용할 경우 두 번을 써야 하지."
 
 translate korean strings:
 

--- a/tutorial/game/tl/korean/indepth_transitions.rpy
+++ b/tutorial/game/tl/korean/indepth_transitions.rpy
@@ -3,7 +3,7 @@
 translate korean demo_transitions_5bbc72fe:
 
     # e "Ren'Py ships with a large number of built-in transitions, and also includes classes that let you define your own."
-    e "렌파이에는 많은 수의 전환이 내장돼 있고, 사용자가 직접 정의할 수 있는 클래스도 있어."
+    e "렌파이에는 많은 수의 전환(transition)이 내장돼 있고, 사용자가 직접 정의할 수 있는 클래스도 있어."
 
 # game/indepth_transitions.rpy:58
 translate korean demo_transitions_menu_3caf78d3:
@@ -15,7 +15,7 @@ translate korean demo_transitions_menu_3caf78d3:
 translate korean demo_simple_transitions_2b4fbae3:
 
     # e "Okay, I can tell you about simple transitions. We call them simple because they don't take much in the way of configuration."
-    e "좋아, 간단한 전환에 대해 알려줄게. 많은 설정을 하지 않을 것이기 때문에 간단하다고 부를 거야."
+    e "좋아, 간단한 전환에 대해 알려줄게. 많이 변형하지 않을 거라서 간단하다고 불러."
 
 # game/indepth_transitions.rpy:97
 translate korean demo_simple_transitions_4b235ac2:
@@ -99,31 +99,31 @@ translate korean demo_simple_transitions_fbf11906:
 translate korean demo_simple_transitions_51c1c5b8:
 
     # e "I was about to demonstrate 'vpunch'... well, I guess I just did."
-    e "나는 'vpunch'를 보여주려 했어. 잘 한 것 같아..."
+    e "방금 'vpunch'를 보여주려 한 건데... 잘 한 것 같네."
 
 # game/indepth_transitions.rpy:154
 translate korean demo_simple_transitions_57f19473:
 
     # e "We can also shake the screen horizontally, with 'hpunch'. These were defined using the 'Move' function."
-    e "'hpunch'로 화면을 수평으로 흔들 수도 있어. 이것들은 'Move' 기능을 사용해 정의됐지."
+    e "'hpunch'로 화면을 수평으로 흔들 수도 있어. 모두 'Move' 기능을 사용해 정의됐지."
 
 # game/indepth_transitions.rpy:156
 translate korean demo_simple_transitions_fce83e12:
 
     # e "There's also the 'move' transition, which is confusingly enough defined using the 'MoveTransition' function."
-    e "'MoveTransition'기능을 사용하여 혼란스럽게 정의된 이동(move) 전환도 있습니다."
+    e "'MoveTransition'기능을 사용하여 혼란스럽게 정의된 이동(move) 전환도 있어."
 
 # game/indepth_transitions.rpy:164
 translate korean demo_simple_transitions_1050b6a4:
 
     # e "The 'move' transition finds images that have changed placement, and slides them to their new place. It's an easy way to get motion in your game."
-    e "'이동' 전환은 위치가 변경된 이미지를 찾아서 새 위치로 슬라이드해. 게임에서 동작을 얻는 쉬운 방법이지."
+    e "'이동' 전환은 위치가 변경된 이미지를 찾아서 새 위치로 슬라이드해. 게임에서 뭔가를 움직이는 쉬운 방법이지."
 
 # game/indepth_transitions.rpy:168
 translate korean demo_simple_transitions_dc776e59:
 
     # e "That's it for the simple transitions."
-    e "그건 간단한 변환을 위한 거야."
+    e "간단한 변환을 위한 거야."
 
 # game/indepth_transitions.rpy:175
 translate korean demo_imagedissolve_transitions_2db67018:
@@ -159,7 +159,7 @@ translate korean demo_imagedissolve_transitions_12e2e0d0:
 translate korean demo_imagedissolve_transitions_bbf73d1c:
 
     # e "I'm not sure why anyone would want to use it, but it was used in some translated games, so we added it."
-    e "나는 왜 누군가가 그것을 사용하고 싶어하는지 모르겠지만, 번역된 몇몇 게임에서 사용되었기 때문에 그것을 추가했어."
+    e "대체 왜, 누가 이런 걸 사용하고 싶어하는지 모르겠지만, 몇몇 번역된 게임에서 쓰였기 때문에 추가했어."
 
 # game/indepth_transitions.rpy:207
 translate korean demo_imagedissolve_transitions_0ab2902d:
@@ -171,7 +171,7 @@ translate korean demo_imagedissolve_transitions_0ab2902d:
 translate korean demo_imagedissolve_transitions_54aa9bf9:
 
     # e "These ones require an image the size of the screen, and so we couldn't include them as the size of the screen can change from game to game."
-    e "이러한 것들은 화면 크기의 이미지를 필요로 하기 때문에 화면 크기가 게임마다 다를 수 있어서 라이브러리에 포함시킬 수 없었어."
+    e "이런 것들은 화면 크기의 이미지를 필요로 하기 때문에, 라이브러리에 포함시킬 수 없었어. 화면 크기는 게임마다 다를 수 있으니까."
 
 # game/indepth_transitions.rpy:215
 translate korean demo_imagedissolve_transitions_ca316184:
@@ -213,7 +213,7 @@ translate korean demo_imagedissolve_transitions_72ba11d4:
 translate korean demo_imagedissolve_transitions_fc3b3339:
 
     # e "When we use an ImageDissolve, the white will dissolve in first, followed by progressively darker colors. Let's try it."
-    e "우리가 이미지디졸브를 사용할 때, 흰색이 먼저 디졸브되고, 점차 어두운 색이 뒤를 따르게 돼. 한번 해보자."
+    e "우리가 이미지디졸브를 사용할 때, 흰색이 먼저 디졸브되고, 점차 어두운 색이 뒤따르게 돼. 한번 해보자."
 
 # game/indepth_transitions.rpy:255
 translate korean demo_imagedissolve_transitions_4327dca2:
@@ -237,13 +237,13 @@ translate korean demo_imagedissolve_transitions_20d9cf6c:
 translate korean demo_imagedissolve_transitions_906f7800:
 
     # e "A dissolve only seems to affect parts of the scene that have changed..."
-    e "디졸브는 변경된 장면에만 영향을 미치는 것 같아..."
+    e "디졸브는 변경된 장면에만 영향을 미치는 것처럼 보여..."
 
 # game/indepth_transitions.rpy:277
 translate korean demo_imagedissolve_transitions_4b557a29:
 
     # e "... which is how we apply the teleport effect to a single character."
-    e "... 우리가 텔레포트 효과를 한 캐리터에 적용하는 방법이야."
+    e "... 텔레포트 효과를 한 캐릭터에 적용하는 방법이야."
 
 # game/indepth_transitions.rpy:285
 translate korean demo_cropmove_transitions_1711a91e:
@@ -255,7 +255,7 @@ translate korean demo_cropmove_transitions_1711a91e:
 translate korean demo_cropmove_transitions_6d82cfd7:
 
     # e "I'll stand offscreen, so you can see some of its modes. I'll read out the mode name after each transition."
-    e "나는 화면에서 벗어날 거야, 그것으로 너는 그것의 모드 일부를 볼 수 있어. 각각의 전환 후에 모드 이름을 읽어줄게."
+    e "내가 화면에서 벗어날 거고, 너는 각각의 모드의 이름을 볼 수 있어. 각각의 전환 후에 모드 이름을 읽어줄게."
 
 # game/indepth_transitions.rpy:296
 translate korean demo_cropmove_transitions_4427c78c:
@@ -363,7 +363,7 @@ translate korean demo_cropmove_transitions_016a1e0a:
 translate korean demo_cropmove_transitions_08d753ed:
 
     # e "It's enough to make you feel a bit dizzy."
-    e "조금 어지러움을 느끼기엔 충분하지."
+    e "충분히 어지러웠던 것 같네."
 
 # game/indepth_transitions.rpy:393
 translate korean demo_pushmove_transitions_003e506d:
@@ -447,7 +447,7 @@ translate korean demo_movetransition_bbb75540:
 translate korean demo_movetransition_dc5ccd54:
 
     # e "And that's all there is."
-    e "그리고 그게 다야."
+    e "그리고 이게 다야."
 
 # game/indepth_transitions.rpy:508
 translate korean demo_alphadissolve_51613c02:

--- a/tutorial/game/tl/korean/indepth_translations.rpy
+++ b/tutorial/game/tl/korean/indepth_translations.rpy
@@ -3,7 +3,7 @@
 translate korean translations_c4ef181f:
 
     # e "Ren'Py includes support for translating your game into languages other than the one it was originally written in."
-    e "렌파이는 처음에 작성한 언어가 아닌 다른 언어로 게임을 번역할 수 있도록 지원을 포함하고 있어."
+    e "렌파이는 처음에 작성한 언어가 아닌 다른 언어로 게임을 번역할 수 있도록 지원하고 있어."
 
 # game/indepth_translations.rpy:14
 translate korean translations_20b9a600:
@@ -15,13 +15,13 @@ translate korean translations_20b9a600:
 translate korean translations_07c7643c:
 
     # e "While Ren'Py can find dialogue and menu choice strings for you, you'll have to indicate which other strings need translation."
-    e "렌파이는 지문과 분기 선택 문자열을 찾을 수 있지만 번역이 필요한 다른 문자열을 표시해야 해."
+    e "렌파이가 지문과 분기 선택 문자열을 찾을 수 있긴 하지만, 번역이 필요한 다른 문자열을 표시해줄 필요가 있어."
 
 # game/indepth_translations.rpy:20
 translate korean translations_317d73e5:
 
     # e "For example, here is how we define a character and her name."
-    e "이건 우리가 어떻게 캐릭터와 이름을 정의하는지에 대한 예야."
+    e "이건 캐릭터와 이름을 정의하는 방법에 대한 예시야."
 
 # game/indepth_translations.rpy:24
 translate korean translations_ab0f3c94:
@@ -33,7 +33,7 @@ translate korean translations_ab0f3c94:
 translate korean translations_c81acfc7:
 
     # e "Notice how we don't translate the reddish color that we use for her name. That stays the same for all languages."
-    e "우리가 그녀의 이름으로 사용하는 붉은 색을 어떻게 번역하지 않는지 주목해. 그것은 모든 언어에 대해 동일하게 유지돼."
+    e "그녀의 이름으로 사용하는 붉은 색을 번역하지 않는 방법에 주목해. 모든 언어에 대해 똑같은 방법이야."
 
 # game/indepth_translations.rpy:33
 translate korean translations_8272a0ef:
@@ -45,25 +45,25 @@ translate korean translations_8272a0ef:
 translate korean translations_fde34832:
 
     # e "After you type in the name of the language you'll be translating to, choosing Generate Translations will scan your game and create translation files."
-    e "번역할 언어의 이름을 입력하고 번역파일 만들기를 선택하면 게임을 조사하고 번역 파일을 만들 거야."
+    e "번역할 언어의 이름을 입력하고 번역파일 만들기를 선택하면, 게임을 스캔한 뒤 번역 파일을 만들 거야."
 
 # game/indepth_translations.rpy:37
 translate korean translations_e2ebb4af:
 
     # e "The files will be generated in game/tl/language, where language is the name of the language you typed in."
-    e "파일들은 네가 언어의 이름으로 입력한 이름으로 game/tl/언어에 생성될 거야."
+    e "파일들은 네가 언어의 이름으로 입력한 이름으로 game/tl/language에 생성될 거야."
 
 # game/indepth_translations.rpy:39
 translate korean translations_28ec40b9:
 
     # e "You'll need to edit those files to include translations for everything in your game."
-    e "게임이 모든 내용을 번역본에 포함하도록 파일을 편집해야 해."
+    e "게임의 모든 내용이 번역본에 포함되도록 파일을 편집해야 돼."
 
 # game/indepth_translations.rpy:41
 translate korean translations_f6d3fd2d:
 
     # e "If you want to localize image files, you can also place them in game/tl/language."
-    e "만약에 이미지 파일의 현지화를 원한다면, 이미지 파일들을 game/tl/언어에 같은 이름의 파일을 넣으면 돼."
+    e "만약 이미지 파일의 현지화를 원한다면, 이미지 파일들을 game/tl/language에 같은 이름의 파일을 넣으면 돼."
 
 # game/indepth_translations.rpy:48
 translate korean translations_71bf6e72:
@@ -87,13 +87,13 @@ translate korean translations_a0042025:
 translate korean translations_b10990ce:
 
     # e "If you need to add new files, such as font files, you can place them into the game/tl/language directory where Ren'Py will find them."
-    e "글꼴 파일과 같은 새 파일을 추가해야 하는 경우에는 렌파이가 찾을 수 있게 game/tl/언어 디렉토리에 저장할 수 있어."
+    e "글꼴 파일과 같은 새 파일을 추가해야 하는 경우에는 렌파이가 찾을 수 있게 game/tl/language 디렉토리에 저장할 수 있어."
 
 # game/indepth_translations.rpy:58
 translate korean translations_01fcacc2:
 
     # e "Finally, you'll have to add support for picking the language of the game. That usually goes into the preferences screen, found in screens.rpy."
-    e "마지막으로 게임 언어 선택에 대한 지원을 추가해야 해. 일반적으로 screen.rpy에 있는 preferences 스크린에 작성할 수 있어."
+    e "마지막으로 게임 언어 선택 기능을 추가해야 돼. 일반적으로 screen.rpy에 있는 preferences 스크린에 작성할 수 있어."
 
 # game/indepth_translations.rpy:60
 translate korean translations_a91befcc:
@@ -105,5 +105,5 @@ translate korean translations_a91befcc:
 translate korean translations_9b7d6401:
 
     # e "The None language is special, as it's the default language that the visual novel was written in. Since this tutorial was written in English, Language(None) selects English."
-    e "None 언어는 시각 소설이 작성된 기본 언어이기 때문에 특별해. 이 길라잡이는 영어를 기본으로 작성되었으므로 English는 Language(None)을 선택해."
+    e "None 언어는 비주얼 노벨이 작성된 기본 언어이기 때문에 특별해. 이 길라잡이는 영어를 기본으로 작성되었으므로 English는 Language(None)을 선택해."
 

--- a/tutorial/game/tl/korean/script.rpy
+++ b/tutorial/game/tl/korean/script.rpy
@@ -9,13 +9,13 @@ translate korean start_0e6a5bb4:
 translate korean start_d3abb53c:
 
     # e "In this tutorial, we'll teach you the basics of Ren'Py, so you can make games of your own. We'll also demonstrate many features, so you can see what Ren'Py is capable of."
-    e "이 길라잡이에서, 우리는 네게 너만의 게임을 만들 수 있게 렌파이의 기본을 알려줄 거야. 또한 렌파이가 어떤 기능을 제공하는지 알 수 있도록 많은 기능을 선보일 거야."
+    e "이 길라잡이는 네가 너만의 게임을 만들 수 있도록, 렌파이의 기본을 알려줄 거야. 또한 렌파이가 어떤 기능을 제공하는지 알 수 있도록 많은 기능을 선보일 거야."
 
 # game/script.rpy:205
 translate korean end_b2482727:
 
     # e "Thank you for viewing this tutorial."
-    e "이 길라잡이을 봐줘서 고마와."
+    e "이 길라잡이를 봐줘서 고마워."
 
 # game/script.rpy:207
 translate korean end_38362e36:
@@ -27,13 +27,13 @@ translate korean end_38362e36:
 translate korean end_02527d05:
 
     # e "You can download new versions of Ren'Py from {a=https://www.renpy.org/}https://www.renpy.org/{/a}. For help and discussion, check out the {a=https://lemmasoft.renai.us/forums/}Lemma Soft Forums{/a}."
-    e "너는 {a=https://www.renpy.org/}https://www.renpy.org/{/a}에서 렌파이의 새 버전을 내려받을 수 있어. 도움과 토론을 위한다면, {a=https://lemmasoft.renai.us/forums/}렘마 소프트 포럼{/a}을 방문해 줘."
+    e "너는 {a=https://www.renpy.org/}https://www.renpy.org/{/a}에서 렌파이의 새 버전을 내려받을 수 있어. 도움을 받거나 토론을 하려면, {a=https://lemmasoft.renai.us/forums/}렘마 소프트 포럼{/a}을 방문해 줘."
 
 # game/script.rpy:211
 translate korean end_c9d03136:
 
     # e "We'd like to thank Piroshki for contributing my sprites; Mugenjohncel for Lucy, the band, and drawn backgrounds; and Jake for the magic circle."
-    e "우리는 내 스프라이트를 만든 피로스키(Piroshki)와; 루시, 밴드, 배경을 그려준 무겐존셀(Mugenjohncel); 매직 서클을 만들어준 제이크(Jake)에게 감사를 전하고 싶어."
+    e "내 스프라이트를 만들어준 피로스키(Piroshki)와; 루시, 밴드, 배경을 그려준 무겐존셀(Mugenjohncel); 매직 서클을 만들어준 제이크(Jake)에게 감사를 전하고 싶어."
 
 # game/script.rpy:213
 translate korean end_762dc07a:
@@ -45,7 +45,7 @@ translate korean end_762dc07a:
 translate korean end_a634d396:
 
     # e "We look forward to seeing what you create with Ren'Py. Have fun!"
-    e "우리는 네가 렌파이로 만드는 것을 보길 고대해. 즐겨봐!"
+    e "네가 렌파이로 뭘 만드는지 보고 싶어. 즐겨봐!"
 
 translate korean strings:
 
@@ -171,4 +171,4 @@ translate korean strings:
 
     # script.rpy:170
     old "Is there anything else you'd like to see?"
-    new "더 궁금한 것이 있어?"
+    new "더 궁금한 게 있어?"

--- a/tutorial/game/tl/korean/tutorial_director.rpy
+++ b/tutorial/game/tl/korean/tutorial_director.rpy
@@ -3,7 +3,7 @@
 translate korean director_e4543d9b:
 
     # e "There are a few tools you can access by pressing the right commands on the keyboard."
-    e "키보드에서 명령으로 액세스할 수 있는 몇 가지 도구가 있어."
+    e "키보드에서 바로 명령할 수 있는 몇 가지 도구가 있어."
 
 # game/tutorial_director.rpy:7
 translate korean director_ebf40500:
@@ -45,7 +45,7 @@ translate korean director_62734181:
 translate korean director_aec4c7d4:
 
     # e "You'll need to make your own project, and try it out there. But I can tell you how to use it."
-    e "너는 프로젝트를 만들고 그것을 시도해야 할 거야. 그전에 사용법을 알려줄게."
+    e "프로젝트를 직접 만든 다음 시도해 봐. 그 전에, 우선 사용법을 알려줄게."
 
 # game/tutorial_director.rpy:29
 translate korean director_453d4d67:
@@ -93,7 +93,7 @@ translate korean director_292d58b5:
 translate korean director_c875c1a7:
 
     # e "You can edit or remove statements with the pencil icon. You can move me to the right by editing the show statement, then clicking '(transform)', 'right', and 'Change'."
-    e "연필 아이콘으로 명령문을 편집하거나 제거할 수 있어. show 문을 편집하고 '(변형)', 'right'및 '교체'를 클릭하여 나를 오른쪽으로 이동할 수 있어."
+    e "연필 아이콘으로 명령문을 편집하거나 제거할 수 있어. show 문을 편집하고 '(transform)', 'right' 및 'change'를 클릭하여 나를 오른쪽으로 이동할 수 있어."
 
 # game/tutorial_director.rpy:54
 translate korean director_4e04a74e:
@@ -105,7 +105,7 @@ translate korean director_4e04a74e:
 translate korean director_1364b336:
 
     # l "Finally, I get some more screen time!"
-    l "마침내, 나는 더 많은 샷을 받을 수 있어!"
+    l "야호, 내 분량이 더 많아졌다!"
 
 # game/tutorial_director.rpy:69
 translate korean director_c6dd0c81:
@@ -117,11 +117,11 @@ translate korean director_c6dd0c81:
 translate korean director_9d03b14b:
 
     # e "However, we reset this tutorial when the game restarts, so you can try again from a clean slate. That won't happen with your own visual novel."
-    e "그런데, 게임이 다시 시작될 때 이 길라잡이를 다시 설정하기 때문에 깨끗한 슬레이트에서 다시 시도할 수 있어. 실제 네 시각 소설이 아닌 자습용이니까."
+    e "하지만, 이 길라잡이는 게임이 다시 시작될 때마다 재설정되기 때문에, 깨끗한 슬레이트에서 여러 번 다시 시도해볼 수 있어. 실제 네 비주얼 노벨이 아닌 자습용이니까."
 
 # game/tutorial_director.rpy:73
 translate korean director_dbfa07b2:
 
     # e "I hope these tools make developing your visual novel that much easier."
-    e "이 도구로 시각 소설을 훨씬 쉽게 개발할 수 있기를 기대할게."
+    e "이 도구로 비주얼 노벨을 훨씬 쉽게 개발할 수 있기를 기대할게."
 

--- a/tutorial/game/tl/korean/tutorial_distribute.rpy
+++ b/tutorial/game/tl/korean/tutorial_distribute.rpy
@@ -3,7 +3,7 @@
 translate korean distribute_7db9b042:
 
     # e "One thing Ren'Py makes easy is building distributions of your visual novel so you can give it to players."
-    e "렌파이가 쉽게 할 수 있는 것들 중 하나는 시각 소설의 배포판을 제작하여 플레이어에게 줄 수 있다는 거야."
+    e "렌파이가 쉽게 할 수 있는 것들 중 하나는 비주얼 노벨의 배포판을 제작하여 플레이어에게 전달해주는 거야."
 
 # game/tutorial_distribute.rpy:5
 translate korean distribute_d373903b:
@@ -15,19 +15,19 @@ translate korean distribute_d373903b:
 translate korean distribute_2f970565:
 
     # e "While not every potential problem lint reports is a real issue, they generally are, and you should try to understand what might be wrong."
-    e "보고서의 모든 잠재된 문제들이 실제로는 문제가 되지 않을 수 있지만, 그것들은 일반적으로 문제가 되기 때문에, 무엇이 문제인지 이해해야 해."
+    e "보고서의 모든 잠재된 문제들이 실제로 문제를 발생시키는 건 아니지만, 보통은 문제가 되니까, 어느 것이 문제인지 이해하는 게 좋아."
 
 # game/tutorial_distribute.rpy:12
 translate korean distribute_29aea017:
 
     # e "After lint has finished, you can choose Build Distributions to build the Windows, Linux, and Mac distributions of your game."
-    e "오류 검사가 완료된 다음에는, '배포판 만들기'를 선택하여 게임의 Windows, Linux 및 Mac 배포판 빌드를 만들 수 있어."
+    e "오류 검사를 마친 다음에는, '배포판 만들기'를 선택하여 게임의 Windows, Linux 및 Mac 배포판 빌드를 만들 수 있어."
 
 # game/tutorial_distribute.rpy:14
 translate korean distribute_821be97b:
 
     # e "This can be as simple as clicking the Build button, when you're not on a Mac."
-    e "Mac을 사용하지 않는 경우에는 간단히 '만들기' 버튼을 클릭하는 것만으로 빌드를 할 수 있어."
+    e "Mac을 사용하지 않는 경우에는 간단히 빌드 버튼을 클릭하는 것만으로 빌드를 할 수 있어."
 
 # game/tutorial_distribute.rpy:16
 translate korean distribute_638f964a:
@@ -51,7 +51,7 @@ translate korean distribute_0b547b7b:
 translate korean distribute_50a57bcf:
 
     # e "Mobile platforms might also require you to change your visual novel a little, due to the smaller limited devices. For example, buttons need to be made large enough for a person to touch."
-    e "모바일 플랫폼들은 작은 장치라는 제한이 있기 때문에 제작한 시각 소설을 조금 변경해야 할 수도 있어. 예를 들면, 버튼은 사람이 터치할 수 있을 정도로 커야 하지."
+    e "모바일 플랫폼들은 작은 장치라는 제한이 있기 때문에 제작한 비주얼 노벨을 조금 변경해야 할 수도 있어. 예를 들면, 버튼은 사람이 터치할 수 있을 정도로 커야 하지."
 
 # game/tutorial_distribute.rpy:27
 translate korean distribute_a9a2149f:
@@ -63,11 +63,11 @@ translate korean distribute_a9a2149f:
 translate korean distribute_f1cbc9d0:
 
     # e "Thanks to the distribution tools Ren'Py ships with, there are thousands of visual novels available."
-    e "렌파이가 제공하는 배포 도구 덕분에 우리는 수천 개의 시각 소설을 이용할 수 있어."
+    e "렌파이가 제공하는 배포 도구 덕분에, 우리는 수천 개의 비주얼 노벨을 플레이할 수 있어."
 
 # game/tutorial_distribute.rpy:33
 translate korean distribute_500b3e7f:
 
     # e "I hope that soon, yours will be one of them!"
-    e "나는 곧 네 시각 소설이 그중 하나가 되기를 바랄게!"
+    e "네 비주얼 노벨이 곧 그중 하나가 되기를 바랄게!"
 

--- a/tutorial/game/tl/korean/tutorial_playing.rpy
+++ b/tutorial/game/tl/korean/tutorial_playing.rpy
@@ -3,7 +3,7 @@
 translate korean tutorial_playing_2985ab86:
 
     # e "As someone who has played more than a few visual novels, there are many features that I expect all games to have."
-    e "어느 정도 시각 소설을 플레이한 사람으로서, 모든 게임에서 기대할 수 있는 많은 기능들이 있어."
+    e "어느 정도 비주얼 노벨을 플레이한 사람이라면, 모든 게임에 기대할만한 많은 기능들이 있어."
 
 # game/tutorial_playing.rpy:13
 translate korean tutorial_playing_ca4769bb:
@@ -93,13 +93,13 @@ translate korean tutorial_playing_bc29822e:
 translate korean tutorial_playing_dc0f9cf7:
 
     # e "When I'm liking a visual novel, I want to see all the endings. Ren'Py's skip function lets me easily do this, by skipping text that I've already seen."
-    e "나는 좋아하는 시각 소설에서 모든 결말을 보길 원해. 렌파이의 넘기기 기능은 이미 본 것들을 넘김으로써 이러한 것들을 우리가 쉽게 할 수 있도록 도와줘."
+    e "만약 좋아하는 비주얼 노벨의 모든 분기의 엔딩을 보길 원한다면, 렌파이의 넘기기 기능은 이미 본 것들을 넘김으로써 이러한 것들을 우리가 쉽게 할 수 있도록 도와줘."
 
 # game/tutorial_playing.rpy:57
 translate korean tutorial_playing_93f7b8f9:
 
     # e "I can skip a few lines by holding down Control, or I can toggle skip mode by clicking the skip button at the bottom of the screen."
-    e "나는 컨트롤(Control, Ctrl)을 누르고 있는 것으로 몇 줄을 넘기거나, 화면 아래에 넘기기 버튼을 클릭해서 넘기기 기능을 토글할 수 있어."
+    e "나는 컨트롤(Ctrl)을 누르고 있는 것으로 몇 줄을 넘기거나, 화면 아래에 넘기기 버튼을 클릭해서 넘기기 기능을 토글할 수 있어."
 
 # game/tutorial_playing.rpy:59
 translate korean tutorial_playing_d3553fbe:
@@ -123,7 +123,7 @@ translate korean tutorial_playing_14e1c854:
 translate korean tutorial_playing_5d6e4c0f:
 
     # e "Pressing the 's' key saves a screenshot to disk, so I can upload pictures of the game to websites like {a=https://www.renpy.org}renpy.org{/a}."
-    e "'s'키를 누르면 갈무리를 디스크에 저장해, 그러면 나는 {a=https://www.renpy.org}renpy.org{/a}와 같은 웹사이트에 저장된 갈무리를 업로드할 수 있어."
+    e "'s'키를 누르면 스크린샷을 디스크에 저장해, 그러면 나는 {a=https://www.renpy.org}renpy.org{/a}와 같은 웹사이트에 저장된 스크린샷을 업로드할 수 있어."
 
 # game/tutorial_playing.rpy:67
 translate korean tutorial_playing_73f3cfec:
@@ -171,7 +171,7 @@ translate korean tutorial_rollback_5b73f822:
 translate korean tutorial_rollback_de0b6f5a:
 
     # e "Well, are you going to try it?"
-    e "음, 정말로 해본 거야?"
+    e "음, 정말 해본 거 맞아?"
 
 # game/tutorial_playing.rpy:98
 translate korean tutorial_rollback_6bbdedaa:

--- a/tutorial/game/tl/korean/tutorial_screen_displayables.rpy
+++ b/tutorial/game/tl/korean/tutorial_screen_displayables.rpy
@@ -417,7 +417,7 @@ translate korean swimming_405542a5:
 translate korean swimming_264b5873:
 
     # e "Swimming seems like a lot of fun, but I didn't bring my bathing suit with me."
-    e "수영은 정말 재밌지만, 나는 오늘 수영복을 가져오지 않았어."
+    e "수영은 정말 재밌지만, 오늘 수영복을 가져오지 않았어."
 
 # game/tutorial_screen_displayables.rpy:665
 translate korean science_83e5c0cc:
@@ -429,19 +429,19 @@ translate korean science_83e5c0cc:
 translate korean science_319cdf4b:
 
     # e "I've heard that some schools have a competitive science team, but to me research is something that can't be rushed."
-    e "몇몇 학교는 경쟁적인 과학 팀을 가지고 있다고 들었지만, 나에게 있어 연구는 서둘러서는 안 되는 거야."
+    e "몇몇 학교는 경쟁적인 과학 팀을 가지고 있다고 들었지만, 나에게 있어 연구란 서둘러서는 안 되는 거라구."
 
 # game/tutorial_screen_displayables.rpy:672
 translate korean art_d2a94440:
 
     # e "You chose art."
-    e "아트를 선택했어."
+    e "예술을 선택했어."
 
 # game/tutorial_screen_displayables.rpy:674
 translate korean art_e6af6f1d:
 
     # e "Really good background art is hard to make, which is why so many games use filtered photographs. Maybe you can change that."
-    e "정말 좋은 배경 아트는 만들기 어려워. 그래서 많은 게임들이 필터링된 사진을 사용하지. 어쩌면 너는 그것을 바꿀 수 있을지도."
+    e "정말 좋은 배경 아트는 만들기 어려워. 그래서 많은 게임들이 필터링한 사진을 사용하지. 너라면 바꿀 수 있을지도."
 
 # game/tutorial_screen_displayables.rpy:680
 translate korean home_373ea9a5:


### PR DESCRIPTION
Fixed some awkward Korean Translations
ex) game/tl/언어 -> game/tl/languages (directory names should not be translated...)
시각 소설 -> 비주얼 노벨 ('비주얼 노벨' is much more common form than '시각 소설')
and some translationese... like 그것은, 우리는, ...