### PR TITLE
Added TogglePause on MusicRoom

### DIFF
--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2021 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2021 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -117,6 +117,39 @@ init -1500 python:
 
         def get_selected(self):
             return renpy.music.get_playing() is None
+
+        def periodic(self, st):
+            if self.selected != self.get_selected():
+                self.selected = self.get_selected()
+                renpy.restart_interaction()
+
+            self.mr.periodic(st)
+
+            return .1
+    
+    @renpy.pure
+    class __MusicRoomTogglePause(Action, FieldEquality):
+        """
+        The action returned by MusicRoom.TogglePause.
+        """
+
+        identity_fields = [ "mr" ]
+
+        def __init__(self, mr):
+            self.mr = mr
+            self.selected = self.get_selected()
+
+        def __call__(self):
+            if renpy.music.get_playing(self.mr.channel) is None:
+                return self.mr.play()
+
+            if renpy.music.get_pause(self.mr.channel):
+                self.mr.Music_pause(None)
+            else:
+                self.mr.Music_pause(True)
+
+        def get_selected(self):
+            return renpy.music.get_pause() is None
 
         def periodic(self, st):
             if self.selected != self.get_selected():
@@ -377,6 +410,14 @@ init -1500 python:
 
             renpy.music.stop(channel=self.channel, fadeout=self.fadeout)
 
+        def Music_pause(self,flg):
+            """
+            Pause the music from playing.
+            """
+
+            renpy.music.set_pause(flg, channel=self.channel)
+        
+
         def next(self):
             """
             Plays the next file in the playlist.
@@ -445,6 +486,20 @@ init -1500 python:
             """
 
             return __MusicRoomStop(self)
+        
+        def TogglePause(self):
+            """
+            :doc: music_room method
+
+            If music is currently playing it will pause, otherwise it will resume from where it stopped.
+
+            In case a music has already finished the queue will play the music again from the beginning the next time it is called.
+
+            If the music is playing the button will receive the selected status and when paused it will be removed.
+            """
+
+            return __MusicRoomTogglePause(self)
+
 
         def Next(self):
             """

--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -138,6 +138,11 @@ init -1500 python:
 
         def get_sensitive(self):
             return renpy.music.get_playing(self.mr.channel)
+        
+        def periodic(self, st):
+            self.mr.periodic(st)
+
+            return .1
 
 
     @renpy.pure
@@ -157,39 +162,6 @@ init -1500 python:
 
         def get_selected(self):
             return renpy.music.get_playing() is None
-
-        def periodic(self, st):
-            if self.selected != self.get_selected():
-                self.selected = self.get_selected()
-                renpy.restart_interaction()
-
-            self.mr.periodic(st)
-
-            return .1
-    
-    @renpy.pure
-    class __MusicRoomTogglePause(Action, FieldEquality):
-        """
-        The action returned by MusicRoom.TogglePause.
-        """
-
-        identity_fields = [ "mr" ]
-
-        def __init__(self, mr):
-            self.mr = mr
-            self.selected = self.get_selected()
-
-        def __call__(self):
-            if renpy.music.get_playing(self.mr.channel) is None:
-                return self.mr.play()
-
-            if renpy.music.get_pause(self.mr.channel):
-                self.mr.Music_pause(None)
-            else:
-                self.mr.Music_pause(True)
-
-        def get_selected(self):
-            return renpy.music.get_pause() is None
 
         def periodic(self, st):
             if self.selected != self.get_selected():
@@ -450,14 +422,6 @@ init -1500 python:
 
             renpy.music.stop(channel=self.channel, fadeout=self.fadeout)
 
-        def Music_pause(self,flg):
-            """
-            Pause the music from playing.
-            """
-
-            renpy.music.set_pause(flg, channel=self.channel)
-        
-
         def next(self):
             """
             Plays the next file in the playlist.
@@ -538,20 +502,6 @@ init -1500 python:
             """
 
             return __MusicRoomStop(self)
-        
-        def TogglePause(self):
-            """
-            :doc: music_room method
-
-            If music is currently playing it will pause, otherwise it will resume from where it stopped.
-
-            In case a music has already finished the queue will play the music again from the beginning the next time it is called.
-
-            If the music is playing the button will receive the selected status and when paused it will be removed.
-            """
-
-            return __MusicRoomTogglePause(self)
-
 
         def Next(self):
             """

--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -41,14 +41,6 @@ init -1500 python:
             self.selected = self.get_selected()
 
         def __call__(self):
-
-            renpy.restart_interaction()
-
-            if renpy.music.get_playing(self.mr.channel) == self.filename:
-                if renpy.music.get_pause(self.mr.channel):
-                    renpy.music.set_pause(False, self.mr.channel)
-                    return
-
             self.mr.play(self.filename, 0)
 
         def get_sensitive(self):
