### PR TITLE
Skip recording deltas for stores that don't change in rollback

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -101,9 +101,6 @@ def get_store_module(name):
 
 from renpy.pydict import DictItems, find_changes
 
-EMPTY_DICT = { }
-EMPTY_SET = set()
-
 
 class StoreDict(dict):
     """
@@ -161,7 +158,7 @@ class StoreDict(dict):
             self.old = new
 
         if rv is None:
-            return EMPTY_DICT, EMPTY_SET
+            return None
 
         delta_ebc = set()
 

--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -561,7 +561,9 @@ class RollbackLog(renpy.object.Object):
         # Update self.current.stores with the changes from each store.
         # Also updates .ever_been_changed.
         for name, sd in renpy.python.store_dicts.items():
-            self.current.stores[name], self.current.delta_ebc[name] = sd.get_changes(begin)
+            delta = sd.get_changes(begin)
+            if delta:
+                self.current.stores[name], self.current.delta_ebc[name] = delta
 
         # Update the list of mutated objects and what we need to do to
         # restore them.


### PR DESCRIPTION
Games that make liberal use of stores end up with (a small amount of) redundant work being done during rollback, saving, and loading; proportional to the number of stores used and length of rollback, even if the majority are infrequently changed. This PR seeks to improve that without detriment to the more typical case involving no more stores than Ren'Py creates itself (14 including the default).

---

Currently keys for every store are added to a `Rollback` object's `stores`
and `delta_ebc` dicts, even if they contain no data. When rolling back
these dicts are iterated over, and the empty stores amount to no-ops.
These empty data structures are also serialised/de-serialised by the
save system (albeit efficiently) but yield no benefit.

This change is to skip recording entries for stores that haven't
changed, the resulting log should be functionally equivalent to existing
behaviour, but cut down on the amount of extraneous work to handle them.

As the [code](https://github.com/renpy/renpy/blob/fea0be65ed6908fd0e261995f53ebda7303d57a7/renpy/rollback.py#L354-L372) [processing](https://github.com/renpy/renpy/blob/fea0be65ed6908fd0e261995f53ebda7303d57a7/renpy/memory.py#L457-L465) the log doesn't change or mind stores being
omitted, this change should be completely transparent and both forward
and backward compatible.