### PR TITLE
Correct work of dynamic stack for sub StoreModule.

### DIFF
--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -362,6 +362,9 @@ class Context(renpy.object.Object):
 
             if i in store:
                 self.dynamic_stack[index][i] = store[i]
+            elif "." in i:
+                field, _, v = i.partition(".")
+                self.dynamic_stack[index][i] = store[field].__dict__[v]
             else:
                 self.dynamic_stack[index][i] = Delete()
 
@@ -374,11 +377,16 @@ class Context(renpy.object.Object):
         if not self.dynamic_stack:
             return
 
-        store = renpy.store.__dict__
+        _store = renpy.store.__dict__
 
         dynamic = self.dynamic_stack.pop()
 
         for k, v in dynamic.items():
+            if "." in k:
+                field, _, k = k.partition(".")
+                store = _store[field].__dict__
+            else:
+                store = _store
             if isinstance(v, Delete):
                 store.pop(k, None)
             else:


### PR DESCRIPTION
I've noticed that when creating dynamic variables for sub StoreModule, this doesn't work correctly.
I left a case with an example below.
Also with comments on how dynamic stack behaves.

```renpy 
default current_label = None
default previous_label = None
default test.current_label = None
default test.previous_label = None


init -999 python:
    def reach_label(label, action):
        if label.startswith("_"):
            return
        renpy.dynamic("current_label", "previous_label")
        renpy.dynamic("test.current_label", "test.previous_label")
        store.test.previous_label = store.test.current_label
        store.test.current_label = label
        store.previous_label, store.current_label = store.current_label, label

    config.label_callback = reach_label


label pre_start():
    "[current_label] == [test.current_label]"  # pre_start == pre_start
    return


label start():
    "[current_label] == [test.current_label]"  # start == start
    call pre_start()
    "[current_label] != [test.current_label]"  # start != pre_start
    jump start
```