### PR TITLE
Fixed mouse area hovering

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2449,7 +2449,7 @@ class MouseArea(renpy.display.core.Displayable):
         if renpy.display.focus.pending_focus_type == 'keyboard':
             is_hovered = False
 
-        if (ev.type == renpy.display.core.TIMEEVENT) and ev.modal:
+        elif (ev.type == renpy.display.core.TIMEEVENT) and ev.modal:
             is_hovered = False
 
         else:


### PR DESCRIPTION
Mouseareas are supposed to not hover if the keyboard is being used for focusing, but this was broken by an if/else statement that changed the is_hovered value again without regard to if it had already been set to false because of keyboard focusing. Changing it to elif/else ensures the value of is_hovered is only changed if it hasn't already been set to false because of keyboard focusing.