### PR TITLE
Fast-forward focused ATL tweaks

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1157,7 +1157,7 @@ class Interpolation(Statement):
         elif trans.atl_state is not None:
             first_frame = True
         elif st_or_at == 0:
-            first_frame = True
+            first_frame = st <= self.duration
         else:
             # This is the case when we're skipping through a displayable to
             # find the right time.

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1703,7 +1703,7 @@ class Function(Statement):
         if fr is not None:
             return "continue", None, fr
         else:
-            return "next", 0, None
+            return "next", st, None
 
 
 # This parses an ATL block.


### PR DESCRIPTION
Addresses two issues with ATL related to fast-forwarding:

- The first commit resolves an issue where, when fast-forwarding, ATL would block on a function call that returned None.

- The second tackles an issue where, when fast-forwarding through ATL, one frame from every interpolation is shown in rapid succession due to the first_frame flag. To avoid this, we only set the flag if the `st` rests within the duration of the interpolation. This ensures that the flag is correctly set, but only for the single interpolation that will be active when `st` is reached.