### PR TITLE
Document config.has_channel side-effects

### DIFF
--- a/gui/game/options.rpy
+++ b/gui/game/options.rpy
@@ -44,9 +44,9 @@ define build.name = "gui"
 
 ## Sounds and music ############################################################
 
-## These three variables control which mixers are shown to the player
-## by default. Setting one of these to False will hide the appropriate
-## mixer.
+## These three variables control, among other things, which mixers are
+## shown to the player by default. Setting one of these to False will
+## hide the appropriate mixer.
 
 define config.has_sound = True
 define config.has_music = True


### PR DESCRIPTION
`config.has_sound`, `config.has_music` and `config.has_voice` have other side-effects than toggling the appropriate mixers in the preferences screen. Such are hard to debug if not documented.

I believe this is the proper file to be copied in the new game as the default template.
The translations will need to be updated.