### PR TITLE
Rewrite docs for Creator-Defined Statements

### DIFF
--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -3,66 +3,192 @@
 Creator-Defined Statements
 ==========================
 
-Creator-Defined Statements (CDS) allow you to add your own statements to Ren'Py. This
-makes it possible to add things that are not supported by the current syntax of
-Ren'Py. CDS are more flexible than the direct Python code. Most often, CDS are used
-when you have a repeatable construction. For example, calling a function with one argument.
-Ren'Py does not know what this function does and how it should be executed,
-so Ren'Py does not do anything with it until execution and has an error if an exception occurs.
-Using the CDS allows you to check the correctness of the syntax using parse
-(for example, check that the argument is a valid string), to ignore incorrect data
-at execution (for non-critical functions, it is better to skip the execute than
-to throw an exception), predict displayables (if the function uses them),
-and give you addition information during lint (if at runtime it was ignored you
-can have a report here). The CDS does not guarantee that the execution will be successful,
+Creator-Defined Statements (CDS) allow you to add your own statements to
+Ren'Py's scripting language. This makes it possible to add functionality that
+is not supported by the current syntax.
+
+CDS can be more flexible than the direct Python code equivalent.
+
+For example, picking a line of dialogue at random:
+
+::
+
+    label introduction:
+        python:
+            greetings = ['Hello.', 'Welcome.', 'Can I help you?']
+            greeting = renpy.random.choice(greetings)
+
+        "[greeting]"
+
+
+Ren'Py's parser does not know ahead of time what happens in the python block or how it should be executed.
+It does not do anything with this code until execution and triggers an error if an exception occurs.
+
+Using a CDS allows you to:
+
+- Check the correctness of the parsed syntax (For example, check that the items in the list sent to renpy.random.choice have valid text)
+
+- Ignore incorrect data at execution (For non-critical functions, it is often better to skip the execution than to throw an exception)
+
+- Predict Displayables (If the function uses them)
+
+- Give you addition information during lint (If at runtime an error was ignored you can have a report here).
+
+For example, the above behaviour, but written as a CDS:
+
+::
+
+    python early:
+        def parse_random(lexer):
+            subblock_lexer = lexer.subblock_lexer()
+            choices = []
+
+            while subblock_lexer.advance():
+                with subblock_lexer.catch_error():
+                    statement = subblock_lexer.renpy_statement()
+                    choices.append(statement)
+
+            return choices
+
+
+        def next_random(choices):
+            return renpy.random.choice(choices)
+
+
+        def lint_random(parsed_object):
+            for i in parsed_object:
+                renpy.check_text_tags(i.what)
+
+
+        renpy.register_statement(
+            name="random",
+            block=True,
+            parse=parse_random,
+            next=next_random,
+            lint=lint_random,
+        )
+
+
+``random`` is now available as a statement:
+
+::
+
+    label introduction:
+        random:
+            "Hello."
+            "Welcome."
+            "Can I help you?"
+
+
+Using a CDS does not guarantee that the execution will be successful,
 but the better you code your statement, the better Ren'Py can "understand" what
 you expect from it.
 
-Creator-defined statements must be defined in a ``python early`` block. What's more,
-the filename containing the user-defined statement must be be loaded earlier
-than any file that uses it. Since Ren'Py loads files in Unicode sort order, it
-generally makes sense to prefix the name of any file containing a user-defined
-statement with 01, or some other small number.
 
-A creator-defined statement cannot be used in the file in which it is defined.
+Usage
+-----
 
