### PR TITLE
Distinguish renpy_base correctly even if it is inside gamedir

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -174,16 +174,25 @@ def elide_filename(fn):
     or relative to the Ren'Py directory.
     """
 
-    original_fn = fn
     fn = fn.replace("\\", "/")
 
-    for d in [ renpy.config.basedir, renpy.config.renpy_base ]:
-        d = os.path.abspath(d).replace("\\", "/") + "/"
+    basedir = os.path.abspath(renpy.config.basedir).replace("\\", "/") + "/"
+    renpy_base = os.path.abspath(renpy.config.renpy_base).replace("\\", "/") + "/"
+
+    # This is SDK inside the project, for some reason, or it is the same path
+    if renpy_base.startswith(basedir):
+        dirs = [renpy_base, basedir]
+
+    # This is a projects dir inside SDK or it's different paths
+    else:
+        dirs = [basedir, renpy_base]
+
+    for d in dirs:
         if fn.startswith(d):
             rv = fn[len(d):]
             break
     else:
-        rv = original_fn.replace("\\", "/")
+        rv = fn
 
     return rv
 


### PR DESCRIPTION
This fixes the issue when SDK is by path inside projects directory, lint `if common(node)` behaved wrong.
This change is backwards compatible, because at the end (built game) renpy_base and basedir are the same path.