### PR TITLE
Allow Transform-defined transforms to take strings

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -764,6 +764,7 @@ class Transform(Container):
         return None
 
     def __call__(self, child=None, take_state=True, _args=None):
+        child = renpy.easy.displayable_or_none(child)
 
         if child is None:
             child = self.child


### PR DESCRIPTION
This allows
```rpy
define centr = Transform(align=(0.5, 1.0))
image test = centr("#fff")
```
following the example of
```rpy
transform centr:
    align (0.5, 1.0)
image test = centr("#fff")
```