### PR TITLE
fix (tutorial): Correct typos

### DIFF
--- a/tutorial/game/indepth_minigame.rpy
+++ b/tutorial/game/indepth_minigame.rpy
@@ -223,14 +223,14 @@ label demo_minigame:
 
     e "Screens will work for many simulation-style games and RPGs."
 
-    e "When screens are not enough you can write a creator-defined displayable to extend Ren'Py itself. A Creator-defined displayables can process raw events and draw to the screen."
+    e "When screens are not enough, you can write a creator-defined displayable to extend Ren'Py itself. A creator-defined displayable can process raw events and draw to the screen."
 
     e "That makes it possible to create all kinds of minigames. Would you like to play some pong?"
 
 example minigame hide:
     label play_pong:
 
-        window hide  # Hide the window and  quick menu while in pong
+        window hide  # Hide the window and quick menu while in pong
         $ quick_menu = False
 
         call screen pong

--- a/tutorial/game/indepth_style.rpy
+++ b/tutorial/game/indepth_style.rpy
@@ -193,7 +193,7 @@ label style_basics:
 
     e "Each displayable has a default style name. By default, it's usually the lower-case displayable name, like 'text' for Text, or 'button' for buttons."
 
-    e "In a screen, a displayable can be given the style_prefix property to give a prefix for that displayable and it's children."
+    e "In a screen, a displayable can be given the style_prefix property to give a prefix for that displayable and its children."
 
     e "For example, a text displayable with a style_prefix of 'help' will be given the style 'help_text'."
 
@@ -590,9 +590,9 @@ label style_button:
     show screen button('example_button')
     with dissolve
 
-    e "I'll start off with this style, which everything will inherit from. To make our lives easier, it inherits from the default style, rather than the customizes buttons in this game's GUI."
+    e "I'll start off with this style, which everything will inherit from. To make our lives easier, it inherits from the default style, rather than the customized buttons in this game's GUI."
 
-    e "The first style property is the background property. It adds a background to the a button or window. Since this is a button, idle and hover variants choose different backgrounds when focused."
+    e "The first style property is the background property. It adds a background to a button or window. Since this is a button, idle and hover variants choose different backgrounds when focused."
 
     e "We also center the two buttons, using the xalign position property."
 
@@ -814,7 +814,7 @@ label style_bar:
 
     show screen bar('thumb_bar')
 
-    e "The thumb style property gives a thumb image, that's placed based on the bars value. In the case of a scrollbar, it's resized if possible."
+    e "The thumb style property gives a thumb image, that's placed based on the bar's value. In the case of a scrollbar, it's resized if possible."
 
     e "Here, we use it with the base_bar style property, which sets both bar images to the same displayable."
 

--- a/tutorial/game/tutorial_screen_displayables.rpy
+++ b/tutorial/game/tutorial_screen_displayables.rpy
@@ -173,7 +173,7 @@ label add_displayable:
                 xalign 0.5 ypos 50
                 add "images/logo base.png"
 
-    e "An image can also be referred to by it's filename, relative to the game directory."
+    e "An image can also be referred to by its filename, relative to the game directory."
 
     example large:
 
@@ -233,7 +233,7 @@ label text_displayable:
 
     e "The text displayable can also interpolate values enclosed in square brackets."
 
-    e "When text is displayed in a screen using the text statement variables defined in the screen take precedence over those defined outside it."
+    e "When text is displayed in a screen using the text statement, variables defined in the screen take precedence over those defined outside it."
 
     e "Those variables may be parameters given to the screen, defined with the default or python statements, or set using the SetScreenVariable action."
 
@@ -470,7 +470,7 @@ label button_displayables:
                         text _("Heal") style "button_text" yalign 0.5
                         bar value AnimatedValue(health, 100, 1.0) yalign 0.5 xsize 200
 
-    e "A button takes another displayable as children. Since that child can be a layout, it can takes as many children as you want."
+    e "A button takes another displayable as children. Since that child can be a layout, it can take as many children as you want."
 
     example large:
         screen textbutton_example():
@@ -601,7 +601,7 @@ label bar_displayables:
 
     e "The top style is the 'bar' style. It's used to display values that the player can't adjust, like a life or progress bar."
 
-    e "The middle stye is the 'slider' value. It's used for values the player is expected to adjust, like a volume preference."
+    e "The middle style is the 'slider' value. It's used for values the player is expected to adjust, like a volume preference."
 
     e "Finally, the bottom style is the 'scrollbar' style, which is used for horizontal scrollbars. When used as a scrollbar, the thumb in the center changes size to reflect the visible area of a viewport."
 

--- a/tutorial/game/tutorial_screen_displayables.rpy
+++ b/tutorial/game/tutorial_screen_displayables.rpy
@@ -470,7 +470,7 @@ label button_displayables:
                         text _("Heal") style "button_text" yalign 0.5
                         bar value AnimatedValue(health, 100, 1.0) yalign 0.5 xsize 200
 
-    e "A button takes another displayable as children. Since that child can be a layout, it can take as many children as you want."
+    e "A button takes another displayable as a child. Since that child can be a layout, it can take as many children as you want."
 
     example large:
         screen textbutton_example():

--- a/tutorial/game/tutorial_screens.rpy
+++ b/tutorial/game/tutorial_screens.rpy
@@ -262,7 +262,7 @@ label screens_showing:
                         action Return(True)
 
 
-    e "Here's an example of a very simple screen. The screen statement is used to tell Ren'Py this is a screen, and it's name is simple_screen."
+    e "Here's an example of a very simple screen. The screen statement is used to tell Ren'Py this is a screen, and its name is simple_screen."
 
     e "Inside the screen statement, lines introduces displayables such as frame, vbox, text, and textbutton; or properties like action, xalign, and ypos."
 


### PR DESCRIPTION
I found a few more typos after submitting https://github.com/renpy/renpy/pull/3491. I waited until I was done with the rest of the tutorial so they could all be handled in the same commit. They're all in the dialogue except one that's in an example's comment (just an extra space between two words).