### PR TITLE
Fix potential typo in build exclusions and fix build.remove

### DIFF
--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -96,11 +96,16 @@ init -1500 python in build:
         ( "renpy/", "all"),
         ( "renpy/**.py", "renpy"),
 
-        ( "renpy/**.pyx", None),
+        # Ignore Cython source files.
         ( "renpy/**.pxd", None),
         ( "renpy/**.pxi", None),
+        ( "renpy/**.pyx", None),
+
+        # Ignore legacy Python bytcode files (unless allowed above).
         ( "renpy/**.pyc", None),
         ( "renpy/**.pyo", None),
+
+        # Ignore Python interface files.
         ( "renpy/**.pyi", None),
 
         ( "renpy/common/", "all"),

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -97,7 +97,7 @@ init -1500 python in build:
         ( "renpy/**.py", "renpy"),
 
         ( "renpy/**.pyx", None),
-        ( "renpy/**.pyd", None),
+        ( "renpy/**.pxd", None),
         ( "renpy/**.pxi", None),
         ( "renpy/**.pyc", None),
         ( "renpy/**.pyo", None),

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -243,7 +243,7 @@ init -1500 python in build:
         Removes the pattern from the list.
         """
 
-        l[:] = [ (p, fl) for i in l if p != pattern ]
+        l[:] = [ (p, fl) for p, fl in l if p != pattern ]
 
     # Archiving.
 


### PR DESCRIPTION
Given it's placement in the list, my guess is that the current `pyd` exclusion is a typo, with the intent being to exclude Cython `pxd` files. However since the `pyd` extension is used to denote a Windows-specific Python DLL, this isn't a certainty only likely.

Also noticed and fixed `build.remove` which was non-functional.