### PR TITLE
Remove bogus onlayer parsing on scene statements

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -797,8 +797,13 @@ def call_statement(l, loc):
 
 @statement("scene")
 def scene_statement(l, loc):
-    # Empty.
-    if l.eol():
+    layer = None
+    if l.keyword('onlayer'):
+        layer = l.require(l.name)
+        l.expect_eol()
+
+    if layer or l.eol():
+        # No displayable.
         l.advance()
         return ast.Scene(loc, None, layer)
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -797,11 +797,6 @@ def call_statement(l, loc):
 
 @statement("scene")
 def scene_statement(l, loc):
-    if l.keyword('onlayer'):
-        layer = l.require(l.name)
-    else:
-        layer = "master"
-
     # Empty.
     if l.eol():
         l.advance()


### PR DESCRIPTION
```rpy
label scn:
    scene sand6
    "scene sand6"
    scene wet onlayer screens
    "scene wet onlayer screens"
    # scene onlayer screens bashar onlayer master
    # "scene onlayer screens bashar onlayer master"
    # scene onlayer master sand6 onlayer screens
    # "scene onlayer master sand6 onlayer screens"
    scene
    "scene"
    # scene onlayer screens wet
    # "scene onlayer screens wet"
    scene onlayer screens
    "scene onlayer screens"
    jump scn
```
The commented-out lines were previously bogus, as they didn't raise a parsing error but their first onlayer clause was silently ignored.
Now, they raise parsing errors.
Fei, the separate onlayer parsing is required for the last scene statement to function properly.

This PR offers no compat, for the same reasons as in ddc4eab5fd0001b6b9e30e49112885911fb7c3df.
But if one is requested, I have a lead on how to do it differently.