### PR TITLE
Duplicate child during ATLTranform `__call__`

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -464,6 +464,9 @@ class ATLTransformBase(renpy.object.Object):
         if child is None:
             child = self.child
 
+        if getattr(child, '_duplicatable', False):
+            child = child._duplicate(_args)
+
         # Create a new ATL Transform.
         parameters = renpy.ast.ParameterInfo({ }, positional, None, None)
 


### PR DESCRIPTION
This fixes the issue with such code
```
label main_menu:
    return

define config.default_transform = None

image base:
    Text("image 1")
    pause 1.0
    Text("image 2")
    pause 1.0
    repeat

transform centr:
    align (0.5, 0.5)

image test = centr("base")

label start:
    pause
    show test
    pause
    hide test
    pause
    show test
    pause
    return
```
Where if `test` was hidden in state of `Text("image 2")` it does not starts from the beggining on second show, which is inconsistent with  `define centr = Transform(align=(0.5, 0.5))`.

Fixes 2nd point in #2102.