### PR TITLE
fix (tutorial): Correct typo in dialogue

### DIFF
--- a/tutorial/game/tutorial_atl.rpy
+++ b/tutorial/game/tutorial_atl.rpy
@@ -570,7 +570,7 @@ label tutorial_atl:
 
     show example atl_transform
 
-    e "The simplest thing we can to is to statically position an image. This is done by giving the names of the position properties, followed by the property values."
+    e "The simplest thing we can do is to statically position an image. This is done by giving the names of the position properties, followed by the property values."
 
     show example atl_transform1
     show logo base at move_jump


### PR DESCRIPTION
Just noticed this while going through the tutorial. I'm not sure if the second "to" is actually needed, but I am fairly sure the first one is supposed to be "do."