### PR TITLE
Fix and simplify the "List filenames" dev action

### DIFF
--- a/renpy/common/_developer/developer.rpym
+++ b/renpy/common/_developer/developer.rpym
@@ -581,16 +581,18 @@ label _filename_list:
         FILES_TXT = os.path.join(renpy.config.basedir, "files.txt")
 
         with open(FILES_TXT, "w") as f:
-            for dirname, dirs, files in os.walk(config.gamedir):
+            for dirname, _dirs, files in os.walk(config.gamedir):
 
-                dirs.sort()
                 files.sort()
+                if dirname.startswith(config.gamedir):
+                    dirname = dirname[len(config.gamedir)+1:]
 
                 for fn in files:
                     fn = os.path.join(dirname, fn)
-                    fn = fn[len(config.gamedir) + 1:]
-                    print(fn.encode("utf-8", "replace"), file=f)
-                    print(fn.encode("utf-8", "replace"))
+                    if PY2:
+                        fn = fn.encode("utf-8", "replace")
+                    print(fn, file=f)
+                    print(fn)
 
         renpy.launch_editor([ FILES_TXT ], transient=1)
 


### PR DESCRIPTION
In py3 it resulted in a bunch of `b'somepath'` being written to the file and in the console, now it's good, back to `somepath`.
I also changed things internally to simplify it.