### PR TITLE
Add text to Placeholder

### DIFF
--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -32,7 +32,7 @@ init -1500 python:
         def after_setstate(self):
             self.child = None
 
-        def __init__(self, base=None, full=False, flip=None, **properties):
+        def __init__(self, base=None, full=False, flip=None, name=None, **properties):
             """
             `base`
                 The type of image to display. This should be one of:
@@ -63,6 +63,11 @@ init -1500 python:
 
             `flip`
                 If true, the sprite is flipped horizontally.
+
+            `name`
+                The name the placeholder will be given. If provided, no other
+                text than this will be displayed on the placeholder. If not,
+                the text will reflect the show instruction used to display it.
             """
 
 
@@ -74,6 +79,8 @@ init -1500 python:
 
             # A list of name components.
             self.name = [ ]
+            if name:
+                self.name.append(name)
 
             # The child of this placeholder, if known.
             self.child = None
@@ -193,7 +200,10 @@ init -1500 python:
             args = args or self._args
 
             rv = Placeholder(self.base, self.full, self.flip)
-            rv.name = list(args.name) + list(args.args)
+            if self.name:
+                rv.name = self.name
+            else:
+                rv.name = list(args.name) + list(args.args)
             rv._duplicatable = False
 
             return rv

--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -32,7 +32,7 @@ init -1500 python:
         def after_setstate(self):
             self.child = None
 
-        def __init__(self, base=None, full=False, flip=None, name=None, **properties):
+        def __init__(self, base=None, full=False, flip=None, text=None, **properties):
             """
             `base`
                 The type of image to display. This should be one of:
@@ -64,10 +64,10 @@ init -1500 python:
             `flip`
                 If true, the sprite is flipped horizontally.
 
-            `name`
-                The name the placeholder will be given. If provided, no other
-                text than this will be displayed on the placeholder. If not,
-                the text will reflect the show instruction used to display it.
+            `text`
+                If provided, no other text than this will be displayed on the
+                placeholder. If not, the text will reflect the show
+                instruction that was used to display it.
             """
 
 
@@ -79,8 +79,8 @@ init -1500 python:
 
             # A list of name components.
             self.name = [ ]
-            if name:
-                self.name.append(name)
+            if text:
+                self.name.append(text)
 
             # The child of this placeholder, if known.
             self.child = None

--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -94,7 +94,7 @@ init -1500 python:
             if not self.name:
                 return 'girl'
 
-            tag = self.name[0]
+            tag = self.name[0].partition(' ')[0]
 
             if tag in ( "bg", "cg", "event" ):
                 return "bg"

--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -200,10 +200,7 @@ init -1500 python:
             args = args or self._args
 
             rv = Placeholder(self.base, self.full, self.flip)
-            if self.name:
-                rv.name = self.name
-            else:
-                rv.name = list(args.name) + list(args.args)
+            rv.name = self.name or list(args.name) + list(args.args)
             rv._duplicatable = False
 
             return rv


### PR DESCRIPTION
Allows for Placeholders with constant names, such as the error message ("no live2D") mentioned in #3093.

This extends (and simplify) the Placeholder displayable to use it outside of an image name call.

The implementation is a middle-ground between an outside function calling the Placeholder class, and a supplementary name_override argument to the Placeholder constructor. Either version could arguably be preferred to this one.