### PR TITLE
Update notification

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -262,7 +262,20 @@ label start:
 
     jump expression renpy.session.pop("launcher_start_label", "front_page")
 
+default has_update = False
+
 label front_page:
+    if persistent.daily_update_check and ((not persistent.last_update_check) or (datetime.date.today() > persistent.last_update_check)):
+        python hide:
+            import datetime
+        
+            for chan in update_label_function():
+                if (chan["channel"] == "Release"):
+                    if (chan["split_version"] > list(renpy.version_tuple)):
+                        renpy.store.has_update = True
+                    break
+        $ persistent.last_update_check = datetime.date.today()
+
     call screen front_page
     jump front_page
 

--- a/launcher/game/interface.rpy
+++ b/launcher/game/interface.rpy
@@ -126,7 +126,15 @@ screen bottom_info:
                     xalign 1.0
 
                     if ability.can_update:
-                        textbutton _("update") action Jump("update") style "l_link"
+                        textbutton _("update") action Jump("update") style "l_link":
+                            if has_update:
+                                # text_color "#F96854"
+                                # text_hover_color Color("#F96854").tint(.8)
+                                text_color "#fff"
+                                at transform:
+                                    ease 1 matrixcolor TintMatrix("#f96854")
+                                    ease 1 matrixcolor TintMatrix(TEXT)
+                                    repeat
 
                     textbutton _("preferences") style "l_link" action Jump("preferences")
                     textbutton _("quit") style "l_link" action Quit(confirm=False)

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -208,6 +208,9 @@ screen preferences:
                         textbutton _("Dark theme") style "l_checkbox" action [SetField(persistent, "theme", "dark", None), RestartAtPreferences()]
                         textbutton _("Custom theme") style "l_checkbox" action [SetField(persistent, "theme", "custom", None), RestartAtPreferences()]
 
+                        if ability.can_update:
+                            textbutton _("Daily check for update") style "l_checkbox" action [ToggleField(persistent, "daily_update_check"), SetField(persistent, "last_update_check", None)] selected persistent.daily_update_check
+
 
                 if translations:
 

--- a/launcher/game/updater.rpy
+++ b/launcher/game/updater.rpy
@@ -102,7 +102,7 @@ screen update_channel(channels):
 
                     for c in channels:
 
-                        if  c["split_version"] != list(renpy.version_tuple):
+                        if c["split_version"] != list(renpy.version_tuple):
                             $ action = updater.Update(c["url"], simulate=UPDATE_SIMULATE, public_key=PUBLIC_KEY, confirm=False)
                             $ current = ""
                         else:
@@ -185,6 +185,14 @@ screen updater:
 label update:
 
     python hide:
+        channels = update_label_function()
+
+        renpy.call_screen("update_channel", channels)
+
+    jump front_page
+
+init python:
+    def update_label_function():
         interface.processing(_("Fetching the list of update channels"))
 
         import urllib2
@@ -196,7 +204,4 @@ label update:
         with interface.error_handling(_("parsing the list of update channels")):
             channels = json.load(channel_data)["releases"]
 
-        renpy.call_screen("update_channel", channels)
-
-    jump front_page
-
+        return channels


### PR DESCRIPTION
As per #2961.
Makes the update textbutton glow red when a Release update is available.

The check is performed when accessing the main menu of the launcher (internally referred to as the front page), if the related preference has been checked and if no check has already been performed in the same day (or if the preference has been toggled back and forth since then).

Caveats :
Currently the glow doesn't reappear if the launcher is closed then reopened, should be fixed soon using persistent.
The `update_label_function` function should probably be renamed.