### PR TITLE
Add build_info.json during distribution to help log.txt get the game name and version

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -922,6 +922,14 @@ change_renpy_executable()
 
                     self.add_file("all", "game/script_version.txt", script_version_txt)
 
+            if self.build["build_info"]:
+                build_info_json = self.temp_filename("build_info.json")
+
+                with open(build_info_json, "w") as f:
+                    json.dump(self.build["build_info"], f, indent=2)
+
+                self.add_file("all", "game/cache/build_info.json", build_info_json)
+
         def add_file_list_hash(self, list_name):
             """
             Hashes a file list, then adds that file to the Ren'Py distribution.

--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -28,6 +28,7 @@ import os
 import sys
 import subprocess
 import io
+import json
 
 import __main__
 
@@ -249,6 +250,16 @@ You may be using a system install of python. Please run {0}.sh,
     renpy.import_all()
 
     renpy.loader.init_importer()
+
+    # Load build_info.json once we have accessed the loader.
+    try:
+        with renpy.loader.load("cache/build_info.json") as f:
+            renpy.session['build_info'] = json.load(f)
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        # Could fail if file does not exists
+        renpy.session['build_info'] = {}
 
     exit_status = None
 

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -568,6 +568,12 @@ init -1500 python in build:
 
         rv["_sdk_fonts"] = _sdk_fonts
 
+        # Data saved in cache/build_info.json
+        rv["build_info"] = {
+            "name": config.name,
+            "version": config.version,
+        }
+
         return rv
 
 init 1500 python in build:

--- a/renpy/display/__init__.py
+++ b/renpy/display/__init__.py
@@ -60,7 +60,7 @@ def get_info():
 
 
 # Logs we use.
-log = renpy.log.open("log", developer=False, append=False)
+log = renpy.log.open("log", developer=False, append=False, flush=True)
 ic_log = renpy.log.open("image_cache", developer=True, append=False)
 to_log = renpy.log.open("text_overflow", developer=True, append=True)
 

--- a/renpy/log.py
+++ b/renpy/log.py
@@ -143,7 +143,11 @@ class LogFile(object):
             except Exception:
                 self.write("Unknown platform.")
             self.write("%s", renpy.version)
-            self.write("%s %s", renpy.config.name, renpy.config.version)
+
+            build_info_get = renpy.session['build_info'].get
+            name = build_info_get("name", renpy.config.name)
+            version = build_info_get("version", renpy.config.version)
+            self.write("%s %s", name, version)
             self.write("")
 
             return True


### PR DESCRIPTION
This actually does not work because `repny.loader.load` don't have searchpath yet and in time it does we already have log.txt written.