### PR TITLE
Move overfull check in the Grid's add method

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -535,8 +535,8 @@ class Grid(Container):
 
         return rv
 
-    def per_interact(self):
-        super(Grid, self).per_interact()
+    def add(self, d):
+        super(Grid, self).add(d)
 
         delta = (self.cols * self.rows) - len(self.children)
         if delta == 0:
@@ -545,16 +545,20 @@ class Grid(Container):
         elif delta < 0:
             raise Exception("Grid overfull.")
 
-        if self.allow_underfull is None:
-            allow_underfull = renpy.config.allow_underfull_grids
-        else:
-            allow_underfull = self.allow_underfull
+    def per_interact(self):
+        super(Grid, self).per_interact()
 
-        if not allow_underfull:
-            raise Exception("Grid not completely full.")
-        else:
-            for _ in range(delta):
-                self.add(Null())
+        delta = (self.cols * self.rows) - len(self.children)
+        if delta > 0:
+            allow_underfull = self.allow_underfull
+            if allow_underfull is None:
+                allow_underfull = renpy.config.allow_underfull_grids
+
+            if not allow_underfull:
+                raise Exception("Grid not completely full.")
+            else:
+                for _ in range(delta):
+                    self.add(Null())
 
 
 class IgnoreLayers(Exception):

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -538,11 +538,7 @@ class Grid(Container):
     def add(self, d):
         super(Grid, self).add(d)
 
-        delta = (self.cols * self.rows) - len(self.children)
-        if delta == 0:
-            return
-
-        elif delta < 0:
+        if len(self.children) > (self.cols * self.rows):
             raise Exception("Grid overfull.")
 
     def per_interact(self):


### PR DESCRIPTION
fix #2795

Having the line number for the *grid* is "simple" (don't quote me on this), having the line number for the *element* making it overfull is not.
I guess that by writing the SL parser differently, it could report the line of the extraneous element by itself, but I wouldn't recommand going that way just for more accurate error reports.