### PR TITLE
Allow Python statements to be run from JS (emscripten)

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -4303,25 +4303,18 @@ class Interface(object):
         """
 
         if not renpy.emscripten:
-            # Allowing execution of untrusted Python statements from outside
-            # the browser would be a security risk
             return
 
-        # Use a command file in MEMFS so that no sync is required
-        cmd_file = '/_js_cmd.py'
-
-        # Check if a command needs to be executed
-        if not os.path.exists(cmd_file):
+        # Retrieve the command to be executed from a global JS variable
+        # (an empty string is returned if the variable is not defined)
+        cmd = emscripten.run_script_string("window._renpy_cmd")
+        if len(cmd) == 0:
             return
 
-        # Read command file content
-        with open(cmd_file, "rt") as f:
-            cmd = f.read()
+        # Delete command variable to prevent executing the command again
+        emscripten.run_script("delete window._renpy_cmd")
 
-        # Delete command file to prevent executing the same command again
-        os.unlink(cmd_file)
-
-        # Execute the command file content
+        # Execute the command
         try:
             renpy.python.py_exec(cmd)
         except Exception as e:

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3430,8 +3430,16 @@ class Interface(object):
                 renpy.display.draw.ready_one_texture()
                 step += 1
 
-            # Step 3: Predict more images.
+            # Step 3: Execute commands from JS (on emscripten)
             elif step == 3:
+
+                if expensive and renpy.emscripten:
+                    self.exec_js_cmd()
+
+                step += 1
+
+            # Step 4: Predict more images.
+            elif step == 4:
 
                 if not self.prediction_coroutine:
                     step += 1
@@ -3452,29 +3460,21 @@ class Interface(object):
                     if not expensive:
                         step += 1
 
-            # Step 4: Preload images (on emscripten)
-            elif step == 4:
+            # Step 5: Preload images (on emscripten)
+            elif step == 5:
 
                 if expensive and renpy.emscripten:
                     renpy.display.im.cache.preload_thread_pass()
 
                 step += 1
 
-            # Step 5: Autosave.
-            elif step == 5:
+            # Step 6: Autosave.
+            elif step == 6:
 
                 if not self.did_autosave:
                     renpy.loadsave.autosave()
                     renpy.persistent.check_update()
                     self.did_autosave = True
-
-                step += 1
-
-            # Step 6: Execute commands from JS (on emscripten)
-            elif step == 6:
-
-                if expensive and renpy.emscripten:
-                    self.exec_js_cmd()
 
                 step += 1
 


### PR DESCRIPTION
This PR allows Python statements to be executed in Ren'Py process from Javascript. Currently, the interface between JS and Ren'Py is pretty limited and adding new functionalities to it requires to recompile the emscripten application, as there is no feature in emscripten/SDL to allow generic communications between JS and the application. Being able to execute Python statements in Ren'Py process directly allows more powerful controls from JS without having to recompile anything.

The changes make Ren'Py look for a specific MEMFS file during idle frames, and execute its content as a Python script. Using a file in MEMFS makes sure the lookup will be fast and no FS sync is required. The file creation and execution errors are handled by JS (see the related PR in renpyweb).
I don't know Ren'Py architecture well enough to see if there is a better place in the code to check for that file. The main problem with doing it during idle frames is that no such execution can happen when the browser window is not visible.

It should be safe to execute any external Python statements when running from the browser (emscripten) as the Python process cannot do more harm than what can be done from JS already. It is unsafe for other platforms though.

I'll post a PR in renpyweb with the JS interface to run Python statements, and a concrete use case (see renpy/renpyweb#23).