### PR TITLE
Pause audio when window is minimized

### DIFF
--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -218,6 +218,9 @@ init -1500 python:
          * Preference("high contrast text", "toggle") - Toggles high contrast text.
 
 
+         * Preference("audio when minimized", "enable") - Enable sounds playing when the window is not in focus.
+         * Preference("audio when minimized", "disable") - Disable sounds playing when the window is not in focus.
+         * Preference("audio when minimized", "toggle") - Toggle sounds playing when the window is not in focus.
 
          Values that can be used with bars are:
 
@@ -499,6 +502,14 @@ init -1500 python:
                 elif value == "toggle":
                     return [ ToggleField(_preferences, "high_contrast"), _DisplayReset() ]
 
+            elif name == _("audio when minimized"):
+
+                if value == "enable":
+                    return SetField(_preferences, "audio_when_minimized", True)
+                elif value == "disable":
+                    return SetField(_preferences, "audio_when_minimized", False)
+                elif value == "toggle":
+                    return SetField(_preferences, "audio_when_minimized")
 
             mixer_names = {
                 "music" : "music",

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -4177,7 +4177,17 @@ class Interface(object):
 
                     if ev.state & 2:
                         self.keyboard_focused = ev.gain
-
+                    
+                    # If the window becomes inactive as a result of this event
+                    # pause the audio according to preference
+                    if not renpy.game.preferences.audio_when_minimized:
+                        if not pygame.display.get_active():
+                            renpy.audio.audio.pause_all()
+                        # If the window had not gone inactive or has regained activity
+                        # unpause the audio
+                        else:
+                            renpy.audio.audio.unpause_all()
+                    
                     pygame.key.set_mods(0)
 
                 # This returns the event location. It also updates the

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -2014,6 +2014,9 @@ class Interface(object):
         # Should we clear the screenshot at the start of the next interaction?
         self.clear_screenshot = False
 
+        # Is our audio paused?
+        self.audio_paused = False
+
         for layer in renpy.config.layers + renpy.config.top_layers:
             if layer in renpy.config.layer_clipping:
                 x, y, w, h = renpy.config.layer_clipping[layer]
@@ -4181,12 +4184,14 @@ class Interface(object):
                     # If the window becomes inactive as a result of this event
                     # pause the audio according to preference
                     if not renpy.game.preferences.audio_when_minimized:
-                        if not pygame.display.get_active():
+                        if not pygame.display.get_active() and not self.audio_paused:
                             renpy.audio.audio.pause_all()
+                            self.audio_paused = True
                         # If the window had not gone inactive or has regained activity
                         # unpause the audio
-                        else:
+                        elif pygame.display.get_active() and self.audio_paused:
                             renpy.audio.audio.unpause_all()
+                            self.audio_paused = False
                     
                     pygame.key.set_mods(0)
 

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -170,6 +170,8 @@ Preference("system_cursor", False)
 # Do we force high contrast text?
 Preference("high_contrast", False)
 
+# Should sound continue playing when the window is minimized?
+Preference("audio_when_minimized", False)
 
 class Preferences(renpy.object.Object):
     """
@@ -217,6 +219,7 @@ class Preferences(renpy.object.Object):
         font_line_spacing = 1.0
         system_cursor = False
         high_contrast = False
+        audio_when_minimized = False
 
     def init(self):
         """

--- a/sphinx/source/preferences.rst
+++ b/sphinx/source/preferences.rst
@@ -153,6 +153,12 @@ can then change it again.)
     :var:`config.mouse` value. If False, it will not. The equivalent of the
     "system cursor" preference.
 
+.. var:: preferences.audio_when_minimized = False
+
+    If True, audio channels are not stopped from playing when the window is
+    minimized. If False audio channels will be stopped when the window is minimized. 
+    The equivalent of the "audio when minimized" preference.
+
 Mixer Functions
 ---------------
 


### PR DESCRIPTION
Attempted implementation of #2645. Governed by a preference; should pause all audio tracks when the game window is minimized and resume them when it is maximized by default.