### PR TITLE
Prevent possible crash in `Script.load_script`

### DIFF
--- a/renpy/script.py
+++ b/renpy/script.py
@@ -273,7 +273,9 @@ class Script(object):
         script_files = self.script_files
 
         # Sort script files by filename.
-        script_files.sort()
+        # We need this key to prevet possible crash when comparing None to str
+        # during sorting
+        script_files.sort(key=lambda item: (item[0] or "") or (item[1] or ""))
 
         initcode = [ ]
 


### PR DESCRIPTION
Had a crash like this
```
  File ".../renpy/renpy/script.py", line 276, in load_script
    script_files.sort()
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```
### Explanation:
Since script directory can be `None` (if the script file is in an archive), during sorting we might compare `str` to `None`. For example, when there's 2 scripts with the same name, but one is in an archive. This is a very rare case, but I thought we could still fix it.
Apparently it's fine in Python 2 (somehow?), but in Python 3, it will crash.

Building doesn't seem to be affected, before files w/o dir would come first, now they are treated as `""` which should put them ahead of the other files just like before.