### PR TITLE
More internal references within the documentation

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1437,7 +1437,7 @@ def imagemap(ground, selected, hotspots, unselected=None, overlays=False,
 
 def pause(delay=None, music=None, with_none=None, hard=False, predict=False, checkpoint=None):
     """
-    :doc: other
+    :doc: se_pause
     :args: (delay=None, *, hard=False, predict=False)
 
     Causes Ren'Py to pause. Returns true if the user clicked to end the pause,

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -1,3 +1,5 @@
+.. _building-distributions:
+
 Building Distributions
 ======================
 

--- a/sphinx/source/conditional.rst
+++ b/sphinx/source/conditional.rst
@@ -1,3 +1,5 @@
+.. _conditional-statements:
+
 Conditional Statements
 ======================
 

--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -63,6 +63,7 @@ backslash to prevent it from closing the string. For example::
 
        "I walked past a sign saying, \"Let's give it 100%!\""
 
+.. _defining-character-objects:
 
 Defining Character Objects
 --------------------------

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -519,3 +519,11 @@ Image Functions
 ===============
 
 .. include:: inc/image_func
+
+See also
+========
+
+:ref:`statement-equivalents` : how to use most of the features described here in a
+python context.
+
+:ref:`displayables` : other objects to display, more diverse than basic images.

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -1,5 +1,9 @@
+.. _labels-control-flow:
+
 Labels & Control Flow
 =====================
+
+.. _label-statement:
 
 Label Statement
 ---------------

--- a/sphinx/source/quickstart.rst
+++ b/sphinx/source/quickstart.rst
@@ -535,7 +535,7 @@ presents menus to the user.
 Menus, Labels, and Jumps
 -------------------------
 
-*Main articles: :ref:`in-game-menus` and :ref:`labels-control-flow`*
+*Main articles: :ref:`menus` and :ref:`labels-control-flow`*
 
 The ``menu`` statement lets presents a choice to the player::
 
@@ -596,7 +596,7 @@ in how you organize the script of a larger game.
 Supporting Flags using the Default, Python and If Statements
 ------------------------------------------------------------
 
-*Main articles: :ref:`python-statements` and :ref:`conditional-statements`*
+*Main articles: :ref:`python` and :ref:`conditional-statements`*
 
 While some games can be made by only using the statements given above,
 other games require data to be stored and recalled later. For example,

--- a/sphinx/source/quickstart.rst
+++ b/sphinx/source/quickstart.rst
@@ -86,8 +86,8 @@ The launcher will then ask you for a project name. Since
 "The Question" is already taken, you should enter something different,
 like "My Question", and type enter.
 
-After that, the launcher will ask you to select the project resolution. The
-default of 1280x720 is a good compromise between game size and image quality.
+After that, the launcher will ask you to select the project resolution.
+1280x720 is a good compromise between game size and image quality.
 For the purpose of this tutorial, we will select 1280x720 to match
 "The Question" game art, then click "Continue".
 
@@ -141,14 +141,14 @@ and play through this example game.
 
 This example shows some of the commonly-used Ren'Py statements.
 
-The first line is a label statement. The label statement is used to
-give a name to a place in the program. In this case, we create a label
-named ``start``. The start label is special, as it's where Ren'Py
-scripts begin running when the user clicks "Start Game" on the main
-menu.
+The first line is a :ref:`label statement <label-statement>`. The label
+statement is used to give a name to a place in the program. In this case,
+we create a label named ``start``. The start label is special, as it's
+where Ren'Py scripts begin running when the user clicks "Start Game" on
+the main menu.
 
-The other lines are say statements. There are two forms of the say
-statement. The first is a string (beginning with a double-quote,
+The other lines are :ref:`say statements <say-statement>`. There are two
+forms of the say statement. The first is a string (beginning with a double-quote,
 containing characters, and ending with a double-quote) on a line by
 itself, which is used for narration, and the thoughts of the main
 character. The second form consists of two strings. It's used for
@@ -174,6 +174,8 @@ in a little bit, but first, let's see how to define characters.
 
 Characters
 ----------
+
+*Main article: :ref:`defining-character-objects`*
 
 One problem with the first example is that it requires you to
 repeatedly type the name of a character each time they speak. In a
@@ -217,6 +219,8 @@ we defined.
 
 Images
 ------
+
+*Main article: :ref:`displaying-images`*
 
 A visual novel isn't much of a visual novel without pictures. Here's another
 scene from "The Question". This also includes statements that show images
@@ -338,6 +342,8 @@ discussed :ref:`elsewhere <displaying-images>`.
 Transitions
 -----------
 
+*Main article: :ref:`transitions`*
+
 In the script above, pictures pop in and out instantaneously. Since
 changing location or having a character enter or leave a scene is
 important, Ren'Py supports transitions that allow effects to be
@@ -414,6 +420,8 @@ anything to the player.
 Positions
 ---------
 
+*Main article: :ref:`transforms`*
+
 By default, images are shown centered horizontally, and with their
 bottom edge touching the bottom of the screen. This is usually okay
 for backgrounds and single characters, but when showing more than one
@@ -438,6 +446,8 @@ but that's outside of the scope of this quickstart.
 
 Music and Sound
 ---------------
+
+*Main article: :ref:`audio`*
 
 Most Ren'Py games play music in the background. Music is played with the
 ``play music`` statement. The play music statement takes a filename that
@@ -488,6 +498,8 @@ For example, if "game/audio/illurock.ogg" exists, we can write::
 See :ref:`the audio namespace <audio-namespace>` for more details.
 
 
+.. _pause-statement:
+
 Pause Statement
 ---------------
 
@@ -522,6 +534,8 @@ presents menus to the user.
 
 Menus, Labels, and Jumps
 -------------------------
+
+*Main articles: :ref:`in-game-menus` and :ref:`labels-control-flow`*
 
 The ``menu`` statement lets presents a choice to the player::
 
@@ -582,8 +596,10 @@ in how you organize the script of a larger game.
 Supporting Flags using the Default, Python and If Statements
 ------------------------------------------------------------
 
+*Main articles: :ref:`python-statements` and :ref:`conditional-statements`*
+
 While some games can be made by only using the statements given above,
-other games requires data to be stored and recalled later. For example,
+other games require data to be stored and recalled later. For example,
 it might make sense for a game to remember a choice a player has made,
 return to a common section of the script, and act on the choice later. This
 is one of the reasons why Ren'Py has embedded Python support.
@@ -689,6 +705,9 @@ before releasing it:
 
     * The `Completed Games section of the Lemma Soft Forums <https://lemmasoft.renai.us/forums/viewforum.php?f=11>`_ is a
       good place to tell fellow creators about your game.
+
+More advanced vays of customizing the building of the distribution of your game
+can be found in the :ref:`building-distributions` section.
 
 Script of The Question
 -----------------------

--- a/sphinx/source/statement_equivalents.rst
+++ b/sphinx/source/statement_equivalents.rst
@@ -63,7 +63,7 @@ arguments to character calls.
 Choice Menus
 ============
 
-The :ref:`menu statement <in-game-menus>` has an equivalent Python function.
+The :ref:`menu statement <menus>` has an equivalent Python function.
 
 .. include:: inc/se_menu
 

--- a/sphinx/source/statement_equivalents.rst
+++ b/sphinx/source/statement_equivalents.rst
@@ -103,4 +103,4 @@ Pause
 
 The equivalent of the :ref:`pause-statement` is the :func:`renpy.pause` function.
 
-..include:: inc/se_pause
+.. include:: inc/se_pause

--- a/sphinx/source/statement_equivalents.rst
+++ b/sphinx/source/statement_equivalents.rst
@@ -13,8 +13,8 @@ equivalent to the statement.
 Dialogue
 ========
 
-The Ren'Py say statement is equivalent to calling the character object
-as a function. The following displays the same line twice::
+The Ren'Py :ref:`say-statement` is equivalent to calling the character
+object as a function. The following displays the same line twice::
 
     e "Hello, world."
 
@@ -63,7 +63,7 @@ arguments to character calls.
 Choice Menus
 ============
 
-The menu statement has an equivalent Python function.
+The :ref:`menu statement <in-game-menus>` has an equivalent Python function.
 
 .. include:: inc/se_menu
 
@@ -72,14 +72,14 @@ Displaying Images
 =================
 
 The image, scene, show, and hide statements each have an equivalent
-Python function.
+Python function (see :ref:`displaying-images` for the original statements).
 
 .. include:: inc/se_images
 
 Transitions
 ===========
 
-The equivalent of the with statement is the :func:`renpy.with_statement`
+The equivalent of the :ref:`with-statement` is the :func:`renpy.with_statement`
 function.
 
 .. include:: inc/se_with
@@ -87,13 +87,20 @@ function.
 Jump
 ====
 
-The equivalent of the jump statement is the :func:`renpy.jump` function.
+The equivalent of the :ref:`jump-statement` is the :func:`renpy.jump` function.
 
 .. include:: inc/se_jump
 
 Call
 ====
 
-The equivalent of the call statement is the :func:`renpy.call` function.
+The equivalent of the :ref:`call-statement` is the :func:`renpy.call` function.
 
 .. include:: inc/se_call
+
+Pause
+=====
+
+The equivalent of the :ref:`pause-statement` is the :func:`renpy.pause` function.
+
+..include:: inc/se_pause


### PR DESCRIPTION
This adds another wiki thing to the doc : the "Main article" references at the beginning of a section. I'm not too sure about the term "article", as it was taken from wikipedia but may be less relevant here.
This also moves the renpy.pause function from the "others" page to the statement equivalents page.