### PR TITLE
Add lint warning for unreachable statements

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1755,7 +1755,8 @@ class Return(Node):
 
     __slots__ = [ 'expression']
 
-    should_be_reachable = True
+    # should_be_reachable = None
+    # there are implicit return statements in various places
 
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2097,6 +2097,14 @@ class If(Node):
 
     should_be_reachable = True
 
+    @property
+    def block(self):
+        """
+        Aligns If with other containers for easier recursion.
+        Uses tuple instead of list to prevent the illusion of possible side-effects.
+        """
+        return tuple(n for (_c, nodlist) in self.entries for n in nodlist)
+
     def __init__(self, loc, entries):
         """
         @param entries: A list of (condition, block) tuples.

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -567,6 +567,14 @@ class Node(object):
     # * "force" force it to start.
     rollback = "normal"
 
+    # Does it make sense to find this outside of an init block or before a
+    # label ?
+    #
+    # True - it should only be reachable
+    # None - it doesn't matter
+    # False - it should not be reachable
+    should_be_reachable = None
+
     def __init__(self, loc):
         """
         Initializes this Node object.
@@ -768,6 +776,8 @@ class Say(Node):
         'rollback',
         'identifier',
         ]
+
+    should_be_reachable = True
 
     def diff_info(self):
         return (Say, self.who, self.what)
@@ -1073,6 +1083,8 @@ class Python(Node):
         'store',
         ]
 
+    should_be_reachable = True
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.store = "store"
@@ -1129,6 +1141,8 @@ class EarlyPython(Node):
         'store',
         ]
 
+    should_be_reachable = False
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.store = "store"
@@ -1175,6 +1189,8 @@ class Image(Node):
         'code',
         'atl',
         ]
+
+    should_be_reachable = False
 
     def __init__(self, loc, name, expr=None, atl=None):
         """
@@ -1233,6 +1249,8 @@ class Transform(Node):
         # The parameters associated with the transform, if any.
         'parameters',
         ]
+
+    should_be_reachable = False
 
     default_parameters = EMPTY_PARAMETERS
 
@@ -1365,6 +1383,8 @@ class Show(Node):
         'atl',
         ]
 
+    should_be_reachable = True
+
     warp = True
 
     def __init__(self, loc, imspec, atl=None):
@@ -1409,6 +1429,8 @@ class ShowLayer(Node):
         'atl',
         ]
 
+    should_be_reachable = True
+
     def __init__(self, loc, layer, at_list, atl):
         super(ShowLayer, self).__init__(loc)
 
@@ -1449,6 +1471,8 @@ class Camera(Node):
         'atl',
         ]
 
+    should_be_reachable = True
+
     def __init__(self, loc, layer, at_list, atl):
         super(Camera, self).__init__(loc)
 
@@ -1486,6 +1510,8 @@ class Scene(Node):
         'layer',
         'atl',
         ]
+
+    should_be_reachable = True
 
     warp = True
 
@@ -1538,6 +1564,8 @@ class Hide(Node):
     __slots__ = [
         'imspec',
         ]
+
+    should_be_reachable = True
 
     warp = True
 
@@ -1606,6 +1634,8 @@ class With(Node):
         'paired',
         ]
 
+    should_be_reachable = True
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.paired = None
@@ -1658,6 +1688,8 @@ class Call(Node):
         'arguments',
         'expression',
         ]
+
+    should_be_reachable = True
 
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
@@ -1723,6 +1755,8 @@ class Return(Node):
 
     __slots__ = [ 'expression']
 
+    should_be_reachable = True
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.expression = None
@@ -1785,6 +1819,8 @@ class Menu(Node):
         'item_arguments',
         'rollback',
         ]
+
+    should_be_reachable = True
 
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
@@ -1929,6 +1965,8 @@ class Jump(Node):
         'expression',
         ]
 
+    should_be_reachable = True
+
     def __init__(self, loc, target, expression):
         super(Jump, self).__init__(loc)
 
@@ -2005,6 +2043,8 @@ class While(Node):
         'block',
         ]
 
+    should_be_reachable = True
+
     def __init__(self, loc, condition, block):
         super(While, self).__init__(loc)
 
@@ -2053,6 +2093,8 @@ class While(Node):
 class If(Node):
 
     __slots__ = [ 'entries' ]
+
+    should_be_reachable = True
 
     def __init__(self, loc, entries):
         """
