### PR TITLE
Add the xycenter proxy style property

### DIFF
--- a/module/generate_styles.py
+++ b/module/generate_styles.py
@@ -275,11 +275,11 @@ property_priority = sorted_dict(
 )
 
 # A list of synthetic style properties, where each property is expanded into
-# multiple style properties. Each property are mapped into a list of tuples,
+# multiple style properties. Each property is mapped into a list of tuples,
 # with each consisting of:
 #
-# * The name of the style to assign.
-# * A string giving the name of a functon to call to get the value to assign, a constant
+# * The name of the style property to assign.
+# * A string giving the name of a function to call to get the value to assign, a constant
 #   numeric value, or None to not change the argument.
 synthetic_properties = sorted_dict(
 
@@ -419,6 +419,13 @@ synthetic_properties = sorted_dict(
 
     ycenter=[
         ('ypos', None),
+        ('yanchor', 0.5),
+        ],
+
+    xycenter=[
+        ('xpos', 'index_0'),
+        ('ypos', 'index_1'),
+        ('xanchor', 0.5),
         ('yanchor', 0.5),
         ],
     )

--- a/renpy/sl2/slproperties.py
+++ b/renpy/sl2/slproperties.py
@@ -49,12 +49,14 @@ position_property_names = [
     "clipping",
     "xfill",
     "yfill",
-    # no center, since it can conflict with the center transform.
     "xcenter",
     "ycenter",
+    "xycenter",
+    # not center, since it can conflict with the center transform.
     "xsize",
     "ysize",
     "xysize",
+    # not size, which is a text style property
     "alt",
     "debug",
     ]

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -307,6 +307,11 @@ or on the screen when not inside a layout.
     Equivalent to setting ypos to the value of this property, and
     yanchor to 0.5.
 
+.. style-property:: xycenter tuple of (position, position)
+
+    Equivalent to setting xcenter to the first component of the tuple,
+    and ycenter to the second.
+
 .. style-property:: xoffset int
 
     Gives a number of pixels that are added to the horizontal position


### PR DESCRIPTION
Not tested in any way.

https://github.com/renpy/renpy/blob/xycenter-style/sphinx/source/keywords.py and https://github.com/renpy/renpy/blob/xycenter-style/tutorial/game/keywords.py should probably be updated, but I'm not sure how to do that.