### PR TITLE
Add missing field to Module node

### DIFF
--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -476,7 +476,7 @@ class Context(renpy.object.Object):
         """
 
         ps = pyast.Pass(lineno=node.linenumber, col_offset=0)
-        module = pyast.Module(lineno=node.linenumber, col_offset=0, body=[ ps ])
+        module = pyast.Module(lineno=node.linenumber, col_offset=0, body=[ ps ], type_ignores=[])
         code = compile(module, node.filename, 'exec')
         exec(code)
 


### PR DESCRIPTION
the field is required for it to compile in python 3.8+