### PR TITLE
Fix opening a file with encoding from an archive

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -460,6 +460,7 @@ def listdirfiles(common=True):
 
 
 class SubFile(object):
+    closed = False
 
     def __init__(self, fn, base, length, start):
         self.fn = fn
@@ -511,6 +512,9 @@ class SubFile(object):
 
         return (rv1 + rv2)
 
+    def readable(self):
+        return True
+
     def readline(self, length=None):
 
         if self.f is None:
@@ -559,6 +563,12 @@ class SubFile(object):
             rv.append(l)
 
         return rv
+
+    def seekable(self):
+        return True
+
+    def writable(self):
+        return False
 
     def xreadlines(self):
         return self


### PR DESCRIPTION
Addresses `AttributeError: 'SubFile' object has no attribute 'readable'` and series of follow up issues when using a `SubFile` object with `io.TextIOWrapper`.

Triggered by calling `renpy.open_file(path, encoding='utf8')` where `path` is inside an RPA.