### PR TITLE
Fix Python bytecode inclusion for SDK

### DIFF
--- a/launcher/game/options.rpy
+++ b/launcher/game/options.rpy
@@ -323,16 +323,27 @@ init python:
         else goes into source.
         """
 
-        if not py:
-            build.classify_renpy(pattern + "/**__pycache__/", None)
-            build.classify_renpy(pattern + "/**.pyc", None)
-            build.classify_renpy(pattern + "/**.pyo", None)
-        elif PY2:
-            build.classify_renpy(pattern + "/**__pycache__/", None)
-            build.classify_renpy(pattern + "/**.pyo", binary)
-        else:
+        if py is True:
+            py = 'pyo' if PY2 else 'pycache'
+
+        if py == 'pycache':
             build.classify_renpy(pattern + "/**__pycache__/", binary)
             build.classify_renpy(pattern + "/**__pycache__/*.{}.pyc".format(sys.implementation.cache_tag), binary)
+            build.classify_renpy(pattern + "/**.pyc", None)
+            build.classify_renpy(pattern + "/**.pyo", None)
+
+        elif py == 'pyc':
+            build.classify_renpy(pattern + "/**__pycache__/", None)
+            build.classify_renpy(pattern + "/**.pyc", binary)
+            build.classify_renpy(pattern + "/**.pyo", None)
+
+        elif py == 'pyo':
+            build.classify_renpy(pattern + "/**__pycache__/", None)
+            build.classify_renpy(pattern + "/**.pyc", None)
+            build.classify_renpy(pattern + "/**.pyo", binary)
+
+        else:
+            build.classify_renpy(pattern + "/**__pycache__/", None)
             build.classify_renpy(pattern + "/**.pyc", None)
             build.classify_renpy(pattern + "/**.pyo", None)
 
@@ -399,7 +410,7 @@ init python:
         build.classify_renpy("renpy2.sh", "binary")
     else:
         source_and_binary("lib/py3-**", "binary", "binary")
-        source_and_binary("lib/python3**", "binary", "binary")
+        source_and_binary("lib/python3**", "binary", "binary", py='pyc')
         build.classify_renpy("renpy3.sh", "binary")
 
     build.classify_renpy("lib/", "binary")


### PR DESCRIPTION
- Ensures that py2 excludes .pyc (were previously being included in `/renpy/`)
- Ensures that py3 includes .pyc files for the stdlib

note: The defaulting of `py` based on `PY2` could also be done in the function definition if it's felt that's more readable.

Here are the generated lists with the pertinent sections pulled out:

---
<details><summary>py2 list</summary>

Exclusion of `.pyc` from `/renpy/`, as we only need `.pyo` for py2.

```
[...]
('renpy/**__pycache__/', None)
('renpy/**.pyc', None)
('renpy/**.pyo', ['binary'])
('renpy/**.rpyc', ['binary'])
('renpy/**.rpymc', ['binary'])
('renpy/**/cache/*', ['binary'])
('renpy/**', ['source'])
[...]
```
<blockquote><details><summary>full py2 list</summary>

```
('**~', None)
('**/#*', None)
('**/thumbs.db', None)
('**/.*', None)
('atom/', ['atom-all'])
('atom/default-dot-atom/**', ['atom-all'])
('atom/atom-windows/**', ['atom-windows'])
('atom/Atom.app/**', ['atom-mac'])
('atom/atom-linux**', ['atom-linux'])
('rapt/**/libLive2DCubismCore.so', None)
('rapt/**', ['rapt'])
('renios/prototype/base/', None)
('renios/prototype/prototype.xcodeproj/*.xcworkspace/', None)
('renios/prototype/prototype.xcodeproj/xcuserdata/', None)
('renios/prototype/**', ['renios'])
('renios/buildlib/**', ['renios'])
('renios/ios.py', ['renios'])
('renios/version.txt', ['renios'])
('renios/', ['renios'])
('web/game.zip', None)
('web/**', ['web'])
('**.old', None)
('**.new', None)
('**.bak', None)
('**/log.txt', None)
('**/traceback.txt', None)
('**/errors.txt', None)
('**/steam_appid.txt', None)
('**/saves/', None)
('**/tmp/', None)
('**/.Editra', None)
('renpy.py', ['binary'])
('renpy/**__pycache__/', None)
('renpy/**.pyc', None)
('renpy/**.pyo', ['binary'])
('renpy/**.rpyc', ['binary'])
('renpy/**.rpymc', ['binary'])
('renpy/**/cache/*', ['binary'])
('renpy/**', ['source'])
('launcher/game/theme/', None)
('gui/game/gui/', None)
('launcher/**__pycache__/', None)
('launcher/**.pyc', None)
('launcher/**.pyo', None)
('launcher/**.rpyc', ['binary'])
('launcher/**.rpymc', ['binary'])
('launcher/**/cache/*', ['binary'])
('launcher/**', ['source'])
('gui/**__pycache__/', None)
('gui/**.pyc', None)
('gui/**.pyo', None)
('gui/**.rpyc', None)
('gui/**.rpymc', None)
('gui/**/cache/*', None)
('gui/**', ['source'])
('the_question/**__pycache__/', None)
('the_question/**.pyc', None)
('the_question/**.pyo', ['binary'])
('the_question/**.rpyc', ['binary'])
('the_question/**.rpymc', ['binary'])
('the_question/**/cache/*', ['binary'])
('the_question/**', ['source'])
('tutorial/**__pycache__/', None)
('tutorial/**.pyc', None)
('tutorial/**.pyo', ['binary'])
('tutorial/**.rpyc', ['binary'])
('tutorial/**.rpymc', ['binary'])
('tutorial/**/cache/*', ['binary'])
('tutorial/**', ['source'])
('sdk-fonts/**', ['source'])
('doc/', ['source'])
('doc/.doctrees/', None)
('doc/_sources/', None)
('doc/**', ['source'])
('LICENSE.txt', ['source'])
('sphinx/', ['source_only'])
('sphinx/build.sh', ['source_only'])
('sphinx/checks.py', ['source_only'])
('sphinx/game/**', ['source_only'])
('sphinx/source/inc/', None)
('sphinx/source/**', ['source_only'])
('module/', ['source'])
('module/*.c', ['source'])
('module/gen/', None)
('module/*.h', ['source'])
('module/*.py*', ['source'])
('module/include/', ['source'])
('module/include/*.pxd', ['source'])
('module/include/*.pxi', ['source'])
('module/pysdlsound/', ['source'])
('module/pysdlsound/*.py', ['source'])
('module/pysdlsound/*.pyx', ['source'])
('module/fribidi-src/**', ['source'])
('lib/**/*steam_api*', ['steam'])
('lib/**/*Live2D*', None)
('lib/*linux-armv7l/', ['raspi'])
('lib/*linux-armv7l/**', ['raspi'])
('lib/py2-**/**__pycache__/', None)
('lib/py2-**/**.pyc', None)
('lib/py2-**/**.pyo', ['binary'])
('lib/py2-**/**.rpyc', ['binary'])
('lib/py2-**/**.rpymc', ['binary'])
('lib/py2-**/**/cache/*', ['binary'])
('lib/py2-**/**', ['binary'])
('lib/python2**/**__pycache__/', None)
('lib/python2**/**.pyc', None)
('lib/python2**/**.pyo', ['binary'])
('lib/python2**/**.rpyc', ['binary'])
('lib/python2**/**.rpymc', ['binary'])
('lib/python2**/**/cache/*', ['binary'])
('lib/python2**/**', ['binary'])
('renpy2.sh', ['binary'])
('lib/', ['binary'])
('jedit/**', ['jedit'])
```
</details></blockquote></details>

---
<details><summary>py3 list</summary>

Inclusion of non-pycache `.pyc` files from `/lib/python3**/`.

```
[...]
('lib/python3**/**__pycache__/', None)
('lib/python3**/**.pyc', ['binary'])
('lib/python3**/**.pyo', None)
('lib/python3**/**.rpyc', ['binary'])
('lib/python3**/**.rpymc', ['binary'])
('lib/python3**/**/cache/*', ['binary'])
('lib/python3**/**', ['binary'])
[...]
```
<blockquote><details><summary>full py3 list</summary>

```
('**~', None)
('**/#*', None)
('**/thumbs.db', None)
('**/.*', None)
('atom/', ['atom-all'])
('atom/default-dot-atom/**', ['atom-all'])
('atom/atom-windows/**', ['atom-windows'])
('atom/Atom.app/**', ['atom-mac'])
('atom/atom-linux**', ['atom-linux'])
('rapt/**/libLive2DCubismCore.so', None)
('rapt/**', ['rapt'])
('renios/prototype/base/', None)
('renios/prototype/prototype.xcodeproj/*.xcworkspace/', None)
('renios/prototype/prototype.xcodeproj/xcuserdata/', None)
('renios/prototype/**', ['renios'])
('renios/buildlib/**', ['renios'])
('renios/ios.py', ['renios'])
('renios/version.txt', ['renios'])
('renios/', ['renios'])
('web/game.zip', None)
('web/**', ['web'])
('**.old', None)
('**.new', None)
('**.bak', None)
('**/log.txt', None)
('**/traceback.txt', None)
('**/errors.txt', None)
('**/steam_appid.txt', None)
('**/saves/', None)
('**/tmp/', None)
('**/.Editra', None)
('renpy.py', ['binary'])
('renpy/**__pycache__/', ['binary'])
('renpy/**__pycache__/*.cpython-39.pyc', ['binary'])
('renpy/**.pyc', None)
('renpy/**.pyo', None)
('renpy/**.rpyc', ['binary'])
('renpy/**.rpymc', ['binary'])
('renpy/**/cache/*', ['binary'])
('renpy/**', ['source'])
('launcher/game/theme/', None)
('gui/game/gui/', None)
('launcher/**__pycache__/', None)
('launcher/**.pyc', None)
('launcher/**.pyo', None)
('launcher/**.rpyc', ['binary'])
('launcher/**.rpymc', ['binary'])
('launcher/**/cache/*', ['binary'])
('launcher/**', ['source'])
('gui/**__pycache__/', None)
('gui/**.pyc', None)
('gui/**.pyo', None)
('gui/**.rpyc', None)
('gui/**.rpymc', None)
('gui/**/cache/*', None)
('gui/**', ['source'])
('the_question/**__pycache__/', ['binary'])
('the_question/**__pycache__/*.cpython-39.pyc', ['binary'])
('the_question/**.pyc', None)
('the_question/**.pyo', None)
('the_question/**.rpyc', ['binary'])
('the_question/**.rpymc', ['binary'])
('the_question/**/cache/*', ['binary'])
('the_question/**', ['source'])
('tutorial/**__pycache__/', ['binary'])
('tutorial/**__pycache__/*.cpython-39.pyc', ['binary'])
('tutorial/**.pyc', None)
('tutorial/**.pyo', None)
('tutorial/**.rpyc', ['binary'])
('tutorial/**.rpymc', ['binary'])
('tutorial/**/cache/*', ['binary'])
('tutorial/**', ['source'])
('sdk-fonts/**', ['source'])
('doc/', ['source'])
('doc/.doctrees/', None)
('doc/_sources/', None)
('doc/**', ['source'])
('LICENSE.txt', ['source'])
('sphinx/', ['source_only'])
('sphinx/build.sh', ['source_only'])
('sphinx/checks.py', ['source_only'])
('sphinx/game/**', ['source_only'])
('sphinx/source/inc/', None)
('sphinx/source/**', ['source_only'])
('module/', ['source'])
('module/*.c', ['source'])
('module/gen/', None)
('module/*.h', ['source'])
('module/*.py*', ['source'])
('module/include/', ['source'])
('module/include/*.pxd', ['source'])
('module/include/*.pxi', ['source'])
('module/pysdlsound/', ['source'])
('module/pysdlsound/*.py', ['source'])
('module/pysdlsound/*.pyx', ['source'])
('module/fribidi-src/**', ['source'])
('lib/**/*steam_api*', ['steam'])
('lib/**/*Live2D*', None)
('lib/*linux-armv7l/', ['raspi'])
('lib/*linux-armv7l/**', ['raspi'])
('lib/py3-**/**__pycache__/', ['binary'])
('lib/py3-**/**__pycache__/*.cpython-39.pyc', ['binary'])
('lib/py3-**/**.pyc', None)
('lib/py3-**/**.pyo', None)
('lib/py3-**/**.rpyc', ['binary'])
('lib/py3-**/**.rpymc', ['binary'])
('lib/py3-**/**/cache/*', ['binary'])
('lib/py3-**/**', ['binary'])
('lib/python3**/**__pycache__/', None)
('lib/python3**/**.pyc', ['binary'])
('lib/python3**/**.pyo', None)
('lib/python3**/**.rpyc', ['binary'])
('lib/python3**/**.rpymc', ['binary'])
('lib/python3**/**/cache/*', ['binary'])
('lib/python3**/**', ['binary'])
('renpy3.sh', ['binary'])
('lib/', ['binary'])
('jedit/**', ['jedit'])
```
</details></blockquote></details>