### PR TITLE
Fix: Adding focus for `renpy.text.text.Text'.

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -2021,6 +2021,9 @@ class Text(renpy.display.core.Displayable):
             if clicked is not None:
                 target = layout.hyperlink_targets.get(renpy.display.focus.argument, None)
 
+                if target is None:
+                    return
+
                 if not self.hyperlink_sensitive(target):
                     return None
 


### PR DESCRIPTION
If we inherit from `renpy.text.text.Text` and give it a forced focus,
we will have `None` at the moment of checking on `target` in `event` method.

```renpy
init python:
    class SubOf(renpy.text.text.Text):
        def render(self, width, height, st, at):
            rv = super(SubOf, self).render(width, height, st, at)
            rv.add_focus(self, None, 0, 0, width, height)
            return rv

    (renpy.register_sl_displayable("subof", SubOf, "text", nchildren=0)
        .add_positional("text")
        .add_property_group("text")
    )
```