### PR TITLE
Fix code copy button doesn't copy the translated example

### DIFF
--- a/tutorial/game/01example.rpy
+++ b/tutorial/game/01example.rpy
@@ -444,14 +444,14 @@ init python:
 
             last_blank = not i
 
+            i = regex.sub(translate, i)
+
+            if not (persistent.show_translation_marker or showtrans):
+                i = re.sub(r'__?\((".*?")\)', r'\1', i)
+                i = re.sub(r"__?\(('.*?')\)", r'\1', i)
+                i = i.replace("!t]", "]")
+
             if not raw:
-                i = regex.sub(translate, i)
-
-                if not (persistent.show_translation_marker or showtrans):
-                    i = re.sub(r'__?\((".*?")\)', r'\1', i)
-                    i = re.sub(r"__?\(('.*?')\)", r'\1', i)
-                    i = i.replace("!t]", "]")
-
                 i = quote(i)
                 i = regex.sub(colorize, i)
 


### PR DESCRIPTION
Now the translation of the example isn't ignored when copying it.

Fixes #2388