### PR TITLE
Allows the launcher to perform repair updates

### DIFF
--- a/launcher/game/updater.rpy
+++ b/launcher/game/updater.rpy
@@ -78,6 +78,7 @@ init python:
     _("Nightly (Ren'Py 7, Python 2)")
     _("The bleeding edge of Ren'Py development. This may have the latest features, or might not run at all.")
 
+default allow_repair_update = False
 
 screen update_channel(channels):
 
@@ -108,8 +109,8 @@ screen update_channel(channels):
 
                     for c in channels:
 
-                        if c["split_version"] != list(renpy.version_tuple):
-                            $ action = [SetField(persistent, "has_update", None), SetField(persistent, "last_update_check", None), updater.Update(c["url"], simulate=UPDATE_SIMULATE, public_key=PUBLIC_KEY, confirm=False)]
+                        if c["split_version"] != list(renpy.version_tuple) or allow_repair_update:
+                            $ action = [SetField(persistent, "has_update", None), SetField(persistent, "last_update_check", None), updater.Update(c["url"], simulate=UPDATE_SIMULATE, public_key=PUBLIC_KEY, confirm=False, force=allow_repair_update)]
 
                             if c["channel"].startswith("Release"):
                                 $ current = _("• {a=https://www.renpy.org/doc/html/changelog.html}View change log{/a}")


### PR DESCRIPTION
Not meant to get documented.
When the previous update failed or is doubted of, its possible to set the `allow_repair_updates` variable to true in the console, which enables upgrading to the same version we're (supposed to be) in.

We could add this for the general public as a smol "(repair)" button alongside the disabled button of the current version.