### PR TITLE
Fix scope deletion in screen.py

### DIFF
--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -638,16 +638,8 @@ class ScreenDisplayable(renpy.display.layout.Container):
 
             renpy.ui.close()
 
-        # Avoid suppressing errors during evaluation, we should log what happened and report it
-        except:
-            import traceback
-
-            print("While evaluating screen ", self.screen_name)
-            traceback.print_exc()
-            print()
-
         finally:
-            # Safe removal as to not reraise another exception
+            # Safe removal as to not reraise another exception and lose the last one
             self.scope.pop("_scope", None)
 
             renpy.ui.screen = old_ui_screen

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -1238,7 +1238,7 @@ def predict_screen(_screen_name, *_args, **kwargs):
             print()
 
     finally:
-        del scope["_scope"]
+        scope.pop("_scope", None)
 
     renpy.ui.reset()
 
@@ -1293,7 +1293,7 @@ def use_screen(_screen_name, *_args, **kwargs):
     try:
         screen.function(**scope)
     finally:
-        del scope["_scope"]
+        scope.pop("_scope", None)
 
     _current_screen.old_transfers = old_transfers
 

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -638,8 +638,17 @@ class ScreenDisplayable(renpy.display.layout.Container):
 
             renpy.ui.close()
 
+        # Avoid suppressing errors during evaluation, we should log what happened and report it
+        except:
+            import traceback
+
+            print("While evaluating screen ", self.screen_name)
+            traceback.print_exc()
+            print()
+
         finally:
-            del self.scope["_scope"]
+            # Safe removal as to not reraise another exception
+            self.scope.pop("_scope", None)
 
             renpy.ui.screen = old_ui_screen
             pop_current_screen()


### PR DESCRIPTION
the `try`/`finally` block in screen.py still had exception possibilities, and when raised due to an unsafe dict key removal in the `finally`  block, the original exception was completely lost, leaving what was shown as something somewhat unrelated and very misleading.

This PR adds the `except` block and prints its exception info to the log file, making it easier to see what went wrong and where, additionally I have changed the `del` statement to be safer, using `dict.pop` with a default value of `None` as to not raise a further exception.

Examples from traceback:
![image](https://user-images.githubusercontent.com/22531674/135884572-653949a8-478b-4430-93a9-6f8e96fed618.png)
![image](https://user-images.githubusercontent.com/22531674/135884642-a86f660a-4d30-4482-afbd-b936c9ec0bc4.png)

Where `_scope` isn't used at all in our game's code.

![image](https://user-images.githubusercontent.com/22531674/135884801-fac616bc-32b9-4c84-98e5-44240e47265e.png)
Rest of the trace leads back here.