### PR TITLE
[DOC] improved translation ID example

### DIFF
--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -211,9 +211,9 @@ of being translated into Russian.
 
 This can be done by including an ``id`` clause as part of the
 say statement, giving the translation ID to use for this
-statement. For example:
-
-    e "This used to have a typo." id start_61b861a2
+statement. For example::
+    label start:
+        e "This used to have a typo." id start_61b861a2
 
 Tips
 ----


### PR DESCRIPTION
```py
label start:
     e "This used to have a typo." id start_61b861a2
```