### PR TITLE
Allow general iterables in some places where only lists were allowed

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -4,6 +4,7 @@ python early in layeredimage:
 
     from store import Transform, ConditionSwitch, Fixed, Null, config, Text, eval, At
     from collections import OrderedDict
+    from collections.abc import Iterable
 
     ATL_PROPERTIES = [ i for i in renpy.atl.PROPERTIES ]
     ATL_PROPERTIES_SET = set(ATL_PROPERTIES)
@@ -95,23 +96,31 @@ python early in layeredimage:
 
         def __init__(self, if_all=[ ], if_any=[ ], if_not=[ ], at=[ ], group_args={}, **kwargs):
 
-            if not isinstance(at, list):
+            if not isinstance(at, Iterable):
                 at = [ at ]
+            elif not isinstance(at, list):
+                at = list(at)
 
             self.at = at
 
-            if not isinstance(if_all, list):
+            if isinstance(if_all, str):
                 if_all = [ if_all ]
+            elif not isinstance(if_all, list):
+                if_all = list(at)
 
             self.if_all = if_all
 
-            if not isinstance(if_any, list):
+            if isinstance(if_any, str):
                 if_any = [ if_any ]
+            elif not isinstance(if_any, list):
+                if_any = list(at)
 
             self.if_any = if_any
 
-            if not isinstance(if_not, list):
+            if isinstance(if_not, str):
                 if_not = [ if_not ]
+            elif not isinstance(if_not, list):
+                if_not = list(at)
 
             self.if_not = if_not
 
@@ -596,8 +605,10 @@ python early in layeredimage:
             for i in attributes:
                 self.add(i)
 
-            if not isinstance(at, list):
+            if not isinstance(at, Iterable):
                 at = [ at ]
+            elif not isinstance(at, list):
+                at = list(at)
 
             self.at = at
 
@@ -1118,7 +1129,9 @@ python early in layeredimage:
             if transform is None:
                 self.transform = [ ]
 
-            elif isinstance(transform, list):
+            elif isinstance(transform, Iterable):
+                if not isinstance(transform, list):
+                    transform = list(transform)
                 self.transform = transform
 
             else:

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -28,6 +28,7 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 import gc
 import io
 import re
+from collections.abc import Iterable
 
 import renpy
 
@@ -658,7 +659,7 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
     if not at_list:
         tt = renpy.config.tag_transform.get(key, None)
         if tt is not None:
-            if not isinstance(tt, list):
+            if not isinstance(tt, Iterable):
                 at_list = [ tt ]
             else:
                 at_list = list(tt)
@@ -2565,8 +2566,10 @@ def show_layer_at(at_list, layer='master', reset=True, camera=False):
         to update that state.
     """
 
-    if not isinstance(at_list, list):
+    if not isinstance(at_list, Iterable):
         at_list = [ at_list ]
+    elif not isinstance(at_list, list):
+        at_list = list(at_list)
 
     renpy.game.context().scene_lists.set_layer_at_list(layer, at_list, reset=reset, camera=camera)
 


### PR DESCRIPTION
`config.tag_transform` and `renpy.show_layer_at` take any iterable of transforms rather than only lists.
Same with the layeredimage's `at` property and argument, the layeredimage layers' `at` property, and the transform parameter to LayeredImageProxy.

The `if_x` properties for layeredimages' layers now take iterables of strings rather than lists of strings. Only this one was granted an str check, because for transforms it makes no sense to use strings anyway.