### PR TITLE
Launcher language prompt

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -235,6 +235,13 @@ label start:
 default persistent.has_update = False
 
 label front_page:
+    if not persistent.chosen_language:
+        if _preferences.language is None:
+            hide screen bottom_info
+            call choose_language
+            show screen bottom_info
+        $ persistent.chosen_language = True
+
     if persistent.daily_update_check and ((not persistent.last_update_check) or (datetime.date.today() > persistent.last_update_check)):
         python hide:
             persistent.last_update_check = datetime.date.today()

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -353,7 +353,8 @@ screen choose_language():
         add SPACER
         add SPACER
 
-        textbutton renpy.translate_string(_("Start using Ren'Py in "), local_lang) + renpy.translate_string("{#language name and font}", chosen_lang):
+        $ lang_name = renpy.translate_string("{#language name and font}", chosen_lang)
+        textbutton renpy.translate_string(_("Start using Ren'Py in [lang_name]"), local_lang):
             xalign .5
             action [Language(chosen_lang), project.SelectTutorial(True), Return()]
             style "l_default"

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -319,6 +319,53 @@ label preferences:
     jump preferences
 
 
+screen choose_language():
+    default local_lang = _preferences.language
+    default chosen_lang = _preferences.language
+    default translations = scan_translations()
+
+    add BACKGROUND
+
+    vbox:
+        xalign .5
+        ypos .25
+        text renpy.translate_string(_("Hello ! Please pick a language"), local_lang):
+            xalign .5
+            style "l_label_text"
+            size 36
+
+        add SPACER
+        add SPACER
+
+        hbox:
+            xalign .5
+            for tran in translations:
+                vbox:
+                    for tlid, tlname in tran:
+                        textbutton tlname:
+                            xmaximum (TWOTHIRDS//3)
+                            action SetScreenVariable("chosen_lang", tlid)
+                            hovered SetScreenVariable("local_lang", tlid)
+                            unhovered SetScreenVariable("local_lang", chosen_lang)
+                            style "l_list"
+                            text_xalign .5
+
+        add SPACER
+        add SPACER
+
+        textbutton renpy.translate_string(_("Start using Ren'Py in "), local_lang) + renpy.translate_string("{#language name and font}", chosen_lang):
+            xalign .5
+            action [Language(chosen_lang), project.SelectTutorial(True), Return()]
+            style "l_default"
+            text_style "l_default"
+            text_size 30
+
+
+label choose_language:
+    call screen choose_language
+    return
+
+
 translate None strings:
     # game/new_project.rpy:77
     old "{#language name and font}"

--- a/launcher/game/tl/french/launcher.rpy
+++ b/launcher/game/tl/french/launcher.rpy
@@ -2072,5 +2072,5 @@
     new "Bienvenue ! Choisissez une langue"
 
     # game/preferences.rpy:327
-    old "Start using Ren'Py in "
-    new "Commencez à utiliser Ren'Py en "
+    old "Start using Ren'Py in [lang_name]"
+    new "Commencez à utiliser Ren'Py en [lang_name]"

--- a/launcher/game/tl/french/launcher.rpy
+++ b/launcher/game/tl/french/launcher.rpy
@@ -2066,3 +2066,11 @@
     # game/updater.rpy:78
     old "Nightly (Ren'Py 7, Python 2)"
     new "Nightly (Ren'Py 7, Python 2)"
+
+    # game/preferences.rpy:327
+    old "Hello ! Please pick a language"
+    new "Bienvenue ! Choisissez une langue"
+
+    # game/preferences.rpy:327
+    old "Start using Ren'Py in "
+    new "Commencez à utiliser Ren'Py en "


### PR DESCRIPTION
I added *some* fancy things : clicking on a language chooses it, and displays its name at the end of the second sentence (in its own language). But the sentences ("Hello" and "Start using renpy") display in the language being hovered by the user (or, if none is hovered, in the chosen language).

The choice isn't enacted using the Language action until the return textbutton is clicked, that is to avoid unnecessary computations.