### PR TITLE
Forbid to use `define persistent.var`

### DIFF
--- a/renpy/common/000namespaces.rpy
+++ b/renpy/common/000namespaces.rpy
@@ -20,8 +20,10 @@
         pure = False
 
         def set(self, name, value):
-            if getattr(persistent, name) is None:
-                setattr(persistent, name, value)
+            if config.allow_define_persistent:
+                self.set_default(persistent, name, value)
+            else:
+                raise Exception("The define statement can not be used with the persistent namespace.")
 
         def set_default(self, name, value):
             if getattr(persistent, name) is None:

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -248,6 +248,9 @@ python early hide:
         if script_version <= (7, 2, 2):
             config.keyword_after_python = True
 
+        if script_version <= (7, 4, 11):
+            config.allow_define_persistent = True
+
     except Exception:
         config.early_script_version = None
         pass

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1213,6 +1213,9 @@ at_exit_callbacks = [ ]
 # when config.developer is true?
 lint_character_statistics = True
 
+# Enables `define persistent.var', pre 7.5 behavior
+allow_define_persistent = False
+
 del os
 del collections
 

--- a/tutorial/game/01example.rpy
+++ b/tutorial/game/01example.rpy
@@ -335,7 +335,7 @@ python early:
 
 
 # A preference that controls if translations are shown.
-define persistent.show_translation_marker = False
+default persistent.show_translation_marker = False
 
 init python:
 


### PR DESCRIPTION
Fixes #3354.
Misses changes to documentation and mention in incompatible changes.