### PR TITLE
Some clean up of Render

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2129,7 +2129,7 @@ class AlphaMask(Container):
 
         nr = renpy.display.render.render(self.null, w, h, st, at)
 
-        rv = renpy.display.render.Render(w, h, opaque=False)
+        rv = renpy.display.render.Render(w, h)
 
         rv.operation = renpy.display.render.IMAGEDISSOLVE
         rv.operation_alpha = 1.0

--- a/renpy/display/pgrender.py
+++ b/renpy/display/pgrender.py
@@ -76,11 +76,6 @@ class Surface(pygame.Surface):
     its mode, as necessary.
     """
 
-    opaque = False
-
-    def is_opaque(self):
-        return self.opaque
-
     def convert_alpha(self, surface=None):
         return copy_surface_unscaled(self, True)
 

--- a/renpy/display/render.pxd
+++ b/renpy/display/render.pxd
@@ -60,7 +60,6 @@ cdef class Render:
     cdef public list pass_focuses
     cdef public object focus_screen
 
-    cdef public object draw_func
     cdef public object render_of
 
     cdef public bint xclipping

--- a/renpy/display/render.pxd
+++ b/renpy/display/render.pxd
@@ -63,9 +63,6 @@ cdef class Render:
     cdef public object draw_func
     cdef public object render_of
 
-    cdef public object opaque
-    cdef public list visible_children
-
     cdef public bint xclipping
     cdef public bint yclipping
 

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -585,7 +585,7 @@ FLATTEN = 4
 
 cdef class Render:
 
-    def __init__(Render self, float width, float height, draw_func=None, layer_name=None): #@DuplicatedSignature
+    def __init__(Render self, float width, float height, layer_name=None): #@DuplicatedSignature
         """
         Creates a new render corresponding to the given widget with
         the specified width and height.
@@ -643,10 +643,6 @@ cdef class Render:
 
         # The displayable(s) that this is a render of. (Set by render)
         self.render_of = [ ]
-
-        # If set, this is a function that's called to draw this render
-        # instead of the default.
-        self.draw_func = draw_func
 
         # Should children be clipped to a rectangle?
         self.xclipping = False

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -494,8 +494,6 @@ def render_screen(root, width, height):
 
     invalidated = False
 
-    rv.is_opaque()
-
     return rv
 
 def mark_sweep():
@@ -587,7 +585,7 @@ FLATTEN = 4
 
 cdef class Render:
 
-    def __init__(Render self, float width, float height, draw_func=None, layer_name=None, bint opaque=False): #@DuplicatedSignature
+    def __init__(Render self, float width, float height, draw_func=None, layer_name=None): #@DuplicatedSignature
         """
         Creates a new render corresponding to the given widget with
         the specified width and height.
@@ -649,16 +647,6 @@ cdef class Render:
         # If set, this is a function that's called to draw this render
         # instead of the default.
         self.draw_func = draw_func
-
-        # Is this displayable opaque? (May be set on init, or later on
-        # if we have opaque children.) This may be True, False, or None
-        # to indicate we don't know yet.
-        self.opaque = opaque
-
-        # A list of our visible children. (That is, children above and
-        # including our uppermost opaque child.) If nothing is opaque,
-        # includes all children.
-        self.visible_children = self.children
 
         # Should children be clipped to a rectangle?
         self.xclipping = False
@@ -1108,9 +1096,6 @@ cdef class Render:
             del self.render_of[:]
             del self.children[:]
 
-        self.opaque = None
-        self.visible_children = self.children
-
         self.focuses = None
         self.pass_focuses = None
 
@@ -1367,41 +1352,6 @@ cdef class Render:
         return rv
 
 
-    def is_opaque(self):
-        """
-        Returns true if this displayable is opaque, or False otherwise.
-        Also sets self.visible_children.
-        """
-
-        if self.opaque is not None:
-            return self.opaque
-
-        # A rotated image is never opaque. (This isn't actually true, but it
-        # saves us from the expensive calculations require to prove it is.)
-        if self.forward:
-            self.opaque = False
-            return False
-
-        rv = False
-        vc = [ ]
-
-        for i in self.children:
-            child, xo, yo, focus, main = i
-
-            if xo <= 0 and yo <= 0:
-                cw, ch = child.get_size()
-                if cw + xo < self.width or ch + yo < self.height:
-                    if child.is_opaque():
-                        vc = [ ]
-                        rv = True
-
-            vc.append(i)
-
-        self.visible_children = vc
-        self.opaque = rv
-        return rv
-
-
     def is_pixel_opaque(self, x, y):
         """
         Determine if the pixel at x and y is opaque or not.
