### PR TITLE
Add interpolation to the default notify screen

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -1263,7 +1263,7 @@ screen notify(message):
     style_prefix "notify"
 
     frame at notify_appear:
-        text "[message!tq]"
+        text "[message!tqi]"
 
     timer 3.25 action Hide('notify')
 


### PR DESCRIPTION
The default notify screen doesn't perform interpolation on the message it's given before displaying it.
I believe the performance impact to be negligible.
Other interpolated data from the default screens don't seem to need this (the game name, the about text, the game version, renpy's version and renpy's license).

The [builtin version](https://github.com/renpy/renpy/blob/140ea481578e69a4a42a23ed4c6e85f44cb2def3/renpy/common/00action_other.rpy#L665) is already different from the default one, so I don't think editing it is necessary, but it's arguable.