### PR TITLE
Fix scoped nested string interpolation

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -164,7 +164,13 @@ class Formatter(string.Formatter):
         if literal:
             yield (literal, None, None, None)
 
+    def get_field(self, field_name, args, kwargs):
+        obj, arg_used = super(Formatter, self).get_field(field_name, args, kwargs)
+
+        return (obj, kwargs), arg_used
+
     def convert_field(self, value, conversion):
+        value, kwargs = value
 
         if conversion is None:
             return value
@@ -194,7 +200,7 @@ class Formatter(string.Formatter):
 
         if "i" in conversion:
             try:
-                value = substitute(value, translate=False)[0]
+                value = self.vformat(value, (), kwargs)
             except RuntimeError: # PY3 RecursionError
                 raise ValueError("Substitution {!r} refers to itself in a loop.".format(value))
 


### PR DESCRIPTION
Previously nested interpolations would lose scope due to it not being
pushed down into the recursive call. Unfortunately the fix is slightly
non-trivial.

The string.Formatter class does not naturally expose the provided scope
to the convert_field method which is where we need it for nested
interpolations. In order to get it there we use the expectation
(documented, see ref) that the value provided to convert_field is the
obj returned by get_field which is supplied with the scope.

Additionally we handle nested interpolation via a call to self.vformat,
rather than round tripping through renpy.substitute since we're actively
not translating or changing the scope.

Fixes https://github.com/renpy/renpy/issues/3492