### PR TITLE
Type hotfix for gl2 model management

### DIFF
--- a/renpy/gl2/gl2shadercache.py
+++ b/renpy/gl2/gl2shadercache.py
@@ -342,7 +342,7 @@ class ShaderCache(object):
         try:
             with renpy.loader.load(self.filename) as f:
                 for l in f:
-                    l = l.strip()
+                    l = l.strip().decode()
                     partnames = tuple(l.strip().split())
 
                     if not partnames:


### PR DESCRIPTION
Fix the last issue in #3217, the gl2/shader part.

This is a hotfix : all gl2 type issues haven't been solved. You can still see this in the log.txt file :
```
Initializing gl2 renderer:
primary display bounds: (0, 0, 1920, 1080)
swap interval: 1 frames
Windowed mode.
Vendor: "b'NVIDIA Corporation'"
Renderer: b'Quadro P1000/PCIe/SSE2'
Version: b'4.6.0 NVIDIA 472.39'
Display Info: None
Screen sizes: virtual=(1280, 720) physical=(1280, 720) drawable=(1280, 720)
Maximum texture size: 4096x4096
```
Notice the b before the strings, indicating use of bytestrings instead of actual strings.
The culprit code is in renpy/gl2/gl2draw.pyx, line 392. Using type `char *` means a use of bytes strings, as opposed to `wchar *` for unicode (I think).

Concern should also be raised about the wide use of `renpy.loader.load`, which opens all files in bytes mode. In this occasion text would have been preferred, in other cases maybe not, but the question probably needs a comprehensive audit.