### PR TITLE
Make lint config.adjust_attributes aware

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -271,6 +271,11 @@ def image_exists(name, expression, tag, precise=True):
     Checks a scene or show statement for image existence.
     """
 
+    orig = name
+    f = renpy.config.adjust_attributes.get(name[0], None) or renpy.config.adjust_attributes.get(None, None)
+    if f is not None:
+        name = f(name)
+
     # Add the tag to the set of known tags.
     tag = tag or name[0]
     image_prefixes[tag] = True
@@ -287,7 +292,7 @@ def image_exists(name, expression, tag, precise=True):
     if image_exists_precise(name):
         return
 
-    report("'%s' is not an image.", " ".join(name))
+    report("'%s' is not an image.", " ".join(orig))
 
 
 # Only check each file once.


### PR DESCRIPTION
Applies the function when checking a recognised image, and stashes the original name so that the error report will match the line in the script being referenced (rather than reporting the adjusted version).

I believe this is the correct ordering, as it means it's the "real" tag that makes it's way into `image_prefixes`, but I'm not 100% sure.

Seeks to address https://github.com/renpy/renpy/issues/2978.