### PR TITLE
Use eq and ne for Matrix comparisons

### DIFF
--- a/renpy/display/matrix.pyx
+++ b/renpy/display/matrix.pyx
@@ -204,13 +204,12 @@ cdef class Matrix:
         elif components == 4:
             return (ox, oy, oz, ow)
 
-    def __richcmp__(Matrix self, Matrix other, op):
-
-        if op != 2:
-            return NotImplemented
-
+    def __eq__(Matrix self, other):
         if self is other:
             return True
+
+        if type(self) != type(other):
+            return False
 
         cdef int i
         cdef double total
@@ -221,6 +220,9 @@ cdef class Matrix:
             total += abs(self.m[i] - other.m[i])
 
         return total < .0001
+
+    def __ne__(Matrix self, other):
+        return not (self == other)
 
     cpdef bint is_unit_aligned(Matrix self):
         """


### PR DESCRIPTION
Uses the standard equality and inequality methods (ne was added for py2 support).
Got rid of the mistaken `Matrix other` in the signature which was enforced.
Added type comparison inside.