### PR TITLE
Readonly RevertableObject with `__slots__`

### DIFF
--- a/renpy/common/000namespaces.rpy
+++ b/renpy/common/000namespaces.rpy
@@ -53,7 +53,7 @@
 
         def set_default(self, name, value):
 
-            undefined = object()
+            undefined = python_object()
 
             if not isinstance(persistent._preference_default, dict):
                 persistent._preference_default = { }

--- a/renpy/common/00action_data.rpy
+++ b/renpy/common/00action_data.rpy
@@ -24,7 +24,7 @@ init -1600 python:
    ##########################################################################
     # Functions that set variables or fields.
 
-    __FieldNotFound = object()
+    __FieldNotFound = python_object()
 
     def __get_field(obj, name, kind):
 

--- a/renpy/common/00definitions.rpy
+++ b/renpy/common/00definitions.rpy
@@ -101,9 +101,12 @@ init -1400:
 
 # Transitions ##################################################################
 
+init -1400 python in _define:
+    pass
+
 init -1400 python:
 
-    _define = define = object()
+    define = _define
 
     # Ease images around. These are basically cosine-warped moves.
     def _ease_out_time_warp(x):

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -133,7 +133,7 @@ init -1100 python in gui:
         # actually changing the language.
         renpy.change_language(_preferences.language, force=True)
 
-    not_set = object()
+    not_set = python_object()
 
     def preference(name, default=not_set):
         """

--- a/renpy/common/00stylepreferences.rpy
+++ b/renpy/common/00stylepreferences.rpy
@@ -33,8 +33,7 @@ init -1500 python:
 
     # Are style preferences dirty? If so, we need to update them at the start of
     # the next operation.
-    __spdirty = object()
-    __spdirty.flag = True
+    __spdirty_flag = True
 
     # A map from preference name to alternative.
     if persistent._style_preferences is None:
@@ -90,12 +89,13 @@ init -1500 python:
         Called at least once per interaction, to update the styles if necessary.
         """
 
-        if not __spdirty.flag:
+        global __spdirty_flag
+        if not __spdirty_flag:
             return
 
         renpy.style.rebuild()
 
-        __spdirty.flag = False
+        __spdirty_flag = False
 
     def __apply_styles():
         """
@@ -120,7 +120,8 @@ init -1500 python:
                 raise Exception("{0} is not a known alternative for style preference {1}.".format(alternative, preference))
 
     def __change_language():
-        __spdirty.flag = True
+        global __spdirty_flag
+        __spdirty_flag = True
         __update()
 
     def __set_style_preference(preference, alternative):
@@ -140,7 +141,8 @@ init -1500 python:
         __check(preference, alternative)
 
         persistent._style_preferences[preference] = alternative
-        __spdirty.flag = True
+        global __spdirty_flag
+        __spdirty_flag = True
 
         renpy.restart_interaction()
 

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -40,18 +40,17 @@
 #     $ voice_sustain()
 #     e "...to play for two lines of dialogue."
 
+init -1500 python in _voice:
+    play = None
+    sustain = False
+    seen_in_lint = False
+    tag = None
+    tlid = None
+    auto_file = None
+    info = None
+    last_playing = 0.0
+
 init -1500 python:
-
-    _voice = object()
-    _voice.play = None
-    _voice.sustain = False
-    _voice.seen_in_lint = False
-    _voice.tag = None
-    _voice.tlid = None
-    _voice.auto_file = None
-    _voice.info = None
-    _voice.last_playing = 0.0
-
     # If true, the voice system ignores the interaction.
     _voice.ignore_interaction = False
 

--- a/renpy/common/_compat/gamemenu.rpym
+++ b/renpy/common/_compat/gamemenu.rpym
@@ -19,8 +19,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-init python:
+init python in _scratch:
+    # This is used to store scratch data that's used by the
+    # library, but shouldn't be saved out as part of the savegame.
+    file_picker_page = None
 
+init python:
     ######################################################################
     # First up, we define a bunch of configuration variable, which the
     # user can change.
@@ -77,10 +81,6 @@ init python:
 
     ######################################################################
     # Next, support code.
-
-    # This is used to store scratch data that's used by the
-    # library, but shouldn't be saved out as part of the savegame.
-    _scratch = object()
 
     # This returns a window containing the game menu navigation
     # buttons, set up to jump to the appropriate screen sections.
@@ -197,8 +197,6 @@ init python:
 
         ui.text(_(u"Empty Slot."), style=style.file_picker_empty_slot[index])
         ui.close()
-
-    _scratch.file_picker_page = None
 
     # The names of the various pages that the file picker knows
     # about.

--- a/renpy/common/_compat/themes.rpym
+++ b/renpy/common/_compat/themes.rpym
@@ -23,10 +23,11 @@
 # Please see the LICENSE.txt distributed with Ren'Py for permission to
 # copy and modify.
 
+init python in theme:
+    pass
+
 init -1100:
     python:
-
-        theme = object()
 
         def RoundRect(color, small=False):
             """
