### PR TITLE
py3 pickle fixes

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -285,7 +285,7 @@ class Backup(_object):
             self.backup_module(m)
 
         # A pickled version of self.objects.
-        self.objects_pickle = pickle.dumps(self.objects, pickle.HIGHEST_PROTOCOL)
+        self.objects_pickle = pickle.dumps(self.objects, pickle.PROTOCOL)
 
         self.objects = { }
 
@@ -329,10 +329,10 @@ class Backup(_object):
             # If we have a problem pickling things, uncomment the next block.
 
             try:
-                pickle.dumps(v, pickle.HIGHEST_PROTOCOL)
+                pickle.dumps(v, pickle.PROTOCOL)
             except:
                 print("Cannot pickle", name + "." + k, "=", repr(v))
-                print("Reduce Ex is:", repr(v.__reduce_ex__(pickle.HIGHEST_PROTOCOL)))
+                print("Reduce Ex is:", repr(v.__reduce_ex__(pickle.PROTOCOL)))
 
     def restore(self):
         """

--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -26,3 +26,6 @@ if PY2:
     from cPickle import dumps, loads, dump, load, HIGHEST_PROTOCOL # type: ignore
 else:
     from pickle import dumps, loads, dump, load, HIGHEST_PROTOCOL
+
+# allows for renpy8 saves to be loaded in renpy7
+PROTOCOL = 2

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -48,23 +48,32 @@ from json import dumps as json_dumps
 
 def dump(o, f):
     if renpy.config.use_cpickle:
-        cPickle.dump(o, f, cPickle.HIGHEST_PROTOCOL)
+        cPickle.dump(o, f, cPickle.PROTOCOL)
     else:
-        pickle.dump(o, f, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(o, f, cPickle.PROTOCOL)
 
 
 def dumps(o):
     if renpy.config.use_cpickle:
-        return cPickle.dumps(o, cPickle.HIGHEST_PROTOCOL)
+        return cPickle.dumps(o, cPickle.PROTOCOL)
     else:
-        return pickle.dumps(o, pickle.HIGHEST_PROTOCOL)
+        return pickle.dumps(o, cPickle.PROTOCOL)
 
 
 def loads(s):
-    if renpy.config.use_cpickle:
-        return cPickle.loads(s)
-    else:
-        return pickle.loads(s)
+    try:
+        if renpy.config.use_cpickle:
+            return cPickle.loads(s)
+        else:
+            return pickle.loads(s)
+    except Exception as e:
+        try:
+            if renpy.config.use_cpickle:
+                return cPickle.loads(s, fix_imports=True, encoding="bytes")
+            else:
+                return pickle.loads(s, fix_imports=True, encoding="bytes")
+        except Exception:
+            raise e
 
 
 # This is used as a quick and dirty way of versioning savegame


### PR DESCRIPTION
The first issue was a discrepancy in pickle.HIGHEST_PROTOCOL between py2 and py3. This has been adressed by setting a (new) preferred protocol, 2 being the highest of the protocols supported by both.
Now, renpy8 saves can be loaded from renpy7 🥳.

The second issue tries to address a [known incompatibility](https://bugs.python.org/issue6784) between pickle from py2 and py3.
Using the keyword-arguments break pickle loading in renpy7 (don't try it at home kids, it erases the launcher preferences), but until the py3 pickle problem is definitively fixed (which it is not) I wanted to keep the main way of doing things as the first thing py3 would try.
*This* fix enables the renpy8 launcher to read the preferences set in the renpy7 launcher, which is the case between two renpy7 installs' launchers. It can be tested by toggling the dark mode in any and seeing it apply on the other. (However, since Atom can't be set as default in renpy8 as of yet, it has the side-effect of setting the editor to Not Set each time the renpy8's launcher is opened...)