### PR TITLE
Clarify Transform's fields' allowed use

### DIFF
--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -53,7 +53,9 @@ The Python equivalent of an ATL transform is a Transform object.
 
     Additional keyword arguments are values that transform properties are set
     to. These transform properties are set each time the transform is drawn,
-    and so may not be changed outside the constructor.
+    and so may not be changed after the Transform object is created, unless
+    (1) it's done within the function passed as the `function` argument, or
+    (2) the :meth:`Transform.update` method is called immediately afterwards.
 
     .. attribute:: hide_request
 
@@ -72,10 +74,9 @@ The Python equivalent of an ATL transform is a Transform object.
 
     .. method:: update()
 
-        This should be called when a transform property field is
-        updated outside of the callback method, to ensure that the
-        change takes effect.
-
+        This should be called when a transform property field is updated
+        outside of the function passed as the `function` argument, to ensure
+        that the change takes effect.
 
 
 Transitions

--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -56,7 +56,7 @@ The Python equivalent of an ATL transform is a Transform object.
     transform is drawn, and so may not be changed after the Transform object
     is created. Fields corresponding to other transform properties, however,
     can be set and changed afterwards, either within the function passed as
-    the `function` parameter, or immediately before calling the
+    the ``function`` parameter, or immediately before calling the
     :meth:`update` method.
 
     .. attribute:: hide_request

--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -53,9 +53,9 @@ The Python equivalent of an ATL transform is a Transform object.
 
     Additional keyword arguments are values that transform properties are set
     to. These transform properties are set each time the transform is drawn,
-    and so may not be changed after the Transform object is created, unless
-    (1) it's done within the function passed as the `function` argument, or
-    (2) the :meth:`Transform.update` method is called immediately afterwards.
+    and so may not be changed after the Transform object is created. Fields
+    corresponding to other transform properties, however, can be set and
+    changed afterwards.
 
     .. attribute:: hide_request
 

--- a/sphinx/source/trans_trans_python.rst
+++ b/sphinx/source/trans_trans_python.rst
@@ -52,10 +52,12 @@ The Python equivalent of an ATL transform is a Transform object.
         called at any time with any value to enable prediction.
 
     Additional keyword arguments are values that transform properties are set
-    to. These transform properties are set each time the transform is drawn,
-    and so may not be changed after the Transform object is created. Fields
-    corresponding to other transform properties, however, can be set and
-    changed afterwards.
+    to. These particular transform properties will be set each time the
+    transform is drawn, and so may not be changed after the Transform object
+    is created. Fields corresponding to other transform properties, however,
+    can be set and changed afterwards, either within the function passed as
+    the `function` parameter, or immediately before calling the
+    :meth:`update` method.
 
     .. attribute:: hide_request
 


### PR DESCRIPTION
The doc initially says that the fields of Transform corresponding to transform properties "may not be modified outside of the constructor", so after object creation.

This is contradicted by two things. First, the `function` argument, whose purpose is to mutate these attributes.

Second, the `update` method, which "should be called when a transform property field is updated outside of the callback method". Although the "callback method" wording is dubious (and I included a correction), it clearly implies the fields are modified outside of the constructor.


So I added a clarification listing these three cases as times when tprop fields can be set.