### PR TITLE
Execute default statements prior to linting

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -785,6 +785,12 @@ def lint():
 
     print("\ufeff" + renpy.version + " lint report, generated at: " + time.ctime())
 
+    # Populate default statement values.
+    renpy.exports.execute_default_statement(True)
+
+    # Initialise store and values set by start callbacks.
+    renpy.exports.call_in_new_context('_start_store')
+
     # This supports check_hide.
     global image_prefixes
     image_prefixes = { }


### PR DESCRIPTION
Resolves #1287 and resolves #3182.

Opted to call `_start_store` rather than loop over `config.start_callbacks` so if something else is added to `_start_store` later this won't need to be revisited.