### PR TITLE
Sphinx-directory-traversal

### DIFF
--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -67,9 +67,9 @@ init -1500 python:
                 If true, the sprite is flipped horizontally.
 
             `text`
-￼                If provided, no other text than this will be displayed on the
-￼                placeholder. If not, the text will reflect the show
-￼                instruction that was used to display it.
+                 If provided, no other text than this will be displayed on the
+                 placeholder. If not, the text will reflect the show
+                 instruction that was used to display it.
             """
 
             super(Placeholder, self).__init__(**properties)

--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -67,9 +67,9 @@ init -1500 python:
                 If true, the sprite is flipped horizontally.
 
             `text`
-                 If provided, no other text than this will be displayed on the
-                 placeholder. If not, the text will reflect the show
-                 instruction that was used to display it.
+￼                If provided, no other text than this will be displayed on the
+￼                placeholder. If not, the text will reflect the show
+￼                instruction that was used to display it.
             """
 
             super(Placeholder, self).__init__(**properties)

--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -169,8 +169,8 @@ def expanded_sl2_properties():
     return rv
 
 
-def write_keywords():
-    f = open("source/keywords.py", "w")
+def write_keywords(srcdir='source'):
+    outf = os.path.join(srcdir, 'keywords.py')
 
     kwlist = set(keyword.kwlist)
     kwlist |= script_keywords()
@@ -184,18 +184,18 @@ def write_keywords():
 
     kwlist.sort()
 
-    f.write("keywords = %r\n" % kwlist)
-    f.write("keyword_regex = %r\n" % ("|".join(re.escape(i) for i in kwlist)))
+    with open(outf, "w") as f:
 
-    properties = [ i for i in expanded_sl2_properties() if i not in kwlist ]
+        f.write("keywords = %r\n" % kwlist)
+        f.write("keyword_regex = %r\n" % ("|".join(re.escape(i) for i in kwlist)))
 
-    f.write("properties = %r\n" % properties)
+        properties = [ i for i in expanded_sl2_properties() if i not in kwlist ]
 
-    f.write("property_regexes = %r\n" % sl2_regexps())
+        f.write("properties = %r\n" % properties)
 
-    f.close()
+        f.write("property_regexes = %r\n" % sl2_regexps())
 
-    shutil.copy("source/keywords.py", "../tutorial/game/keywords.py")
+    shutil.copy(outf, os.path.join(srcdir, "../../tutorial/game/keywords.py"))
 
 
 # A map from filename to a list of lines that are supposed to go into
@@ -331,11 +331,9 @@ def scan_section(name, o):
         scan(name + n, getattr(o, n))
 
 
-def write_line_buffer():
+def write_line_buffer(incdir='source/inc'):
 
     for k, v in line_buffer.items():
-
-        # f = file("source/inc/" + k, "w")
 
         f = io.StringIO()
 
@@ -347,22 +345,23 @@ def write_line_buffer():
 
         s = f.getvalue()
 
-        if os.path.exists("source/inc/" + k):
-            with open("source/inc/" + k) as f:
+        fname = os.path.join(incdir, k)
+        if os.path.exists(fname):
+            with open(fname) as f:
                 if f.read() == s:
                     print("Retaining", k)
                     continue
 
         print("Generating", k)
 
-        with open("source/inc/" + k, "w") as f:
+        with open(fname, "w") as f:
             f.write(s)
 
 
 name_kind = collections.defaultdict(str)
 
 
-def scan_docs():
+def scan_docs(srcdir='source', incdir='source/inc'):
     """
     Scans the documentation for functions, classes, and variables.
     """
@@ -378,12 +377,12 @@ def scan_docs():
 
             name_kind[m.group(2)] = m.group(1)
 
-    for i in os.listdir("source"):
+    for i in os.listdir(srcdir):
         if i.endswith(".rst"):
-            scan_file(os.path.join("source", i))
+            scan_file(os.path.join(srcdir, i))
 
-    for i in os.listdir("source/inc"):
-        scan_file(os.path.join("source", "inc", i))
+    for i in os.listdir(incdir):
+        scan_file(os.path.join(incdir, i))
 
 
 def format_name(name):
@@ -416,7 +415,7 @@ def write_reserved(module, dest, ignore_builtins):
             f.write("* " + format_name(i) + "\n")
 
 
-def write_pure_const():
+def write_pure_const(incdir='source/inc'):
 
     def write_set(f, s):
         l = list(s)
@@ -428,16 +427,16 @@ def write_pure_const():
     pure = renpy.pyanalysis.pure_functions # @UndefinedVariable
     constants = renpy.pyanalysis.constants - pure # @UndefinedVariable
 
-    with open("source/inc/pure_vars", "w") as f:
+    with open(os.path.join(incdir, "pure_vars"), "w") as f:
         write_set(f, pure)
 
