### PR TITLE
Delete temporary renaming file if it exists

### DIFF
--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -287,6 +287,9 @@ class FileLocation(object):
             if not os.path.exists(old):
                 return
 
+            if os.path.exists(old + ".tmp"):
+                os.unlink(old + ".tmp")
+
             os.rename(old, old + ".tmp")
             old = old + ".tmp"
 

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -287,16 +287,9 @@ class FileLocation(object):
             if not os.path.exists(old):
                 return
 
-            if os.path.exists(old + ".tmp"):
-                os.unlink(old + ".tmp")
-
-            os.rename(old, old + ".tmp")
-            old = old + ".tmp"
-
-            if os.path.exists(new):
-                os.unlink(new)
-
-            os.rename(old, new)
+            old_tmp = old + tmp
+            safe_rename(old, old_tmp)
+            safe_rename(old_tmp, new)
             renpy.util.expose_file(new)
 
             self.sync()


### PR DESCRIPTION
After we added the use of save rename function, we have started to get errors referring to WindowsError: [Error 183] Cannot create a file when that file already exists. I don't know why it happens only for some of them, but this should fix the problem.