### PR TITLE
Fix modal behavior

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -519,24 +519,25 @@ class PauseBehavior(renpy.display.layout.Null):
 
     def event(self, ev, x, y, st):
 
-        if ev.type == renpy.display.core.TIMEEVENT and ev.modal:
-            renpy.game.interface.timeout(max(self.delay - st, 0))
-            return
+        if ev.type == renpy.display.core.TIMEEVENT:
+            if ev.modal:
+                renpy.game.interface.timeout(max(self.delay - st, 0))
+                return
 
-        if st >= self.delay:
+            if st >= self.delay:
 
-            if self.voice and renpy.config.nw_voice:
-                if (not renpy.config.afm_callback()) or renpy.display.tts.is_active():
-                    renpy.game.interface.timeout(0.05)
-                    return
+                if self.voice and renpy.config.nw_voice:
+                    if (not renpy.config.afm_callback()) or renpy.display.tts.is_active():
+                        renpy.game.interface.timeout(0.05)
+                        return
 
-            # If we have been drawn since the timeout, simply return
-            # true. Otherwise, force a redraw, and return true when
-            # it comes back.
-            if renpy.game.interface.drawn_since(st - self.delay):
-                return self.result
-            else:
-                renpy.game.interface.force_redraw = True
+                # If we have been drawn since the timeout, simply return
+                # true. Otherwise, force a redraw, and return true when
+                # it comes back.
+                if renpy.game.interface.drawn_since(st - self.delay):
+                    return self.result
+                else:
+                    renpy.game.interface.force_redraw = True
 
         renpy.game.interface.timeout(max(self.delay - st, 0))
 

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -644,6 +644,9 @@ class SayBehavior(renpy.display.layout.Null):
 
                 afm_delay += max_time
 
+            if ev.type == renpy.display.core.TIMEEVENT and ev.modal:
+                return None
+
             if st > afm_delay:
                 if renpy.config.afm_callback:
                     if renpy.config.afm_callback() and not renpy.display.tts.is_active():

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3692,6 +3692,11 @@ class Interface(object):
 
         renpy.plog(1, "final predict")
 
+        if pause is not None:
+            pb = renpy.display.behavior.PauseBehavior(pause)
+            root_widget.add(pb, pause_start, pause_start)
+            focus_roots.append(pb)
+
         # The root widget of all of the layers.
         layers_root = renpy.display.layout.MultiBox(layout='fixed')
         layers_root.layers = { }
@@ -3767,11 +3772,6 @@ class Interface(object):
 
         else:
             root_widget.add(layers_root)
-
-        if pause is not None:
-            pb = renpy.display.behavior.PauseBehavior(pause)
-            root_widget.add(pb, pause_start, pause_start)
-            focus_roots.append(pb)
 
         # Add top_layers to the root_widget.
         for layer in renpy.config.top_layers:


### PR DESCRIPTION
Renpy games were being allowed to advance in the following two scenarios even when a modal screen was being shown: when using auto-forward, and when using the renpy.pause function. With these changes a modal screen will properly block progression in those scenarios.