-    with open("source/inc/const_vars", "w") as f:
+    with open(os.path.join(incdir, "const_vars"), "w") as f:
         write_set(f, constants)
 
 
-def write_easings(ns):
+def write_easings(ns, incdir='source/inc'):
 
-    with open("source/inc/easings", "w") as f:
+    with open(os.path.join(incdir, "easings"), "w") as f:
         f.write(".. csv-table::\n")
         f.write('    :header: "Ren\'Py Name", "easings.net Name"\n')
         f.write('\n')
@@ -452,22 +451,22 @@ def write_easings(ns):
             f.write('    "{}", "{}"\n'.format(name, stdname))
 
 
-def tq_script(name):
+def tq_script(name, srcdir='source'):
 
-    with open("../the_question/game/" + name, "r") as f:
+    with open(os.path.join(srcdir, "../../the_question/game", name), "r") as f:
         lines = f.readlines()
         lines = [ ("    " + i).rstrip() for i in lines ]
         return "\n".join(lines)
 
 
-def write_tq():
-    script = tq_script("script.rpy")
-    options = tq_script("options.rpy")
+def write_tq(srcdir='source'):
+    script = tq_script("script.rpy", srcdir=srcdir)
+    options = tq_script("options.rpy", srcdir=srcdir)
 
-    with open("source/thequestion.txt", "r") as f:
+    with open(os.path.join(srcdir, "thequestion.txt"), "r") as f:
         template = f.read()
 
-    with open("source/thequestion.rst", "w") as f:
+    with open(os.path.join(srcdir, "thequestion.rst"), "w") as f:
         f.write(template.format(script=script, options=options))
 
 

--- a/sphinx/game/script.rpy
+++ b/sphinx/game/script.rpy
@@ -2,7 +2,13 @@ init 1000000 python:
     import doc
     import shaderdoc
 
-    shaderdoc.shaders()
+    srcdir = 'source'
+    if os.path.isdir('sphinx') and os.path.split(os.getcwd())[-1] == 'renpy':
+        srcdir = os.path.join('sphinx', 'source') # ran from renpy/. cwd using sphinx in-game project
+
+    incdir = os.path.join(srcdir, 'inc')        
+
+    shaderdoc.shaders(incdir=incdir)
 
     doc.scan_section("", renpy.store)
     doc.scan_section("renpy.", renpy)
@@ -21,25 +27,24 @@ init 1000000 python:
     doc.scan_section("layeredimage.", layeredimage)
     doc.scan_section("Matrix.", Matrix)
 
-    doc.write_line_buffer()
-    doc.write_keywords()
+    doc.write_line_buffer(incdir=incdir)
+    doc.write_keywords(srcdir=srcdir)
 
-    doc.scan_docs()
-    doc.write_reserved(doc.builtins, "source/inc/reserved_builtins", False)
-    doc.write_reserved(store, "source/inc/reserved_renpy", True)
+    doc.scan_docs(srcdir=srcdir, incdir=incdir)
+    doc.write_reserved(doc.builtins, os.path.join(incdir, "reserved_builtins"), False)
+    doc.write_reserved(store, os.path.join(incdir, "reserved_renpy"), True)
 
-    doc.write_pure_const()
+    doc.write_pure_const(incdir=incdir)
 
-    doc.write_easings(_warper)
+    doc.write_easings(_warper, incdir=incdir)
 
-    doc.write_tq()
+    doc.write_tq(srcdir=srcdir)
 
     doc.check_dups()
 
     console_commands = _console.help(None, True)
     console_commands = "\n\n".join(console_commands.split("\n"))
-    f = open("source/inc/console_commands", "w")
-    f.write(console_commands)
-    f.close()
-
+    with open(os.path.join(incdir, "console_commands"), "w") as f:
+        f.write(console_commands)
+    
     raise SystemExit

--- a/sphinx/game/shaderdoc.py
+++ b/sphinx/game/shaderdoc.py
@@ -1,11 +1,11 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 
+import os
 import renpy
-import sys
 import textwrap
 
 
-def shaders():
+def shaders(incdir="source/inc"):
 
     def p(s):
         print(s, file=outf)
@@ -15,7 +15,7 @@ def shaders():
         for i in s.split("\n"):
             print("    " + i, file=outf)
 
-    with open("source/inc/shadersource", "w") as outf:
+    with open(os.path.join(incdir, "shadersource"), "w") as outf:
 
         parts = list(renpy.gl2.gl2shadercache.shader_part.values())
 


### PR DESCRIPTION
This fixes sphinx in-game project I/O issues related to relative paths when renpy.py is launched from its base directory instead of from within the sphinx subdirectory.  Older file I/O patterns (open/close) have been updated to their newer forms (with open() as)