@@ -1409,9 +1359,6 @@ cdef class Render:
 
         if x < 0 or y < 0 or x >= self.width or y >= self.height:
             return False
-
-        if self.is_opaque():
-            return True
 
         return renpy.display.draw.is_pixel_opaque(self, x, y)
 

--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -430,7 +430,6 @@ def draw(dest, clip, what, xo, yo, screen):
             dest.forced.add((subx, suby, subx + subw, suby + subh, clip))
         else:
             newdest = dest.subsurface((subx, suby, subw, subh))
-            # what.draw_func(newdest, newx, newy)
             draw_special(what, newdest, newx, newy)
 
         return
@@ -624,7 +623,7 @@ def draw_transformed(dest, clip, what, xo, yo, alpha, forward, reverse):
 
             dest = dest.subsurface((x, y, width, height))
 
-    if what.draw_func or what.operation != BLIT:
+    if what.operation != BLIT:
         child = what.pygame_surface(True)
         draw_transformed(dest, clip, child, xo, yo, alpha, forward, reverse)
         return

--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -486,12 +486,12 @@ def draw(dest, clip, what, xo, yo, screen):
 
     # Deal with alpha and transforms by passing them off to draw_transformed.
     if what.alpha != 1 or what.over != 1.0 or (what.forward is not None and what.forward is not IDENTITY):
-        for child, cxo, cyo, _focus, _main in what.visible_children:
+        for child, cxo, cyo, _focus, _main in what.children:
             draw_transformed(dest, clip, child, xo + cxo, yo + cyo,
                              what.alpha * what.over, what.forward, what.reverse)
         return
 
-    for child, cxo, cyo, _focus, _main in what.visible_children:
+    for child, cxo, cyo, _focus, _main in what.children:
         draw(dest, clip, child, xo + cxo, yo + cyo, screen)
 
 
@@ -629,7 +629,7 @@ def draw_transformed(dest, clip, what, xo, yo, alpha, forward, reverse):
         draw_transformed(dest, clip, child, xo, yo, alpha, forward, reverse)
         return
 
-    for child, cxo, cyo, _focus, _main in what.visible_children:
+    for child, cxo, cyo, _focus, _main in what.children:
 
         cxo, cyo = reverse.transform(cxo, cyo)
 
