### PR TITLE
Prevent special namespace sub-store creation

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2286,15 +2286,14 @@ class PostUserStatement(Node):
 
 
 def create_store(name):
-    overname = name
-    while '.' in overname:
-        overname, _, _ = overname.rpartition('.')
-        if overname in renpy.config.special_namespaces:
-            renpy.config.special_namespaces[overname].create_store(name[len(overname):])
-            return
+    if name in renpy.config.special_namespaces:
+        return
 
-    if name not in renpy.config.special_namespaces:
-        renpy.python.create_store(name)
+    i = name.find('.', 6) # next dot after "store."
+    if i > 0 and name[:i] in renpy.config.special_namespaces:
+        raise Exception('Creating stores within the {} namespace is not supported.'.format(name[6:i]))
+
+    renpy.python.create_store(name)
 
 
 class StoreNamespace(object):

--- a/renpy/common/000namespaces.rpy
+++ b/renpy/common/000namespaces.rpy
@@ -16,9 +16,6 @@
         def get(self, name):
             return getattr(self.nso, name)
 
-        def create_store(self, name):
-            raise Exception("Submodules cannot be created within the {} namespace.".format(self.name))
-
     class _PersistentNamespace(object):
         pure = False
 
@@ -32,9 +29,6 @@
 
         def get(self, name):
             return getattr(persistent, name)
-
-        def create_store(self, name):
-            raise Exception("Submodules cannot be created within the persistent namespace.")
 
     class _ErrorNamespace(object):
         pure = False
@@ -50,9 +44,6 @@
 
         def get(self, name):
             raise Exception("The default and define statements can not be used with the {} namespace.".format(self.name))
-
-        def create_store(self, name):
-            raise Exception("Submodules cannot be created within the {} namespace.".format(self.name))
 
     class _PreferencesNamespace(object):
         pure = False
@@ -88,9 +79,6 @@
         def get(self, name):
             raise Exception("The define statement can not be used with the preferences namespace.")
 
-        def create_store(self, name):
-            raise Exception("Submodules cannot be created within the preferences namespace.")
-
     class _GuiNamespace(object):
         pure = True
 
@@ -102,9 +90,6 @@
 
         def get(self, name):
             return getattr(gui, name)
-
-        def create_store(self, name):
-            raise Exception("Submodules cannot be created within the gui namespace.")
 
     config.special_namespaces["store.config"] = _ObjectNamespace(config, "config")
     config.special_namespaces["store.persistent"] = _PersistentNamespace()


### PR DESCRIPTION
For now special namespace sub-stores isn't possible or supported, so
there's no need for the machinery to support it. At such time we have
a clean way to implement it this method can be updated to support it.

Talked it over with @Gouvernathor and they're happy with this and will
re-introduce delegation machinery if/when there's a clean solution to
add sub-stores to the persistent namespace.

Considered defining `STORE_DOT = len('store.')` to avoid the magic `6`,
but ultimately decided that a comment should be sufficient.