### PR TITLE
Fix Matrix's getitem, setitem and repr

### DIFF
--- a/renpy/display/matrix.pyx
+++ b/renpy/display/matrix.pyx
@@ -33,6 +33,7 @@ fields = [
     "xdz", "ydz", "zdz", "wdz",
     "xdw", "ydw", "zdw", "wdw",
     ]
+# not the same as documented
 
 cdef inline bint absne(float a, float b):
     return abs(a - b) > .0001
@@ -176,13 +177,13 @@ cdef class Matrix:
 
     def __getitem__(Matrix self, int index):
         if 0 <= index < 16:
-            return self.m[index]
+            return self.m[(index%4)*4+index//4]
 
         raise IndexError("Matrix index out of range.")
 
     def __setitem__(Matrix self, int index, float value):
         if 0 <= index < 16:
-            self.m[index] = value
+            self.m[(index%4)*4+index//4] = value
             return
 
         raise IndexError("Matrix index out of range.")
@@ -196,7 +197,7 @@ cdef class Matrix:
             if y:
                 rv += "\n        "
             for 0 <= x < 4:
-                rv += "{:10.7f}, ".format(self.m[x + y * 4])
+                rv += "{:10.7f}, ".format(self.m[x * 4 + y])
 
         return rv + "])"
 


### PR DESCRIPTION
fixes #3184
Having `matrix[k] != matrix.m[k]` is weird, granted. But changing the really faulty thing here, the `fields` list, would break compatibility with the existing matrices having been constructed and accessed via the .?d? accessors.
A quick look in the current code shows no use of the [ ] operator on Matrix instances, and it is undocumented, so this one should be broken rather than the three-letter accessors.

An argument could be made to remove the getitem and setitem methods altogether, since 1) it's undocumented, 2) it's about to change behavior, 3) it accesses the elements of the matrix in one-dimension when the matrix has two dimensions.

There could also be a renpy.object.Object-like \_\_version__, getstate and setstate but since current Matrix instances have no version-tracking attribute and since they do not derive from Object, I'm quite sure it wouldn't work.
If such a solution is preferred, this PR does not interferes with a later implementation of the versioning solution, since it does not mangle with the actual data (the setstate, the getstate and the self.m array). Maybe changing from a `.m` array to a `.a` could be a way to go ? But I don't trust myself to try and do that without being able to test it.

___This code has not been tested___, because it's a pyx file.