### PR TITLE
Pass gallery object to gallery navigation screen

### DIFF
--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -635,9 +635,9 @@ init -1500:
         key "game_menu" action gallery.Return()
 
         if gallery.navigation:
-            use gallery_navigation
+            use gallery_navigation(gallery)
 
-    screen gallery_navigation():
+    screen gallery_navigation(gallery):
         hbox:
             spacing 20
 


### PR DESCRIPTION
The parametrisation of the `gallery_navigation` screen in 95dc99f972ac8aeb139e411a01cbda23a3ba671c rendered it unable to access the `gallery` object, the fix is to explicitly pass it as a parameter.

This is the fix that was suggested by the original reporter (lsf user RFB).

ref: https://lemmasoft.renai.us/forums/viewtopic.php?p=552591#p552591