### PR TITLE
Report translate nodes with duplicate id clause

### DIFF
--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -156,6 +156,13 @@ class ScriptTranslator(object):
             elif type_n is Translate:
 
                 if n.language is None:
+                    if n.identifier in self.default_translates:
+                        old_node = self.default_translates[n.identifier]
+                        raise Exception("Line with id %s appeared twice, at %s:%d and %s:%d." %
+                                          (n.identifier,
+                                           old_node.filename, old_node.linenumber,
+                                           n.filename, n.linenumber))
+
                     self.default_translates[n.identifier] = n
                     self.file_translates[filename].append((label, n))
                 else:


### PR DESCRIPTION
Such code will be executed correctly on default language, but chained translations will have corrupted return point.
```
label start:
    "Line 1" id start_00000000
    "Line 1" id start_00000000
    return
```