### PR TITLE
Add Update Actions

### DIFF
--- a/renpy/common/00action_data.rpy
+++ b/renpy/common/00action_data.rpy
@@ -21,7 +21,7 @@
 
 init -1600 python:
 
-   ##########################################################################
+    ##########################################################################
     # Functions that set variables or fields.
 
     __FieldNotFound = object()
@@ -52,13 +52,13 @@ init -1600 python:
     @renpy.pure
     class SetField(Action, FieldEquality):
         """
-         :doc: data_action
-         :args: (object, field, value)
+        :doc: data_action
+        :args: (object, field, value)
 
-         Causes the a field on an object to be set to a given value.
-         `object` is the object, `field` is a string giving the name of the
-         field to set, and `value` is the value to set it to.
-         """
+        Causes the a field on an object to be set to a given value.
+        `object` is the object, `field` is a string giving the name of the
+        field to set, and `value` is the value to set it to.
+        """
 
         identity_fields = [ "object" ]
         equality_fields = [ "field", "value" ]
@@ -95,10 +95,10 @@ init -1600 python:
     @renpy.pure
     class SetDict(Action, FieldEquality):
         """
-         :doc: data_action
+        :doc: data_action
 
-         Causes the value of `key` in `dict` to be set to `value`.
-         """
+        Causes the value of `key` in `dict` to be set to `value`.
+        """
 
         identity_fields = [ "dict" ]
         equality_fields = [ "key", "value" ]
@@ -187,17 +187,17 @@ init -1600 python:
     @renpy.pure
     class ToggleField(Action, FieldEquality):
         """
-         :doc: data_action
-         :args: (object, field, true_value=None, false_value=None)
+        :doc: data_action
+        :args: (object, field, true_value=None, false_value=None)
 
-         Toggles `field` on `object`. Toggling means to invert the boolean
-         value of that field when the action is performed.
+        Toggles `field` on `object`. Toggling means to invert the boolean
+        value of that field when the action is performed.
 
-         `true_value`
-             If not None, then this is the true value we use.
-         `false_value`
-             If not None, then this is the false value we use.
-         """
+        `true_value`
+            If not None, then this is the true value we use.
+        `false_value`
+            If not None, then this is the false value we use.
+        """
 
         identity_fields = [ "object"]
         equality_fields = [ "field", "true_value", "false_value"  ]
@@ -261,16 +261,16 @@ init -1600 python:
     @renpy.pure
     class ToggleDict(Action, FieldEquality):
         """
-         :doc: data_action
+        :doc: data_action
 
-         Toggles the value of `key` in `dict`. Toggling means to invert the
-         value when the action is performed.
+        Toggles the value of `key` in `dict`. Toggling means to invert the
+        value when the action is performed.
 
-         `true_value`
-             If not None, then this is the true value used.
-         `false_value`
-             If not None, then this is the false value used.
-         """
+        `true_value`
+            If not None, then this is the true value used.
+        `false_value`
+            If not None, then this is the false value used.
+        """
 
         identity_fields = [ "dict", ]
         equality_fields = [ "key", "true_value", "false_value" ]

--- a/renpy/common/00action_data.rpy
+++ b/renpy/common/00action_data.rpy
@@ -49,6 +49,8 @@ init -1600 python:
         except Exception:
             raise NameError("The {} {} does not exist.".format(kind, name))
 
+    ### Actions that SET variables
+
     @renpy.pure
     class SetField(Action, FieldEquality):
         """
@@ -184,6 +186,9 @@ init -1600 python:
         return SetDict(sys._getframe(1).f_locals, name, value)
 
 
+    ### Actions that UPDATE variables
+
+
     @renpy.pure
     class UpdateField(Action, FieldEquality):
         """
@@ -213,7 +218,6 @@ init -1600 python:
 
             renpy.restart_interaction()
 
-
     @renpy.pure
     def UpdateVariable(name, callback):
         """
@@ -225,7 +229,6 @@ init -1600 python:
         when the user presses a button.
         """
         return UpdateField(store, name, callback, kind="variable")
-
 
     @renpy.pure
     class UpdateDict(Action, FieldEquality):
@@ -250,7 +253,6 @@ init -1600 python:
             self.dict[self.key] = self.callback(value)
 
             renpy.restart_interaction()
-
 
     @renpy.pure
     class UpdateScreenVariable(Action, DictEquality):
@@ -283,7 +285,6 @@ init -1600 python:
 
             renpy.restart_interaction()
 
-
     # Not pure.
     def UpdateLocalVariable(name, callback):
         """
@@ -304,6 +305,9 @@ init -1600 python:
         has been defined in - it can't be passed in from somewhere else.
         """
         return UpdateDict(sys._getframe(1).f_locals, name, callback)
+
+
+    ### Actions that TOGGLE variables
 
 
     @renpy.pure
@@ -519,6 +523,10 @@ init -1600 python:
 
 
             return rv
+
+
+    ### Actions to work with sets
+
 
     @renpy.pure
     class AddToSet(Action, FieldEquality):


### PR DESCRIPTION
I've seen a few cases where people have tried to change a variable using the `SetVariable` action (or similar), but since the value is being evaluated during creation of the action, the variable will only change once.
Example:
```renpy
screen MyScreen():
    default my_variable = 0

    text "My variable: [my_variable]"
    textbutton "Increment variable":
        # This won't work
        action SetScreenVariable("my_variable", my_variable + 1)
```
Usually it's not a big deal, you just create a custom function and change your value there. It's not too much trouble for a global variable, but to do it with a screen variable, the developer has to access the screen scope, which is a quite advanced thing to do.

With my changes one will be able to do:
```renpy
screen MyScreen():
    default my_variable = 0

    text "My variable: [my_variable]"
    textbutton "Increment variable":
        # Works!
        action UpdateScreenVariable("my_variable", lambda i: i+1)
```
which I think is very elegant and easy to do.

The following code allows to test all new actions:
```renpy
screen TestNewUpdateActions():
    default var_a = 0

    vbox:
        anchor (0.5, 0.5)
        pos (0.5, 0.5)

        text "screen var a: [var_a]"
        textbutton "Update a":
            action UpdateScreenVariable("var_a", lambda i: i+1)

        use _TestUsedScreen

        text "global var c: [var_c]"
        textbutton "Update c":
            action UpdateVariable("var_c", lambda i: i+1)

        text "global dict d: {}".format(store.var_d).replace("{", "{{")
        textbutton "Update d":
            action UpdateDict(store.var_d, "my_key", lambda i: i+1)

        text "global object field e: [var_e]"
        textbutton "Update e":
            action UpdateField(store.var_e, "field", lambda i: i+1)

        textbutton "Exit":
            action Return()

screen _TestUsedScreen():
    default var_b = 0

    text "used screen var b: [var_b]"
    textbutton "Update b":
        action UpdateLocalVariable("var_b", lambda i: i+1)

init python:
    class TestObj():
        def __init__(self, field=0):
            self.field = field
        def __repr__(self):
            return "{}(field={})".format(
                type(self).__name__,
                self.field
            )

default var_c = 0
default var_d = {"my_key": 0}
default var_e = TestObj()

label main_menu:
    return

label start:
    $ renpy.retain_after_load()
    call screen TestNewUpdateActions()
    return
```