### PR TITLE
Implement `ToggleFocus`

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -739,7 +739,7 @@ init -1500 python:
         """
         :doc: focus_action
 
-        If the focus exist, clears it, otherwise captures it.
+        If the focus exists, clears it, otherwise captures it.
         """
 
         def __init__(self, name="default"):

--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -734,6 +734,28 @@ init -1500 python:
             renpy.clear_capture_focus(self.name)
             renpy.restart_interaction()
 
+    @renpy.pure
+    class ToggleFocus(Action, DictEquality):
+        """
+        :doc: focus_action
+
+        If the focus exist, clears it, otherwise captures it.
+        """
+
+        def __init__(self, name="default"):
+            self.name = name
+
+        def __call__(self):
+            name = self.name
+
+            if renpy.get_focus_rect(name) is not None:
+                renpy.clear_capture_focus(name)
+
+            else:
+                renpy.capture_focus(name)
+
+            renpy.restart_interaction()
+
     def GetFocusRect(name="default"):
         """
         :doc: focus_action

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -221,8 +221,9 @@ usage is with :ref:`tooltips <tooltips>`.
 The rectangles aside of which the nearrect places things can be captured by
 the new :func:`CaptureFocus` action, which captures the location of the current
 button on the screen. After being captured, the :func:`GetFocusRect` function
-can get the focus rectangle, and the :func:`ClearFocus` can clear the
-captured focus.
+can get the focus rectangle, the :func:`ClearFocus` action can clear the
+captured focus, and the :func:`ToggleFocus` action allows to
+capture and clear focus based on the current focus state.
 
 ATL and Transforms
 ------------------

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -975,7 +975,7 @@ One use of nearrect is for dropdown menus::
 
                 # This action captures the focus rectangle, and in doing so,
                 # displays the dropdown.
-                action CaptureFocus("diff_drop")
+                action ToggleFocus("diff_drop")
 
             textbutton "Done":
                 action Return()
@@ -988,7 +988,7 @@ One use of nearrect is for dropdown menus::
 
             # If the player clicks outside the frame, dismiss the dropdown.
             # The ClearFocus action dismisses this dropdown.
-            dismiss action ClearFocus("diff_drop")
+            dismiss action ClearFocus("diff_drop") modal False
 
             # This positions the displayable near (usually under) the button above.
             nearrect:
@@ -997,8 +997,6 @@ One use of nearrect is for dropdown menus::
                 # Finally, this frame contains the choices in the dropdown, with
                 # each using ClearFocus to dismiss the dropdown.
                 frame:
-                    modal True
-
                     has vbox
 
                     textbutton "Easy" action [ SetVariable("difficulty", "Easy"), ClearFocus("diff_drop") ]


### PR DESCRIPTION
This is a shortcut to
```renpy
If(
    GetFocusRect("my_focus"),
    ClearFocus("my_focus"),
    CaptureFocus("my_focus")
)
```
So one can do
```renpy
ToggleFocus("my_focus")
```