### PR TITLE
Simplified Chinese translation: Correct term

### DIFF
--- a/launcher/game/tl/schinese/common.rpy
+++ b/launcher/game/tl/schinese/common.rpy
@@ -455,7 +455,7 @@ translate schinese strings:
 
     # 00library.rpy:281
     old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
-    new "本程序包含了由数个许可证授权的免费软件，包括 MIT 许可证和 GNU 宽松通用公共许可证。完整软件列表及源代码链接，请{a=https://www.renpy.org/l/license}访问此处{/a}。"
+    new "本程序包含了由数个许可证授权的自由软件，包括 MIT 许可证和 GNU 宽松通用公共许可证。完整软件列表及源代码链接，请{a=https://www.renpy.org/l/license}访问此处{/a}。"
 
     # 00preferences.rpy:240
     old "display"


### PR DESCRIPTION
Change 免费软件 (means "free-of-charge software") -> 自由软件 (which is closer in meaning to "libre software")