### PR TITLE
add renpy.warp_to_line func

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1932,6 +1932,20 @@ def return_statement(value=None):
     jump("_renpy_return")
 
 
+def warp_to_line(warp_spec):
+    """
+    :doc: debug
+
+    This takes as an argument a filename:linenumber pair, and tries to warp to
+    the statement before that line number.
+
+    This works samely as the `--warp` command.
+    """
+
+    renpy.warp.warp_spec = warp_spec
+    renpy.warp.warp()
+
+
 def screenshot(filename):
     """
     :doc: other


### PR DESCRIPTION
This simply allow to use --warp command in console.

This would not be useful on its own, but it would be useful if this is able to be called by the editor in some way.
That allows Ren'Py to jump to the current editor line like engines that are integrated with the development environment like Light.vn or other.