### PR TITLE
android: Notify system that we're finishing

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3188,6 +3188,9 @@ class Interface(object):
         self.mobile_save()
 
         if renpy.config.quit_on_mobile_background:
+            if renpy.android:
+                android.activity.finishAndRemoveTask()
+
             sys.exit(0)
 
         renpy.exports.free_memory()
@@ -3201,6 +3204,9 @@ class Interface(object):
             ev = pygame.event.wait()
 
             if ev.type == pygame.APP_TERMINATING:
+                if renpy.android:
+                    android.activity.finish()
+
                 sys.exit(0)
 
             if ev.type == pygame.APP_DIDENTERFOREGROUND:


### PR DESCRIPTION
These calls appear to be the suggested way to notify an Android system that your app is ending. While `finish` will leave the app in the "recent activities" screen, `finishAndRemoveTask` will remove it.

I've only had the chance to test these calls via the console, but the behaviour they exhibit matches my expectations based on the Android docs, and what seems to make sense for backgrounding behaviour and the `quit_on_mobile_background` config flag.

https://developer.android.com/reference/android/app/Activity#finish()
https://developer.android.com/reference/android/app/Activity#finishAndRemoveTask()