### PR TITLE
Optimizations for building Web packages

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -436,7 +436,7 @@ change_renpy_executable()
         This manages the process of building distributions.
         """
 
-        def __init__(self, project, destination=None, reporter=None, packages=None, build_update=True, open_directory=False, noarchive=False, packagedest=None, report_success=True, scan=True, macapp=None, force_format=None):
+        def __init__(self, project, destination=None, reporter=None, packages=None, build_update=True, open_directory=False, noarchive=False, packagedest=None, report_success=True, scan=True, macapp=None, force_format=None, files_filter=None):
             """
             Distributes `project`.
 
@@ -474,6 +474,11 @@ change_renpy_executable()
 
             `force_format`
                 If given, forces the format of the distribution to be this.
+
+            `files_filter`
+                If given, use this object to decide which files must be included.
+                The object must contains the `filter(file, variant, format)`
+                method which must return True is the file must be included.
             """
 
             # A map from a package to a unique update version hash.
@@ -645,6 +650,8 @@ change_renpy_executable()
 
             # The time of the update version.
             self.update_version = int(time.time())
+
+            self.files_filter = files_filter
 
             for p in build_packages:
 
@@ -1520,6 +1527,9 @@ change_renpy_executable()
                 if f.directory:
                     pkg.add_directory(f.name, f.path)
                 else:
+                    if self.files_filter is not None and not self.files_filter.filter(f, variant, format):
+                        # Ignore file
+                        continue
                     pkg.add_file(f.name, f.path, f.executable)
 
             self.reporter.progress_done()


### PR DESCRIPTION
When packaging a Web build, all the files are put in a game.zip file first before being selectively removed based on whether they should be downloaded progressively or not. This is a waste of time and disk space (the ZIP file content is duplicated), especially for novels with lots of images.

This PR adds a generic file filtering feature to the Distributor class so that builder scripts can filter out the files to package based on their specific needs. The Web builder script uses that to prevent the files to be downloaded progressively from being put in the ZIP archive at all, and copy them to the destination folder on the fly. The original progressive download filtering logic is preserved, but it happens sooner.

With these changes, empty folders are put in the ZIP archive though, but it should be harmless. Detecting empty folders is tricky without relying on a second pass.