### PR TITLE
Revisit the original intention of ATL first frame

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1196,22 +1196,12 @@ class Interpolation(Statement):
         else:
             st_or_at = trans.st
 
-        # True if we want want to make sure this interpolation is shown for at
-        # least one frame.
-        if self.warper == "instant":
-            first_frame = False
-        elif state is not None:
-            first_frame = False
-        elif (self.duration == 0) and (not self.properties and not self.revolution and not self.splines):
-            first_frame = True
-        elif trans.atl_state is not None:
-            first_frame = True
-        elif st_or_at == 0:
-            first_frame = st <= self.duration
+        # Special case `pause 0` to always display a frame. This is intended to
+        # support single-frame animations that shouldn't skip.
+        if self.warper == "pause" and self.duration == 0 and renpy.config.atl_one_frame:
+            force_frame = True
         else:
-            # This is the case when we're skipping through a displayable to
-            # find the right time.
-            first_frame = False
+            force_frame = False
 
         if self.duration:
             complete = min(1.0, st / self.duration)
@@ -1335,7 +1325,7 @@ class Interpolation(Statement):
             value = interpolate_spline(complete, values)
             setattr(trans.state, name, value)
 
-        if (st >= self.duration) and ((not first_frame) or (not renpy.config.atl_one_frame)):
+        if (st >= self.duration) and (not force_frame):
             return "next", st - self.duration, None
         else:
             if not self.properties and not self.revolution and not self.splines:


### PR DESCRIPTION
Seeks to address #1650, without triggering regressions in #1254, #2834, #3041, or #3305.

Takes the original intent from 6a3aad948ffb6837b8ca85a2e8dfb3d9d84c4671 - to allow `pause 0` to ensure that at least one frame is shown before progressing, even when technically there isn't time to do so.

Where the previous approach applied this behaviour unilaterally, carving out various exceptions, this approach opts to instead actively target the special case and deal with it in isolation, which limits the impact of the forced frame on catch up in various scenarios that have appeared over the years - see referenced issues.