### PR TITLE
Modified ConditionSwitch to include a 'continuous' argument.

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -915,6 +915,9 @@ optimize_texture_bounds = True
 # Should we predict everything in a ConditionSwitch?
 conditionswitch_predict_all = False
 
+# How long should a continuous ConditionSwitch wait before updating itself? (seconds)
+conditionswitch_refresh_rate = 0.1
+
 # Transform events to deliver each time one happens.
 repeat_transform_events = [ "show", "replace", "update" ]
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1596,6 +1596,10 @@ def condition_switch_show(st, at, switch, predict_all=None):
     return condition_switch_pick(switch), None
 
 
+def continuous_switch_show(st, at, switch, predict_all=None):
+    return condition_switch_pick(switch), renpy.config.conditionswitch_refresh_rate
+
+
 def condition_switch_predict(switch, predict_all=None):
 
     if predict_all is None:
@@ -1611,7 +1615,7 @@ def ConditionSwitch(*args, **kwargs):
     """
     :name: ConditionSwitch
     :doc: disp_dynamic
-    :args: (*args, predict_all=None, **properties)
+    :args: (*args, predict_all=None, continuous=False, **properties)
 
     This is a displayable that changes what it is showing based on
     Python conditions. The positional arguments should be given in
@@ -1623,13 +1627,21 @@ def ConditionSwitch(*args, **kwargs):
     The first true condition has its displayable shown, at least
     one condition should always be true.
 
-    The conditions uses here should not have externally-visible side-effects.
+    The conditions used here should not have externally-visible side-effects.
 
     `predict_all`
         If True, all of the possible displayables will be predicted when
         the displayable is shown. If False, only the current condition is
         predicted. If None, :var:`config.conditionswitch_predict_all` is
         used.
+
+    `continuous`
+        If True, the conditions are rechecked continuously, and the
+        displayable responds to changes inbetween interactions. If False,
+        the displayable only changes what it is showing at the start of an
+        interaction. The rate at which these conditions are rechecked is
+        set by :var:`config.conditionswitch_refresh_rate`
+
 
     ::
 
@@ -1639,6 +1651,7 @@ def ConditionSwitch(*args, **kwargs):
     """
 
     predict_all = kwargs.pop("predict_all", None)
+    continuous = kwargs.pop("continuous", False)
     kwargs.setdefault('style', 'default')
 
     switch = [ ]
@@ -1655,7 +1668,8 @@ def ConditionSwitch(*args, **kwargs):
         d = renpy.easy.displayable(d)
         switch.append((cond, d))
 
-    rv = DynamicDisplayable(condition_switch_show,
+    rv = DynamicDisplayable(continuous_switch_show if continuous
+                                else condition_switch_show,
                             switch,
                             predict_all,
                             _predict_function=condition_switch_predict)


### PR DESCRIPTION
Modified *ConditionSwitch* to include a new argument: `continuous`

If `continuous` is true, the *ConditionSwitch* displayable continuously rechecks its conditions every `config.conditionswitch_refresh_rate` seconds, and responds to changes in variables, etc. in between interactions, instead of just at the start.

It's cleaner and easier than *DynamicDisplayable* for some situations- could be useful for e.g. a character whose eyes actively follow a sprite, or current mouse position; or with python code that runs in between say statements, or in the background as a thread. 

Could also be useful for creators who don't quite grasp, or need something as flexible as, *DynamicDisplayable*.

------
*(Either way, DynamicDisplayables were getting too cumbersome. I couldn't implement this in the script, so I had to alter the engine. Now hopefully, I wont have to re-appy this feature whenever RenPy gets updated)*