### PR TITLE
Avoid distributing python interface files

### DIFF
--- a/launcher/game/options.rpy
+++ b/launcher/game/options.rpy
@@ -320,7 +320,7 @@ init python:
         """
         Classifies source and binary files beginning with `pattern`.
         .pyo, .rpyc, .rpycm, and .rpyb go into binary, everything
-        else goes into source.
+        else but .pyi files go into source.
         """
 
         if py is True:
@@ -351,6 +351,7 @@ init python:
         build.classify_renpy(pattern + "/**.rpymc", binary)
         build.classify_renpy(pattern + "/**/cache/*", binary)
 
+        build.classify_renpy(pattern + "/**.pyi", None)
         build.classify_renpy(pattern + "/**", source)
 
     build.classify_renpy("renpy.py", "binary")

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -105,9 +105,6 @@ init -1500 python in build:
         ( "renpy/**.pyc", None),
         ( "renpy/**.pyo", None),
 
-        # Ignore Python interface files.
-        ( "renpy/**.pyi", None),
-
         ( "renpy/common/", "all"),
         ( "renpy/common/_compat/**", "renpy"),
         ( "renpy/common/**.rpy", "renpy"),


### PR DESCRIPTION
Move existing exclusion from the game level to the SDK level.