### PR TITLE
Expand doc on @ and minus for image attributes

### DIFF
--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -125,24 +125,12 @@ is equivalent to::
         show eileen happy
         e "But it's just a passing thing."
 
-
-When the image attribute begins with an @, the change is temporary, and
-reverts to the previously displaying image at the end of the line of dialogue.
+In the above example, the ``mad`` and ``happy`` replace one another.
+But it is possible to revert to a ``happy``\ -less eileen without specifying
+the ``mad`` attribute. An attribute name prepended with the minus sign ( - )
+has that effect, just as it does with the :ref:`show statement <show-statement>`.
 
 For example::
-
-    define e = Character("Eileen", image="eileen")
-
-    label start:
-
-        show eileen mad
-        e "I'm a little upset at you."
-
-        e @ happy "That's funny."
-
-        e "But don't think it gets you out of hot water."
-
-is equivalent to::
 
     define e = Character("Eileen")
 
@@ -154,13 +142,34 @@ is equivalent to::
         show eileen happy
         e "That's funny."
 
-        show eileen mad
-        e "But don't think it gets you out of hot water."
+        show eileen -happy
+        e "I'm not sure what to think now."
 
-The two syntaxes can be combined, with the permanent changes coming before
-the @ and the temporary ones coming after. ::
+When an @ is included in the list of attributes, any element placed after it
+has an only temporary effect, and is reverted at the end of the line of dialogue.
+
+For example, the following code is equivalent to the previous example::
+
+    define e = Character("Eileen", image="eileen")
+
+    label start:
+
+        show eileen mad
+        e "I'm a little upset at you."
+
+        e @ happy "That's funny."
+
+        e "I'm not sure what to think now."
+
+A single line can combine permanent changes coming before
+the @, and temporary ones coming after. ::
 
     e happy @ vhappy "Really! That changes everything."
+
+The minus sign can also be used after the @ sign::
+
+    e @ right -mad "My anger is temporarily suspended..."
+    e "HOWEVER !"
 
 To cause a transition to occur whenever the images are changed in this way, set
 :var:`config.say_attribute_transition` to a transition. For more control,

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -244,7 +244,25 @@ Some example show statements are::
     # Show an image on a user-defined layer.
     show moon onlayer user_layer
 
-**Show Expression.**
+Attributes management
+---------------------
+
+As shown above, attributes can be set, added and replaced.
+
+They can also be removed using the minus sign::
+
+     # show susan being neutral
+     show susan
+
+     # show susan being happy
+     show susan happy
+
+     # show susan being neutral again
+     show susan -happy
+
+Show expression
+---------------
+
 A variant of the show statement replaces the image name with the
 keyword ``expression``, followed by a simple expression. The
 expression must evaluate to a displayable, and the displayable

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -273,7 +273,9 @@ For example::
 
     show expression "moon.png" as moon
 
-** Show Layer.**
+Show Layer
+----------
+
 The ``show layer`` statement is discussed alongside the camera statement,
 below.
 


### PR DESCRIPTION
fix #3443

I also expanded the doc about the show statement to include how the minus sign behaves.