### PR TITLE
Avoid trying to clear the mappingproxy type

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -657,11 +657,6 @@ def reload_all():
             del sys.modules[i]
 
         elif any(issubmodule(i, m) for m in reload_modules):
-            m = sys.modules[i]
-
-            if m is not None:
-                m.__dict__.clear()
-
             del sys.modules[i]
 
     # Restore the state of all modules from backup.


### PR DESCRIPTION
In py3 modules get `mappingproxy`s for their `__dict__`, which are essentially immutable dicts. As such they have no `clear` method and trying to use it raises exactly as you'd expect. Some modules do end up with real dicts for various reasons, so in theory we could typecheck this, but as we're deleting the module anyway, I believe that should suffice to see it garbage collected, and the removal from `sys.modules` should ensure it's re-imported/executed.