### PR TITLE
Upgrade input's caret

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -219,6 +219,7 @@ init -1900 python:
         if version <= (7, 4, 6):
             config.adjust_minimums = False
             config.atl_start_on_show = False
+            config.input_caret_blink = False
 
     # The version of Ren'Py this script is intended for, or
     # None if it's intended for the current version.

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1162,6 +1162,9 @@ audio_filename_callback = None
 # Should minimums be adjusted when x/yminimum and x/ymaximum are both floats?
 adjust_minimums = True
 
+# Should the default input caret blink ?
+input_caret_blink = True
+
 del os
 del collections
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1163,7 +1163,7 @@ audio_filename_callback = None
 adjust_minimums = True
 
 # Should the default input caret blink ?
-input_caret_blink = True
+input_caret_blink = 1.
 
 del os
 del collections

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1131,11 +1131,10 @@ def input_post_per_interact():
 
 
 def blink(trans, st, at, caret_blink):
-    if int(st*2/caret_blink)%2:
-        trans.alpha = .0
-    else:
-        trans.alpha = 1.
-    return (caret_blink/2)-(st%(caret_blink/2))
+    ttl = caret_blink - st % caret_blink
+    trans.alpha = ttl > caret_blink / 2.
+    return ttl % (caret_blink / 2.)
+
 
 class Input(renpy.text.text.Text): # @UndefinedVariable
     """

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1202,10 +1202,8 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
 
         caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
         if caret_blink:
-            self.caret = renpy.store.Fixed(renpy.display.transform.Transform(caret, function=renpy.curry.curry(blink)(caret_blink=caret_blink)),
-                                           xsize=0,)
-        else:
-            self.caret = renpy.store.Fixed(caret, xsize=0)
+            caret = renpy.display.transform.Transform(caret, function=renpy.curry.partial(blink, caret_blink=caret_blink))
+    self.caret = renpy.store.Fixed(caret, xsize=0)
         self.caret_pos = len(self.content)
         self.old_caret_pos = self.caret_pos
 

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1203,7 +1203,7 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
         caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
         if caret_blink:
             caret = renpy.display.transform.Transform(caret, function=renpy.curry.partial(blink, caret_blink=caret_blink))
-    self.caret = renpy.store.Fixed(caret, xsize=0)
+        self.caret = renpy.store.Fixed(caret, xsize=0)
         self.caret_pos = len(self.content)
         self.old_caret_pos = self.caret_pos
 

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1161,6 +1161,7 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
                  pixel_width=None,
                  value=None,
                  copypaste=False,
+                 caret_blink=renpy.config.input_caret_blink,
                  **properties):
 
         super(Input, self).__init__("", style=style, replaces=replaces, substitute=False, **properties)
@@ -1192,7 +1193,13 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
             if i.endswith("color"):
                 caretprops[i] = properties[i]
 
-        self.caret = renpy.display.image.Solid(xmaximum=1, style=style, **caretprops)
+        caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
+        if caret_blink:
+            self.caret = renpy.store.Fixed(renpy.display.anim.Animation(caret, 0.5,
+                                                                        renpy.display.layout.Null(xsize=1), 0.5),
+                                           xsize=0)
+        else:
+            self.caret = renpy.store.Fixed(caret, xsize=0)
         self.caret_pos = len(self.content)
         self.old_caret_pos = self.caret_pos
 

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1130,6 +1130,13 @@ def input_post_per_interact():
             i.caret_pos = len(content)
 
 
+def blink(trans, st, at, caret_blink):
+    if int(st*2/caret_blink)%2:
+        trans.alpha = .0
+    else:
+        trans.alpha = 1.
+    return (caret_blink/2)-(st%(caret_blink/2))
+
 class Input(renpy.text.text.Text): # @UndefinedVariable
     """
     This is a Displayable that takes text as input.
@@ -1195,13 +1202,7 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
 
         caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
         if caret_blink:
-            def blink(trans, st, at):
-                if int(st*2)%2:
-                    trans.alpha = .0
-                else:
-                    trans.alpha = 1.
-                return .5
-            self.caret = renpy.store.Fixed(renpy.display.transform.Transform(caret, function=blink),
+            self.caret = renpy.store.Fixed(renpy.display.transform.Transform(caret, function=renpy.curry.curry(blink)(caret_blink=caret_blink)),
                                            xsize=0,)
         else:
             self.caret = renpy.store.Fixed(caret, xsize=0)

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1167,10 +1167,13 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
                  pixel_width=None,
                  value=None,
                  copypaste=False,
-                 caret_blink=renpy.config.input_caret_blink,
+                 caret_blink=None,
                  **properties):
 
         super(Input, self).__init__("", style=style, replaces=replaces, substitute=False, **properties)
