### PR TITLE
Move some functions from the "Others" page to more specific places in the doc

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -159,7 +159,7 @@ keyup_cache = { }
 
 def clear_keymap_cache():
     """
-    :doc: other
+    :doc: keymap
 
     Clears the keymap cache. This allows changes to :var:`config.keymap` to
     take effect without restarting Ren'Py.

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2833,7 +2833,7 @@ def load_string(s, filename="<string>"):
 
 def pop_call():
     """
-    :doc: other
+    :doc: label
     :name: renpy.pop_call
 
     Pops the current call from the call stack, without returning to

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2289,13 +2289,13 @@ def last_interact_type():
     return getattr(renpy.game.context().info, "_last_interact_type", None)
 
 
-def dynamic(*vars, **kwargs): # @ReservedAssignment
+def dynamic(*args, **kwargs):
     """
-    :doc: other
+    :doc: label
 
-    This can be given one or more variable names as arguments. This makes
-    the variables dynamically scoped to the current call. The variables will
-    be reset to their original value when the call returns.
+    This can be given one or more variable names as arguments. This makes the
+    variables dynamically scoped to the current call. When the call returns, the
+    variables will be reset to the value they had when this function was called.
 
     If the variables are given as keyword arguments, the value of the argument
     is assigned to the variable name.
@@ -2306,14 +2306,14 @@ def dynamic(*vars, **kwargs): # @ReservedAssignment
         $ renpy.dynamic(players=2, score=0)
     """
 
-    vars = vars + tuple(kwargs) # @ReservedAssignment
-    renpy.game.context().make_dynamic(vars)
+    args = args + tuple(kwargs)
+    renpy.game.context().make_dynamic(args)
 
     for k, v in kwargs.items():
         setattr(renpy.store, k, v)
 
 
-def context_dynamic(*vars): # @ReservedAssignment
+def context_dynamic(*args):
     """
     :doc: other
 
@@ -2326,7 +2326,7 @@ def context_dynamic(*vars): # @ReservedAssignment
         $ renpy.context_dynamic("x", "y", "z")
     """
 
-    renpy.game.context().make_dynamic(vars, context=True)
+    renpy.game.context().make_dynamic(args, context=True)
 
 
 def seen_label(label):

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -4005,7 +4005,7 @@ def get_identifier_checkpoints(identifier):
 
 def get_adjustment(bar_value):
     """
-    :doc: other
+    :doc: screens
 
     Given `bar_value`, a  :class:`BarValue`, returns the :func:`ui.adjustment`
     if uses. The adjustment has the following to attributes defined:

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2580,7 +2580,7 @@ def free_memory():
 
 def flush_cache_file(fn):
     """
-    :doc: other
+    :doc: image_func
 
     This flushes all image cache entries that refer to the file `fn`.  This
     may be called when an image file changes on disk to force Ren'Py to

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3840,7 +3840,7 @@ def clear_line_log():
 
 def add_layer(layer, above=None, below=None, menu_clear=True):
     """
-    :doc: other
+    :doc: image_func
 
     Adds a new layer to the screen. If the layer already exists, this
     function does nothing.
@@ -3860,7 +3860,7 @@ def add_layer(layer, above=None, below=None, menu_clear=True):
 
     `menu_clear`
         If true, this layer will be cleared when entering the game menu
-        context, and restored when leaving the
+        context, and restored when leaving it.
     """
 
     layers = renpy.config.layers

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2851,7 +2851,7 @@ pop_return = pop_call
 
 def call_stack_depth():
     """
-    :doc: other
+    :doc: label
 
     Returns the depth of the call stack of the current context - the number
     of calls that have run without being returned from or popped from the

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3671,7 +3671,7 @@ def count_newly_seen_dialogue_blocks():
 
 def substitute(s, scope=None, translate=True):
     """
-    :doc: other
+    :doc: text_utility
 
     Applies translation and new-style formatting to the string `s`.
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1897,7 +1897,7 @@ def jump(label):
 
 def jump_out_of_context(label):
     """
-    :doc: label
+    :doc: context
 
     Causes control to leave the current context, and then to be
     transferred in the parent context to the given label.

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2315,7 +2315,7 @@ def dynamic(*args, **kwargs):
 
 def context_dynamic(*args):
     """
-    :doc: other
+    :doc: context
 
     This can be given one or more variable names as arguments. This makes
     the variables dynamically scoped to the current context. The variables will

--- a/renpy/game.py
+++ b/renpy/game.py
@@ -250,7 +250,7 @@ def context(index=-1):
 
 def invoke_in_new_context(callable, *args, **kwargs): # @ReservedAssignment
     """
-    :doc: label
+    :doc: context
 
     This function creates a new context, and invokes the given Python
     callable (function) in that context. When the function returns
@@ -313,7 +313,7 @@ def invoke_in_new_context(callable, *args, **kwargs): # @ReservedAssignment
 
 def call_in_new_context(label, *args, **kwargs):
     """
-    :doc: label
+    :doc: context
 
     This creates a new context, and then starts executing Ren'Py script
     from the given label in that context. Rollback is disabled in the

--- a/sphinx/source/keymap.rst
+++ b/sphinx/source/keymap.rst
@@ -263,3 +263,5 @@ Gamepads that do not work without special initialization are disabled by
 default. This includes the Nintendo Switch Pro Controller, which requires
 special initialization to work on a PC. This blocklisting is controlled by
 :var:`config.controller_blocklist`.
+
+.. include:: inc/keymap

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -203,3 +203,8 @@ Labels & Control Flow Functions
 -------------------------------
 
 .. include:: inc/label
+
+Contexts
+---------
+
+.. include:: inc/context

--- a/sphinx/source/other.rst
+++ b/sphinx/source/other.rst
@@ -78,11 +78,6 @@ Memory Profiling
 
 .. include:: inc/memory
 
-Contexts
----------
-
-.. include:: inc/context
-
 renpy.random
 -------------
 


### PR DESCRIPTION
Aside from reassigning specific functions to specific include places, this creates a Contexts section in the "Labels and control flow" page, which receives 1) the functions which were listed in the now removed Contexts section of the "Others" page 2) a function from the general Others list 3) three functions previously listed in the label-related functions.
Some explanations about what a context actually is is outside of the scope of this PR, but would be a good addition to that section.