@@ -649,8 +649,6 @@ def do_draw_screen(screen_render, full_redraw, swdraw):
     """
 
     yoffset = xoffset = 0
-
-    screen_render.is_opaque()
 
     clip = (xoffset, yoffset, xoffset + screen_render.width, yoffset + screen_render.height)
     clipper = clippers[0]
@@ -881,15 +879,15 @@ class SWDraw(object):
         # This doesn't work perfectly, but this should be a rare case and
         # swdraw is going away.
         if what.operation == IMAGEDISSOLVE:
-            a0 = self.is_pixel_opaque(what.visible_children[0][0], x, y)
-            a2 = self.is_pixel_opaque(what.visible_children[2][0], x, y)
+            a0 = self.is_pixel_opaque(what.children[0][0], x, y)
+            a2 = self.is_pixel_opaque(what.children[2][0], x, y)
 
             return a0 * a2
 
         if x < 0 or y < 0 or x >= what.width or y >= what.height:
             return 0
 
-        for (child, xo, yo, _focus, _main) in what.visible_children:
+        for (child, xo, yo, _focus, _main) in what.children:
             cx = x - xo
             cy = y - yo
 

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -370,7 +370,7 @@ class Dissolve(Transition):
         width = min(top.width, bottom.width)
         height = min(top.height, bottom.height)
 
-        rv = renpy.display.render.Render(width, height, opaque=not (self.alpha or renpy.config.dissolve_force_alpha))
+        rv = renpy.display.render.Render(width, height)
 
         rv.operation = renpy.display.render.DISSOLVE
         rv.operation_alpha = self.alpha or renpy.config.dissolve_force_alpha
@@ -533,7 +533,7 @@ class ImageDissolve(Transition):
         width = min(bottom.width, top.width, image.width)
         height = min(bottom.height, top.height, image.height)
 
-        rv = renpy.display.render.Render(width, height, opaque=not (self.alpha or renpy.config.dissolve_force_alpha))
+        rv = renpy.display.render.Render(width, height)
 
         complete = st / self.delay
 
@@ -651,7 +651,7 @@ class AlphaDissolve(Transition):
 
         control = render(self.control, width, height, st, at)
 
-        rv = renpy.display.render.Render(width, height, opaque=not self.alpha)
+        rv = renpy.display.render.Render(width, height)
 
         rv.operation = renpy.display.render.IMAGEDISSOLVE
         rv.operation_alpha = self.alpha or renpy.config.dissolve_force_alpha

--- a/renpy/gl/gldraw.pyx
+++ b/renpy/gl/gldraw.pyx
@@ -736,8 +736,6 @@ cdef class GLDraw:
         else:
             reverse = IDENTITY
 
-        surftree.is_opaque()
-
         self.draw_render_textures(surftree, 0)
 
         xmul = 1.0 * self.drawable_size[0] / self.physical_size[0]
@@ -831,7 +829,7 @@ cdef class GLDraw:
             non_aligned |= (rend.forward.xdy != 0)
             non_aligned |= (rend.forward.ydy != 0)
 
-        for child, cxo, cyo, focus, main in rend.visible_children:
+        for child, cxo, cyo, focus, main in rend.children:
 
             self.draw_render_textures(child, non_aligned)
 
@@ -1054,7 +1052,7 @@ cdef class GLDraw:
         else:
             child_reverse = reverse
 
-        for child, cx, cy, focus, main in rend.visible_children:
+        for child, cx, cy, focus, main in rend.children:
 
             # The type of cx and cy depends on if this is a subpixel blit or not.
             if type(cx) is float:
@@ -1090,9 +1088,6 @@ cdef class GLDraw:
             clip = self.default_clip
 
             self.draw_transformed(what, clip, 0, 0, 1.0, 1.0, self.virt_to_draw, renpy.config.nearest_neighbor, False)
-
-        if isinstance(what, render.Render):
-            what.is_opaque()
 
         rv = gltexture.texture_grid_from_drawing(width, height, draw_func, self.rtt, self.environ)
 
@@ -1174,9 +1169,6 @@ cdef class GLDraw:
             clip = (0, 0, width, height)
 
             draw.draw_transformed(what, clip, 0, 0, 1.0, 1.0, reverse, renpy.config.nearest_neighbor, False)
-
-        if isinstance(what, render.Render):
-            what.is_opaque()
 
         rv = gltexture.texture_grid_from_drawing(width, height, draw_func, self.rtt, self.environ)
 

--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -810,9 +810,6 @@ cdef class GL2Draw:
         if surf is None:
             return
 
-        # Compute visible_children.
-        surf.is_opaque()
-
         # Load all the textures and RTTs.
         self.load_all_textures(surf)
 
@@ -932,9 +929,6 @@ cdef class GL2Draw:
             return 0
 
         what = what.subsurface((x, y, 1, 1))
-
-        # Compute visible_children.
-        what.is_opaque()
 
         # Load all the textures and RTTs.
         self.load_all_textures(what)
@@ -1300,7 +1294,7 @@ cdef class GL2DrawingContext:
 
             properties["has_depth"] = True
 
-        children = r.visible_children
+        children = r.children
 
         if r.cached_model is not None:
             children = [ (r.cached_model, 0, 0, False, False) ]


### PR DESCRIPTION
This removes `Render.opaque`, `Render.visible_children`, `Render.is_opaque` and `Surface.is_opaque` and all its uses.
If I understand correctly, it was only useful in SWDraw, and since it's not used to render creator things now, it can be removed. Also, it has not been used since 2018 and no one seems to be hurt about it.

This fixes #3089