### PR TITLE
Allow function list and None for function statement in ATL ant parameter of Transform

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1702,10 +1702,11 @@ class Function(Statement):
 
     def execute(self, trans, st, state, events):
         min_fr = None
-        for f in self.function:
-            fr = f(trans, st, trans.at)
-            if fr is not None and (min_fr is None or fr < min_fr):
-                min_fr = fr
+        if self.function is not None:
+            for f in self.function:
+                fr = f(trans, st, trans.at)
+                if fr is not None and (min_fr is None or fr < min_fr):
+                    min_fr = fr
 
         if min_fr is not None:
             return "continue", None, min_fr

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1692,16 +1692,23 @@ class Function(Statement):
     def __init__(self, loc, function):
         super(Function, self).__init__(loc)
 
-        self.function = function
+        if function is None or isinstance(function, list):
+            self.function = function
+        else:
+            self.function = [function]
 
     def _handles_event(self, event):
         return True
 
     def execute(self, trans, st, state, events):
-        fr = self.function(trans, st, trans.at)
+        min_fr = None
+        for f in self.function:
+            fr = f(trans, st, trans.at)
+            if fr is not None and (min_fr is None or fr < min_fr):
+                min_fr = fr
 
-        if fr is not None:
-            return "continue", None, fr
+        if min_fr is not None:
+            return "continue", None, min_fr
         else:
             return "next", 0, None
 

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -438,7 +438,10 @@ class Transform(Container):
 
         super(Transform, self).__init__(style=style, focus=focus, default=default, _args=_args)
 
-        self.function = function
+        if function is None or isinstance(function, list):
+            self.function = function
+        else:
+            self.function = [function]
 
         child = renpy.easy.displayable_or_none(child)
         if child is not None:
@@ -674,7 +677,8 @@ class Transform(Container):
         d.replaced_response = True
 
         if d.function is not None:
-            d.function(d, st, at)
+            for f in d.function:
+                f(d, st, at)
         elif isinstance(d, ATLTransform):
             d.execute(d, st, at)
 
@@ -725,12 +729,16 @@ class Transform(Container):
         if self.arguments is not None:
             self.default_function(self, self.st, self.at)
 
+        min_fr = None
         if self.function is not None:
-            fr = self.function(self, self.st, self.at)
+            for f in self.function:
+                fr = f(self, self.st, self.at)
+                if fr is not None and (min_fr is None or fr < min_fr):
+                    min_fr = fr
 
             # Order a redraw, if necessary.
-            if fr is not None:
-                renpy.display.render.redraw(self, fr)
+            if min_fr is not None:
+                renpy.display.render.redraw(self, min_fr)
 
         self.active = True
 

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -502,7 +502,7 @@ Function Statement
 ------------------
 
 The ``function`` statement allows ATL to use Python functions to control the ATL
-properties.
+properties. This takes function or the list of functions.
 
 .. productionlist:: atl
     atl_function : "function" `expression`
@@ -520,7 +520,8 @@ The functions have the same signature as those used with :func:`Transform`:
 * If the function returns a number, it will be called again after that
   number of seconds has elapsed. (0 seconds means to call the function as
   soon as possible.) If the function returns None, control will pass to the
-  next ATL statement.
+  next ATL statement. If the list of functions is used and some functions
+  return a number, the minimal number is used.
 
 This function should not have side effects other
 than changing the Transform object in the first argument, and may be

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -502,7 +502,7 @@ Function Statement
 ------------------
 
 The ``function`` statement allows ATL to use Python functions to control the ATL
-properties. This takes function or the list of functions.
+properties. If not None, this takes function or the list of functions.
 
 .. productionlist:: atl
     atl_function : "function" `expression`

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -521,7 +521,7 @@ The functions have the same signature as those used with :func:`Transform`:
   number of seconds has elapsed. (0 seconds means to call the function as
   soon as possible.) If the function returns None, control will pass to the
   next ATL statement. If the list of functions is used and some functions
-  return a number, the minimal number is used.
+  return a number, the minimum number is used.
 
 This function should not have side effects other
 than changing the Transform object in the first argument, and may be

--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -47,7 +47,7 @@ The Python equivalent of an ATL transform is a Transform object.
         The function should return a delay, in seconds, after which it will
         be called again, or None to be called again at the start of the next
         interaction. If the list of functions is used and some functions 
-        return a number, the minimal number is used.
+        return a number, the minimum number is used.
 
         This function should not have side effects other
         than changing the Transform object in the first argument, and may be

--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -36,8 +36,9 @@ The Python equivalent of an ATL transform is a Transform object.
         The child the transform applies to.
 
     `function`
-        If not none, this is a function that is called when the transform
-        is rendered. The function is called with three arguments:
+        If not none, this is a function or the list of function
+        these are called when the transform is rendered.
+        The function is called with three arguments:
 
         * The transform object.
         * The shown timebase, in seconds.
@@ -45,7 +46,8 @@ The Python equivalent of an ATL transform is a Transform object.
 
         The function should return a delay, in seconds, after which it will
         be called again, or None to be called again at the start of the next
-        interaction.
+        interaction. If the list of functions is used and some functions 
+        return a number, the minimal number is used.
 
         This function should not have side effects other
         than changing the Transform object in the first argument, and may be


### PR DESCRIPTION
I allowed function list for function statement in ATL ant parameter of Transform.
This allows below code.  the minimum number is used when some functions return a number .
```
show test:
    function [func1, func2]
```

I also allowed None for function statement in ATL.
Now, below code can disable function.
```
show test:
    function function_test
    time 2.
    function None
```