### PR TITLE
Subclass functools.partial for better performance

### DIFF
--- a/renpy/curry.py
+++ b/renpy/curry.py
@@ -47,6 +47,7 @@ class Curry(object):
         return rv
 
     def __setstate__(self, state):
+        state.pop('hash', None)
         state = (state.pop('callable'), state.pop('args'), state.pop('kwargs'), state)
         return super(Partial, self).__setstate__(state)
 

--- a/renpy/curry.py
+++ b/renpy/curry.py
@@ -79,7 +79,9 @@ class Partial(functools.partial):
 
     __slots__ = ("hash",)
 
-    hash = None
+    def __init__(self, *args, **kwargs):
+        super(Partial, self).__init__(*args, **kwargs)
+        self.hash = None
 
     def __repr__(self):
         return "<partial %s %r %r>" % (self.func, self.args, self.keywords)

--- a/renpy/curry.py
+++ b/renpy/curry.py
@@ -77,19 +77,16 @@ class Partial(functools.partial):
     supplied to the call.
     """
 
-    __slots__ = ("hash",)
-
+    __slots__ = ('hash',)
 
     def __repr__(self):
         return "<partial %s %r %r>" % (self.func, self.args, self.keywords)
 
     def __eq__(self, other):
-
-        return (
-            isinstance(other, Partial) and
-            self.func == other.func and
-            self.args == other.args and
-            self.keywords == other.keywords)
+        return (isinstance(other, Partial) and
+                self.func == other.func and
+                self.args == other.args and
+                self.keywords == other.keywords)
 
     def __ne__(self, other):
         return not (self == other)

--- a/renpy/curry.py
+++ b/renpy/curry.py
@@ -35,10 +35,13 @@ class Curry(object):
     """
 
     def __new__(cls, *args, **kwargs):
-        if not args: # probably unpickling, pass arbitrary callable
-            args = (hash,)
+        if args:
+            return Partial(*args, **kwargs)
 
-        rv = Partial(*args, **kwargs)
+        # No args supplied, so likely we're trying to unpickle an instance
+        # from an old save. Create a new Partial with an arbitrary function
+        # which will be updated in a moment by __setstate__.
+        rv = Partial(hash)
         rv.__setstate__ = cls.__setstate__.__get__(rv)
 
         return rv

--- a/renpy/curry.py
+++ b/renpy/curry.py
@@ -79,9 +79,6 @@ class Partial(functools.partial):
 
     __slots__ = ("hash",)
 
-    def __init__(self, *args, **kwargs):
-        super(Partial, self).__init__(*args, **kwargs)
-        self.hash = None
 
     def __repr__(self):
         return "<partial %s %r %r>" % (self.func, self.args, self.keywords)
@@ -98,14 +95,17 @@ class Partial(functools.partial):
         return not (self == other)
 
     def __hash__(self):
+        _hash = getattr(self, 'hash', None)
 
-        if self.hash is None:
-            self.hash = hash(self.func) ^ hash(self.args)
+        if _hash is None:
+            _hash = hash(self.func) ^ hash(self.args)
 
             for i in self.keywords.items():
-                self.hash ^= hash(i)
+                _hash ^= hash(i)
 
-        return self.hash
+            setattr(self, 'hash', _hash)
+
+        return _hash
 
 
 def curry(fn):


### PR DESCRIPTION
Builds on @Gouvernathor's work in #3246 to address some of the compatibility concerns and provide a clean migration path when deserialising old save data, without introducing further dependency on the old Curry class.

To help give confidence in the unpickling approach, a small demonstration of pickles being created with the old code, and unpickled with the new code (in py2, and py3) can be found here: https://gist.github.com/mal/65d2a5aa3dc22480b712b2088c452282. 

Relevant notes from commit messages:

> The underlying functools.partial doesn't have an \_\_init__ method, so the
> super call bounces up to object which doesn't take arguments. This is
> fine in normal use but presented issues in some pickling scenarios.
> 
> Since we can be slightly more efficient without it, and it avoids the
> edge cases with pickle, nuke it.

> [Migration] is done by having [Curry]'s \_\_new__ method return a Partial instance
> created with a placeholder callable (hash), and rebound setstate method
> capable of converting the state of the old Curry instance into the
> format that functools.partial expects.
> 
> Any attempt to create a new instance of the Curry class directly will
> result in an instance of Partial, avoiding further propagation of the
> deprecated class.
> 
> As all of the extra work for compatibility only occurs when attempting
> to deserialise Curry instances, we don't impact performance of the new
> Partial class, or compromise it's API into the future.