### PR TITLE
Add `renpy.include_module`

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2777,7 +2777,6 @@ def load_module(name, **kwargs):
     renpy.config.locked = False
 
     initcode = renpy.game.script.load_module(name)
-    initcode.sort(key=lambda i: i[0])
 
     context = renpy.execution.Context(False)
     context.init_phase = True
@@ -2844,6 +2843,26 @@ def load_string(s, filename="<string>"):
 
     finally:
         renpy.game.exception_info = old_exception_info
+
+
+def include_module(name):
+    """
+    :doc: other
+
+    Similar to :func:`renpy.load_module`, but instead of loading the module right away,
+    inserts it into the init queue somewhere after the current AST node.
+
+    The module may not contain init blocks lower than the block that includes the module.
+    For example, if your module contains an init 10 block, the latest you can load it is
+    init 10.
+
+    Module loading may only occur from inside an init block.
+    """
+
+    if not renpy.game.context().init_phase:
+        raise Exception("Module loading is only allowed in init code.")
+
+    renpy.game.script.include_module(name)
 
 
 def pop_call():

--- a/renpy/game.py
+++ b/renpy/game.py
@@ -98,6 +98,9 @@ persistent = None # type: Any
 # The current preferences.
 preferences = None # type: Any
 
+# Current id of the AST node in script initcode
+initcode_ast_id = 0
+
 
 class ExceptionInfo(object):
     """

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -550,7 +550,9 @@ def main():
 
         renpy.game.exception_info = 'While executing init code:'
 
-        for _prio, node in game.script.initcode:
+        for id_, (_prio, node) in enumerate(game.script.initcode):
+
+            renpy.game.initcode_ast_id = id_
 
             if isinstance(node, renpy.ast.Node):
                 node_start = time.time()

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -487,6 +487,8 @@ class Script(object):
 
         stmts = self.finish_load(stmts, initcode, False)
 
+        initcode.sort(key=lambda i: i[0])
+
         return stmts, initcode
 
     def finish_load(self, stmts, initcode, check_names=True, filename=None):

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -410,12 +410,14 @@ class Script(object):
         initcode into the script current initcode
         """
         module_initcode = self.load_module(name)
+        if not module_initcode:
+            return
 
         # We may not insert elements at or prior the current id!
         current_id = renpy.game.initcode_ast_id
 
         if module_initcode[0][0] < self.initcode[current_id][0]:
-            raise Exception("Module %s contains nodes with priority lower than the node that loads it" %name)
+            raise Exception("Module %s contains nodes with priority lower than the node that loads it" % name)
 
         merge_id = current_id + 1
         current_tail = self.initcode[merge_id:]

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -417,7 +417,7 @@ class Script(object):
 
         # We may not insert elements at or prior the current id!
         current_id = renpy.game.initcode_ast_id
-        print("{} < {}".format(module_initcode[0][0], self.initcode[current_id][0]))
+
         if module_initcode[0][0] < self.initcode[current_id][0]:
             raise Exception("Module %s contains nodes with priority lower than the node that loads it" %name)
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -374,13 +374,9 @@ class Script(object):
 
             self.load_appropriate_file(".rpyc", [ "_ren.py", ".rpy" ], dir, fn, initcode)
 
-        # Make the sort stable.
-        initcode = [ (prio, index, code) for index, (prio, code) in
-                     enumerate(initcode) ]
+        initcode.sort(key=lambda i: i[0])
 
-        initcode.sort(key=lambda i: (i[0], i[1]))
-
-        self.initcode = [ (prio, code) for prio, index, code in initcode ]
+        self.initcode = initcode
 
         self.translator.chain_translates()
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -46,13 +46,84 @@ BYTECODE_VERSION = 1
 
 # The python magic code.
 if PY2:
+    import heapq
     import imp
     MAGIC = imp.get_magic()
 
     # Change this to force a recompile when required.
     MAGIC += b'_v2.1'
 
