### PR TITLE
Restore blocking to functions that delay

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1738,12 +1738,14 @@ class Function(Statement):
         return True
 
     def execute(self, trans, st, state, events):
-        fr = self.function(trans, st if state else 0, trans.at)
+        block = state or renpy.config.atl_function_always_blocks
+
+        fr = self.function(trans, st if block else 0, trans.at)
 
         if fr is not None:
             return "continue", True, fr
         else:
-            return "next", 0 if state else st, None
+            return "next", 0 if block else st, None
 
 
 # This parses an ATL block.

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -1738,12 +1738,12 @@ class Function(Statement):
         return True
 
     def execute(self, trans, st, state, events):
-        fr = self.function(trans, st, trans.at)
+        fr = self.function(trans, st if state else 0, trans.at)
 
         if fr is not None:
-            return "continue", None, fr
+            return "continue", True, fr
         else:
-            return "next", st, None
+            return "next", 0 if state else st, None
 
 
 # This parses an ATL block.

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -237,6 +237,7 @@ init -1100 python:
             config.layeredimage_offer_screen = False
             config.narrator_menu = False
             config.gui_text_position_properties = False
+            config.atl_function_always_blocks = True
 
 
     # The version of Ren'Py this script is intended for, or

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -831,6 +831,9 @@ say_arguments_callback = None
 # Should we show an atl interpolation for one frame?
 atl_one_frame = True
 
+# Should function statements in ATL block fast-forward?
+atl_function_always_blocks = False
+
 # Should we keep the show layer state?
 keep_show_layer_state = True
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -270,6 +270,10 @@ shown time begins each time it is shown.
 The default for the :tpref:`crop_relative` transform property has been changed to
 True.
 
+The ``function`` statement will now block execution only if producing a delay,
+which allows transforms using it to behave more naturally when catching up with
+an inherited timebase.
+
 Image Gallery
 -------------
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -121,6 +121,12 @@ can display differently in different contexts, you can use::
 Or you can also toggle it for specific layeredimages by passing them the
 ``offer_screen`` property.
 
+The ``function`` statement in ATL will only block catch-up in cases where it
+executes more than once. To revert to the old behavior, where ATL would block
+at a function, use::
+
+    define config.atl_function_always_blocks = True
+
 
 .. _incompatible-7.4.11:
 


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/3636, and adds documentation and compat for the original change.