### PR TITLE
Allow config.version to be any object

### DIFF
--- a/gui/game/options.rpy
+++ b/gui/game/options.rpy
@@ -23,9 +23,13 @@ define config.name = _("Ren'Py 7 Default GUI")
 define gui.show_name = True
 
 
-## The version of the game.
+## The version of the game used in log file and traceback file. This could be any object.
 
 define config.version = "1.0"
+
+## The version of the game displayed to user in about screen.
+
+define gui.version = "1.0"
 
 
 ## Text that is placed on the game's about screen. Place the text between

--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -370,7 +370,7 @@ screen main_menu():
             text "[config.name!t]":
                 style "main_menu_title"
 
-            text "[config.version]":
+            text "[gui.version]":
                 style "main_menu_version"
 
 
@@ -553,7 +553,7 @@ screen about():
         vbox:
 
             label "[config.name!t]"
-            text _("Version [config.version!t]\n")
+            text _("Version [gui.version!t]\n")
 
             ## gui.about is usually set in options.rpy.
             if gui.about:

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -581,7 +581,7 @@ init 1500 python in build:
 
             directory_name = name
 
-            if config.version:
+            if version:
                 directory_name += "-" + version
 
         if not executable_name:

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -573,7 +573,7 @@ init -1500 python in build:
 init 1500 python in build:
 
     if version is None:
-        version = config.version
+        version = str(config.version)
 
     if name is not None:
 

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -29,6 +29,8 @@ init -1150 python in gui:
 
     _null = Null()
 
+    version = None
+
     def init(width, height, fov=75):
         """
         :doc: gui
@@ -77,6 +79,10 @@ init -1150 python in gui:
 
         if persistent._gui_preference_default is None:
             persistent._gui_preference_default = { }
+
+        global version
+        if version is None:
+            version = str(config.version)
 
     # A list of variant, function tuples.
     variant_functions = [ ]

--- a/renpy/dump.py
+++ b/renpy/dump.py
@@ -115,7 +115,7 @@ def dump(error):
 
     # The name and version.
     result["name"] = renpy.config.name
-    result["version"] = renpy.config.version
+    result["version"] = str(renpy.config.version)
 
     # The JSON object we return.
     location = { }

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -203,7 +203,7 @@ def report_exception(e, editor=True):
     try:
         print(str(platform.platform()), str(platform.machine()), file=full)
         print(renpy.version, file=full)
-        print(renpy.config.name + " " + renpy.config.version, file=full)
+        print("%s %r" % (renpy.config.name, renpy.config.version), file=full)
         print(str(time.ctime()), file=full)
     except Exception:
         pass

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -203,7 +203,7 @@ def report_exception(e, editor=True):
     try:
         print(str(platform.platform()), str(platform.machine()), file=full)
         print(renpy.version, file=full)
-        print("%s %r" % (renpy.config.name, renpy.config.version), file=full)
+        print("%s %s" % (renpy.config.name, renpy.config.version), file=full)
         print(str(time.ctime()), file=full)
     except Exception:
         pass

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -412,7 +412,7 @@ def save(slotname, extra_info='', mutate_flag=False):
 
     screenshot = renpy.game.interface.get_screenshot()
 
-    json = { "_save_name" : extra_info, "_renpy_version" : list(renpy.version_tuple), "_version" : renpy.config.version }
+    json = { "_save_name" : extra_info, "_renpy_version" : list(renpy.version_tuple), "_version" : str(renpy.config.version) }
 
     for i in renpy.config.save_json_callbacks:
         i(json)

--- a/renpy/log.py
+++ b/renpy/log.py
@@ -143,7 +143,7 @@ class LogFile(object):
             except Exception:
                 self.write("Unknown platform.")
             self.write("%s", renpy.version)
-            self.write("%s %s", renpy.config.name, renpy.config.version)
+            self.write("%s %r", renpy.config.name, renpy.config.version)
             self.write("")
 
             return True

--- a/renpy/log.py
+++ b/renpy/log.py
@@ -143,7 +143,7 @@ class LogFile(object):
             except Exception:
                 self.write("Unknown platform.")
             self.write("%s", renpy.version)
-            self.write("%s %r", renpy.config.name, renpy.config.version)
+            self.write("%s %s", renpy.config.name, renpy.config.version)
             self.write("")
 
             return True

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -74,7 +74,7 @@ use.
 
    This variable should not contain special characters like spaces,
    colons, and semicolons. If not set, it defaults to :var:`build.name`
-   a dash, and :var:`config.version`.
+   a dash, and string representation of :var:`config.version`.
 
 .. var:: build.executable_name = "..."
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -58,11 +58,12 @@ Commonly Used
     To locate the save directory, read :var:`config.savedir` instead of
     this variable.
 
-.. var:: config.version = ""
+.. var:: config.version = ...
 
-    This should be a string giving the version of the game. This is included
-    as part of tracebacks and other log files, helping to identify the
-    version of the game being used.
+    This should be an object representing the version of the game. This is
+    included as part of tracebacks and other log files, helping to identify the
+    version of the game being used. This may be a string or an object of any
+    other class but then it should have ``__str__`` method.
 
 .. var:: config.window = None
 

--- a/sphinx/source/oshs/game/screens.rpy
+++ b/sphinx/source/oshs/game/screens.rpy
@@ -546,7 +546,7 @@ screen about():
         vbox:
 
             label "[config.name!t]"
-            text _("Version [config.version!t]\n")
+            text _("Version [gui.version!t]\n")
 
             ## gui.about is usually set in options.rpy.
             if gui.about:


### PR DESCRIPTION
The idea is to allow developers to add full version information to the log file and (more importantly, since you can't write to that file) the traceback file, but the human-readable version may be different from that.
For example, in the git version I add the hex of the current commit, and in the release versions I add the additional hotfix number used when updating, which allows me to see if the bug report is out of date.

This is intended to be used like
```py
python early:
    class GameVersion(object):  # or str subclass
        def __str__(self):
            return "0.999"

        def __repr__(self):
            return "0.999.999"

    config.version = GameVersion()
```

Alternative solution could be to add another config.variable.
TODO: document it

I also want to fix the issue with `[config.name] [config.version]` not being printed in log.txt because it happens before any script read. I think we could add additional file like `script_version.txt` with that info during build, so if people send `log.txt` instead of `traceback.txt` I know the version they use wilthout usage of undocumented `renpy.write_log(config.version)`. Alternatively we could write it in the middle of the log before execute init code.