@@ -517,4 +518,3 @@ init -1100:
             theme.roundrect(**args)
 
         theme.roundrect_red = theme_roundrect_red
-

--- a/renpy/common/_layout/classic_load_save.rpym
+++ b/renpy/common/_layout/classic_load_save.rpym
@@ -19,8 +19,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-init python:
 
+# This is used to store scratch data that's used by the
+# library, but shouldn't be saved out as part of the savegame.
+init python in __scratch:
+    file_picker_page = None
+
+init python:
     layout.provides('load_save')
 
     # Define styles
@@ -82,11 +87,6 @@ init python:
 
     # True if we should prompt before loading a game.
     _load_prompt = True
-
-    # This is used to store scratch data that's used by the
-    # library, but shouldn't be saved out as part of the savegame.
-    __scratch = object()
-    __scratch.file_picker_page = None
 
     def _render_savefile(index, name, extra_info, screenshot, mtime, newest, clicked):
 

--- a/renpy/common/_layout/imagemap_load_save.rpym
+++ b/renpy/common/_layout/imagemap_load_save.rpym
@@ -19,8 +19,17 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-init python:
+init python in __scratch:
+    # This is used to store scratch data that's used by the
+    # library, but shouldn't be saved out as part of the savegame.
+    file_picker_page = None
+    initialized = False
+    per_page = 0
+    pages = 0
+    has_autosave = False
+    has_quicksave = False
 
+init python:
     layout.provides('load_save')
     renpy.load_module("_layout/imagemap_common")
 
@@ -67,16 +76,6 @@ init python:
 
     # True if we should prompt before loading a game.
     _load_prompt = True
-
-    # This is used to store scratch data that's used by the
-    # library, but shouldn't be saved out as part of the savegame.
-    __scratch = object()
-    __scratch.file_picker_page = None
-    __scratch.initialized = False
-    __scratch.per_page = 0
-    __scratch.pages = 0
-    __scratch.has_autosave = False
-    __scratch.has_quicksave = False
 
     def _render_savefile(ime, index, name, extra_info, screenshot, mtime, newest, clicked):
 

--- a/renpy/common/_layout/scrolling_load_save.rpym
+++ b/renpy/common/_layout/scrolling_load_save.rpym
@@ -19,13 +19,12 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-init python:
-
-    layout.provides('load_save')
-
+init python in __session:
     # Store some global information that won't be saved.
-    __session = object()
-    __session.scrollbar_position = None
+    scrollbar_position = None
+
+init python:
+    layout.provides('load_save')
 
     # Should we prompt to load?
     _load_prompt = True

--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -91,6 +91,9 @@ else:
                 elif name == "datetime":
                     return unpickle_datetime
 
+            if (module == "renpy.python") and (name == "RevertableObject"):
+                name = "OpenRevertableObject"
+
             return super().find_class(module, name)
 
     def load(f):

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -237,7 +237,7 @@ class Context(renpy.object.Object):
 
         self.rollback = rollback
         self.runtime = 0
