### PR TITLE
Fix paired parameter of with_callback

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1635,7 +1635,7 @@ class With(Node):
         else:
             paired = None
 
-        renpy.exports.with_statement(trans, paired)
+        renpy.exports.with_statement(trans, paired=paired)
 
     def predict(self):
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -229,8 +229,10 @@ font_replacement_map = { }
 
 # A callback that is called when a with statement (but not
 # the with clause of a say or menu statement) executes. If not None,
-# it's called with a single argument, the transition supplied to the
-# with clause.
+# it's called with a two arguments, the transition supplied to the
+# with clause and the transition it is paired with. The latter is
+# None except in the case of the implicit None transition produced
+# by inline with statements.
 with_callback = None
 
 # The framerate limit, in frames per second.


### PR DESCRIPTION
Parameter order of `renpy.with_statement` changed [11 years ago](https://github.com/renpy/renpy/commit/23240e634ae93039093719643b3cb73fbf44323e#diff-6add03b804c4c72050f3509ad4c97251fbc5a63c153ac4be12051121259c1af0R839) (I suspect by accident - it was a docs commit) which resulted in the value intended for the `paired` parameter being passed to `always` instead. This in turn meant that the `paired` parameter for `with_callback` was always `None`.

https://github.com/renpy/renpy/blob/f50dd2f02de94fb9b657173b107b99f7ca806315/renpy/exports.py#L1606

I believe the only time that `paired` (and thus `always`) would be truthy without this fix would be when `trans is None`, since the only paired transition is the implicit `with None` added prior to inline `with` statements, and since the purpose of `always` is to prevent `trans` being overridden to `None` it doesn't do anything useful, so it no longer being passed here shouldn't matter.

Also updated the documentation for `config.with_callback` which erroneously described the callback as having a single parameter despite having had two since way back in 4564820e3c4a16840caddb7ea62ce55d48706c69.

---

As an aside `with_callback` has no visibility of dict-based transitions (unless they provide a `None` key, in which case it can see that part only), but improvement in that space is left as a future exercise should it be considered useful and warranted.