### PR TITLE
py3: Update mobilebuild exception logging

### DIFF
--- a/launcher/game/mobilebuild.rpy
+++ b/launcher/game/mobilebuild.rpy
@@ -173,9 +173,9 @@ init -1 python:
 
             self.cmd = cmd
 
-            f = open(self.filename, "ab")
+            f = open(self.filename, "a")
 
-            f.write(b"\n\n\n")
+            f.write("\n\n\n")
 
             if cancel:
                 cancel_action = self.cancel


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/3711

In py3 the print_exc function prints a str, which files opened in binary
mode do not like. Conversely py2 doesn't seem to mind whether the file
is in binary mode or not.

This matches the approach taken in the rest of the file, where various
logs and outputs are also not opened in binary mode any longer.

Error recreated and change tested with this code on Linux using python2 binary from 7.4.11, and python3 binary from 8.0.0:

_This represents the fix, see comments for bug recreation._
```py
import subprocess
import traceback

for bin in ('sh', 'nonexistant'):
    with open('tmp.txt', 'a') as f: # change to 'ab' to recreate bug report
        f.write("\n\n\n")           # change to b"\n\n\n" when recreating bug report
        try:
            subprocess.Popen([bin, '-c', 'echo foo'],
                             stdout=f, stderr=f, stdin=subprocess.PIPE)
        except Exception:
            traceback.print_exc(file=f)
```