### PR TITLE
Fixed SetPreference rebuild attribute

### DIFF
--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -146,7 +146,9 @@ init -1100 python in gui:
             prefs = persistent._gui_preference
 
             prefs[self.name] = self.value
-            rebuild()
+
+            if self.rebuild:
+                rebuild()
 
         def get_selected(self):
             prefs = persistent._gui_preference


### PR DESCRIPTION
Now when SetPreference is defined with rebuild=False the rebuild function won't be called, as said in the documentation.