### PR TITLE
add Language style property "anywhere" which allow linebreaking at anywhere

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -682,7 +682,7 @@ class Layout(object):
                 elif language == "japanese-strict":
                     textsupport.annotate_unicode(par_glyphs, False, 3)
                 elif language == "anywhere":
-                    textsupport.annotate_anywhere(par_glyphs, False, 3)
+                    textsupport.annotate_anywhere(par_glyphs)
                 else:
                     raise Exception("Unknown language: {0}".format(language))
 

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -681,6 +681,8 @@ class Layout(object):
                     textsupport.annotate_unicode(par_glyphs, False, 2)
                 elif language == "japanese-strict":
                     textsupport.annotate_unicode(par_glyphs, False, 3)
+                elif language == "anywhere":
+                    textsupport.annotate_anywhere(par_glyphs, False, 3)
                 else:
                     raise Exception("Unknown language: {0}".format(language))
 

--- a/renpy/text/textsupport.pyx
+++ b/renpy/text/textsupport.pyx
@@ -179,6 +179,25 @@ def annotate_western(list glyphs):
         else:
             g.split = SPLIT_NONE
 
+
+def annotate_anywhere(list glyphs):
+    """
+    allow all characters without ruby to be used for linebreaking.
+    """
+
+    cdef Glyph g
+
+    for g in glyphs:
+
+        # Don't split ruby.
+        if g.ruby != RUBY_NONE:
+            continue
+
+        if g.character == 0x20 or g.character == 0x200b:
+            g.split = SPLIT_INSTEAD
+        else:
+            g.split = SPLIT_BEFORE
+
 # This is used to tailor the unicode break algorithm. If a character in this
 # array is mapped to not
 cdef char break_tailor[65536]

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -536,6 +536,9 @@ Text Style Properties
         Allows breaking only at whitespace. Suitable for most
         languages.
 
+    ``"anywhere"``
+        Allows breaking at anywhere without ruby.
+
     The three Japanese breaking modes are taken from the `CSS3 text module <http://www.w3.org/TR/css3-text/#line-break>`_.
 
 .. style-property:: layout string


### PR DESCRIPTION
I add Language style property "anywhere" which allow linebreaking at anywhere without ruby.
This is intended to be used when keeping a layout is preferred.