### PR TITLE
Add config.default_attributes callback dictionary

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1149,7 +1149,7 @@ adjust_attributes = { }
 
 # A dictionary from a tag to a function that produces default attributes
 # for that tag.
-default_attributes = {}
+default_attribute_callbacks = { }
 
 # The compatibility mode for who/what substitutions.
 # 0: ver < 7.4

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1147,6 +1147,10 @@ gl_lod_bias = -.5
 # of that tag.
 adjust_attributes = { }
 
+# A dictionary from a tag to a function that produces default attributes
+# for that tag.
+default_attributes = {}
+
 # The compatibility mode for who/what substitutions.
 # 0: ver < 7.4
 # 1: 7.4 <= ver <= 7.4.4

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -921,8 +921,21 @@ class ShownImageInfo(renpy.object.Object):
 
         nametag = name[0]
 
-        # The set of attributes a matching image may have.
-        optional = list(wanted) + list(self.attributes.get((layer, tag), [ ]))
+        # Start building the set of attributes a matching image may have.
+        optional = list(wanted)
+
+        # Find any attributes applied previously.
+        defaults = self.attributes.get((layer, tag), None)
+
+        # If no record, it's the first show, so try to fetch defaults.
+        if defaults is None:
+            f = renpy.config.default_attributes.get(name[0], None)
+            if f is not None:
+                defaults = f(name)
+
+        # Add any defaults to the set of attributes a matching image may have.
+        if defaults:
+            optional += list(defaults)
 
         # The list of attributes a matching image must have.
         required = [ ]

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -929,7 +929,8 @@ class ShownImageInfo(renpy.object.Object):
 
         # If no record, it's the first show, so try to fetch defaults.
         if defaults is None:
-            f = renpy.config.default_attributes.get(name[0], None)
+            f = renpy.config.default_attribute_callbacks.get(name[0], None) \
+                or renpy.config.default_attribute_callbacks.get(None, None)
             if f is not None:
                 defaults = f(name)
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -403,6 +403,23 @@ Occasionally Used
     window to the window size, this can be used to report cases where the
     dialogue is too large for its window.
 
+.. var:: config.default_attributes = { }
+
+    When a statement or function that contains image attributes executes or is
+    predicted, and the tag is not currently being shown, it's looked up in this
+    dictionary.
+
+    If found, it is expected to be a function. The function is given an image
+    name, a tuple consisting of the tag and any attributes. It should return an
+    iterable which contains any additional attributes to be applied when an
+    image is first shown.
+
+    The results of the function are treated as additive-only, and any explicit
+    conflicting or negative attributes will still take precedence.
+
+    As this function may be called during prediction, it should not rely on the
+    image's state.
+
 .. var:: config.default_tag_layer = "master"
 
     The layer an image is shown on if its tag is not found in config.tag_layer.

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -228,8 +228,8 @@ Occasionally Used
     attributes. It should return an adjusted tuple, which contains
     and a potential new set of attributes.
 
-    As this function may be called during prediction, it should not
-    rely on the image's state.
+    As this function may be called during prediction, it must not rely
+    on any state.
 
 .. var:: config.after_load_callbacks = [ ... ]
 
@@ -403,22 +403,22 @@ Occasionally Used
     window to the window size, this can be used to report cases where the
     dialogue is too large for its window.
 
-.. var:: config.default_attributes = { }
+.. var:: config.default_attribute_callbacks = { }
 
     When a statement or function that contains image attributes executes or is
     predicted, and the tag is not currently being shown, it's looked up in this
-    dictionary.
+    dictionary. If it is not found, the None key is looked up instead.
 
-    If found, it is expected to be a function. The function is given an image
-    name, a tuple consisting of the tag and any attributes. It should return an
-    iterable which contains any additional attributes to be applied when an
-    image is first shown.
+    If either is found, they're expected to be a function. The function is
+    given an image name, a tuple consisting of the tag and any attributes. It
+    should return an iterable which contains any additional attributes to be
+    applied when an image is first shown.
 
     The results of the function are treated as additive-only, and any explicit
     conflicting or negative attributes will still take precedence.
 
-    As this function may be called during prediction, it should not rely on the
-    image's state.
+    As this function may be called during prediction, it must not rely on any
+    state.
 
 .. var:: config.default_tag_layer = "master"
 


### PR DESCRIPTION
This is to support images having a "weak" set of default attributes
applied to them when they are first shown, allowing for more complex use
cases with a minimum of boilerplate in scripts.

While similar in nature to the existing `config.adjust_attributes`, this
feature only applies to images when they are first shown, and is "weak"
in the sense that it may not countermand attributes from the script.