### PR TITLE
Patch config.nvl_page_ctc not being a displayable, fix #3116

### DIFF
--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -354,7 +354,7 @@ init -1500 python:
             page = self.clear or nvl_clear_next()
 
             if config.nvl_page_ctc and page:
-                display_args["ctc"] = config.nvl_page_ctc
+                display_args["ctc"] = renpy.easy.displayable_or_none(config.nvl_page_ctc)
                 display_args["ctc_position"] = config.nvl_page_ctc_position
 
             if config.nvl_paged_rollback:


### PR DESCRIPTION
`config.nvl_page_ctc` overrides Character's (actually ADVCharacter's) `ctc` argument.
In the constructor, the argument is converted using `renpy.easy.displayable_or_none`, so passing a string replaces it with a displayable, internally. Which means the code accessing it relies on it being a displayable.
That conversion is not done in the case of `config.nvl_page_ctc`. Which means the `display_say` function finds itself with a string and calls `_duplicatable` on it.
I patched the only place in the code where the config variable is read, by wrapping it in the displayable_or_none function.