### PR TITLE
Update German translation in common.rpy

### DIFF
--- a/launcher/game/tl/german/common.rpy
+++ b/launcher/game/tl/german/common.rpy
@@ -3,71 +3,71 @@ translate german strings:
 
     # 00action_file.rpy:26
     old "{#weekday}Monday"
-    new "{#weekday}Monday"
+    new "{#weekday}Montag"
 
     # 00action_file.rpy:26
     old "{#weekday}Tuesday"
-    new "{#weekday}Tuesday"
+    new "{#weekday}Dienstag"
 
     # 00action_file.rpy:26
     old "{#weekday}Wednesday"
-    new "{#weekday}Wednesday"
+    new "{#weekday}Mittwoch"
 
     # 00action_file.rpy:26
     old "{#weekday}Thursday"
-    new "{#weekday}Thursday"
+    new "{#weekday}Donnerstag"
 
     # 00action_file.rpy:26
     old "{#weekday}Friday"
-    new "{#weekday}Friday"
+    new "{#weekday}Freitag"
 
     # 00action_file.rpy:26
     old "{#weekday}Saturday"
-    new "{#weekday}Saturday"
+    new "{#weekday}Samstag"
 
     # 00action_file.rpy:26
     old "{#weekday}Sunday"
-    new "{#weekday}Sunday"
+    new "{#weekday}Sonntag"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Mon"
-    new "{#weekday_short}Mon"
+    new "{#weekday_short}Mo"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Tue"
-    new "{#weekday_short}Tue"
+    new "{#weekday_short}Di"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Wed"
-    new "{#weekday_short}Wed"
+    new "{#weekday_short}Mi"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Thu"
-    new "{#weekday_short}Thu"
+    new "{#weekday_short}Do"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Fri"
-    new "{#weekday_short}Fri"
+    new "{#weekday_short}Fr"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Sat"
-    new "{#weekday_short}Sat"
+    new "{#weekday_short}Sa"
 
     # 00action_file.rpy:37
     old "{#weekday_short}Sun"
-    new "{#weekday_short}Sun"
+    new "{#weekday_short}So"
 
     # 00action_file.rpy:47
     old "{#month}January"
-    new "{#month}January"
+    new "{#month}Januar"
 
     # 00action_file.rpy:47
     old "{#month}February"
-    new "{#month}February"
+    new "{#month}Februar"
 
     # 00action_file.rpy:47
     old "{#month}March"
-    new "{#month}March"
+    new "{#month}März"
 
     # 00action_file.rpy:47
     old "{#month}April"
@@ -75,15 +75,15 @@ translate german strings:
 
     # 00action_file.rpy:47
     old "{#month}May"
-    new "{#month}May"
+    new "{#month}Mai"
 
     # 00action_file.rpy:47
     old "{#month}June"
-    new "{#month}June"
+    new "{#month}Juni"
 
     # 00action_file.rpy:47
     old "{#month}July"
-    new "{#month}July"
+    new "{#month}Juli"
 
     # 00action_file.rpy:47
     old "{#month}August"
@@ -95,7 +95,7 @@ translate german strings:
 
     # 00action_file.rpy:47
     old "{#month}October"
-    new "{#month}October"
+    new "{#month}Oktober"
 
     # 00action_file.rpy:47
     old "{#month}November"
@@ -103,7 +103,7 @@ translate german strings:
 
     # 00action_file.rpy:47
     old "{#month}December"
-    new "{#month}December"
+    new "{#month}Dezember"
 
     # 00action_file.rpy:63
     old "{#month_short}Jan"
@@ -115,7 +115,7 @@ translate german strings:
 
     # 00action_file.rpy:63
     old "{#month_short}Mar"
-    new "{#month_short}Mar"
+    new "{#month_short}Mär"
 
     # 00action_file.rpy:63
     old "{#month_short}Apr"
@@ -123,7 +123,7 @@ translate german strings:
 
     # 00action_file.rpy:63
     old "{#month_short}May"
-    new "{#month_short}May"
+    new "{#month_short}Mai"
 
     # 00action_file.rpy:63
     old "{#month_short}Jun"
@@ -143,7 +143,7 @@ translate german strings:
 
     # 00action_file.rpy:63
     old "{#month_short}Oct"
-    new "{#month_short}Oct"
+    new "{#month_short}Okt"
 
     # 00action_file.rpy:63
     old "{#month_short}Nov"
@@ -151,7 +151,7 @@ translate german strings:
 
     # 00action_file.rpy:63
     old "{#month_short}Dec"
-    new "{#month_short}Dec"
+    new "{#month_short}Dez"
 
     # 00action_file.rpy:235
     old "%b %d, %H:%M"
@@ -187,19 +187,19 @@ translate german strings:
 
     # 00gui.rpy:233
     old "Are you sure you want to end the replay?"
-    new "Are you sure you want to end the replay?"
+    new "Sind Sie sicher, dass sie die Szenen-Wiederholung beenden möchten?"
 
     # 00gui.rpy:234
     old "Are you sure you want to begin skipping?"
-    new "Sind Sie sicher, dass Sie vorspulen möchten?"
+    new "Sind Sie sicher, dass Sie Text überspringen möchten?"
 
     # 00gui.rpy:235
     old "Are you sure you want to skip to the next choice?"
-    new "Sind Sie sicher, dass Sie zur nächsten Auswahl vorspulen möchten?"
+    new "Sind Sie sicher, dass Sie zur nächsten Auswahl springen möchten?"
 
     # 00gui.rpy:236
     old "Are you sure you want to skip unseen dialogue to the next choice?"
