### PR TITLE
Fix repr for Displayable subclasses

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1060,18 +1060,6 @@ class ADVCharacter(object):
         else:
             images.predict_show(None, image_with_attrs, show=False)
 
-    def __unicode__(self):
-
-        who = self.name
-
-        if self.dynamic:
-            if callable(who):
-                who = who()
-            else:
-                who = renpy.python.py_eval(who)
-
-        return renpy.substitutions.substitute(who)[0]
-
     def __str__(self):
 
         who = self.name

--- a/renpy/common/_developer/inspector.rpym
+++ b/renpy/common/_developer/inspector.rpym
@@ -24,6 +24,22 @@
 style _hyperlink_button is _default
 style _hyperlink_button_text is _hyperlink
 
+init python:
+    def _inspector_repr(d):
+        if type(d) is renpy.display.screen.ScreenDisplayable:
+            clname =  "Screen"
+        elif type(d) is renpy.display.layout.MultiBox:
+            clname =  d._classname()
+        else:
+            clname =  type(d).__name__
+
+        info = d._repr_info
+        if info is None:
+            return clname
+        if callable(info):
+            info = info()
+        return clname + " " + info
+
 screen _inspector:
     zorder 1010
     modal True
@@ -75,7 +91,7 @@ screen _inspector:
 
                 for depth, width, height, d in tree:
 
-                    $ t = "  " * depth + u"\u2022 " + unicode(d)
+                    $ t = "  " * depth + u"\u2022 " + _inspector_repr(d)
                     $ s = __format_style(d.style.parent)
 
 
@@ -118,7 +134,7 @@ screen _style_inspector:
             xfill True
             spacing gui._scale(10)
 
-        $ displayable_name = unicode(d)
+        $ displayable_name = _inspector_repr(d)
         label _("Inspecting Styles of [displayable_name!q]")
 
         $ styles = d.style.inspect()

--- a/renpy/common/_developer/inspector.rpym
+++ b/renpy/common/_developer/inspector.rpym
@@ -201,9 +201,7 @@ init python:
         else:
             clname = type(d).__name__
 
-        info = d._repr_info
+        info = d._repr_info()
         if info is None:
             return clname
-        if callable(info):
-            info = info()
         return clname + " " + info

--- a/renpy/common/_developer/inspector.rpym
+++ b/renpy/common/_developer/inspector.rpym
@@ -176,9 +176,9 @@ init python:
 
     def __safe_repr(name):
         try:
-            s = unicode(repr(name))
+            s = str(repr(name))
             if len(s) > 51:
-                s = s[:50] + u"\u2026"
+                s = s[:50] + "\u2026"
 
             return s
         except:

--- a/renpy/common/_developer/inspector.rpym
+++ b/renpy/common/_developer/inspector.rpym
@@ -24,22 +24,6 @@
 style _hyperlink_button is _default
 style _hyperlink_button_text is _hyperlink
 
-init python:
-    def _inspector_repr(d):
-        if type(d) is renpy.display.screen.ScreenDisplayable:
-            clname = "Screen"
-        elif type(d) is renpy.display.layout.MultiBox:
-            clname = d._classname()
-        else:
-            clname = type(d).__name__
-
-        info = d._repr_info
-        if info is None:
-            return clname
-        if callable(info):
-            info = info()
-        return clname + " " + info
-
 screen _inspector:
     zorder 1010
     modal True
@@ -208,3 +192,18 @@ init python:
         renpy.ui.interact(mouse="screen", type="screen", suppress_overlay=True, suppress_underlay=True)
 
     config.inspector = __inspect
+
+    def _inspector_repr(d):
+        if type(d) is renpy.display.screen.ScreenDisplayable:
+            clname = "Screen"
+        elif type(d) is renpy.display.layout.MultiBox:
+            clname = d._classname()
+        else:
+            clname = type(d).__name__
+
+        info = d._repr_info
+        if info is None:
+            return clname
+        if callable(info):
+            info = info()
+        return clname + " " + info

--- a/renpy/common/_developer/inspector.rpym
+++ b/renpy/common/_developer/inspector.rpym
@@ -27,11 +27,11 @@ style _hyperlink_button_text is _hyperlink
 init python:
     def _inspector_repr(d):
         if type(d) is renpy.display.screen.ScreenDisplayable:
