### PR TITLE
Expand get_ordered_image_attributes doc

### DIFF
--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -149,7 +149,7 @@ def get_ordered_image_attributes(tag, attributes=(), sort=None):
     """
     :doc: image_func
 
-    Returns a list of image tags, ordered in a way that makes sense to
+    Returns a list of image attributes, ordered in a way that makes sense to
     present to the user.
 
     `attributes`
@@ -158,9 +158,10 @@ def get_ordered_image_attributes(tag, attributes=(), sort=None):
         can be in a single image at the same time.)
 
     `sort`
-        If not None, the returned list of attributes is sorted. This is a function
-        that should be used as a tiebreaker.
-
+        If not None, the returned list of attributes is sorted. This is a
+        one-argument function that should be used as a tiebreaker - see
+        `this tutorial <https://docs.python.org/3/howto/sorting.html#key-functions>`_
+        for more information.
     """
 
     sequences = [ ]


### PR DESCRIPTION
This includes an off-site link to a python official tutorial, as well as a lignt fix - as far as I understand it, the function doesn't return tags.