-Creator-defined statement are registered using the :func:`renpy.register_statement`
-function.
+Creator-Defined Statements (CDS) must conform to the following rules:
+
+- They must be defined in a ``python early`` block.
+
+- They cannot be used in the same file in which they are defined.
+
+- The file containing the CDS must be loaded earlier than any file that uses it.
+(Since Ren'Py loads files in Unicode sort order, it generally makes sense to
+prefix the name of any file containing a CDS with 01 or some other small number.)
+
+Creator-Defined Statements are registered using the :func:`renpy.register_statement`
+function. This functions takes other functions that perform operations on the content of the CDS.
+
+For example, a new statement named ``line`` that allows lines of text to be specified
+without quotes.
+
+::
+
+    line e "These quotes will show up," Eileen said, "and don't need to be backslashed."
+
+The parse function will be sent the lexed content for parsing.
+The execute function should run an operation on the parsed content.
+The lint function should report any errors in the parsed content.
+
+::
+
+    python early:
+        def parse_smartline(lexer):
+            who = lexer.simple_expression()
+            what = lexer.rest()
+            return (who, what)
+
+        def execute_smartline(parsed_object):
+            who, what = parsed_object
+            renpy.say(eval(who), what)
+
+        def lint_smartline(parsed_object):
+            who, what = parsed_object
+            try:
+                eval(who)
+            except Exception:
+                renpy.error("Character not defined: {}".format(who))
+
+            tte = renpy.check_text_tags(what)
+            if tte:
+                renpy.error(tte)
+
+        renpy.register_statement(
+            "line",
+            parse=parse_smartline,
+            execute=execute_smartline,
+            lint=lint_smartline,
+        )
+
+
+API Reference
+-------------
 
 .. include:: inc/statement_register
 
-The parse method takes a Lexer object:
+
+Lexer object
+~~~~~~~~~~~~
+
+A custom statement's parse function takes an instance of a Lexer object.
 
 .. class:: Lexer
 
     .. method:: error(msg)
 
-        Adds a `msg` (with the current position) in the list of detected
+        :param str msg: Message to add to the list of detected parsing errors.
+
+        Add `msg` (with the current position) to the list of detected
         parsing errors. This interrupts the parsing of the current statement,
         but does not prevent further parsing.
 
     .. method:: require(thing, name=None)
 
-        Tries to parse `thing`, and reports an error if it cannot be done.
+        Try to parse `thing` and report an error if it cannot be done.
 