-            clname =  "Screen"
+            clname = "Screen"
         elif type(d) is renpy.display.layout.MultiBox:
-            clname =  d._classname()
+            clname = d._classname()
         else:
-            clname =  type(d).__name__
+            clname = type(d).__name__
 
         info = d._repr_info
         if info is None:

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -446,10 +446,19 @@ class Displayable(renpy.object.Object):
         return True
 
     def __str__(self):
+        # returns bytes in PY2, unicode in PY3
         return self.__class__.__name__
 
     def __repr__(self):
-        return "<{} at {:x}>".format(str(self), id(self))
+        rep = object.__repr__(self)
+        reprinfo = getattr(self, _repr_info, None)
+        if reprinfo is None:
+            return rep
+        if callable(reprinfo):
+            reprinfo = reprinfo()
+        # return rep[:-1] + " " + reprinfo + ">"
+        parto = rep.partition("at")
+        return parto[0] + "(" + reprinfo + ") at" + parto[2]
 
     def find_focusable(self, callback, focus_name):
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -445,10 +445,6 @@ class Displayable(renpy.object.Object):
 
         return True
 
-    def __str__(self):
-        # returns bytes in PY2, unicode in PY3
-        return self.__class__.__name__
-
     _repr_info = None
 
     def __repr__(self):

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -445,9 +445,6 @@ class Displayable(renpy.object.Object):
 
         return True
 
-    def __unicode__(self):
-        return self.__class__.__name__
-
     def __str__(self):
         return self.__class__.__name__
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -454,9 +454,10 @@ class Displayable(renpy.object.Object):
             return rep
         if callable(reprinfo):
             reprinfo = reprinfo()
-        # return rep[:-1] + " " + reprinfo + ">"
+        if reprinfo and not ((reprinfo[0] == '(') and (reprinfo[-1] == ')')):
+            reprinfo = "".join(("(", reprinfo, ")"))
         parto = rep.rpartition(" at ")
-        return parto[0] + " (" + reprinfo + ") at " + parto[2]
+        return parto[0] + " " + reprinfo + " at " + parto[2]
 
     def find_focusable(self, callback, focus_name):
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -451,7 +451,7 @@ class Displayable(renpy.object.Object):
 
     def __repr__(self):
         rep = object.__repr__(self)
-        reprinfo = getattr(self, _repr_info, None)
+        reprinfo = getattr(self, '_repr_info', None)
         if reprinfo is None:
             return rep
         if callable(reprinfo):

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -449,9 +449,11 @@ class Displayable(renpy.object.Object):
         # returns bytes in PY2, unicode in PY3
         return self.__class__.__name__
 
+    _repr_info = None
+
     def __repr__(self):
         rep = object.__repr__(self)
-        reprinfo = getattr(self, '_repr_info', None)
+        reprinfo = self._repr_info
         if reprinfo is None:
             return rep
         if callable(reprinfo):

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -455,8 +455,8 @@ class Displayable(renpy.object.Object):
         if callable(reprinfo):
             reprinfo = reprinfo()
         # return rep[:-1] + " " + reprinfo + ">"
-        parto = rep.partition("at")
-        return parto[0] + "(" + reprinfo + ") at" + parto[2]
+        parto = rep.rpartition(" at ")
+        return parto[0] + " (" + reprinfo + ") at " + parto[2]
 
     def find_focusable(self, callback, focus_name):
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -445,15 +445,14 @@ class Displayable(renpy.object.Object):
 
         return True
 
-    _repr_info = None
+    def _repr_info(self):
+        return None
 
     def __repr__(self):
         rep = object.__repr__(self)
-        reprinfo = self._repr_info
+        reprinfo = self._repr_info()
         if reprinfo is None:
             return rep
-        if callable(reprinfo):
-            reprinfo = reprinfo()
         if reprinfo and not ((reprinfo[0] == '(') and (reprinfo[-1] == ')')):
             reprinfo = "".join(("(", reprinfo, ")"))
         parto = rep.rpartition(" at ")

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -457,7 +457,10 @@ class Displayable(renpy.object.Object):
         if reprinfo and not ((reprinfo[0] == '(') and (reprinfo[-1] == ')')):
             reprinfo = "".join(("(", reprinfo, ")"))
         parto = rep.rpartition(" at ")
