### PR TITLE
Improve Self-voicing documentation

### DIFF
--- a/sphinx/source/self_voicing.rst
+++ b/sphinx/source/self_voicing.rst
@@ -89,8 +89,12 @@ Alternative text
                 color color_from_badness(badness)
                 alt "Information for you : [text]. Badness is " + str(badness)
 
-            text "ORIGINOFMESSAGE{color=#f00}[planet]{/color}":
+            text "ORIGIN_OF_MESSAGE_{color=#f00}[planet!u]{/color}":
                 alt "Origin of message is " + planet
+
+    In the above example, the ``badness`` and ``planet`` variables
+    cannot be substituted directly using "[badness]". Concatenating
+    it manually is a solution.
 
     Supplying the `who_alt` and `what_alt` parameters to Character
     sets the alt style property for the character name and body text,
@@ -103,7 +107,7 @@ Alternative text
 Descriptive Text
     Descriptive text is text that is displayed (and spoken) by the narrator if
     self-voicing is enabled. The text is not displayed if self-voicing is
-    disabled. Self-voicing text uses the :var:`sv` variable, which is defined to
+    disabled. Self-voicing text uses the :var:`alt` variable, which is defined to
     be similar to a character.
 
     .. var:: alt = ...

--- a/sphinx/source/self_voicing.rst
+++ b/sphinx/source/self_voicing.rst
@@ -81,6 +81,16 @@ Alternative text
     from a displayable and its children, but such child text is made
     available as the "[text]" string substitution. No other string
     substitutions are allowed.
+    
+    For example::
+
+        screen information(message, planet, badness):
+            text message:
+                color color_from_badness(badness)
+                alt "Information for you : [text]. Badness is " + str(badness)
+
+            text "ORIGINOFMESSAGE{color=#f00}[planet]{/color}":
+                alt "Origin of message is " + planet
 
     Supplying the `who_alt` and `what_alt` parameters to Character
     sets the alt style property for the character name and body text,


### PR DESCRIPTION
I tried to find an example where we would want to include in the alt a) something non textually visible (the color) and b) something already visible but which would need to be phrased differently to be properly spoken.
Improvement in the second part of the example, to make more clear what it tries to show, is welcome.

The end of the file is a bit weird : the `sv` variable is mentioned but there's no information about what it does or how it should be used.