### PR TITLE
Edit and fix documentation

### DIFF
--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -456,7 +456,7 @@ The differences are:
   explicitly cleared.
 
 * ``show layer`` requires a layer name, while ``camera`` defaults to the
-   master layer.
+  master layer.
 
 
 Hide and Show Window

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -193,8 +193,9 @@ The show statement takes the following properties:
     left-to-right order.
 
     If no at clause is given, Ren'Py will retain any existing
-    transform that has been applied to the image. If no transform
-    exists, the image will be displayed using the :var:`default`
+    transform that has been applied to the image, if they were
+    created with ATL or with :class:`Transform`. If no transform
+    is specified, the image will be displayed using the :var:`default`
     transform.
 
     See the section on :ref:`replacing transforms <replacing-transforms>`

--- a/sphinx/source/layeredimage.rst
+++ b/sphinx/source/layeredimage.rst
@@ -394,8 +394,8 @@ overridden by the same property of the attribute itself.
 **Pattern.** The image pattern used consists of:
 
 * The name of the image, with spaces replaced with underscores.
-* The name of the group.
-* The name of the variant.
+* The name of the group, if the group is not ``multiple``.
+* The name of the variant, if there is one.
 * The name of the attribute.
 
 all combined with underscores. For example, if we have a layered image with

--- a/sphinx/source/transforms.rst
+++ b/sphinx/source/transforms.rst
@@ -33,19 +33,19 @@ Ren'Py ships with a number of transforms defined by default. These
 transforms position things on the screen. Here's a depiction of where
 each default transform will position an image. ::
 
-   +-----------------------------------------------------------+
-   |topleft, reset               top                   topright|
-   |                                                           |
-   |                                                           |
-   |                                                           |
-   |                                                           |
-   |                          truecenter                       |
-   |                                                           |
-   |                                                           |
-   |                                                           |
-   |                                                           |
-   |left                   center, default                right|
-   +-----------------------------------------------------------+
+                +-----------------------------------------------------------+
+                |topleft, reset               top                   topright|
+                |                                                           |
+                |                                                           |
+                |                                                           |
+                |                                                           |
+   offscreenleft|                          truecenter                       |offscreenright
+                |                                                           |
+                |                                                           |
+                |                                                           |
+                |                                                           |
+                |left                   center, default                right|
+                +-----------------------------------------------------------+
 
 The offscreenleft and offscreenright transforms position images off the
 screen. These transforms can be used to move things off the screen


### PR DESCRIPTION
In layeredimages, when a group is `multiple` it's as if there was no group for the purpose of automatic name generating.
It's now documented.