### PR TITLE
Add workaround advice for live2d being missing or disabled

### DIFF
--- a/sphinx/source/live2d.rst
+++ b/sphinx/source/live2d.rst
@@ -203,6 +203,21 @@ defining different zooms and scaling factors. ::
     image hiyori close = Live2D("Resources/Hiyori", base=.6)
     image hiyori far = Live2D("Resources/Hiyori", base=.9)
 
+Keep in mind that the user's hardware may be unable to init Live2D, and in that
+case a single call to Live2D() will keep the entire project from loading. The same
+happens in the case of a game distributed in a web version. If your game should be able
+to work even without Live2D, you could use a wrapper or workaround, for example::
+
+    init python:
+        def MyLive2D(*args, **kwargs, fallback=Placeholder(text="no live2d")):
+            if renpy.has_live2d():
+                 return Live2D(*args, **kwargs)
+            else:
+                 return fallback
+
+    image kobayashi = MyLive2D(...)
+    image eileen moving = MyLive2D(..., fallback="eileen happy")
+
 Using Animations
 ----------------
 

--- a/sphinx/source/live2d.rst
+++ b/sphinx/source/live2d.rst
@@ -209,7 +209,7 @@ happens in the case of a game distributed in a web version. If your game should 
 to work even without Live2D, you could use a wrapper or workaround, for example::
 
     init python:
-        def MyLive2D(*args, **kwargs, fallback=Placeholder(text="no live2d")):
+        def MyLive2D(*args, fallback=Placeholder(text="no live2d"), **kwargs):
             if renpy.has_live2d():
                  return Live2D(*args, **kwargs)
             else:


### PR DESCRIPTION
Adapted from [this advice](https://github.com/renpy/renpy/issues/3093#issuecomment-945160706) from #3093.

Watch out, the code I added only works in python 3. A py2-compatible way is `return kwargs.pop("fallback", None) or Placeholder(text="no live2d")`.