### PR TITLE
add doc about movie with alpha channel

### DIFF
--- a/sphinx/source/movie.rst
+++ b/sphinx/source/movie.rst
@@ -37,7 +37,12 @@ Movies can be displayed fullscreen or in a displayable. Fullscreen movies
 are more efficient.
 
 It depends on the ffmpeg native decoders whether movies with alpha channel work
-correctly. We recommend using mask or side_mask for that purpose.
+correctly. We recommend using mask or side_mask for that purpose. Here is an
+ffmpeg example of encoding a webm file for side-by-side mask mode from a mov
+file with an alpha channel. ::
+
+        ffmpeg -i original.mov -filter:v alphaextract mask.mov
+        ffmpeg -i original.mov -i mask.mov -filter_complex "hstack" -codec:v vp8 -crf 10 output.webm
 
 Movies are not supported on the Web platform.
 

--- a/sphinx/source/movie.rst
+++ b/sphinx/source/movie.rst
@@ -36,6 +36,9 @@ VP9, VP8, or Theora; Opus or Vorbis; and WebM, Matroska, or Ogg.)
 Movies can be displayed fullscreen or in a displayable. Fullscreen movies
 are more efficient.
 
+It depends on the ffmpeg native decoders whether movies with alpha channel work
+correctly. We recommend using mask or side_mask for that purpose.
+
 Movies are not supported on the Web platform.
 
 


### PR DESCRIPTION
I add the below sentence doc.

It depends on the ffmpeg native decoders whether movies with alpha channel work
correctly. We recommend using mask or side_mask for that purpose.