### PR TITLE
add config.show_volume_in_mute

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -978,7 +978,7 @@ ftfont_vertical_extent_scale = { }
 default_shader = "renpy.geometry"
 
 # If True, the volume of a channel is shown when it is mute.
-show_volume_in_mute = False
+preserve_volume_when_muted = False
 
 
 def say_attribute_transition_callback(*args):

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -977,6 +977,9 @@ ftfont_vertical_extent_scale = { }
 # The default shader.
 default_shader = "renpy.geometry"
 
+# If True, the volume of a channel is shown when it is mute.
+show_volume_in_mute = False
+
 
 def say_attribute_transition_callback(*args):
     """

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -260,7 +260,7 @@ class Preferences(renpy.object.Object):
         self.init()
 
     def set_volume(self, mixer, volume):
-        if not renpy.config.show_volume_in_mute and volume != 0:
+        if not renpy.config.preserve_volume_when_muted and volume != 0:
             self.mute[mixer] = False
 
         self.volumes[mixer] = volume
@@ -269,7 +269,7 @@ class Preferences(renpy.object.Object):
         if mixer not in self.volumes:
             return 0.0
 
-        if not renpy.config.show_volume_in_mute and self.mute.get(mixer, False):
+        if not renpy.config.preserve_volume_when_muted and self.mute.get(mixer, False):
             return 0.0
 
         return self.volumes[mixer]
@@ -277,7 +277,7 @@ class Preferences(renpy.object.Object):
     def set_mute(self, mixer, mute):
         self.mute[mixer] = mute
 
-        if not renpy.config.show_volume_in_mute:
+        if not renpy.config.preserve_volume_when_muted:
             if (not mute) and (self.volumes.get(mixer, 1.0) == 0.0):
                 self.volumes[mixer] = 1.0
 

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -260,7 +260,7 @@ class Preferences(renpy.object.Object):
         self.init()
 
     def set_volume(self, mixer, volume):
-        if volume != 0:
+        if not renpy.config.show_volume_in_mute and volume != 0:
             self.mute[mixer] = False
 
         self.volumes[mixer] = volume
@@ -269,7 +269,7 @@ class Preferences(renpy.object.Object):
         if mixer not in self.volumes:
             return 0.0
 
-        if self.mute.get(mixer, False):
+        if not renpy.config.show_volume_in_mute and self.mute.get(mixer, False):
             return 0.0
 
         return self.volumes[mixer]
@@ -277,8 +277,9 @@ class Preferences(renpy.object.Object):
     def set_mute(self, mixer, mute):
         self.mute[mixer] = mute
 
-        if (not mute) and (self.volumes.get(mixer, 1.0) == 0.0):
-            self.volumes[mixer] = 1.0
+        if not renpy.config.show_volume_in_mute:
+            if (not mute) and (self.volumes.get(mixer, 1.0) == 0.0):
+                self.volumes[mixer] = 1.0
 
     def get_mute(self, mixer):
         if mixer not in self.volumes:

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1007,6 +1007,12 @@ Occasionally Used
 
     If None, the default, this defaults to the value of :var:`config.name`.
 
+.. var:: config.show_volume_in_mute = False
+
+    If False, the default, the volume of channels are shown as 0 and
+    changing it disables mute when the channel is mute.
+    Otherwise, It is shown and adjustable while keeping mute.
+
 
 
 Rarely or Internally Used

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1007,7 +1007,7 @@ Occasionally Used
 
     If None, the default, this defaults to the value of :var:`config.name`.
 
-.. var:: config.show_volume_in_mute = False
+.. var:: config.preserve_volume_when_muted = False
 
     If False, the default, the volume of channels are shown as 0 and
     changing it disables mute when the channel is mute.


### PR DESCRIPTION
Currently, volume bars show that value as 0 when it is mute and changing the bar disables mute.
I added config.show_volume_in_mute.
If False, the default, the behavior isn't changed. Otherwise, volumes are shown and adjustable while keeping mute when it is mute.