### PR TITLE
Fixing str for bytes error, thrown while choosing project directory.

### DIFF
--- a/launcher/game/EasyDialogsWin.py
+++ b/launcher/game/EasyDialogsWin.py
@@ -798,7 +798,7 @@ def AskFolder(
     callback = BrowseCallbackProc(BrowseCallback)
 
     browseInfo = BROWSEINFO()
-    browseInfo.pszDisplayName = ctypes.c_char_p('\0' * (MAX_PATH+1))
+    browseInfo.pszDisplayName = ctypes.c_char_p(b'\0' * (MAX_PATH+1))
     browseInfo.lpszTitle = message
     browseInfo.lpfn = callback
     #~ browseInfo.ulFlags = BIF_EDITBOX
@@ -809,7 +809,7 @@ def AskFolder(
     if not pidl:
         result = None
     else:
-        path = ctypes.c_char_p('\0' * (MAX_PATH+1))
+        path = ctypes.c_char_p(b'\0' * (MAX_PATH+1))
         shell32.SHGetPathFromIDList(pidl, path)
         ole32.CoTaskMemFree(pidl)
         result = path.value


### PR DESCRIPTION
While choosing project directory where new projects are saved by default renpy crashes and gave a traceback saying bytes or integer address expected not str. I convert those strings to bytes. It's just a small fix