-        If `thing` is a string, tries to parse it using :func:`match`.
-        Otherwise, thing must be a other method on this lexer object,
-        which is called without arguments. If `name` is not specified,
-        the name of the method will be used in the message
-        (or `thing` if it's a string), otherwise the `name` will be used.
+        If `thing` is a string, try to parse it using :func:`match`.
+
+        Otherwise, thing must be another method on this lexer object which is
+        called without arguments.
+
+        If `name` is not specified, the name of the method will be used in the
+        message (or `thing` if it's a string), otherwise `name` will be used.
 
     .. method:: eol()
 
-        True if the lexer is at the end of the line.
+        :return: True if the lexer is at the end of the line, else False.
+        :rtype: bool
 
     .. method:: expect_eol()
 
-        If we are not at the end of the line, raise an error.
+        If not at the end of the line, raise an error.
 
     .. method:: expect_noblock(stmt)
 
         Called to indicate this statement does not expect a block.
-        If a block is found, raises an error. `stmt` should be a string,
+        If a block is found, raise an error. `stmt` should be a string,
         it will be added to the message with an error.
 
     .. method:: expect_block(stmt)
@@ -73,11 +199,12 @@ The parse method takes a Lexer object:
 
     .. method:: has_block()
 
-        True if the current line has a non-empty block.
+        :return: True if the current line has a non-empty block, else False.
+        :rtype: bool
 
     .. method:: match(re)
 
-        Matches an arbitrary regexp string.
+        Match an arbitrary regexp string.
 
         All of the statements in the lexer that match things are implemented
         in terms of this function. They first skip whitespace, then attempt
@@ -87,52 +214,59 @@ The parse method takes a Lexer object:
 
     .. method:: keyword(s)
 
-        Matches `s` as a keyword.
+        Match `s` as a keyword.
 
     .. method:: name()
 
-        Matches a name. This does not match built-in keywords.
+        Match a name. This does not match built-in keywords.
 
     .. method:: word()
 
-        Matches any word, including keywords. Returns the text of the
-        matched word.
+        :return: The text of the matched word.
+        :rtype: str
+
+        Match any word, including keywords.
 
     .. method:: image_name_component()
 
-        Matches an image name component. Unlike a word, a image name
+        Match an image name component. Unlike a word, an image name
         component can begin with a number.
 
     .. method:: string()
 
-        Matches a Ren'Py string.
+        Match a Ren'Py string.
 
     .. method:: integer()
 
-        Matches an integer, returns a string containing the integer.
+        :return: String containing the found integer.
+        :rtype: str
+
+        Match an integer.
 
     .. method:: float()
 
-        Matches a floating point number, returns a string containing the
-        floating point number.
+        :return: String containing the found floating point number.
+        :rtype: str
+
+        Match a floating point number.
 
     .. method:: label_name(declare=False)
 
-        Matches a label name, either absolute or relative. If `declare`
+        Match a label name, either absolute or relative. If `declare`
         is true, then the global label name is set. (Note that this does not
         actually declare the label - the statement is required to do that
         by returning it from the `label` function.)
 
     .. method:: simple_expression()
 
-        Matches a simple Python expression, returns it as a string.
+        Match a simple Python expression, returns it as a string.
         This is often used when you expect a variable name.
         It is not recommended to change the result. The correct action is
         to evaluate the result in the future.
 
     .. method:: delimited_python(delim)
 
-        Matches a Python expression that ends in a `delim`, for example ':'.
+        Match a Python expression that ends in a `delim`, for example ':'.
         This is often used when you expect a condition until the delimiter.
         It is not recommended to change the result. The correct action is
         to evaluate the result in the future. This raises an error if
@@ -150,11 +284,11 @@ The parse method takes a Lexer object:
 
     .. method:: rest()
 
-        Skips whitespace, then returns the rest of the line.
+        Skip whitespace, then return the rest of the line.
 
     .. method:: checkpoint()
 
-        Returns an opaque object representing the current state of the lexer.
+        Return an opaque object representing the current state of the lexer.
 
     .. method:: revert(o)
 
@@ -164,12 +298,12 @@ The parse method takes a Lexer object:
 
     .. method:: subblock_lexer()
 
-        Return a Lexer for the block associated with the current line.
+        :return: A Lexer for the block associated with the current line.
 
     .. method:: advance()
 
-        In a subblock lexer, advances to the next line. This must be called
-        before the first line, so the first line can be parsed. Returns True
+        In a subblock lexer, advance to the next line. This must be called
+        before the first line, so the first line can be parsed. Return True
         if we've successfully advanced to a line in the block, or False
         if we have advanced beyond all lines in the block.
 
@@ -182,13 +316,13 @@ The parse method takes a Lexer object:
         not be stored except as part of the parse result of the statement.
 
         When the statement returned from this completes, control is
-        transfered to the statement after the creator-defined statement.
+        transferred to the statement after the creator-defined statement.
         (Which might be the statement created using post_execute).
 
     .. method:: renpy_block(empty=False)
 
-        This parses all of the remaining lines in the current block
-        as Ren'Py script, and returns a SubParse corresponding to the
+        Parse all of the remaining lines in the current block
+        as Ren'Py script, and return a SubParse corresponding to the
         first statement in the block. The block is chained together such
         that all statements in the block are run, and then control is
         transferred to the statement after this creator-defined statement.
@@ -242,47 +376,9 @@ The parse method takes a Lexer object:
                 return { "strings" : strings }
 
 
-
-
-
-
 Lint Utility Functions
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
-These functions are useful in writing lint functions.
+These functions are useful when writing lint functions.
 
 .. include:: inc/lint
-
-Example
--------
-
-This creates a new statement ``line`` that allows lines of text to be specified
-without quotes. ::
-
-    python early:
-
-        def parse_smartline(lex):
-            who = lex.simple_expression()
-            what = lex.rest()
-            return (who, what)
-
-        def execute_smartline(o):
-            who, what = o
-            renpy.say(eval(who), what)
-
-        def lint_smartline(o):
-            who, what = o
-            try:
-                eval(who)
-            except Exception:
-                renpy.error("Character not defined: %s" % who)
-
-            tte = renpy.check_text_tags(what)
-            if tte:
-                renpy.error(tte)
-
-        renpy.register_statement("line", parse=parse_smartline, execute=execute_smartline, lint=lint_smartline)
-
-This can be used by writing::
-
-    line e "These quotes will show up," Eileen said, "and don't need to be backslashed."


### PR DESCRIPTION
This PR makes the following changes to the CDS docs:

- Move the example section to the top of the page. This established a hierarchy for the information from broad to increasing in specific detail.
- Adds return values to the Lexer class docs.
- Change Lexer method docs from a passive voice ("Returns the apple") to an active voice ("Return the apple")