+
+        if caret_blink is None:
+            caret_blink = renpy.config.input_caret_blink
 
         if value:
             self.value = value

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1195,9 +1195,14 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
 
         caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
         if caret_blink:
-            self.caret = renpy.store.Fixed(renpy.display.anim.Animation(caret, 0.5,
-                                                                        renpy.display.layout.Null(xsize=1), 0.5),
-                                           xsize=0)
+            def blink(trans, st, at):
+                if int(st*2)%2:
+                    trans.alpha = .0
+                else:
+                    trans.alpha = 1.
+                return .5
+            self.caret = renpy.store.Fixed(renpy.display.transform.Transform(caret, function=blink),
+                                           xsize=0,)
         else:
             self.caret = renpy.store.Fixed(caret, xsize=0)
         self.caret_pos = len(self.content)

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -598,13 +598,6 @@ Occasionally Used
 
     If not False, sets the blinking period of the default caret, in seconds.
 
-.. var:: config.key_repeat = (.3, .03)
-
-    Controls the rate of keyboard repeat. When key repeat is enabled, this
-    should be a tuple. The first item in the tuple is the delay before the
-    first repeat, and the second item is the delay between repeats. Both
-    are in seconds. If None, keyboard repeat is disabled.
-
 .. var:: config.language = None
 
     If not None, this should be a string giving the default language

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -594,9 +594,9 @@ Occasionally Used
     can be repeatedly loaded, hurting performance. If not none,
     :var:`config.image_cache_size` is used instead of this variable.
 
-.. var:: config.input_caret_blink = True
+.. var:: config.input_caret_blink = 1.0
 
-    Sets whether or not the default caret in an input will blink or not.
+    If not False, sets the blinking period of the default caret, in seconds.
 
 .. var:: config.key_repeat = (.3, .03)
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -594,6 +594,10 @@ Occasionally Used
     can be repeatedly loaded, hurting performance. If not none,
     :var:`config.image_cache_size` is used instead of this variable.
 
+.. var:: config.input_caret_blink = True
+
+    Sets whether or not the default caret in an input will blink or not.
+
 .. var:: config.key_repeat = (.3, .03)
 
     Controls the rate of keyboard repeat. When key repeat is enabled, this

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -672,7 +672,8 @@ The input statement takes no parameters, and the following properties:
     the text. This can be used to mask out a password.
 
 `caret_blink`
-    If True, the default caret will blink. Overrides :var:`config.input_caret_blink`.
+    If not False, the blinking period of the default caret.
+    Overrides :var:`config.input_caret_blink`.
 
 
 It also takes:

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -671,6 +671,10 @@ The input statement takes no parameters, and the following properties:
     If given, a string that replaces each displayable character in
     the text. This can be used to mask out a password.
 
+`caret_blink`
+    If True, the default caret will blink. Overrides :var:`config.input_caret_blink`.
+
+
 It also takes:
 
 * :ref:`Common Properties <common-properties>`

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -455,7 +455,7 @@ Text Style Properties
 
     If not None, this should be a displayable. The input widget will
     use this as the caret at the end of the text. If None, a 1 pixel
-    wide line is used as the caret.
+    wide blinking line is used as the caret.
 
 .. style-property:: color color
 


### PR DESCRIPTION
From @mal's idea and code.

Makes the default input caret blinking, and stops it from offsetting characters by 1px when activating/deactivating like it did before (that's the `xsize=0` part, no I don't understand it either but it works).

The blinking effect has 3 opt-outs :
1. you can set `config.input_caret_blink` to a False value for the whole game
2. you can override it for a specific input by setting its new `caret_blink` property
3. you can override all of this by replacing the default caret using the already existing `caret` style property

An addition to `renpy/common/00compat.rpy` can easily be done to disable it for previous versions, although I don't think it's worth it.
Adding `caret_blink` as a keyword in `renpy/screenlang.py` and `renpy/sl2/sldisplayables.py` didn't seem necessary to make it work (as far as I tested) but it can be added.
The config variable and the property could be renamed to reflect that they only change the default caret, and don't apply when a custom one is supplied via the `caret` style property, but I feel it would make their names too long.