### PR TITLE
Clean up disused kwargs on attribute functions

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -915,13 +915,13 @@ class ADVCharacter(object):
             properties=self.properties,
             **self.show_args)
 
-    def resolve_say_attributes(self, predict, attrs, wanted=[], remove=[]):
+    def resolve_say_attributes(self, predict, attrs):
         """
         Deals with image attributes associated with the current say
         statement. Returns True if an image is shown, None otherwise.
         """
 
-        if not (attrs or wanted or remove):
+        if not attrs:
             return
 
         if not self.image_tag:
@@ -943,7 +943,7 @@ class ADVCharacter(object):
         # If image is showing already, resolve it, then show or predict it.
         if images.showing(layer, (self.image_tag,)):
 
-            new_image = images.apply_attributes(layer, self.image_tag, tagged_attrs, wanted, remove)
+            new_image = images.apply_attributes(layer, self.image_tag, tagged_attrs)
 
             if new_image is None:
                 new_image = tagged_attrs
@@ -951,7 +951,7 @@ class ADVCharacter(object):
             if images.showing(layer, new_image, exact=True):
                 return
 
-            show_image = (self.image_tag,) + attrs + tuple(wanted) + tuple("-" + i for i in remove)
+            show_image = (self.image_tag,) + attrs
 
             if predict:
                 renpy.exports.predict_show(new_image)
@@ -965,7 +965,7 @@ class ADVCharacter(object):
 
                 tagged_attrs = (renpy.config.side_image_prefix_tag,) + tagged_attrs
 
-                new_image = images.apply_attributes(layer, self.image_tag, tagged_attrs, wanted, remove)
+                new_image = images.apply_attributes(layer, self.image_tag, tagged_attrs)
 
                 if new_image is None:
                     new_image = tagged_attrs

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -900,7 +900,7 @@ class ShownImageInfo(renpy.object.Object):
 
         self.shown.discard((layer, tag))
 
-    def apply_attributes(self, layer, tag, name, wanted=[], remove=[]):
+    def apply_attributes(self, layer, tag, name):
         """
         Given a layer, tag, and an image name (with attributes),
         returns the canonical name of an image, if one exists. Raises
@@ -916,16 +916,13 @@ class ShownImageInfo(renpy.object.Object):
             layer = renpy.config.tag_layer.get(tag, "master")
 
         # If the name matches one that exactly exists, return it.
-        if (name in images) and not (wanted or remove):
+        if name in images:
             ca = getattr(images[name], "_choose_attributes", None)
 
             if ca is None:
                 return name
 
         nametag = name[0]
-
-        # Start building the set of attributes a matching image may have.
-        optional = list(wanted)
 
         # Find any attributes applied previously.
         defaults = self.attributes.get((layer, tag), None)
@@ -937,9 +934,8 @@ class ShownImageInfo(renpy.object.Object):
             if f is not None:
                 defaults = f(name)
 
-        # Add any defaults to the set of attributes a matching image may have.
-        if defaults is not None:
-            optional.extend(defaults)
+        # The list of attributes a matching image may have.
+        optional = list(defaults) if defaults else [ ]
 
         # The list of attributes a matching image must have.
         required = [ ]
@@ -957,10 +953,6 @@ class ShownImageInfo(renpy.object.Object):
 
             else:
                 required.append(i)
-
-        for i in remove:
-            if i in optional:
-                optional.remove(i)
 
         return self.choose_image(nametag, required, optional, name)
 


### PR DESCRIPTION
The `wanted` and `remove` kwargs on `Character.resolve_say_attributes` and
`images.apply_attributes` were previously used to support the speaking
attribute feature, however that has since moved over to using the
temporary attribute functionality and these parameters are never passed
as anything beside empty lists, so we can clean them up.