### PR TITLE
Fix and expose ContrastMatrix

### DIFF
--- a/renpy/common/00matrixcolor.rpy
+++ b/renpy/common/00matrixcolor.rpy
@@ -233,19 +233,19 @@ init -1500 python:
 
 
     class ContrastMatrix(ColorMatrix):
+        """
+        :doc: colormatrix
+
+        A ColorMatrix that can be used with :tpref:`matrixcolor` to change
+        the brightness of an image, while leaving the Alpha channel
+        alone.
+
+        `value`
+            The contrast value. Values between 0.0 and 1.0 decrease
+            the contrast, while values above 1.0 increase the contrast.
+        """
 
         def get(self, value):
-            """
-            :doc: colormatrix
-
-            A ColorMatrix that can be used with :tpref:`matrixcolor` to change
-            the brightness of an image, while leaving the Alpha channel
-            alone.
-
-            `value`
-                The contrast value. Values between 0.0 and 1.0 decrease
-                the contrast, while values above 1.0 increase the contrast.
-            """
 
             v = value
 
@@ -259,9 +259,9 @@ init -1500 python:
                              0, 0, v, 0,
                              0, 0, 0, 1, ])
 
-            step3 = Matrix([ 1, 0, 0, -.5,
-                             0, 1, 0, -.5,
-                             0, 0, 1, -.5,
+            step3 = Matrix([ 1, 0, 0, .5,
+                             0, 1, 0, .5,
+                             0, 0, 1, .5,
                              0, 0, 0, 1, ])
 
             return step3 * step2 * step1

--- a/renpy/common/00matrixcolor.rpy
+++ b/renpy/common/00matrixcolor.rpy
@@ -246,25 +246,13 @@ init -1500 python:
         """
 
         def get(self, value):
+            d = value
+            v = value / -2 + .5
 
-            v = value
-
-            step1 = Matrix([ 1, 0, 0, -.5,
-                             0, 1, 0, -.5,
-                             0, 0, 1, -.5,
-                             0, 0, 0, 1, ])
-
-            step2 = Matrix([ v, 0, 0, 0,
-                             0, v, 0, 0,
-                             0, 0, v, 0,
-                             0, 0, 0, 1, ])
-
-            step3 = Matrix([ 1, 0, 0, .5,
-                             0, 1, 0, .5,
-                             0, 0, 1, .5,
-                             0, 0, 0, 1, ])
-
-            return step3 * step2 * step1
+            return Matrix([ d, 0, 0, v,
+                            0, d, 0, v,
+                            0, 0, d, v,
+                            0, 0, 0, 1, ])
 
 
     class ColorizeMatrix(ColorMatrix):


### PR DESCRIPTION
Messy diff, ([hiding whitespace helps](/renpy/renpy/pull/3111/files?w=1)) but the tl;dr is:
- `ContrastMatrix` was using `-.5` in `step3` rather than `.5` leading to poor results.
- The doc block was in the method instead of the class, and so not being generated for the website.
- Turns out Contrast is a scaled and inverted InvertMatrix, which allows us to avoid the triple Matrix combination.

The first two points are hopefully pretty unobjectionable, but if you feel the third hurts maintainability I can remove that commit, it's definitely not as straight-forward to grok.