+    def heapq_merge(it_a, it_b, key=None, reverse=False):
+        """
+        Backported from py3 for compatibility, can only merge 2 iterables
+        """
+        iterables = [it_a, it_b]
+        h = []
+        h_append = h.append
+
+        if reverse:
+            _heapify = heapq._heapify_max
+            _heappop = heapq._heappop_max
+            _heapreplace = heapq._heapreplace_max
+            direction = -1
+        else:
+            _heapify = heapq.heapify
+            _heappop = heapq.heappop
+            _heapreplace = heapq.heapreplace
+            direction = 1
+
+        if key is None:
+            for order, it in enumerate(map(iter, iterables)):
+                try:
+                    next = it.next
+                    h_append([next(), order * direction, next])
+                except StopIteration:
+                    pass
+            _heapify(h)
+            while len(h) > 1:
+                try:
+                    while True:
+                        value, order, next = s = h[0]
+                        yield value
+                        s[0] = next() # raises StopIteration when exhausted
+                        _heapreplace(h, s) # restore heap condition
+                except StopIteration:
+                    _heappop(h) # remove empty iterator
+            if h:
+                # fast case when only a single iterator remains
+                value, order, next = h[0]
+                yield value
+                for v in next.__self__:
+                    yield v
+            return
+
+        for order, it in enumerate(map(iter, iterables)):
+            try:
+                next = it.next
+                value = next()
+                h_append([key(value), order * direction, value, next])
+            except StopIteration:
+                pass
+        _heapify(h)
+        while len(h) > 1:
+            try:
+                while True:
+                    key_value, order, value, next = s = h[0]
+                    yield value
+                    value = next()
+                    s[0] = key(value)
+                    s[2] = value
+                    _heapreplace(h, s)
+            except StopIteration:
+                _heappop(h)
+        if h:
+            key_value, order, value, next = h[0]
+            yield value
+            for v in next.__self__:
+                yield v
+
 else:
+    from heapq import merge as heapq_merge
     from importlib.util import MAGIC_NUMBER as MAGIC
 
     # Change this to force a recompile when required.
@@ -331,9 +402,33 @@ class Script(object):
         if renpy.parser.report_parse_errors():
             raise SystemExit(-1)
 
+        initcode.sort(key=lambda i: i[0])
+
         self.translator.chain_translates()
 
         return initcode
+
+    def include_module(self, name):
+        """
+        Loads a module with the provided name and inserts its
+        initcode into the script current initcode
+        """
+        module_initcode = self.load_module(name)
+
+        # We may not insert elements at or prior the current id!
+        current_id = renpy.game.initcode_ast_id
+        print("{} < {}".format(module_initcode[0][0], self.initcode[current_id][0]))
+        if module_initcode[0][0] < self.initcode[current_id][0]:
+            raise Exception("Module %s contains nodes with priority lower than the node that loads it" %name)
+
+        merge_id = current_id + 1
+        current_tail = self.initcode[merge_id:]
+
+        # Since script initcode and module initcode are both sorted,
+        # we can use heap to merge them
+        new_tail = heapq_merge(current_tail, module_initcode, key=lambda i: i[0])
+
+        self.initcode[merge_id:] = list(new_tail)
 
     def assign_names(self, stmts, fn):
         # Assign names to statements that don't have one already.


### PR DESCRIPTION
## Main change
This PR closes #3960 by adding a new function `renpy.include_module`. It allows the developer to control which module will be *included* in the script during init (where `renpy.load_module` loads the module right away, "ignoring" the init order).

## Additional changes
This also moves the sort I added in #3959 directly in `Script.load_module` and also adds sort to `Script.load_string`, now they are consistent with `Script.load_script`. Sorry, I missed it the first time.
Since timsort is a stable sorting algorithm (as of Python 2.3), I removed the old code with decorated sort to make it run a bit faster.

## Notes
I had to add `heapq_merge` which looks ugly and scary, but it's just a port from the Python 3.10 sources that works in Python 2.7. It can be removed down the line when you decide to no longer support py2.

If any edits are required, I can do them.  Otherwise if this PR looks good to you, I can add the changelog.