-    new "Are you sure you want to skip unseen dialogue to the next choice?"
+    new "Sind Sie sicher, dass sie ungesehenen Dialog bis zur nächsten Entscheidung überspringen möchten?"
 
     # 00keymap.rpy:250
     old "Saved screenshot as %s."
@@ -207,7 +207,7 @@ translate german strings:
 
     # 00library.rpy:142
     old "Self-voicing disabled."
-    new "Self-voicing disabled."
+    new "Sprachausgabe deaktiviert."
 
     # 00library.rpy:143
     old "Clipboard voicing enabled. "
@@ -215,15 +215,15 @@ translate german strings:
 
     # 00library.rpy:144
     old "Self-voicing enabled. "
-    new "Self-voicing enabled. "
+    new "Sprachausgabe aktiviert. "
 
     # 00library.rpy:179
     old "Skip Mode"
-    new "Vorspulen"
+    new "Skip-Modus"
 
     # 00library.rpy:262
     old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
-    new "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
+    new "Dieses Programm enthält kostenlose Software unter einer Reihe von Lizenzen, einschließlich der MIT License und der GNU Lesser General Public License. Eine vollständige Liste aller Software, inklusive Links zum vollständigen Quellcode, kann {a=https://www.renpy.org/l/license}hier{/a} gefunden werden." 
 
     # 00preferences.rpy:422
     old "Clipboard voicing enabled. Press 'shift+C' to disable."
@@ -231,47 +231,47 @@ translate german strings:
 
     # 00preferences.rpy:424
     old "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
-    new "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
+    new "Sprachausgabe würde \"[renpy.display.tts.last]\" sagen. Zum deaktivieren 'alt+shift+V' drücken."
 
     # 00preferences.rpy:426
     old "Self-voicing enabled. Press 'v' to disable."
-    new "Self-voicing enabled. Press 'v' to disable."
+    new "Sprachausgabe aktiviert. Zum deaktivieren 'v' drücken."
 
     # 00iap.rpy:217
     old "Contacting App Store\nPlease Wait..."
-    new "Contacting App Store\nPlease Wait..."
+    new "Kontaktiert App Store\nBitte warten..."
 
     # 00updater.rpy:367
     old "The Ren'Py Updater is not supported on mobile devices."
-    new "The Ren'Py Updater is not supported on mobile devices."
+    new "Der Ren'Py Updater wird auf Mobilgeräten nicht unterstützt."
 
     # 00updater.rpy:486
     old "An error is being simulated."
-    new "An error is being simulated."
+    new "Ein Error wird simuliert."
 
     # 00updater.rpy:662
     old "Either this project does not support updating, or the update status file was deleted."
-    new "Either this project does not support updating, or the update status file was deleted."
+    new "Entweder unterstützt dieses Projekt keine Updates, oder die Update-Status-Datei wurde gelöscht."
 
     # 00updater.rpy:676
     old "This account does not have permission to perform an update."
-    new "This account does not have permission to perform an update."
+    new "Dieser Account hat keine Erlaubnis, Updates durchzuführen."
 
     # 00updater.rpy:679
     old "This account does not have permission to write the update log."
-    new "This account does not have permission to write the update log."
+    new "Dieser Account hat keine Erlaubnis, Update-Logs zu schreiben."
 
     # 00updater.rpy:704
     old "Could not verify update signature."
-    new "Could not verify update signature."
+    new "Konnte die Update-Signatur nicht verifizieren."
 
     # 00updater.rpy:975
     old "The update file was not downloaded."
-    new "The update file was not downloaded."
+    new "Die Update-Datei wurde nicht heruntergeladen."
 
     # 00updater.rpy:993
     old "The update file does not have the correct digest - it may have been corrupted."
-    new "The update file does not have the correct digest - it may have been corrupted."
+    new "Die Update-Datei hat nicht das richtige Format - sie wurde möglicherweise beschädigt."
 
     # 00updater.rpy:1049
     old "While unpacking {}, unknown type {}."
@@ -283,7 +283,7 @@ translate german strings:
 
     # 00updater.rpy:1404
     old "This program is up to date."
-    new "Dieses Programm ist aktuell."
+    new "Dieses Programm ist auf dem neuesten Stand."
 
     # 00updater.rpy:1406
     old "[u.version] is available. Do you want to install it?"
@@ -291,27 +291,27 @@ translate german strings:
 
     # 00updater.rpy:1408
     old "Preparing to download the updates."
-    new "Vorbereiten, um die Aktualisierungen herunterzuladen."
+    new "Bereitet das Herunterladen der Updates vor."
 
     # 00updater.rpy:1410
     old "Downloading the updates."
-    new "Aktualisierungen werden heruntergeladen."
+    new "Updates werden heruntergeladen."
 
     # 00updater.rpy:1412
     old "Unpacking the updates."
-    new "Aktualisierungen werden entpackt."
+    new "Updates werden entpackt."
 
     # 00updater.rpy:1416
     old "The updates have been installed. The program will restart."
-    new "Die Aktualisierungen wurden installiert. Das Programm wird nun neustarten."
+    new "Die Updates wurden installiert. Das Programm wird nun neu gestartet."
 
     # 00updater.rpy:1418
     old "The updates have been installed."
-    new "Die Aktualisierungen wurden installiert."
+    new "Die Updates wurden installiert."
 
     # 00updater.rpy:1420
     old "The updates were cancelled."
-    new "Die Aktualisierungen wurden abgebrochen."
+    new "Die Updates wurden abgebrochen."
 
     # 00gallery.rpy:563
     old "Image [index] of [count] locked."


### PR DESCRIPTION
I noticed many of the "German" translations were left in English. I tried to fix as many as I could, but a few I was still unsure about. ("Clipboard voicing", in particular.)
As a general note, these older translation files seem to be missing strings from the renderer (shift+G) screen.