### PR TITLE
Update loadsave.py

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -414,7 +414,9 @@ def save(slotname, extra_info='', mutate_flag=False):
         if bad is None:
             reraise(t, e, tb)
 
-        e.args = (e.args[0] + ' (perhaps {})'.format(bad),) + e.args[1:]
+        if len(e.args) > 1:
+            e.args = (e.args[0] + ' (perhaps {})'.format(bad),) + e.args[1:]
+
         reraise(t, e, tb)
 
     if mutate_flag and renpy.python.mutate_flag:


### PR DESCRIPTION
While stuck in an infinite loop during saving, trying to break from it with a keyboard interrupt causes a crash because that exception args is an empty tuple, so we get an uncaught exception here, this checks that looking args[0] or args[1:] won't lead to a crash.