### PR TITLE
Exception when setting GL props on Model displayable

### DIFF
--- a/renpy/display/model.py
+++ b/renpy/display/model.py
@@ -171,7 +171,7 @@ class Model(renpy.display.core.Displayable):
         self.uniforms[name] = value
         return self
 
-    def properties(self, name, value):
+    def property(self, name, value):
         """
         :doc: model_displayable method
 


### PR DESCRIPTION
Renames `properties` setter (now `property`) in line with siblings (`shader`, `texture`, etc) to avoid conflict with instance property of the same name. Non-breaking as any attempt to call this method previously would have found the instance property and resulted in:
```
TypeError: 'dict' object is not callable
```

Found while poking around #3024, but is tangential and does not address that issue itself.