### PR TITLE
Clarify the build/distribute functions

### DIFF
--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -227,9 +227,8 @@ init -1500 python in build:
         Classifies files that match `pattern` into `file_list`, which can
         also be an archive name.
 
-        If the name given as `file_list` doesn't exist, it is created and
-        added to the set of valid file lists taken by :func:`build.archive`
-        or :func:`build.package`.
+        If the name given as `file_list` doesn't exist as an archive or file
+        list name, it is created and added to the set of valid file lists.
         """
 
         base_patterns.append((pattern, make_file_lists(file_list)))

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -270,6 +270,10 @@ init -1500 python in build:
         If any file is included in the "secret" archive using the
         :func:`build.classify` function, the file will be included inside
         the secret.rpa archive in the windows builds.
+
+        As with the :func:`build.classify` function, if the name given as
+        `file_list` doesn't exist as a file list name, it is created and
+        added to the set of valid file lists.
         """
 
         archives.append((name, make_file_lists(file_list)))

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -225,6 +225,9 @@ init -1500 python in build:
         :doc: build
 
         Classifies files that match `pattern` into `file_list`.
+        If the name given as `file_list` doesn't exist, it is created and
+        added to the set of valid file lists taken by :func:`build.archive`
+        or :func:`build.package`.
         """
 
         base_patterns.append((pattern, make_file_lists(file_list)))

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -224,7 +224,9 @@ init -1500 python in build:
         """
         :doc: build
 
-        Classifies files that match `pattern` into `file_list`.
+        Classifies files that match `pattern` into `file_list`, which can
+        also be an archive name.
+
         If the name given as `file_list` doesn't exist, it is created and
         added to the set of valid file lists taken by :func:`build.archive`
         or :func:`build.package`.
@@ -257,21 +259,18 @@ init -1500 python in build:
         :doc: build
 
         Declares the existence of an archive, whose `name` is added to the
-        list of available file lists.
+        list of available archive names, which can be passed to
+        :func:`build.classify`.
 
         If one or more files are classified with `name`, `name`.rpa is
-        build as an archive, and then distributed in packages including
+        built as an archive, and then distributed in packages including
         the `file_list` given here. ::
 
             build.archive("secret", "windows")
 
         If any file is included in the "secret" archive using the
-        :func:`build.classify` function, the secret.rpa archive will be
-        created, and included when calling :func:`build.package` with
-        "windows" in the file lists.
-
-        The `file_list` argument should not be given the name of another
-        archive.
+        :func:`build.classify` function, the file will be included inside
+        the secret.rpa archive in the windows builds.
         """
 
         archives.append((name, make_file_lists(file_list)))
@@ -349,8 +348,8 @@ init -1500 python in build:
             makes dlc possible).
 
         `file_lists`
-            A list containing the file lists that will be contained
-            within the package.
+            A list containing the file lists that will be included
+            in the package.
 
         `description`
             An optional description of the package to be built.

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -253,9 +253,22 @@ init -1500 python in build:
         """
         :doc: build
 
-        Declares the existence of an archive. If one or more files are
-        classified with `name`, `name`.rpa is build as an archive. The
-        archive is included in the named file lists.
+        Declares the existence of an archive, whose `name` is added to the
+        list of available file lists.
+
+        If one or more files are classified with `name`, `name`.rpa is
+        build as an archive, and then distributed in packages including
+        the `file_list` given here. ::
+
+            build.archive("secret", "windows")
+
+        If any file is included in the "secret" archive using the
+        :func:`build.classify` function, the secret.rpa archive will be
+        created, and included when calling :func:`build.package` with
+        "windows" in the file lists.
+
+        The `file_list` argument should not be given the name of another
+        archive.
         """
 
         archives.append((name, make_file_lists(file_list)))

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -206,6 +206,13 @@ Say we wanted to build a normal version of our game, and one
 containing bonus material. We could classify the bonus files in to a
 "bonus" file list, and then declare an all-premium package with::
 
+    # Declare a new archive belonging to a new "bonus" file list.
+    build.archive("bonus_archive", "bonus")
+
+    # Put the bonus files into the new archive.
+    build.classify("game/bonus/**", "bonus_archive")
+
+    #  Declare the package.
     build.package("all-premium", "zip", "windows mac linux all bonus")
 
 Supported package types are "zip" and "tar.bz2" to generate files in

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -146,8 +146,18 @@ renpy
     engine files. (Linux, Macintosh, and Windows.)
 android
     These files will be included in Android builds.
+
+This set of valid file lists can be expanded by passing
+:func:`build.classify` new names as its ``file_list`` argument.
+
+Files can also be classified in archives. By default, the "archive"
+archive is declared:
+
 archive
     These files will be included in the archive.rpa archive.
+
+The set of archives can also be expanded, using the :func:`build.archive`
+function.
 
 Files that are not otherwise classified are placed in the "all" file
 list.


### PR DESCRIPTION
Sets the distinction between archive names and file_list names, how to expand these lists of names, and when each is valid or not.
I.e this says that archives should not be included in other archives, or be given as file lists to the build.package function.

fixes #3548