### PR TITLE
Fix uncaught exception in Spanish translation

### DIFF
--- a/launcher/game/tl/spanish/launcher.rpy
+++ b/launcher/game/tl/spanish/launcher.rpy
@@ -1808,7 +1808,7 @@ translate spanish strings:
 
     # game/gui7.rpy:311
     old "{size=-4}\n\nThis will not overwrite gui/main_menu.png, gui/game_menu.png, and gui/window_icon.png, but will create files that do not exist.{/size}"
-    new "size=-4}\n\nEsto no sobrescribirá gui/main_menu.png, gui/game_menu.png y gui/window_icon.png, pero creará archivos que no existen.{/size}"
+    new "{size=-4}\n\nEsto no sobrescribirá gui/main_menu.png, gui/game_menu.png y gui/window_icon.png, pero creará archivos que no existen.{/size}"
 
     # game/ios.rpy:339
     old "There are known issues with the iOS simulator on Apple Silicon. Please test on x86_64 or iOS devices."


### PR DESCRIPTION
I have added a "**{**" at the beginning of the line 1881 to solve an uncaught exception:

# game/gui7.rpy:311
    old "{size=-4}\n\nThis will not overwrite gui/main_menu.png, gui/game_menu.png, and gui/window_icon.png, but will create files that do not exist.{/size}"
    new "size=-4}\n\nEsto no sobrescribirá gui/main_menu.png, gui/game_menu.png y gui/window_icon.png, pero creará archivos que no existen.{/size}"

**Traceback generated by Ren'py prior to this change**:

While processing text tag {/size} in u'{b}Aviso{/b}\nSi contin\xfaas se sobreescribir\xe1n las barras, botones, huecos de partida grabada, barras de desplazamiento y controles deslizantes personalizados.\n\n\xbfQu\xe9 deseas hacer?{size=-4}\n\nEsto no sobrescribir\xe1 gui/main_menu.png, gui/game_menu.png y gui/window_icon.png, pero crear\xe1 archivos que no existen.{/size}'.:
  File "game/gui7.rpy", line 319, in <module>
  File "game/interface.rpy", line 539, in choice
  File "game/interface.rpy", line 329, in common
Exception: u'/size' closes a text tag that isn't open.

Regards.