### PR TITLE
Relative designate for ATL properties

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1270,10 +1270,9 @@ class Interpolation(Statement):
                             raise Exception("tuple isn't available for relative designation")
                         value += old_v
                         abs_values.append(value)
-                    abs_values = tuple(abs_values)
                 else:
                     abs_values = values
-                splines.append((name, [ getattr(trans.state, name) ] + values))
+                splines.append((name, [ getattr(trans.state, name) ] + abs_values))
 
             state = (linear, revolution, splines)
 

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -652,6 +652,9 @@ one block should adjust horizontal position, and one should adjust vertical
 positions. (These may be the same block.) The angle and radius properties set
 both horizontal and vertical positions.
 
+The properties which are numerical type and not None also take relative value
+to the current value by adding property `rel_` prefix.
+
 .. transform-property:: pos
 
     :type: (position, position)


### PR DESCRIPTION
I allowed relative value for ATL properties which are numerical type and not None by adding property `rel_` prefix.

for example, The below 2 code is equivalent.

```
    show bg:
        xpos 0.5 
        linear 1.15 rel_xpos 0.1  knot -0.87 
```

```
    show bg:
        xpos 0.5 
        linear 1.15 xpos 0.6  knot -0.37 
```