### PR TITLE
Remove frozenset from the revertableset methods

### DIFF
--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -382,7 +382,7 @@ class RevertableSet(set):
 
         def newmethod(*args, **kwargs):
             rv = method(*args, **kwargs) # type: ignore
-            if isinstance(rv, (set, frozenset)):
+            if isinstance(rv, set):
                 return RevertableSet(rv)
             else:
                 return rv


### PR DESCRIPTION
Looking at the [python docs](https://docs.python.org/3/library/stdtypes.html#set), "Binary operations that mix set instances with frozenset return the type of the first operand. For example: `frozenset('ab') | set('bc')` returns an instance of frozenset."
Therefore, the functions being wrapped here should never actually return a frozenset.
And even if it somehow did, it would convert a frozenset to be mutable, and I would consider that an even greater mistake.