### PR TITLE
Do not download Atom when environ RENPY_ATOM is set

### DIFF
--- a/launcher/game/editor.rpy
+++ b/launcher/game/editor.rpy
@@ -169,7 +169,7 @@ init 1 python in editor:
             _("Up to 150 MB download required."),
             None)
 
-        e.installed = e.installed and installed
+        e.installed = e.installed and (installed or 'RENPY_ATOM' in os.environ)
 
         fei.append(e)
 

--- a/launcher/game/options.rpy
+++ b/launcher/game/options.rpy
@@ -270,7 +270,6 @@ init python:
     # Atom rules. These have to be very early, since Atom uses names like
     # tmp for packages.
     build.classify_renpy("atom/", "atom-all source_only")
-    build.classify_renpy("atom/Atom.edit.py", "atom-all source_only")
     build.classify_renpy("atom/default-dot-atom/**", "atom-all")
     build.classify_renpy("atom/atom-windows/**", "atom-windows")
     build.classify_renpy("atom/Atom.app/**", "atom-mac")


### PR DESCRIPTION
Pretty self-explainatory. The RENPY_ATOM environment variable allows for a non-renpy-issued version of Atom to be used, so having to download the Atom dlc for this bypass to work is somehow paradoxical.

This is a duct-tape fix, as it involves the existence of the "atom" subfolder even when Atom is not actually installed.
However, the existence of Atom.edit.py was not (and is still not) sufficient for renpy to consider Atom installed, so this shouldn't cause any unintended change in renpy's behavior.
Solving this properly would probably need a comprehensive understanding of how the other editors are handled, and of how things work in other platforms than windows, which I don't have.