-        self.info = renpy.python.RevertableObject()
+        self.info = renpy.python.OpenRevertableObject()
         self.seen = False
 
         # True if there has just been an abnormal transfer of control,

--- a/renpy/object.py
+++ b/renpy/object.py
@@ -37,6 +37,7 @@ class Object(object):
     """
     Our own base class. Contains methods to simplify serialization.
     """
+    __slots__ = ()
 
     __version__ = 0
 

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1219,7 +1219,7 @@ class RevertableObject(object):
     __slots__ = ()
 
     def __new__(cls, *args, **kwargs):
-        self = super(RevertableObject, cls).__new__(cls)
+        self = object.__new__(cls)
 
         log = renpy.game.log
         if log is not None:
@@ -1256,6 +1256,9 @@ class OpenRevertableObject(RevertableObject):
     """
     # custom-made for renpy.execution.Context.info
     # also useful for compat
+
+if PY2:
+    RevertableObject = OpenRevertableObject
 
 
 class AlwaysRollback(RevertableObject):

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1185,7 +1185,7 @@ class RevertableSet(set):
 
         def newmethod(*args, **kwargs):
             rv = method(*args, **kwargs) # type: ignore
-            if isinstance(rv, (set, frozenset)):
+            if isinstance(rv, set):
                 return RevertableSet(rv)
             else:
                 return rv
@@ -1216,6 +1216,7 @@ class RevertableSet(set):
 
 
 class RevertableObject(object):
+    __slots__ = ()
 
     def __new__(cls, *args, **kwargs):
         self = super(RevertableObject, cls).__new__(cls)
@@ -1248,6 +1249,13 @@ class RevertableObject(object):
     def _rollback(self, compressed):
         self.__dict__.clear()
         self.__dict__.update(compressed)
+
+class OpenRevertableObject(RevertableObject):
+    """
+    Opening __slots__, allowing for arbitrary __dict__ editing.
+    """
+    # custom-made for renpy.execution.Context.info
+    # also useful for compat
 
 
 class AlwaysRollback(RevertableObject):


### PR DESCRIPTION
Makes `object().arbitrary = value` as illegal as for the actual python object, by perpetuating its empty `__slots__`.

This would not have yielded any consequence in the code if object() had been used as the native object in the code, unfortunately it was not.
I changed some code using an instance of object as a namespace, something which is illegal in regular python, and made it use namespaces from `init python in ...`. This, in my opinion, yields better code.
In one instance it wasn't possible so I used OpenRevertableObject, an empty subclass of RevertableObject which reopens its `__slots__` and is essentially the same as what RevertableObject initially was.
I also changed some code using (revertable)object instances as sentinels, and while it probably wouldn't yield any bug, it was unnecessary to have them use a revertable object instead of a lighter-weight native object.

You may wonder, why do any of this ? It makes pure instances of RevertableObject more lightweight, but it also makes them useless, so what's the point ?
The point is dual.
First, it enjoins junior creators discovering python not to take bad habits regarding object(), by making python's object and renpy's object more alike.
Second, it allows for `__slots__`-defining classes to be declared in renpy and be actually worth it (they currently inherit an empty `__dict__`, defeating the purpose of having lightweight instances). This also applies to subclassing `__slots__`-using types, such as native types or namedtuple.

Compat :
There are two ways to do it. The one I chose (but it could be reversed) is to make pickle use OpenRevertableObject for pickled RevertableObjects in python3, which is simple, but not doable in py2. So I simply disabled the effects of this whole change in py2, by aliasing RevertableObject to OpenRevertableObject.
Another approach (which I haven't tested) would be to rename the old class BaseRevertableObject, have OpenRevertableObject be named RevertableObject, and have `object` alias the Base one instead of the Open one. That way, pickle finds the equivalent type under the original name and doesn't have to be tricked. It would create some level of benign inconsistency between classes explicitely inheriting RevertableObject and classes defined in rpy, inheriting only BaseRevertableObject. It may actually be the best option, but I'm leaving myself some time to sleep on it.