### PR TITLE
fix: Unavailable `pygame` in `renpy.display.layout`

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -25,7 +25,7 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-import pygame
+import pygame_sdl2 as pygame
 
 import renpy
 from renpy.display.render import render, Render


### PR DESCRIPTION
At the time of import `renpy.import_all` the `pygame` module may not be present.