@@ -78,9 +70,6 @@ init -1500 python:
             self.mr = mr
 
         def __call__(self):
-
-            renpy.restart_interaction()
-
             playlist = self.mr.unlocked_playlist()
 
             if not playlist:
@@ -101,9 +90,6 @@ init -1500 python:
             self.mr = mr
 
         def __call__(self):
-
-            renpy.restart_interaction()
-
             if renpy.music.get_playing(self.mr.channel):
                 return self.mr.stop()
 
@@ -112,38 +98,6 @@ init -1500 python:
 
         def get_selected(self):
             return renpy.music.get_playing(self.mr.channel) is not None
-
-    @renpy.pure
-    class __MusicRoomTogglePause(Action, FieldEquality):
-        """
-        The action returned by MusicRoom.TogglePause
-        """
-
-        identity_fields = [ "mr" ]
-
-        def __init__(self, mr):
-            self.mr = mr
-
-        def __call__(self):
-
-            renpy.restart_interaction()
-
-            if not renpy.music.get_playing(self.mr.channel):
-                return
-
-            renpy.music.set_pause(not renpy.music.get_pause(self.mr.channel), self.mr.channel)
-
-        def get_selected(self):
-            return renpy.music.get_pause(self.mr.channel)
-
-        def get_sensitive(self):
-            return renpy.music.get_playing(self.mr.channel)
-
-        def periodic(self, st):
-            
-            self.mr.periodic(st)
-
-            return .1
 
 
     @renpy.pure
@@ -163,6 +117,39 @@ init -1500 python:
 
         def get_selected(self):
             return renpy.music.get_playing() is None
+
+        def periodic(self, st):
+            if self.selected != self.get_selected():
+                self.selected = self.get_selected()
+                renpy.restart_interaction()
+
+            self.mr.periodic(st)
+
+            return .1
+    
+    @renpy.pure
+    class __MusicRoomTogglePause(Action, FieldEquality):
+        """
+        The action returned by MusicRoom.TogglePause.
+        """
+
+        identity_fields = [ "mr" ]
+
+        def __init__(self, mr):
+            self.mr = mr
+            self.selected = self.get_selected()
+
+        def __call__(self):
+            if renpy.music.get_playing(self.mr.channel) is None:
+                return self.mr.play()
+
+            if renpy.music.get_pause(self.mr.channel):
+                self.mr.Music_pause(None)
+            else:
+                self.mr.Music_pause(True)
+
+        def get_selected(self):
+            return renpy.music.get_pause() is None
 
         def periodic(self, st):
             if self.selected != self.get_selected():
@@ -423,6 +410,14 @@ init -1500 python:
 
             renpy.music.stop(channel=self.channel, fadeout=self.fadeout)
 
+        def Music_pause(self,flg):
+            """
+            Pause the music from playing.
+            """
+
+            renpy.music.set_pause(flg, channel=self.channel)
+        
+
         def next(self):
             """
             Plays the next file in the playlist.
@@ -483,18 +478,6 @@ init -1500 python:
             """
             return __MusicRoomTogglePlay(self)
 
-        def TogglePause(self):
-            """
-            :doc: music_room method
-
-            If music is playing, pauses or unpauses the music as appropriate.
-
-            This button is selected when the music is paused.
-            """
-
-            return __MusicRoomTogglePause(self)
-
-
         def Stop(self):
             """
             :doc: music_room method
@@ -503,6 +486,20 @@ init -1500 python:
             """
 
             return __MusicRoomStop(self)
+        
+        def TogglePause(self):
+            """
+            :doc: music_room method
+
+            If music is currently playing it will pause, otherwise it will resume from where it stopped.
+
+            In case a music has already finished the queue will play the music again from the beginning the next time it is called.
+
+            If the music is playing the button will receive the selected status and when paused it will be removed.
+            """
+
+            return __MusicRoomTogglePause(self)
+
 
         def Next(self):
             """


### PR DESCRIPTION
If music is currently playing it will pause, otherwise it will resume from where it stopped.
In case a music has already finished, the queue will play the music again from the beginning the next time it is called.
If the music is playing the button will receive the selected status and when paused it will be removed.

Note:
`__MusicRoomTogglePause` is based on `__MusicRoomStop`, because in some tests in my project, if `__MusicRoomTogglePause` was the same as `__MusicRoomTogglePlay` it caused some data about the music being played added using `add(action=[SetVariable("jb_title", title)])` not to be displayed.

Inspired by the report I did before #3054

