### PR TITLE
Fixes for show/call/hide screen expression

### DIFF
--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -475,7 +475,7 @@ python early hide:
         """
         name = p["name"]
         if p.get("expression", False):
-            return _try_eval(name, "screen name")
+            return eval(name)
 
         return name
 
@@ -555,7 +555,11 @@ python early hide:
         if not predict:
             return
 
-        name = _get_screen_name(p)
+        try:
+            name = _get_screen_name(p)
+        except Exception:
+            return
+
         a = p["arguments"]
 
         if a is not None:


### PR DESCRIPTION
1. Do not evaluate screen in `audio` namespace.
2. Don't suppress the real exception that occurred in screen evaluation.
3. Return early in screen prediction if screen evaluation failed.