### PR TITLE
Remove obsolete gl2 references in the doc

### DIFF
--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -1034,9 +1034,6 @@ both horizontal and vertical positions.
     that children of this transform draw. See :ref:`matrixcolor` for more
     information.
 
-    This requires model-based rendering to be enabled by setting :var:`config.gl2` to
-    True.
-
 .. transform-property:: blur
 
     :type: None or float
@@ -1046,9 +1043,6 @@ both horizontal and vertical positions.
     of the displayable. The precise details of the blurring may change
     between Ren'Py versions, and the blurring may exhibit artifacts,
     especially when the image being blurred is changing.
-
-    This requires model-based rendering to be enabled by setting :var:`config.gl2` to
-    True.
 
 There are also several sets of transform properties that are documented elsewhere:
 


### PR DESCRIPTION
Obsolete since config.gl2 is now enabled by default.
A message like "This requires model-based rendering, which is enabled by default." could be put in its place, but I don't feel it's really relevent.