-        return parto[0] + " " + reprinfo + " at " + parto[2]
+        return " ".join((parto[0],
+                         reprinfo,
+                         "at",
+                         parto[2]))
 
     def find_focusable(self, callback, focus_name):
 

--- a/renpy/display/dragdrop.py
+++ b/renpy/display/dragdrop.py
@@ -788,8 +788,6 @@ class DragGroup(renpy.display.layout.MultiBox):
 
     _list_type = renpy.python.RevertableList
 
-    __repr__ = object.__repr__
-
     def __init__(self, *children, **properties):
         properties.setdefault("style", "fixed")
         properties.setdefault("layout", "fixed")

--- a/renpy/display/dragdrop.py
+++ b/renpy/display/dragdrop.py
@@ -788,8 +788,7 @@ class DragGroup(renpy.display.layout.MultiBox):
 
     _list_type = renpy.python.RevertableList
 
-    def __unicode__(self):
-        return "DragGroup"
+    __repr__ = object.__repr__
 
     def __init__(self, *children, **properties):
         properties.setdefault("style", "fixed")

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -229,7 +229,7 @@ class Cache(object):
         optimize_bounds = renpy.config.optimize_texture_bounds and image.optimize_bounds
 
         if not isinstance(image, ImageBase):
-            raise Exception("Expected an image of some sort, but got" + type(image).__name__ + ".")
+            raise Exception("Expected an image of some sort, but got" + repr(image) + ".")
 
         if not image.cache:
             surf = image.load()

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -632,11 +632,11 @@ class Image(ImageBase):
         super(Image, self).__init__(filename, **properties)
         self.filename = filename
 
-    def __unicode__(self):
+    def _repr_info(self):
         if len(self.filename) < 20:
-            return u"Image %r" % self.filename
+            return repr(self.filename)
         else:
-            return u"Image \u2026%s" % self.filename[-20:]
+            return repr("\u2026"+self.filename[-20:])
 
     def get_hash(self):
         return renpy.loader.get_hash(self.filename)
@@ -722,8 +722,8 @@ class Data(ImageBase):
         self.data = data
         self.filename = filename
 
-    def __unicode__(self):
-        return u"im.Data(%r)" % self.filename
+    def _repr_info(self):
+        return repr(self.filename)
 
     def load(self):
         f = io.BytesIO(self.data)

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -591,9 +591,6 @@ class ImageBase(renpy.display.core.Displayable):
 
         return self.identity == other.identity
 
