### PR TITLE
Fix regression

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2531,7 +2531,12 @@ def get_at_list(name, layer=None, camera=False):
     tag = name[0]
     layer = default_layer(layer, tag)
 
-    return list(renpy.game.context().scene_lists.at_list[layer].get(tag, None))
+    transforms = renpy.game.context().scene_lists.at_list[layer].get(tag, None)
+
+    if transforms is None:
+        return None
+
+    return list(transforms)
 
 
 def show_layer_at(at_list, layer='master', reset=True, camera=False):


### PR DESCRIPTION
Fixes 3df81cd81: `get_at_list` can return both `None` and `list`, doing `list(None)` raises a `TypeError`.
Could probably do `get(tag, [])`, but to keep things compatible we can None-check.