### PR TITLE
mofify alpha, zoom type in default and reset transform

### DIFF
--- a/renpy/common/00definitions.rpy
+++ b/renpy/common/00definitions.rpy
@@ -27,7 +27,7 @@
 init -1400:
 
     transform reset:
-        alpha 1 rotate None zoom 1 xzoom 1 yzoom 1 align (0, 0) alignaround (0, 0) subpixel False
+        alpha 1.0 rotate None zoom 1.0 xzoom 1.0 yzoom 1.0 align (0, 0) alignaround (0, 0) subpixel False
         xsize None ysize None fit None crop None
 
     # These are positions that can be used inside at clauses. We set
@@ -63,7 +63,7 @@ init -1400:
         xpos 1.0 xanchor 0.0 ypos 1.0 yanchor 1.0
 
     transform default:
-        alpha 1 rotate None zoom 1 xzoom 1 yzoom 1 align (0, 0) alignaround (0, 0) subpixel False
+        alpha 1.0 rotate None zoom 1.0 xzoom 1.0 yzoom 1.0 align (0, 0) alignaround (0, 0) subpixel False
         xsize None ysize None fit None crop None
         xpos 0.5 xanchor 0.5 ypos 1.0 yanchor 1.0
 


### PR DESCRIPTION
The values of alpha and zoom properties are int In default & reset transform.
But these type should be float in the document.
https://www.renpy.org/doc/html/atl.html#transform-property-alpha

