### PR TITLE
atl: Add an insensitive event for buttons

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -900,6 +900,12 @@ class Button(renpy.display.layout.Window):
 
         return rv
 
+    def set_transform_event(self, event):
+        super(Button, self).set_transform_event(self.role + event)
+
+        if self.child is not None:
+            self.child.set_transform_event(self.role + event)
+
     def focus(self, default=False):
         super(Button, self).focus(default)
 
@@ -908,10 +914,7 @@ class Button(renpy.display.layout.Window):
         if not default:
             rv = run(self.hovered)
 
-        self.set_transform_event(self.role + "hover")
-
-        if self.child is not None:
-            self.child.set_transform_event(self.role + "hover")
+        self.set_transform_event("hover")
 
         return rv
 
@@ -924,10 +927,7 @@ class Button(renpy.display.layout.Window):
             run_unhovered(self.hovered)
             run(self.unhovered)
 
-        self.set_transform_event(self.role + "idle")
-
-        if self.child is not None:
-            self.child.set_transform_event(self.role + "idle")
+        self.set_transform_event("idle")
 
     def is_selected(self):
         if self.selected is not None:
@@ -969,9 +969,13 @@ class Button(renpy.display.layout.Window):
 
             if self.clicked is not None:
                 self.set_style_prefix(self.role + "idle_", True)
+                if not self.focusable:
+                    self.set_transform_event("idle")
                 self.focusable = True
             else:
                 self.set_style_prefix(self.role + "insensitive_", True)
+                if self.focusable:
+                    self.set_transform_event("insensitive")
                 self.focusable = False
 
         super(Button, self).per_interact()


### PR DESCRIPTION
Unsure if this fits with the longer-term vision for atl/styles/events/states, so if this is not "the way" it can just be nuked. Filed on the off chance that it makes sense and is more or less the direction we want to head in. May be one to kick to 7.6/8.1 if we want to think on it more.

---

Fires only when changing the `focusable` property to avoid event spam. Also refactors `Button.set_transform_event` to handle dispatching events to the child (if there is one) and prepending the `role` property automatically (reducing copy-paste).

I wasn't able to recreate a scenario that would lead to the button transitioning from `focusable = False` to `focusable = True`, but I've included the `idle` event there on the assumption that it is possible to trigger that code path.