### PR TITLE
Allow to omit `audio/` when specifying the path to the sound.

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -645,7 +645,7 @@ after_replay_callback = None
 wrap_shown_transforms = True
 
 # A list of prefixes Ren'Py will search for assets.
-search_prefixes = [ "", "images/" ]
+search_prefixes = [ "", "images/", "audio/" ]
 
 # Should Ren'Py clear the database of code lines?
 clear_lines = True

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1625,7 +1625,7 @@ Rarely or Internally Used
     archives, and other media, but not scripts. This is initialized to
     a list containing "common" and the name of the game directory.
 
-.. var:: config.search_prefixes = [ "", "images/" ]
+.. var:: config.search_prefixes = [ "", "images/", "audio/" ]
 
     A list of prefixes that are prepended to filenames that are searched
     for.


### PR DESCRIPTION
This fix #2077.