-    def __repr__(self):
-        return "<" + " ".join([repr(i) for i in self.identity]) + ">"
-
     def load(self):
         """
         This function is called by the image cache code to cause this

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -229,7 +229,7 @@ class Cache(object):
         optimize_bounds = renpy.config.optimize_texture_bounds and image.optimize_bounds
 
         if not isinstance(image, ImageBase):
-            raise Exception("Expected an image of some sort, but got" + str(image) + ".")
+            raise Exception("Expected an image of some sort, but got" + type(image).__name__ + ".")
 
         if not image.cache:
             surf = image.load()

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -340,7 +340,7 @@ class ImageReference(renpy.display.core.Displayable):
 
         self.name = name
 
-    def __repr__(self):
+    def _repr_info(self):
         return repr(self.name)
 
     def __hash__(self):
@@ -576,7 +576,7 @@ class DynamicImage(renpy.display.core.Displayable):
     def _scope(self, scope, update):
         return self.find_target(scope, update)
 
-    def __repr__(self):
+    def _repr_info(self):
         return repr(self.name)
 
     def __hash__(self):

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -340,8 +340,8 @@ class ImageReference(renpy.display.core.Displayable):
 
         self.name = name
 
-    def __unicode__(self):
-        return u"<ImageReference {!r}>".format(self.name)
+    def __repr__(self):
+        return repr(self.name)
 
     def __hash__(self):
         return hash(self.name)
@@ -576,8 +576,8 @@ class DynamicImage(renpy.display.core.Displayable):
     def _scope(self, scope, update):
         return self.find_target(scope, update)
 
-    def __unicode__(self):
-        return u"DynamicImage {!r}".format(self.name)
+    def __repr__(self):
+        return repr(self.name)
 
     def __hash__(self):
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -708,7 +708,7 @@ class MultiBox(Container):
         return rv
 
     def __repr__(self):
-        if type(self) == MultiBox:
+        if type(self) is MultiBox:
             layout = self.style.box_layout
 
             if layout is None:

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -723,7 +723,7 @@ class MultiBox(Container):
             else:
                 classname = "MultiBox"
 
-            return "<" + classname + " " + super(MultiBox, self).__repr__().partition(" ")[2]
+            return super(MultiBox, self).__repr__().replace("MultiBox", classname)
         return super(MultiBox, self).__repr__()
 
     def add(self, widget, start_time=None, anim_time=None): # W0221

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -707,21 +707,25 @@ class MultiBox(Container):
 
         return rv
 
+    def _classname(self):
+        if type(self) is not MultiBox:
+            return type(self).__name__
+
+        layout = self.style.box_layout
+        if layout is None:
+            layout = self.default_layout
+
+        if layout == "fixed":
+            return "Fixed"
+        elif layout == "horizontal":
+            return "HBox"
+        elif layout == "vertical":
+            return "VBox"
+        return "MultiBox"
+
     def __repr__(self):
         if type(self) is MultiBox:
-            layout = self.style.box_layout
-
-            if layout is None:
-                layout = self.default_layout
-
-            if layout == "fixed":
-                classname = "Fixed"
-            elif layout == "horizontal":
-                classname = "HBox"
-            elif layout == "vertical":
-                classname = "VBox"
-            else:
-                classname = "MultiBox"
+            classname = self._classname()
 
             return super(MultiBox, self).__repr__().replace("MultiBox", classname)
         return super(MultiBox, self).__repr__()

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -708,21 +708,23 @@ class MultiBox(Container):
         return rv
 
     def __repr__(self):
-        layout = self.style.box_layout
+        if type(self) == MultiBox:
+            layout = self.style.box_layout
 
-        if layout is None:
-            layout = self.default_layout
+            if layout is None:
+                layout = self.default_layout
 
-        if layout == "fixed":
-            classname = "Fixed"
-        elif layout == "horizontal":
-            classname = "HBox"
-        elif layout == "vertical":
-            classname = "VBox"
-        else:
-            classname = "MultiBox"
+            if layout == "fixed":
+                classname = "Fixed"
+            elif layout == "horizontal":
+                classname = "HBox"
+            elif layout == "vertical":
+                classname = "VBox"
+            else:
+                classname = "MultiBox"
 
-        return "<" + classname + " " + super(MultiBox, self).__repr__().partition(" ")[2]
+            return "<" + classname + " " + super(MultiBox, self).__repr__().partition(" ")[2]
+        return super(MultiBox, self).__repr__()
 
     def add(self, widget, start_time=None, anim_time=None): # W0221
         super(MultiBox, self).add(widget)

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -707,20 +707,22 @@ class MultiBox(Container):
 
         return rv
 
-    def __unicode__(self):
+    def __repr__(self):
         layout = self.style.box_layout
 
         if layout is None:
             layout = self.default_layout
 
         if layout == "fixed":
-            return "Fixed"
+            classname = "Fixed"
         elif layout == "horizontal":
-            return "HBox"
+            classname = "HBox"
         elif layout == "vertical":
-            return "VBox"
+            classname = "VBox"
         else:
-            return "MultiBox"
+            classname = "MultiBox"
+
+        return "<" + classname + " " + super(MultiBox, self).__repr__().partition(" ")[2]
 
     def add(self, widget, start_time=None, anim_time=None): # W0221
         super(MultiBox, self).add(widget)

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -427,7 +427,7 @@ class ScreenDisplayable(renpy.display.layout.Container):
         self.phase = PREDICT
 
     def _repr_info(self):
-        return " ".join(self.screen_name)
+        return repr(" ".join(self.screen_name))
 
     def visit(self):
         return [ self.child ]

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -426,8 +426,8 @@ class ScreenDisplayable(renpy.display.layout.Container):
         # The lifecycle phase we are in - one of PREDICT, SHOW, UPDATE, or HIDE.
         self.phase = PREDICT
 
-    def __unicode__(self):
-        return "Screen {}".format(" ".join(self.screen_name))
+    def _repr_info(self):
+        return " ".join(self.screen_name)
 
     def visit(self):
         return [ self.child ]

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -917,7 +917,7 @@ class ATLTransform(renpy.atl.ATLTransformBase, Transform):
         self.active = True
 
     def _repr_info(self):
-        return repr((self.child,) + self.atl.loc)
+        return repr((self.child, self.atl.loc))
 
 
 # Names of transform properties, and if the property should be handles with

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -888,6 +888,9 @@ class Transform(Container):
 
         return rv
 
+    def _repr_info(self):
+        return repr(self.child)
+
 
 class ATLTransform(renpy.atl.ATLTransformBase, Transform):
 
@@ -913,8 +916,8 @@ class ATLTransform(renpy.atl.ATLTransformBase, Transform):
 
         self.active = True
 
-    def __repr__(self):
-        return "<ATL Transform {:x} {!r}>".format(id(self), self.atl.loc)
+    def _repr_info(self):
+        return repr(self.atl.loc)
 
 
 # Names of transform properties, and if the property should be handles with

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -917,7 +917,7 @@ class ATLTransform(renpy.atl.ATLTransformBase, Transform):
         self.active = True
 
     def _repr_info(self):
-        return repr(self.atl.loc)
+        return repr((self.child,) + self.atl.loc)
 
 
 # Names of transform properties, and if the property should be handles with

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -112,7 +112,9 @@ class ParseError(Exception):
 
         Exception.__init__(self, message)
 
-    def __unicode__(self):
+    def __str__(self):
+        if PY2:
+            return self.message.encode()
         return self.message
 
 # Something to hold the expected line number.

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -112,9 +112,7 @@ class ParseError(Exception):
 
         Exception.__init__(self, message)
 
-    def __str__(self):
-        if PY2:
-            return self.message.encode()
+    def __unicode__(self):
         return self.message
 
 # Something to hold the expected line number.

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1643,7 +1643,6 @@ class Text(renpy.display.core.Displayable):
                 s = s[:24] + u"\u2026"
                 break
 
-        s = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
         return repr(s)
 
     def get_all_text(self):

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1632,7 +1632,7 @@ class Text(renpy.display.core.Displayable):
 
         return rv
 
-    def __unicode__(self):
+    def _repr_info(self):
         s = ""
 
         for i in self.text:
@@ -1644,7 +1644,7 @@ class Text(renpy.display.core.Displayable):
                 break
 
         s = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
-        return u"Text \"{}\"".format(s)
+        return repr(s)
 
     def get_all_text(self):
         """


