### PR TITLE
Do not unpickle persistent just after the save

### DIFF
--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -411,6 +411,19 @@ def save():
         if renpy.config.developer:
             raise
 
+    global persistent_mtime
+
+    # Prevent updates just after save
+    mtime = persistent_mtime
+
+    for mtime, _data in renpy.loadsave.location.load_persistent():
+        if mtime <= persistent_mtime:
+            continue
+
+    persistent_mtime = mtime
+
+
+
 ################################################################################
 # MultiPersistent
 ################################################################################

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -344,6 +344,9 @@ class FileLocation(object):
             safe_rename(fn_tmp, fn_new)
             safe_rename(fn_new, fn)
 
+            # Prevent persistent from unpickle just after save
+            self.persistent_mtime = os.path.getmtime(fn)
+
             self.sync()
 
     def unlink_persistent(self):


### PR DESCRIPTION
Without this the code
```
label start:
    $persistent.var = True
    $renpy.save_persistent()
    "Text"
```
will cause reading and unpickle of just saved persistent data by `persistent.update()` in idle frame, which is (I think) redundant.