@@ -2363,6 +2405,8 @@ class Define(Node):
         'index',
         ]
 
+    should_be_reachable = False
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.store = 'store'
@@ -2482,6 +2526,8 @@ class Default(Node):
         'store',
         ]
 
+    should_be_reachable = False
+
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.store = 'store'
@@ -2557,6 +2603,8 @@ class Screen(Node):
     __slots__ = [
         'screen',
         ]
+
+    should_be_reachable = False
 
     def __init__(self, loc, screen):
         """
@@ -2828,6 +2876,8 @@ class Style(Node):
         'variant',
     ]
 
+    should_be_reachable = False
+
     def __init__(self, loc, name):
         """
         `name`
@@ -2911,6 +2961,8 @@ class Testcase(Node):
         'test',
         ]
 
+    should_be_reachable = False
+
     def __init__(self, loc, label, test):
         super(Testcase, self).__init__(loc)
 
@@ -2931,6 +2983,8 @@ class RPY(Node):
     __slots__ = [
         "rest"
         ]
+
+    should_be_reachable = False
 
     def __init__(self, loc, rest):
         super(RPY, self).__init__(loc)

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -860,10 +860,9 @@ def lint():
         if isinstance(node, (renpy.ast.Show, renpy.ast.Scene)):
             precheck_show(node)
 
-    for node in all_stmts:
+    uncommon = [nod for nod in all_stmts if not common(nod)]
 
-        if common(node):
-            continue
+    for node in uncommon:
 
         report_node = node
 

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -713,6 +713,12 @@ def get_reachable_script_statements(all_stmts):
 
     # all_stmts = sorted(all_stmts, key=(lambda x:(x.filename, x.linenumber)))
 
+    def rec_mark_reachable(nodd):
+        for nod in getattr(nodd, "block", ()):
+            if nod.should_be_reachable:
+                rec_mark_reachable(nod)
+                reachable_stmts.add(nod)
+
     has_passed_label = False
     file_ = None
     for node in all_stmts:
@@ -723,11 +729,9 @@ def get_reachable_script_statements(all_stmts):
         if isinstance(node, renpy.ast.Label):
             has_passed_label = True
 
-        if isinstance(node, (renpy.ast.Init, renpy.ast.Translate)):
-            for nod in node.block:
-                # needs to search recursively, if nod has subnodes
-                if nod.should_be_reachable:
-                    reachable_stmts.add(nod)
+        if isinstance(node, (renpy.ast.Init,
+                             renpy.ast.Translate)):
+            rec_mark_reachable(node)
 
         if has_passed_label and node.should_be_reachable:
             reachable_stmts.add(node)

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -723,8 +723,7 @@ def get_reachable_script_statements(all_stmts):
         if isinstance(node, renpy.ast.Label):
             has_passed_label = True
 
-        if isinstance(node, renpy.ast.Init):
-            # translate blocks need to be covered too
+        if isinstance(node, (renpy.ast.Init, renpy.ast.Translate)):
             for nod in node.block:
                 # needs to search recursively, if nod has subnodes
                 if nod.should_be_reachable:

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -840,7 +840,7 @@ def lint():
     # them. We sort them in filename, linenumber order.
 
     all_stmts = list(renpy.game.script.all_stmts)
-    all_stmts.sort(key=lambda n : n.filename)
+    all_stmts.sort(key=lambda n : (n.filename, n.linenumber))
 
     # The current count.
     counts = collections.defaultdict(Count)


### PR DESCRIPTION
Two possible changes :
- the TranslateBlock node takes a block, and it could be added alongside Init and Translate as reaching containers, but I don't know what it's used for (yet), so I don't know
- who-less say statements are sometimes used as docstrings in cookbook files, so it could be considered not to warn about who-less Say nodes. That can be done very easily with a property on the Say node class. The question is, should we adapt lint not to flag bad but common practices, or should we adapt the parser to consider them as docstrings instead of say statements ?