### PR TITLE
Update persistent file while saving on emscripten

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -365,6 +365,11 @@ def save(slotname, extra_info='', mutate_flag=False):
     :func:`renpy.take_screenshot` should be called before this function.
     """
 
+    if renpy.emscripten:
+        # Update persistent file on emscripten now
+        # as it cannot be written when page closes
+        renpy.persistent.update()
+
     if mutate_flag:
         renpy.python.mutate_flag = False
 


### PR DESCRIPTION
Normally, the persistent data file is saved when the game exits. However, on renpyweb/emscripten, this does not happen. It seems @Beuc tried to work on that issue but gave up eventually. My guess is that the `beforeunload` event that is fired when the page is closing does not allow to write new files to the virtual FS.

This PR is a workaround, so that the persistent data file is updated each time a new save is created. Thus, even if the persistent data file is not saved when the page is unloaded, a version that matches the latest save will exist (could be the periodic autosave, but here again, no autosave is written when page is unloaded).