### PR TITLE
Force fsencode to convert to bytes

### DIFF
--- a/launcher/game/mobilebuild.rpy
+++ b/launcher/game/mobilebuild.rpy
@@ -195,7 +195,11 @@ init -1 python:
                 kwargs = { }
 
                 try:
-                    self.process = subprocess.Popen(cmd, cwd=renpy.fsencode(RAPT_PATH), stdout=f, stderr=f, stdin=subprocess.PIPE, startupinfo=startupinfo, **kwargs)
+                    self.process = subprocess.Popen(cmd,
+                                                    cwd=renpy.fsencode(RAPT_PATH, force=True),
+                                                    stdout=f, stderr=f, stdin=subprocess.PIPE,
+                                                    startupinfo=startupinfo,
+                                                    **kwargs)
                     # avoid SIGTTIN caused by e.g. gradle doing empty read on terminal stdin
                     if not yes:
                         self.process.stdin.close()


### PR DESCRIPTION
Tries to fix #3711, but I have no means to test it.
The rationale is that under py3, the first if clause makes the function return a str unless the `force` parameter is passed. So I passed it.