### PR TITLE
Patch module not found in py3

### DIFF
--- a/renpy/common/_developer/developer.rpym
+++ b/renpy/common/_developer/developer.rpym
@@ -161,8 +161,8 @@ label _debugger_screen:
 
     python hide:
 
-        import repr
-        aRepr = repr.Repr()
+        import reprlib
+        aRepr = reprlib.Repr()
         aRepr.maxstring = 120
 
         entries = [ ]


### PR DESCRIPTION
This import fails in renpy8 when doing Shift+D then "Variable Viewer". The new import seems to display things just the same.