### PR TITLE
Fix focus_nearest bug that ignored keyboard_focus

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -525,7 +525,16 @@ def focus_nearest(from_x0, from_y0, from_x1, from_y1,
     current = get_focused()
 
     if not current:
-        change_focus(focus_list[0])
+
+        for f in focus_list:
+
+            if not f.widget.style.keyboard_focus:
+                continue
+
+            change_focus(f)
+
+            break
+
         return
 
     # Find the current focus.

--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -532,8 +532,7 @@ def focus_nearest(from_x0, from_y0, from_x1, from_y1,
                 continue
 
             change_focus(f)
-
-            break
+            return
 
         return
 


### PR DESCRIPTION
If buttons with keyboard_focus True are shown but the first focusable element has keyboard_focus False, the focus_nearest function would focus on that first element when not focused on anything. This commit fixes that.