### PR TITLE
Improve the generation and inclusion of the console commands list

### DIFF
--- a/sphinx/game/script.rpy
+++ b/sphinx/game/script.rpy
@@ -42,8 +42,7 @@ init 1000000 python:
 
     doc.check_dups()
 
-    console_commands = _console.help(None, True)
-    console_commands = "\n\n".join(console_commands.split("\n"))
+    console_commands = _console.help(None, True).replace("\n ", "\n\n* ")
     with open(os.path.join(incdir, "console_commands"), "w") as f:
         f.write(console_commands)
     


### PR DESCRIPTION
Using replace is probably simpler than using split then join.
Also, the markup using a leading whitespace is the quote markup in sphinx, which is a bit ugly. A bullet list renders better, I think.