### PR TITLE
Add JPEG-XL, AVIF support

### DIFF
--- a/renpy/common/00images.rpy
+++ b/renpy/common/00images.rpy
@@ -39,7 +39,7 @@ init -1900 python:
             basename = os.path.basename(fn)
             base, ext = os.path.splitext(basename)
 
-            if not ext.lower() in [ ".jpg", ".jpeg", ".png", ".webp" ]:
+            if not ext.lower() in [ ".jpg", ".jpeg", ".png", ".webp", ".jxl", ".avif" ]:
                 continue
 
             base = base.lower()

--- a/renpy/common/00images.rpy
+++ b/renpy/common/00images.rpy
@@ -58,3 +58,57 @@ init 1900 python:
 
     if config.late_images_scan:
         _scan_images_directory()
+
+init 3000 python:
+    def _heuristic_image_format_check():
+        formats = {
+            # PNG
+            ".png": pygame_sdl2.image.INIT_PNG,
+            # JPEG
+            ".jpg": pygame_sdl2.image.INIT_JPG,
+            ".jpeg": pygame_sdl2.image.INIT_JPG,
+            # TIFF
+            ".tif": pygame_sdl2.image.INIT_TIF,
+            ".tiff": pygame_sdl2.image.INIT_TIF,
+            # WebP
+            ".webp": pygame_sdl2.image.INIT_WEBP,
+            # JPEG-XL
+            ".jxl": pygame_sdl2.image.INIT_JXL,
+            # AVIF
+            ".avif": pygame_sdl2.image.INIT_AVIF,
+            ## There is no real way of checking the below,
+            ## but they are built into SDL2_image by default
+            # QOI
+            ".qoi": 0,
+            # BPM
+            ".bmp": 0, ".ico": 0, ".cur": 0,
+            # GIF
+            ".gif": 0,
+            # TGA
+            ".tga": 0,
+            # XCF
+            ".xcf": 0,
+        }
+
+        from collections import defaultdict
+        counter = defaultdict(lambda: 0)
+
+        for _, d in renpy.display.image.images.items():
+            if isinstance(d, renpy.display.im.Image):
+                _, ext = os.path.splitext(d.filename)
+                if ext:
+                    counter[ext.lower()] += 1
+
+        for ext, count in counter.items():
+            if count > 0:
+                itag = formats.get(ext, None)
+                if itag is None:
+                    renpy.log("Possibly unknown image format: %s (found %d images)" % (ext, count))
+                elif not pygame_sdl2.image.has_init(itag):
+                    renpy.log("Possibly missing image support in Ren'Py/SDL2_image build: %s (found %d images)"
+                        % (ext, count))
+
+        return counter
+    
+    if not renpy.official:
+        _heuristic_image_format_check()

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1300,7 +1300,7 @@ def init():
 
     global autoreload_functions
     autoreload_functions = [
-        (r'\.(png|jpg|jpeg|webp|gif|tif|tiff|bmp)$', renpy.exports.flush_cache_file),
+        (r'\.(png|jpg|jpeg|webp|gif|tif|tiff|bmp|jxl|avif)$', renpy.exports.flush_cache_file),
         (r'\.(mp2|mp3|ogg|opus|wav)$', renpy.audio.audio.autoreload),
         ]
 


### PR DESCRIPTION
Plumb loading of .jxl and .avif files.

The second commit adds some heuristics to unofficial build to hopefully help with issues due to missing (and non-default) support for these formats in users' SDL2_image. It can be removed if unwanted.

Depends on renpy/pygame_sdl2#142

Fixes #3865 #2977 

Tested by converting the_question/images/* to JXL and running the game.

I'm not overly familiar with the codebase, so I may have missed somewhere that needs new image formats mentioned, please point me in the correct direction if so. In pgrender.py, there exists a list of reentrant format loaders; I didn't add the new ones as I don't know if they are and couldn't easily find any information on the topic.

This also assumes that official builds will include support in their bundled SDL2_image build. I haven't looked into any build scripts that may be used for official builds yet so this still needs to be addressed before an official release.