### PR TITLE
Allow quotes inside of triple strings

### DIFF
--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -905,13 +905,13 @@ class Lexer(object):
         newline.
         """
 
-        s = self.match(r'r?"""([^\\"]|\\.)*"""')
+        s = self.match(r'r?"""([^\\]|\\.)*"""')
 
         if s is None:
-            s = self.match(r"r?'''([^\\']|\\.)*'''")
+            s = self.match(r"r?'''([^\\]|\\.)*'''")
 
         if s is None:
-            s = self.match(r"r?```([^\\`]|\\.)*```")
+            s = self.match(r"r?```([^\\]|\\.)*```")
 
         if s is None:
             return None


### PR DESCRIPTION
Unless I am missing some case this covers, I do not see why this regex should disallow quoting inside of triple strings at all. This allows something like the following:

```
label start:
    """
    Test "with" quote in it
    """
```

Which currently does not work.