### PR TITLE
Advise setting config.developer to "auto" in lint

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -1015,7 +1015,8 @@ characters per block. """.format(
 
     print("")
     if renpy.config.developer and (renpy.config.original_developer != "auto"):
-        print("Remember to set config.developer to False before releasing.")
+        print("Remember to set config.developer to False before releasing,")
+        print('or set it to "auto".')
         print("")
 
     print("Lint is not a substitute for thorough testing. Remember to update Ren'Py")


### PR DESCRIPTION
The advice to setting it to False is a bit outdated, but if the creator sees the message it means config.developer was True, which itself is a bit outdated.