### PR TITLE
Use easy.to_list and easy.to_tuple

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -3,7 +3,7 @@
 python early in layeredimage:
 
     from store import Transform, ConditionSwitch, Fixed, Null, config, Text, eval, At
-    from collections import OrderedDict
+    from collections import OrderedDict, defaultdict
 
     ATL_PROPERTIES = [ i for i in renpy.atl.PROPERTIES ]
     ATL_PROPERTIES_SET = set(ATL_PROPERTIES)
@@ -574,9 +574,8 @@ python early in layeredimage:
             self.attributes = [ ]
             self.layers = [ ]
 
-            import collections
-            self.attribute_to_groups = collections.defaultdict(set)
-            self.group_to_attributes = collections.defaultdict(set)
+            self.attribute_to_groups = defaultdict(set)
+            self.group_to_attributes = defaultdict(set)
 
             for i in attributes:
                 self.add(i)

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -95,25 +95,10 @@ python early in layeredimage:
 
         def __init__(self, if_all=[ ], if_any=[ ], if_not=[ ], at=[ ], group_args={}, **kwargs):
 
-            if not isinstance(at, list):
-                at = [ at ]
-
-            self.at = at
-
-            if not isinstance(if_all, list):
-                if_all = [ if_all ]
-
-            self.if_all = if_all
-
-            if not isinstance(if_any, list):
-                if_any = [ if_any ]
-
-            self.if_any = if_any
-
-            if not isinstance(if_not, list):
-                if_not = [ if_not ]
-
-            self.if_not = if_not
+            self.at = renpy.easy.to_list(at)
+            self.if_all = renpy.easy.to_list(if_all)
+            self.if_any = renpy.easy.to_list(if_any)
+            self.if_not = renpy.easy.to_list(if_not)
 
             self.group_args = group_args
             self.transform_args = kwargs
@@ -596,10 +581,7 @@ python early in layeredimage:
             for i in attributes:
                 self.add(i)
 
-            if not isinstance(at, list):
-                at = [ at ]
-
-            self.at = at
+            self.at = renpy.easy.to_list(at)
 
             kwargs.setdefault("xfit", True)
             kwargs.setdefault("yfit", True)
@@ -1118,11 +1100,8 @@ python early in layeredimage:
             if transform is None:
                 self.transform = [ ]
 
-            elif isinstance(transform, list):
-                self.transform = transform
-
             else:
-                self.transform = [ transform ]
+                self.transform = renpy.easy.to_list(transform)
 
         @property
         def image(self):

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -222,8 +222,7 @@ def map_event(ev, keysym):
 
         return False
 
-    if isinstance(keysym, list):
-        keysym = tuple(keysym)
+    keysym = renpy.easy.to_tuple(keysym)
 
     check_code = event_cache.get(keysym, None)
     if check_code is None:
@@ -240,8 +239,7 @@ def map_keyup(ev, keysym):
         if (keysym in ev.eventnames) and ev.up:
             return True
 
-    if isinstance(keysym, list):
-        keysym = tuple(keysym)
+    keysym = renpy.easy.to_tuple(keysym)
 
     check_code = keyup_cache.get(keysym, None)
     if check_code is None:

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -222,7 +222,8 @@ def map_event(ev, keysym):
 
         return False
 
-    keysym = renpy.easy.to_tuple(keysym)
+    if isinstance(keysym, list):
+        keysym = tuple(keysym)
 
     check_code = event_cache.get(keysym, None)
     if check_code is None:
@@ -239,7 +240,8 @@ def map_keyup(ev, keysym):
         if (keysym in ev.eventnames) and ev.up:
             return True
 
-    keysym = renpy.easy.to_tuple(keysym)
+    if isinstance(keysym, list):
+        keysym = tuple(keysym)
 
     check_code = keyup_cache.get(keysym, None)
     if check_code is None:

--- a/renpy/easy.py
+++ b/renpy/easy.py
@@ -19,7 +19,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# Functions that make the user's life easier.
+"""Functions that make the user's life easier."""
 
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
@@ -33,6 +33,11 @@ import renpy
 
 Color = renpy.color.Color
 color = renpy.color.Color
+
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 
 def lookup_displayable_prefix(d):
@@ -258,3 +263,22 @@ def split_properties(properties, *prefixes):
             raise Exception("Property {} begins with an unknown prefix.".format(k))
 
     return rv
+
+def to_list(value, copy=False):
+    """
+    If the value is an iterable, turns it into a list, otherwise wraps it into one.
+    If a list is provided and `copy` is True, a new list will be returned.
+    """
+    if isinstance(value, Iterable) and not isinstance(value, str):
+        if (not copy) and isinstance(value, list):
+            return value
+        return list(value)
+    return [value]
+
+def to_tuple(value):
+    """
+    Same as to_list, but with tuples.
+    """
+    if isinstance(value, Iterable) and not isinstance(value, str):
+        return tuple(value)
+    return (value,)

--- a/renpy/easy.py
+++ b/renpy/easy.py
@@ -269,10 +269,12 @@ def to_list(value, copy=False):
     If the value is an iterable, turns it into a list, otherwise wraps it into one.
     If a list is provided and `copy` is True, a new list will be returned.
     """
-    if isinstance(value, Iterable) and not isinstance(value, str):
-        if (not copy) and isinstance(value, list):
-            return value
+    if isinstance(value, list):
+        return list(value) if copy else value
+        
+    if not isinstance(value, str) and isinstance(value, Iterable):
         return list(value)
+
     return [value]
 
 def to_tuple(value):

--- a/renpy/easy.py
+++ b/renpy/easy.py
@@ -281,6 +281,10 @@ def to_tuple(value):
     """
     Same as to_list, but with tuples.
     """
-    if isinstance(value, Iterable) and not isinstance(value, str):
+    if isinstance(value, tuple):
+        return value
+
+    if not isinstance(value, str) and isinstance(value, Iterable):
         return tuple(value)
+
     return (value,)

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -658,10 +658,7 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
     if not at_list:
         tt = renpy.config.tag_transform.get(key, None)
         if tt is not None:
-            if not isinstance(tt, list):
-                at_list = [ tt ]
-            else:
-                at_list = list(tt)
+            renpy.easy.to_list(tt)
 
     if what is None:
         what = name
@@ -2565,8 +2562,7 @@ def show_layer_at(at_list, layer='master', reset=True, camera=False):
         to update that state.
     """
 
-    if not isinstance(at_list, list):
-        at_list = [ at_list ]
+    at_list = renpy.easy.to_list(at_list)
 
     renpy.game.context().scene_lists.set_layer_at_list(layer, at_list, reset=reset, camera=camera)
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -658,7 +658,7 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
     if not at_list:
         tt = renpy.config.tag_transform.get(key, None)
         if tt is not None:
-            renpy.easy.to_list(tt)
+            renpy.easy.to_list(tt, copy=True)
 
     if what is None:
         what = name


### PR DESCRIPTION
replaces #3944 
I chose to test for str and not basestring, so that the behavior is exactly the same on py2 and py3, but that's arguable (now it only applies to unicode, to be clear).
The default value of `copy` is also arguable.
Another or_none parameter could be added, to avoid returning [None] in some cases.