### PR DESCRIPTION
As per #3069.

The template I used in Displayable subclasses is slightly different from @Andykl's.
Andy's : `<MyModule.MySubclass object at 0x00000000 optional_repr_info>`
Mine : `<MyModule.MySubclass object (optional_repr_info) at 0x00000000>`
The parentheses were chosen to separate the aditional info from the class name and other text such as the "at" and "object" words.
I didn't choose brackets or square-brackets to avoid substitution issues (although they're unlikely to happen).
The placement, between the "object" and the "at", should prevent people from interpreting it as constructor arguments, and also placing it after the address seemed weird.
If you prefer Andy's style, it's available in my code, just commented out.

As it were, MultiBox's repr is a special case which overrides the class name, and DragGroup's is a special case of MultiBox which reverts the override. ~~DragGroup now uses `object`'s repr, instead of Displayable's, which is arguable.~~
I think a better version would be to make it relate to a property such as `__classname` (without trailing underscores) in MultiBox so that the behavior will only apply for MultiBox and not its subclasses. It would special-case only the MultiBox class, instead of having a special-case of a special-case. ~~I'm not sure PY2 will allow it, but I'll try to make it work.~~ **Edit :** Implemented, actually it worked in another way.

ImageBase's subclasses had a modified repr. They used to display every argument passed to the constructor, now they don't. I think this change was intended in Andy's issue, and I believe that's a good thing. However, arguments could be made to modify the `_repr_info` of these classes to include some of the now-omitted data.
But they're all `im.` stuff, so I don't think it really matters anyway.

I also removed Character and Displayable's \_\_unicode__ methods, as they only returned a unicode version of the \_\_str__ method, which is already done by python in the background. I also did it to the parser's ParseError, for which no feature was removed (it's still castable to unicode un PY2 and in PY3) but now it works in PY3, thanks to the new \_\_str__ method.
I can revert this, since it doesn't exactly relate to the base repr issue, but I think \_\_unicode__ has nothing to do in a python code which is interpreted not only by versions superior to 2.7, but also by python 3.