### PR TITLE
Enable all updates in the daily check

### DIFF
--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -62,6 +62,7 @@ default persistent.legacy = False
 default persistent.force_new_tutorial = False
 default persistent.sponsor_message = True
 default persistent.daily_update_check = False
+default persistent.daily_check_nightly = False
 
 screen preferences:
 
@@ -202,15 +203,17 @@ screen preferences:
 
                         textbutton _("Sponsor message") style "l_checkbox" action ToggleField(persistent, "sponsor_message")
 
+                        if ability.can_update:
+                            textbutton _("Daily check for update") style "l_checkbox" action [ToggleField(persistent, "daily_update_check"), SetField(persistent, "last_update_check", None)] selected persistent.daily_update_check
+                            if persistent.daily_update_check:
+                                textbutton _("Include nightly builds") style "l_checkbox" action [ToggleField(persistent, "daily_check_nightly")] sensitive persistent.daily_update_check
+
                         add HALF_SPACER
 
                         textbutton _("Default theme") style "l_checkbox" action [SetField(persistent, "theme", None), RestartAtPreferences() ]
                         # textbutton _("Clear theme") style "l_checkbox" action [SetField(persistent, "theme", "clear", None), RestartAtPreferences() ]
                         textbutton _("Dark theme") style "l_checkbox" action [SetField(persistent, "theme", "dark", None), RestartAtPreferences()]
                         textbutton _("Custom theme") style "l_checkbox" action [SetField(persistent, "theme", "custom", None), RestartAtPreferences()]
-
-                        if ability.can_update:
-                            textbutton _("Daily check for update") style "l_checkbox" action [ToggleField(persistent, "daily_update_check"), SetField(persistent, "last_update_check", None)] selected persistent.daily_update_check
 
 
                 if translations:

--- a/launcher/game/updater.rpy
+++ b/launcher/game/updater.rpy
@@ -207,7 +207,7 @@ init python:
         persistent.has_update = False
 
         for chan in channels:
-            if chan["channel"] == "Release":
+            if (chan["channel"] == "Release") or not persistent.daily_check_nightly:
                 if chan["split_version"] > list(renpy.version_tuple):
                     persistent.has_update = True
                 break


### PR DESCRIPTION
Adds a preference which disables the check whether updates are Releases or not, so that nightly updates (and all others) can trigger the red button.

Also moves the preference up a bit so that theme-related options are back on their own.
The nightly option is not displayed when daily checks are disabled, but it can just be rendered inactive to avoid making the height of the buttons list move back and forth.

Concern should be given to the fact that with this preference button, adding another will make the list overflow, which is already the case when set to piglatin language.
Maybe an advanced version of this could be a single button which would cycle between "check for none", "check for releases" and "check for any" ? But I'm not sure how to implement that.