### PR TITLE
Fix CropMove transitions

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -697,6 +697,10 @@ class AlphaDissolve(Transition):
         return rv
 
 
+def interpolate_tuple(t0, t1, time, scales):
+    return tuple([ round(s * (a * (1.0 - time) + b * time))
+                    for a, b, s in zip(t0, t1, scales) ])
+
 class CropMove(Transition):
     """
     :doc: transition function
@@ -934,12 +938,8 @@ class CropMove(Transition):
         # How we scale each element of a tuple.
         scales = (width, height, width, height)
 
-        def interpolate_tuple(t0, t1):
-            return tuple([ round(s * (a * (1.0 - time) + b * time))
-                           for a, b, s in zip(t0, t1, scales) ])
-
-        crop = interpolate_tuple(self.startcrop, self.endcrop)
-        pos = interpolate_tuple(self.startpos, self.endpos)
+        crop = interpolate_tuple(self.startcrop, self.endcrop, time, scales)
+        pos = interpolate_tuple(self.startpos, self.endpos, time, scales)
 
         top = render(self.top, width, height, st, at)
         bottom = render(self.bottom, width, height, st, at)
@@ -1057,15 +1057,11 @@ class PushMove(Transition):
         # How we scale each element of a tuple.
         scales = (width, height, width, height)
 
-        def interpolate_tuple(t0, t1):
-            return tuple([ int(s * (a * (1.0 - time) + b * time))
-                           for a, b, s in zip(t0, t1, scales) ])
+        new_crop = interpolate_tuple(self.new_startcrop, self.new_endcrop, time, scales)
+        new_pos = interpolate_tuple(self.new_startpos, self.new_endpos, time, scales)
 
-        new_crop = interpolate_tuple(self.new_startcrop, self.new_endcrop)
-        new_pos = interpolate_tuple(self.new_startpos, self.new_endpos)
-
-        old_crop = interpolate_tuple(self.old_startcrop, self.old_endcrop)
-        old_pos = interpolate_tuple(self.old_startpos, self.old_endpos)
+        old_crop = interpolate_tuple(self.old_startcrop, self.old_endcrop, time, scales)
+        old_pos = interpolate_tuple(self.old_startpos, self.old_endpos, time, scales)
 
         new = render(self.new_widget, width, height, st, at)
         old = render(self.old_widget, width, height, st, at)

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -935,7 +935,7 @@ class CropMove(Transition):
         scales = (width, height, width, height)
 
         def interpolate_tuple(t0, t1):
-            return tuple([ int(s * (a * (1.0 - time) + b * time))
+            return tuple([ round(s * (a * (1.0 - time) + b * time))
                            for a, b, s in zip(t0, t1, scales) ])
 
         crop = interpolate_tuple(self.startcrop, self.endcrop)


### PR DESCRIPTION
The reason behind this is interesting : for the crop and the position of the cropped layer (here, the one being appeared), the value for the beginning and the value for the end, both between 0 and 1, are interpolated relative to when we are within the transition, then that is multiplied by the with and heigth to render to. This obviously returns a float, which will very likely not have an integer value. In the case of this transition (as for many others), the float of the position and the float of the crop size add up to the total size (width or height).
These floats (those of the crop and those of the pos) are then clamped *down* to integers, using `int`. And that's where the bug happens. Say we have a width of 1920, and the x pos is 10.6, the x crop is then 1909.4, since they add up to 1920. But when both are clamped down with `int`, it gives 10 and 1909, which add up to 1919, **one (constant) pixel short**.

I suspect this is a dormant bug likely to happen any time a float representing a position is clamped down to an integer. That's not the case every time a float position is used, but it is done sometimes.
Interestingly, removing the `int` cast didn't solve the problem, I suspect the .subsurface and/or .blit methods do another cast under the hood.
Anyway, `round` works, because it rounds to the nearest integer, so in the above example 10.6 would be rounded to 11, solving the missing pixel problem.