### PR TITLE
Document access to the warper functions

### DIFF
--- a/renpy/common/000atl.rpy
+++ b/renpy/common/000atl.rpy
@@ -24,6 +24,8 @@
 
 python early in _warper:
 
+    from renpy.atl import pause, instant
+
     # pause is defined internally, but would look like:
     #
     # @renpy.atl_warper

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -621,8 +621,8 @@ http://www.easings.net/.
 
 .. include:: inc/easings
 
-These warpers can be accessed in the ``renpy.atl.warpers`` dictionary, which maps
-the names listed above to the corresponding functions.
+These warpers can be accessed in the ``_warpers`` read-only module, which contains
+the functions listed above.
 
 New warpers can be defined using the ``renpy.atl_warper`` decorator, in a ``python
 early`` block. It should be placed in a file that is parsed before any file

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -621,6 +621,9 @@ http://www.easings.net/.
 
 .. include:: inc/easings
 
+These warpers can be accessed in the ``renpy.atl.warpers`` dictionary, which maps
+the names listed above to the corresponding functions.
+
 New warpers can be defined using the ``renpy.atl_warper`` decorator, in a ``python
 early`` block. It should be placed in a file that is parsed before any file
 that uses the warper. This looks like::

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -621,7 +621,7 @@ http://www.easings.net/.
 
 .. include:: inc/easings
 
-These warpers can be accessed in the ``_warpers`` read-only module, which contains
+These warpers can be accessed in the ``_warper`` read-only module, which contains
 the functions listed above.
 
 New warpers can be defined using the ``renpy.atl_warper`` decorator, in a ``python

--- a/sphinx/source/transitions.rst
+++ b/sphinx/source/transitions.rst
@@ -156,7 +156,7 @@ transition to a variable::
 
 
 The time_warp argument taken by many transition classes can be given
-builtin warpers found in the ``renpy.atl.warpers`` dictionary,
+builtin warpers found in the ``_warper`` module,
 see :ref:`warpers <warpers>`.
 
 .. include:: inc/transition

--- a/sphinx/source/transitions.rst
+++ b/sphinx/source/transitions.rst
@@ -155,6 +155,10 @@ transition to a variable::
          with annoytheuser
 
 
+The time_warp argument taken by many transition classes can be given
+builtin warpers found in the ``renpy.atl.warpers`` dictionary,
+see :ref:`warpers <warpers>`.
+
 .. include:: inc/transition
 
 Transition Families


### PR DESCRIPTION
Using the transition classes' time_warp arguments is much more easy when access is given to the already-defined functions.
The keys to the dict are already documented.