### PR TITLE
autosave on input config variable

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -550,6 +550,9 @@ adjust_view_size = None
 # True if we should autosave when a choice occurs.
 autosave_on_choice = True
 
+# True if we should autosave when the player has input something.
+autosave_on_input = True
+
 # A list of channels we should emphasize the audio on.
 emphasize_audio_channels = [ 'voice' ]
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -927,7 +927,7 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
 
     renpy.exports.shown_window()
 
-    if not renpy.game.after_rollback:
+    if renpy.config.autosave_on_input and not renpy.game.after_rollback:
         renpy.loadsave.force_autosave(True)
 
     # use normal "say" click behavior if input can't be changed

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1086,6 +1086,11 @@ Rarely or Internally Used
     save time, the autosave occurs while the user is being prompted to confirm
     his or her decision.)
 
+.. var:: config.autosave_on_input = True
+
+    If True, Ren'Py will autosave when the user inputs text.
+    (When :func:`renpy.input` is called.)
+
 .. var:: config.character_callback = None
 
     The default value of the callback parameter of Character.


### PR DESCRIPTION
Almost all places where Ren'Py autosaves have a configuration variable that can be set to False to prevent Ren'Py from autosaving at that time. The exception is the input function. This commit creates a new config variable autosave_on_input which can be set to False to disable autosaving when players input text.