### PR TITLE
Add equality to the Transform class

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -32,6 +32,7 @@ from renpy.display.layout import Container
 
 from renpy.display.accelerator import transform_render
 from renpy.atl import position, any_object, bool_or_none, float_or_none, matrix, mesh
+from renpy.equality import DictEquality
 
 # The null object that's used if we don't have a defined child.
 null = None
@@ -93,7 +94,7 @@ def first_not_none(*args):
     return i
 
 
-class TransformState(renpy.object.Object):
+class TransformState(renpy.object.Object, DictEquality):
 
     last_angle = None
 
@@ -358,7 +359,7 @@ class Proxy(object):
         return setattr(instance.state, self.name, value)
 
 
-class Transform(Container):
+class Transform(Container, DictEquality):
     """
     Documented in sphinx, because we can't scan this object.
     """


### PR DESCRIPTION
Based upon #3162, not viable without it.

With basic DictEquality, comparing `Transform(align=(.5, .5))` with `Transform(align=(.5, .5))` works, which was the main goal, and I believe this is mergeable as-is.

However, `Transform(align=(.5, .5))` does **not** compare with `Transform(xalign=.5, yalign=.5)`, because of the `kwargs` and `arguments` attributes.
I'm not sure these values can be relevent in an equality check in any context, once the Transforms' states are already determined as equal to each other. So if we want to further the equality check and make it more precise, perhaps the best way to do it would be like a FieldEquality but with blacklisted fields instead of whitelisted fields.
Maybe a third equality mixin would be relevent for this case ? A DictEqualityButWithBlacklist class ?