### PR TITLE
Add an adds method to MouseDisplayable

### DIFF
--- a/renpy/common/00mousedisplayable.rpy
+++ b/renpy/common/00mousedisplayable.rpy
@@ -58,6 +58,21 @@ init -1500 python:
             self.cursors[name] = ( renpy.displayable(cursor), x, y )
             return self
 
+        def adds(self, **kwargs):
+            """
+            :doc: mouse_displayable
+
+            This replaces successive calls to the :meth:`add` method. ::
+
+                MouseDisplayable("gui/arrow.png", 0, 0).adds(spin=("mouse spin",
+                                                                   9.9, 9.9),
+                                                             red_square=(Solid("#f00", xysize=(100, 100),
+                                                                         50, 50)))
+            """
+            for k, v in kwargs.items():
+                self.add(k, *v)
+            return self
+
         def render(self, width, height, st, at):
 
             # Determine the name of the mouse to use.


### PR DESCRIPTION
Instead of using successive calls to the `add` method, which can be ugly with multiple pointers, this enables passing all non-default pointers as kwargs.
We could instead add **kwargs to the normal constructor, but then we shadow possible future keyword arguments, and the `"cursor"` pointer name gets inaccessible.
The `adds` method could also simply call `.update(kwargs)` on the inner `self.cursors` dict, but I'd rather not separate the implementation of the two methods, and also this happens at init time so we don't really care about taking more time.

I have two doc suggestions if this is accepted : it should be said that a pointer named "default" replaces the default, and we could undocument the add method in favor of this one.