### PR TITLE
NearRect fixes

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2292,6 +2292,9 @@ class NearRect(Container):
             rect = self.parent_rect
 
         if rect is None:
+            if renpy.config.developer:
+                raise Exception("NearRect is being displayed without focus rect.")
+
             self.offsets = [ (0, 0) ] # type: ignore
 
             return rv

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2286,7 +2286,7 @@ class NearRect(Container):
 
         rv = renpy.display.render.Render(width, height)
 
-        if self.focus:
+        if self.focus_rect:
             rect = renpy.display.focus.get_focus_rect(self.focus_rect)
         else:
             rect = self.parent_rect

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2292,7 +2292,7 @@ class NearRect(Container):
             rect = self.parent_rect
 
         if rect is None:
-            self.offsets = [ None ] # type: ignore
+            self.offsets = [ (0, 0) ] # type: ignore
 
             return rv
 

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -925,7 +925,7 @@ Nearrect takes the following properties:
 `focus`
     If given, this should be a string. This string is passed to the equivalent of
     :func:`GetFocusRect` to find the rectangle. If a focus rectangle with that
-    name is not found, the child is rendered.
+    name is found, the child is rendered.
 
     Passing "tooltip" to this uses the location of the last displayable that
     was focused while displaying a tooltip.
@@ -938,6 +938,10 @@ It also takes:
 * :ref:`Common Properties <common-properties>`
 * :ref:`position-style-properties`
 
+If you provided `focus` to your nearrect, it should only be added to the screen when
+the appropriate focus has been captured. To check that use the :func:`GetFocusRect`
+function.
+
 Nearrect differes from the other layouts in that it positions its child near
 the given rectangle, rather than inside it. The child is first rendered with
 the full width available, and the maximum of the height above and height below
@@ -945,7 +949,7 @@ the rectangle. The y position is then computed as followed.
 
 * If the child will fit above the rectangle and `prefer_top` is given, the child
   is positioned directly abover the rectangle.
-* Otherwise, if the child can fit beklow the rectangle, it's positioned directly
+* Otherwise, if the child can fit below the rectangle, it's positioned directly
   below the rectangle.
 * Otherwise, the child is positioned directly above the rectangle.
 
@@ -983,7 +987,8 @@ One use of nearrect is for dropdown menus::
         # All sorts of other screen elements could be here, but the nearrect needs
         # be at the top level, and the last thing show, apart from its child.
 
-        # If a focus has been captured, display the dropdown.
+        # Only if the focus has been captured, display the dropdown.
+        # You could also use showif instead of basic if
         if GetFocusRect("diff_drop"):
 
             # If the player clicks outside the frame, dismiss the dropdown.


### PR DESCRIPTION
This fixes 2 problems, documents another, and there's potentially one more, but I'm not sure about it.

The first issue is `self.offsets = [ None ]` causes a crash, that's because it's being unpacked as a tuple in the event method. Since it's `None`, it can't be unpacked. I set it to `[(0, 0)]`, but maybe it should be set to an empty list?

The second issue is `if self.focus`, `focus` is a method of the parent class (`Displayable`), that `if` check will always be evaluated to `True`. I think it was intended to be `if self.focus_rect`.

The third issue is using `focus` in the `NearRect` constructor. The `Displayable` class it inherits has a parameter named `focus`, but it seems to be doing something else. In the parent class `focus` sets `focus_name`, in `NearRect` it sets `focus_rect`. Right now it's impossible to pass `focus` to the parent class. This looks wrong to me and I'd rename the parameter while this version has not been released, but it could be done intentionally, so I'm just bringing your attention to this.

Found another issue, `NearRect` won't ever be redrawn. If it returned an empty render, it will always be rendered "empty." I tried to check if it the rect has changed since last time in `per_interact` and redraw if it has, but that makes using transforms impossible (since we just redraw into empty render instantly). So that does not work.
Update: I added that to the docs and also added an exception if `config.developer` is `True` and we have no focus rect to render to.