### PR TITLE
Don't shorten Image's repr

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -668,10 +668,7 @@ class Image(ImageBase):
         self.filename = filename
 
     def _repr_info(self):
-        if len(self.filename) < 20:
-            return repr(self.filename)
-        else:
-            return repr("\u2026"+self.filename[-20:])
+        return repr(self.filename)
 
     def get_hash(self):
         return renpy.loader.get_hash(self.filename)


### PR DESCRIPTION
Three reasons :
1) the im.Data displayable also returns a filename as _repr_info, but doesn't shorten it,
2) if printed in the console, the console repr shortener is clever enough to trigger by itself (although it limit is lengthier), and
3) with the artificially shortened repr there's no way to access the original filename from the console only, typing `long` won't help, you have to know about the private `.filename` attribute. That's not handy when debugging.