### PR TITLE
Tweak changelog formulations

### DIFF
--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -39,8 +39,8 @@ games are:
   way that interpolation works in Ren'Py dialogue. This is only available
   in Python, however, and not in most purely Ren'Py statements.
 
-There are a huge other improvements in the ten major release of Python
-between 2.7 and 3.9, so be sure to read the above and other Python
+There are a huge amount of other improvements in the ten major release of
+Python between 2.7 and 3.9, so be sure to read the above and other Python
 documentation to find out everything that's improved.
 
 One of the greatest advantages is that this moves Ren'Py off Python 2.7,
@@ -368,8 +368,6 @@ been documented, and controls the same thing with multipersistent data.
 The new :var:`config.at_exit_callbacks` function are called when the game
 quits. This is intended to allow the game to save additional data created
 by the developer.
-
-The :func:`HideSelf` action can be used by a screen to hide itself.
 
 The :var:`config.default_attribute_callbacks` variable allows a game to
 specify default attributes for a tag that are used when other attributes

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -39,7 +39,7 @@ games are:
   way that interpolation works in Ren'Py dialogue. This is only available
   in Python, however, and not in most purely Ren'Py statements.
 
-There are a huge amount of other improvements in the ten major release of
+There are a huge number of other improvements in the ten major releases of
 Python between 2.7 and 3.9, so be sure to read the above and other Python
 documentation to find out everything that's improved.
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -27,16 +27,17 @@ so please check that and other Python websites for descriptions.
 That being said, a few things made available to the Python in your Ren'Py
 games are:
 
-* The ability to annotate functions arguments and return values with type
-  information. (This is only supported in Python.)
-
 * Functions can have keyword-only parameters. (These are also supported
   in parameter lists for labels, transforms, and screens.)
 
-* Formatted string literals can now be used in Python code. These are
-  strings like ``f"characters/{character}.chr"``, where the text in
+* The ability to annotate functions arguments and return values with type
+  information. (This is only supported in Python.)
+
+* Formatted string literals can now be used. These
+  are strings like ``f"characters/{character}.chr"``, where the text in
   braces is replaced by a formatted Python variable, similarly to the
-  way that interpolation works in Ren'Py dialogue.
+  way that interpolation works in Ren'Py dialogue. This is only available
+  in Python, however, and not in most purely Ren'Py statements.
 
 There are a huge other improvements in the ten major release of Python
 between 2.7 and 3.9, so be sure to read the above and other Python
@@ -50,7 +51,7 @@ There are a few things that may need to be converted if you used advanced
 Python.
 
 * In Python 3, division always returns a float, rather than an integer.
-  (for example, ``3 / 2`` is now 1.5 rather than 1.) The ``//`` operator
+  (for example, ``3 / 2`` is now 1.5 rather than 1). The ``//`` operator
   divides as an integer. This change can affect Ren'Py positioning,
   where floats are treated differently from integers.
 
@@ -81,7 +82,7 @@ macOS, Linux, Android, and iOS platforms. The web platform will
 be supported in a future release.
 
 When running under Ren'Py 8, Ren'Py now runs without the equivalent of the
-Python ``-O`` flag. This means that docstrings and yield statements are
+Python ``-O`` flag. This means that docstrings and assert statements are
 available.
 
 Our experience is that many games run unchanged under Python 3, especially


### PR DESCRIPTION
- put the part when things are supported outside of Python before the part where thins are only supported inside Python, to make it clearer what we mean by "in Python" in that context
- make it clearer that f-strings are only supported in pure-python areas, and that they aren't recognized by the parser in most other areas
- move a misleading dot, to make it clear that in that context 1 is an integer
- unless I'm mistaken the optimizer flags disable the assert statement, not the yield statement