### PR TITLE
Change conditions for Movie._play being valid

### DIFF
--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -328,7 +328,7 @@ class Movie(renpy.display.core.Displayable):
 
     def after_setstate(self):
         play = self._original_play or self._play
-        if (play is not None) and (not isinstance(play, list) and renpy.loader.loadable(play)
+        if (play is not None) and (isinstance(play, basestring) and renpy.loader.loadable(play)
                                    or all(renpy.loadable(p) for p in play)):
             self._original_play = self._play = play
         else:
@@ -363,7 +363,7 @@ class Movie(renpy.display.core.Displayable):
         self.loop = loop
 
         self._original_play = play
-        if (play is not None) and (not isinstance(play, list) and renpy.loader.loadable(play)
+        if (play is not None) and (isinstance(play, basestring) and renpy.loader.loadable(play)
                                    or all(renpy.loadable(p) for p in play)):
             self._play = play
 

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -328,7 +328,8 @@ class Movie(renpy.display.core.Displayable):
 
     def after_setstate(self):
         play = self._original_play or self._play
-        if (play is not None) and renpy.loader.loadable(play):
+        if (play is not None) and (not isinstance(play, list) and renpy.loader.loadable(play)
+                                   or all(renpy.loadable(p) for p in play)):
             self._original_play = self._play = play
         else:
             self._play = None
@@ -362,7 +363,8 @@ class Movie(renpy.display.core.Displayable):
         self.loop = loop
 
         self._original_play = play
-        if (play is not None) and renpy.loader.loadable(play):
+        if (play is not None) and (not isinstance(play, list) and renpy.loader.loadable(play)
+                                   or all(renpy.loadable(p) for p in play)):
             self._play = play
 
         if side_mask:


### PR DESCRIPTION
In other conditions (the at clause for layeredimages for example), the `play` value would have been turned into a singleton list if not already a list. However, considering that there's already two _play attributes (_play and _original_play) to manage, I think it would have been a bit too complicated. And, the decision to support and document Movie taking lists has not actually been taken, so...

Also, the question was raised of when to consider the argument as being valid or not, if it's a list containing valid and non-valid values. I chose to expedite it as if there's even one invalid, the whole bunch is considered tainted. Another solution such as using `filter` to have a list of only the loadable ones would require adapting the after_setstate function, and I didn't take that risk.

So only the renpy.loadable calls have been protected, other than that, Movie processes the argument just like it did before.