### PR TITLE
Fix a crash in dev menu

### DIFF
--- a/renpy/common/_developer/developer.rpym
+++ b/renpy/common/_developer/developer.rpym
@@ -580,7 +580,7 @@ label _filename_list:
 
         FILES_TXT = os.path.join(renpy.config.basedir, "files.txt")
 
-        with file(FILES_TXT, "w") as f:
+        with open(FILES_TXT, "w") as f:
             for dirname, dirs, files in os.walk(config.gamedir):
 
                 dirs.sort()


### PR DESCRIPTION
Since `file` doesn't exist in py3, I replaced it with `open` instead. During my testing the menu worked again.