### PR TITLE
Re-use audio data to reduce memory and CPU usage (Web)

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -214,7 +214,6 @@ renpyAudio = { };
 renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, relative_volume) => {
 
     let c = get_channel(channel);
-    let array = FS.readFile(file);
 
     let q = {
         source : null,
@@ -227,16 +226,38 @@ renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, rel
         fadein : fadein,
         fadeout: null,
         tight : tight,
-        started_once : false
+        started_once : false,
+        file: file,
     };
+
+    function reuseBuffer(c) {
+        // We can re-use the audio buffer, but not the buffer source
+        c.queued.buffer = c.playing.buffer;
+        c.queued.source = context.createBufferSource();
+        c.queued.source.buffer = c.playing.buffer;
+        c.queued.source.onended = () => { on_end(c); };
+
+        start_playing(c);
+    }
 
     if (c.playing === null) {
         c.playing = q;
         c.paused = paused;
     } else {
         c.queued = q;
+        if (c.playing.file === file) {
+            // Same file, re-use the data to reduce memory and CPU footprint
+            if (c.playing.buffer !== null) {
+                reuseBuffer(c);
+            } else {
+                // Not ready yet, wait for decodeAudioData() to complete
+            }
+
+            return;
+        }
     }
 
+    let array = FS.readFile(file);
     context.decodeAudioData(array.buffer, (buffer) => {
 
         var source = context.createBufferSource();
@@ -247,6 +268,11 @@ renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, rel
         q.buffer = buffer;
 
         start_playing(c);
+
+        if (c.playing === q && c.queued !== null && c.queued.file === q.file) {
+            // Same file, re-use the data to reduce memory and CPU footprint
+            reuseBuffer(c);
+        }
     }, () => {
         console.log(`The audio data in ${file} could not be decoded. The file format may not be supported by this browser.`);
     });

--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -213,9 +213,9 @@ renpyAudio = { };
 
 renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, relative_volume) => {
 
-    let c = get_channel(channel);
+    const c = get_channel(channel);
 
-    let q = {
+    const q = {
         source : null,
         buffer : null,
         name : name,
@@ -257,10 +257,10 @@ renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, rel
         }
     }
 
-    let array = FS.readFile(file);
+    const array = FS.readFile(file);
     context.decodeAudioData(array.buffer, (buffer) => {
 
-        var source = context.createBufferSource();
+        const source = context.createBufferSource();
         source.buffer = buffer;
         source.onended = () => { on_end(c); };
 


### PR DESCRIPTION
It often happens in Renpy that a same audio file is queued twice in a same audio channel, in particular to implement the audio loop feature. In this case, the current audio code decodes the audio file each time it is queued, while the audio data is already available from the currently playing audio file. This means Renpy uses more memory and CPU than it needs, especially when the audio file is big.

This PR checks if the currently playing audio file and the next one are the same, and if so, it re-use the decoded audio data from the currently playing one. It only does that between audio files of a same channel, but it might be possible to check between the files of the different channels (but I doubt it will make a difference).

For the records, I experienced OOM crashes with a Renpy Web game which uses a big audio file (~1 hour) and the partial playback feature because of the audio data duplication. The changes from this PR fixes the crash (but does not fix the long loading time for the big audio file though).