### PR TITLE
Avoid using a dict as a default argument value

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -261,7 +261,9 @@ python early in layeredimage:
             self.image = None
             self.properties = OrderedDict()
 
-        def execute(self, group=None, group_properties={}):
+        def execute(self, group=None, group_properties=None):
+            if group_properties is None:
+                group_properties = {}
 
             if self.image:
                 image = eval(self.image)


### PR DESCRIPTION
It's dangerous as it becomes trivial to accidentally pollute what is expected to be a clean dictionary. The default `group_properties` as it stands never leaves this function, and is never written to, and so the current code is safe in that regard, however leaving it in the codebase becomes a landmine just waiting to be stepped on in future.

```py
>>> def foo(bar={}):
...     return bar
... 
>>> foo()
{}
>>> foo()['qux'] = 'leaky'
>>> foo()
{'qux': 'leaky'}
>>>
```