### PR TITLE
with: Remove previously unreachable code

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1637,12 +1637,6 @@ def with_statement(trans, always=False, paired=None, clear=True):
 
     renpy.exports.mode('with')
 
-    if isinstance(paired, dict):
-        paired = paired.get(None, None)
-
-        if (trans is None) and (paired is None):
-            return
-
     if isinstance(trans, dict):
 
         for k, v in trans.items():

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1739,9 +1739,12 @@ Rarely or Internally Used
     If not None, this should be a function that is called when a :ref:`with
     statement <with-statement>` occurs. This function can be responsible for
     putting up transient things on the screen during the transition. The
-    function is called with a single argument, which is the transition that
-    is occurring. It is expected to return a transition, which may or may not
-    be the transition supplied as its argument.
+    function is called with two arguments: the transition that is occurring,
+    and the transition it is paired with. The latter is None except in the case
+    of the implicit None transition produced by an inline with statement, in
+    which case it is the inline transition that produced the with None. It is
+    expected to return a transition, which may or may not be the transition
+    supplied as its argument.
 
 
 Garbage Collection


### PR DESCRIPTION
Proposed solution to #3690, a regression introduced by #3650.

The code being removed was unreachable prior to 7.5/8.0 due to a bug meaning that the `paired` parameter was never passed. This meant it could never be a `dict`, and that this code was unreachable.

An alternative solution could be to gate this behind a compat flag, however as has been noted in the issue, it appears that no one has missed this for over a decade, and while the information in the callback is useful (hence the fix that lead us here), it's possible that the added flexibility of paired `dict`-transforms is not.