### PR TITLE
Avoid incomparable None error in classic save menu

### DIFF
--- a/renpy/common/_layout/classic_load_save.rpym
+++ b/renpy/common/_layout/classic_load_save.rpym
@@ -237,7 +237,7 @@ init python:
 
                 # Figure out which game is the newest and so on.
                 newest = None
-                newest_mtime = None
+                newest_mtime = 0
                 save_info = { }
 
                 for fn, extra_info, screenshot, mtime in saved_games:


### PR DESCRIPTION
Prevents an error being raised when comparing against `mtime` in the `for` loop just below due to comparing an int to None.