### PR TITLE
add ShowAlternateMenu action

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -535,6 +535,15 @@ style return_button:
     yoffset gui.scale(-30)
 
 
+## alternate menu screen #######################################################
+##
+## This screen is used to display ShowAlternateMenu Action.
+
+    screen alternate_menu(button_list):
+        for text, action in button_list:
+            textbutton text action action
+
+
 ## About screen ################################################################
 ##
 ## This screen gives credit and copyright information about the game and

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -355,45 +355,47 @@ init -1500 python:
 
          """
         def __init__(self, button_list, menu_width=300, menu_height=200, style_prefix=None):
-            self.button_list = button_list
+            self.button_list = []
+            for text, action in button_list:
+                if not isinstance(action, list):
+                    action = [action]
+                action += [Hide("_alternate_menu")]
+                self.button_list.append((text, action))
             self.style_prefix = style_prefix
             self.menu_width = menu_width
             self.menu_height = menu_height
 
         def predict(self):
-            renpy.predict_screen("_alternate_menu", self.button_list, 
+            renpy.predict_screen("_alternate_menu", self.button_list, pos = (x, y), anchor=(xanchor, yanchor),
                 menu_width=self.menu_width, menu_height=self.menu_height, style_prefix=self.style_prefix, _transient=True)
 
         def __call__(self):
 
-            renpy.show_screen("_alternate_menu", self.button_list, 
+            x, y = renpy.get_mouse_pos()
+            if x + self.menu_width > config.screen_width:
+                xanchor = 1.0
+            else:
+                xanchor = 0.0
+            if y + self.menu_height > config.screen_height:
+                yanchor = 1.0
+            else:
+                yanchor = 0.0
+            renpy.show_screen("_alternate_menu", self.button_list, pos = (x, y), anchor=(xanchor, yanchor),
                 menu_width=self.menu_width, menu_height=self.menu_height, style_prefix=self.style_prefix, _transient=True)
             renpy.restart_interaction()
 
 
 init -1500:
 
-    screen _alternate_menu(button_list, menu_width=300, menu_height=200, style_prefix=None):
+    screen _alternate_menu(button_list, pos, anchor, menu_width=300, menu_height=200, style_prefix=None):
         key ["game_menu", "dismiss"] action Hide("_alternate_menu")
         modal True
 
-        $(x, y) = renpy.get_mouse_pos()
 
         frame:
             if style_prefix:
                 style_prefix style_prefix
-            pos (x, y)
-            if x + menu_width > config.screen_width:
-                xanchor 1.0
-            else:
-                xanchor 0.0
-            if y + menu_height > config.screen_height:
-                yanchor 1.0
-            else:
-                yanchor 0.0
+            pos pos
+            anchor anchor
             vbox:
-                xfill False
-                for text, action in button_list:
-                    if not isinstance(action, list):
-                        $action = [action]
-                    textbutton text action action+[Hide("_alternate_menu")]
+                use alternate_menu(button_list)

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -329,3 +329,71 @@ init -1500 python:
 
         def __call__(self):
             _help(self.help)
+
+
+    @renpy.pure
+    class ShowAlternateMenu(Action, DictEquality):
+        """
+         :doc: menu_action
+
+         Show alternate menu screen at the bottom right corner of the cursor.
+         That screen can include textbuttons.
+
+         `button_list`
+             The list of tuple which has two elements. first is a string used
+             as text for textbutton and second is action.
+         `menu_width`
+             If the x-coordinate of the cursor plus this number is greater than
+             :var:`config.scren_witdth`, the menu will be displayed to the left
+             of the cursor. default is 300
+         `menu_height`
+             If the y-coordinate of the cursor plus this number is greater than
+             :var:`config.scren_witdth`, the menu will be displayed to the upper
+             of the cursor. default is 300
+         `style_prefix`
+             If not None, this is used for menu screen as style_prefix.
+
+         """
+        def __init__(self, button_list, menu_width=300, menu_height=200, style=None):
+            self.button_list = button_list
+            self.style = style
+            self.menu_width = menu_width
+            self.menu_height = menu_height
+
+        def predict(self):
+            renpy.predict_screen("_alternate_menu", self.button_list, 
+                menu_width=self.menu_width, menu_height=self.menu_height, style=self.style, _transient=True)
+
+        def __call__(self):
+
+            renpy.show_screen("_alternate_menu", self.button_list, 
+                menu_width=self.menu_width, menu_height=self.menu_height, style=self.style, _transient=True)
+            renpy.restart_interaction()
+
+
+init -1500:
+
+    screen _alternate_menu(button_list, menu_width=300, menu_height=200, style=None):
+        key ["game_menu", "dismiss"] action Hide("_alternate_menu")
+        modal True
+
+        $(x, y) = renpy.get_mouse_pos()
+
+        frame:
+            if style:
+                style_prefix style
+            pos (x, y)
+            if x + menu_width > config.screen_width:
+                xanchor 1.0
+            else:
+                xanchor 0.0
+            if y + menu_height > config.screen_height:
+                yanchor 1.0
+            else:
+                yanchor 0.0
+            vbox:
+                xfill False
+                for text, action in button_list:
+                    if not isinstance(action, list):
+                        $action = [action]
+                    textbutton text action action+[Hide("_alternate_menu")]

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -354,34 +354,34 @@ init -1500 python:
              If not None, this is used for menu screen as style_prefix.
 
          """
