### PR TITLE
Tweak substitution

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -175,10 +175,12 @@ class Formatter(string.Formatter):
         if conversion is None:
             return value
 
+        conversion = conversion.replace("!", "")
+
         if not conversion:
             raise ValueError("Conversion specifier can't be empty.")
 
-        if set(conversion) - set("rstqulci!"):
+        if set(conversion) - set("rstqulci"):
             raise ValueError("Unknown symbols in conversion specifier, this must use only the \"rstqulci\".")
 
         if "r" in conversion:
@@ -214,7 +216,7 @@ class Formatter(string.Formatter):
             value = value.lower()
 
         if "c" in conversion and value:
-            value = value[0].upper() + value[1:]
+            value = value[0].capitalize() + value[1:]
 
         return value
 


### PR DESCRIPTION
- tweak 1ba50f11da46e6f3519f0dbb8a9419cd4df18588 to still disallow "[var!!]" the way "[var!]" is rejected, and to allow the `not conversion` optimization when there's multiple bangs
- tweak 461bddf7f3dd8396daf2b20a7825dde2720583b3 to apply capitalize, not upper, on the first character (see https://docs.python.org/3/library/stdtypes.html#str.capitalize as for why it's different)