### PR TITLE
Fix Movie._play being invalid

### DIFF
--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -313,6 +313,7 @@ class Movie(renpy.display.core.Displayable):
     fullscreen = False
     channel = "movie"
     _play = None
+    _base_play = None
 
     mask = None
     mask_channel = None
@@ -324,6 +325,14 @@ class Movie(renpy.display.core.Displayable):
     play_callback = None
 
     loop = True
+
+    def after_setstate(self):
+        play = self._base_play or self._play
+        if (play is not None) and renpy.loader.loadable(play):
+            self._hidden_play = self._play = play
+        else:
+            self._play = None
+            self._hidden_play = play
 
     def ensure_channel(self, name):
 
@@ -350,8 +359,11 @@ class Movie(renpy.display.core.Displayable):
 
         self.size = size
         self.channel = channel
-        self._play = play
         self.loop = loop
+
+        self._hidden_play = play
+        if (play is not None) and renpy.loader.loadable(play):
+            self._play = play
 
         if side_mask:
             mask = None

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -329,10 +329,10 @@ class Movie(renpy.display.core.Displayable):
     def after_setstate(self):
         play = self._base_play or self._play
         if (play is not None) and renpy.loader.loadable(play):
-            self._hidden_play = self._play = play
+            self._base_play = self._play = play
         else:
             self._play = None
-            self._hidden_play = play
+            self._base_play = play
 
     def ensure_channel(self, name):
 
@@ -361,7 +361,7 @@ class Movie(renpy.display.core.Displayable):
         self.channel = channel
         self.loop = loop
 
-        self._hidden_play = play
+        self._base_play = play
         if (play is not None) and renpy.loader.loadable(play):
             self._play = play
 


### PR DESCRIPTION
fix #3394 
Contrary to #3395, this PR handles the following situation:
```rpy
define good_ending = Movie(...)
define bad_ending = Movie(...)
default ending = bad_ending

label start:
    ...
    show expression ending
```
If a game is saved on a device where the underlying movie file exists, then loaded on a device where it does not, the Movie object will now be unpickled with a None \_play attribute.
If a game is saved on a device where the file does not exist then loaded on a device where it does, the Movie object will be unpickled with the correct filename as a \_play attribute, because it will have been saved as \_base_play.