### PR TITLE
log: Revert to using None to denote unset dirs

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -394,11 +394,11 @@ quit_action = None
 screenshot_crop = None
 
 # Various directories.
-gamedir = ""
-basedir = ""
-renpy_base = ""
-commondir = ""  # type: Optional[str]
-logdir = ""  # type: Optional[str] # Where log and error files go.
+gamedir = None # type: str
+basedir = None # type: str
+renpy_base = None # type: str
+commondir = None # type: str
+logdir = None # type: str # Where log and error files go.
 
 # Should we enable OpenGL mode?
 gl_enable = True


### PR DESCRIPTION
This once again avoids attempting to open a log file before the relevant directories have been set.

Alternative to #3655 which reverts a small part of 69ca7cc44c19ca493f6776a1934e1348f5f5de02 which introduced the issue.