-        def __init__(self, button_list, menu_width=300, menu_height=200, style=None):
+        def __init__(self, button_list, menu_width=300, menu_height=200, style_prefix=None):
             self.button_list = button_list
-            self.style = style
+            self.style_prefix = style_prefix
             self.menu_width = menu_width
             self.menu_height = menu_height
 
         def predict(self):
             renpy.predict_screen("_alternate_menu", self.button_list, 
-                menu_width=self.menu_width, menu_height=self.menu_height, style=self.style, _transient=True)
+                menu_width=self.menu_width, menu_height=self.menu_height, style_prefix=self.style_prefix, _transient=True)
 
         def __call__(self):
 
             renpy.show_screen("_alternate_menu", self.button_list, 
-                menu_width=self.menu_width, menu_height=self.menu_height, style=self.style, _transient=True)
+                menu_width=self.menu_width, menu_height=self.menu_height, style_prefix=self.style_prefix, _transient=True)
             renpy.restart_interaction()
 
 
 init -1500:
 
-    screen _alternate_menu(button_list, menu_width=300, menu_height=200, style=None):
+    screen _alternate_menu(button_list, menu_width=300, menu_height=200, style_prefix=None):
         key ["game_menu", "dismiss"] action Hide("_alternate_menu")
         modal True
 
         $(x, y) = renpy.get_mouse_pos()
 
         frame:
-            if style:
-                style_prefix style
+            if style_prefix:
+                style_prefix style_prefix
             pos (x, y)
             if x + menu_width > config.screen_width:
                 xanchor 1.0


### PR DESCRIPTION
I added ShowAlternateMenu action and _alternate_menu screen

example:
alternate ShowAlternateMenu( [ ("button1", MainMenu()), ("button2"), NullAction()) ],  style_prefix="alternatemenu" )

    class ShowAlternateMenu(Action, DictEquality):
        """
         :doc: menu_action
         Show alternate menu screen at the bottom right corner of the cursor.
         That screen can include textbuttons.
         `button_list`
             The list of tuple which has two elements. first is a string used
             as text for textbutton and second is action.
         `menu_width`
             If the x-coordinate of the cursor plus this number is greater than
             :var:`config.scren_witdth`, the menu will be displayed to the left
             of the cursor. default is 300
         `menu_height`
             If the y-coordinate of the cursor plus this number is greater than
             :var:`config.scren_witdth`, the menu will be displayed to the upper
             of the cursor. default is 300
         `style_prefix`
             If not None, this is used for menu screen as style_prefix.

![image](https://user-images.githubusercontent.com/1556311/154980945-69f9c6c6-8862-4661-8dee-8a428f62ca79.png)
