### PR TITLE
Improve duplicatable check to consolidate coercion

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -774,7 +774,7 @@ class Transform(Container):
         if child is None:
             child = self.child
 
-        if (child is not None) and getattr(child, '_duplicatable', False):
+        if getattr(child, '_duplicatable', False):
             child = child._duplicate(_args)
 
         rv = Transform(

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -770,12 +770,11 @@ class Transform(Container):
         return None
 
     def __call__(self, child=None, take_state=True, _args=None):
-        child = renpy.easy.displayable_or_none(child)
 
         if child is None:
             child = self.child
 
-        if (child is not None) and (child._duplicatable):
+        if (child is not None) and getattr(child, '_duplicatable', False):
             child = child._duplicate(_args)
 
         rv = Transform(


### PR DESCRIPTION
Trying to coerce the `child` arg to `Transform.__call__` into a displayable
adds an avoidable call and could lead to redundant duplication (in the
case where the coercion yields a duplicatable displayable).

Instead, use `getattr` in the duplicatable check to prevent raising and
allow `__init__` (which already does arg coercion) to handle it as normal.

Related to #2102, and #3228. /cc @Gouvernathor 