### PR TITLE
Fix `renpy.load_module` not respecting init order

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2777,6 +2777,7 @@ def load_module(name, **kwargs):
     renpy.config.locked = False
 
     initcode = renpy.game.script.load_module(name)
+    initcode.sort(key=lambda i: i[0])
 
     context = renpy.execution.Context(False)
     context.init_phase = True


### PR DESCRIPTION
Before AST nodes would run in the order they were in the script. Now we're sorting them before running them.