### PR TITLE
Fix datetime pickle hack

### DIFF
--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -63,33 +63,30 @@ else:
 
     def make_datetime(cls, *args, **kwargs):
         """
-        Makes a datetime.date, datetime.time, or date.timetime object from
-        a surrogateescaped str. This is used when unpickling a datetime object
-        that was first created in Python 2.
+        Makes a datetime.date, datetime.time, or datetime.datetime object
+        from a surrogateescaped str. This is used when unpickling a datetime
+        object that was first created in Python 2.
         """
 
         if (len(args) == 1) and isinstance(args[0], str):
             data = args[0].encode("utf-8", "surrogateescape")
             return cls.__new__(cls, data.decode("latin-1"))
 
-
         return cls.__new__(cls, *args, **kwargs)
 
-    unpickle_date = functools.partial(make_datetime, datetime.date)
-    unpickle_time = functools.partial(make_datetime, datetime.time)
-    unpickle_datetime = functools.partial(make_datetime, datetime.datetime)
-
     class Unpickler(pickle.Unpickler):
+        date = functools.partial(make_datetime, datetime.date)
+        time = functools.partial(make_datetime, datetime.time)
+        datetime = functools.partial(make_datetime, datetime.datetime)
 
         def find_class(self, module, name):
             if module == "datetime":
-
                 if name == "date":
-                    return unpickle_date
+                    return self.date
                 elif name == "time":
-                    return unpickle_time
+                    return self.time
                 elif name == "datetime":
-                    return unpickle_datetime
+                    return self.datetime
 
             return super().find_class(module, name)
 


### PR DESCRIPTION
This fixes an error occuring when reloading a py3 game defining datetime objects.
Why it works, with the partial objects being class attributes and not instance attributes defined in `__init__`, is anyone's guess.