### PR TITLE
Allow multipliers in {size=<value>}

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1184,6 +1184,8 @@ class Layout(object):
 
                     if value[0] in "+-":
                         push().size += int(value)
+                    elif value[0] == "*":
+                        push().size = int(float(value[1:]) * push().size)
                     else:
                         push().size = int(value)
 

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -368,6 +368,12 @@ Tags that apply to all text are:
    decreased by that amount. ::
 
        "{size=+10}Bigger{/size} {size=-10}Smaller{/size} {size=24}24 px{/size}."
+   
+   You can also provide a floating point number preceded by a \*, in
+   which case the size will be multiplied by that number and then
+   rounded down. ::
+   
+       "{size=*2}Twice as big{/size} {size=*0.5}half as big.{/size}"
 
 .. text-tag:: space
 


### PR DESCRIPTION
Sometimes, your tag doesn't know what size it will be, but `+`/`-` is not enough, and turned out that in some circumstances I actually need a multiplier, rather than an addition, never mind that it's an int in the end.

Could this be added?

```
"{size=*2}This is double size{/size} and this is {size=*0.5}half size{/size}"
```