### PR TITLE
Lifecycle doc page

### DIFF
--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -147,6 +147,8 @@ If the optional expression is given to return, it is evaluated, and it's result
 is stored in the ``_return`` variable. This variable is dynamically scoped to each
 context.
 
+.. _special-labels:
+
 Special Labels
 --------------
 

--- a/sphinx/source/lifecycle.rst
+++ b/sphinx/source/lifecycle.rst
@@ -36,10 +36,10 @@ The init phase
 
 After parsing/early phase, the "init" phase starts. Several statements are executed at that time,
 including the :ref:`init-python-statement`, the :ref:`define-statement`, the
-:ref:`default-statement`, the :ref:`transform-statement`, the :ref:`image-statement`, the
-:ref:`screen-statement`, and the :doc:`style <style>` statement. The init phase is divided in
-successive epochs, or init priorities, from -999 to 999. Contrary to what it may imply, epochs of
-lower priority are executed before epochs of higher priority.
+:ref:`transform-statement`, the :ref:`image-statement`, the :ref:`screen-statement`, and the
+:doc:`style <style>` statement. The init phase is divided in successive epochs, or init priorities,
+from -999 to 999. Contrary to what the term may imply, epochs of lower priority are executed before
+epochs of higher priority.
 
 .. image define default transform (init) screen (testcase) (translation) style
 
@@ -104,4 +104,5 @@ In-game phase
 -------------
 
 This part is when a playthrough starts. It typically begins with the :class:`Start` action, but
-there are other ways (such as loading a save, or returning from the ``main_menu`` label).
+there are other ways (such as loading a save, or returning from the ``main_menu`` label). As
+explained in :doc:`label`, when returning, control goes back to the main menu.

--- a/sphinx/source/lifecycle.rst
+++ b/sphinx/source/lifecycle.rst
@@ -1,0 +1,107 @@
+==========================
+Lifecycle of a Ren'Py game
+==========================
+
+When launching a Ren'Py game, be it from the executable or from the launcher, it follows a series
+of steps up until the point where it is closed. This page exposes the various phases of this
+lifecycle, and various related statements.
+
+Boot time
+=========
+
+There are a lot of things happening before the game window appears. This is the boot time. The
+only thing that's possibly visible at that point is the :ref:`presplash <presplash>`.
+
+.. _early-phase:
+
+Parsing phase
+-------------
+
+To read the games's code, Ren'Py reads each of the game's ``.rpy`` (and ``_ren.py``) files one by
+one, in the unicode order of their filepaths. That's the "parsing" phase, or "early" phase.
+
+The first creator-written code being executed is what's written in ``python early`` blocks. These
+are executed after the file they're in has been read and parsed, but before the next file gets
+read. This is why statements which modify how parsing works, like :doc:`cds`,
+:ref:`creator-defined-sl` or new custom :ref:`warpers`, must be written in ``python early``
+blocks.
+
+The ``init python early`` syntax is sometimes encountered, but it's redundant and doesn't change
+anything in how the code gets executed.
+
+.. _init-phase:
+
+The init phase
+--------------
+
+After parsing/early phase, the "init" phase starts. Several statements are executed at that time,
+including the :ref:`init-python-statement`, the :ref:`define-statement`, the
+:ref:`default-statement`, the :ref:`transform-statement`, the :ref:`image-statement`, the
+:ref:`screen-statement`, and the :doc:`style <style>` statement. The init phase is divided in
+successive epochs, or init priorities, from -999 to 999. Contrary to what it may imply, epochs of
+lower priority are executed before epochs of higher priority.
+
+.. image define default transform (init) screen (testcase) (translation) style
+
+By default, these statements are executed at init offset 0. However, they can be offset using
+the :ref:`init-offset-statement` or by other means. The :ref:`image-statement` is an exception to
+both of these rules, as it executes at an init priority of 500 by default, and the init offset
+statement adds or substracts from this 500, rather than replacing it.
+
+Automatic image definition from the :ref:`image-directory` occurs at init priority 0.
+
+Note that while the :ref:`default <default-statement>` statements are not executed at init time,
+the priority of the statements influences the order in which they will be executed, relative to
+one another.
+
+.. _init-offset-statement:
+
+Init Offset Statement
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``init offset`` statement sets a priority offset for all statements
+that run at init time. It should be placed at the top of the file, and it applies to all following
+statements in the current block and child blocks, up to the next
+init priority statement. The statement::
+
+    init offset = 42
+
+sets the priority offset to 42. In::
+
+    init offset = 2
+    define foo = 2
+
+    init offset = 1
+    define foo = 1
+
+    init offset = 0
+
+The first define statement is run at priority 2, which means it runs
+after the second define statement, and hence ``foo`` winds up with
+a value of 2.
+
+Game running time
+=================
+
+This is what happens once the game window becomes visible. This is when normal Ren'Py statements
+execute, and when the rules described in :doc:`label` apply. This is also the time when the
+variables from :ref:`default statements <default-statement>` are set for the first time - as
+opposed to :ref:`define statements <define-statement>` which are set at init time.
+
+Splashscreen
+------------
+
+If it exists, the :ref:`splashscreen <adding-a-splashscreen>` label is executed until it returns.
+
+Main menu
+---------
+
+If it exists, the ``before_main_menu`` label is executed. Then, once it returns, the
+:ref:`main_menu <main-menu-screen>` screen is shown, unless a ``main_menu`` label exists, in which
+case it is executed instead. See :ref:`special-labels` for more information.
+
+In-game phase
+-------------
+
+This part is when a playthrough starts. It typically begins with the :class:`Start` action, but
+there are other ways (such as loading a save, or returning from the ``main_menu`` label).

--- a/sphinx/source/python.rst
+++ b/sphinx/source/python.rst
@@ -218,33 +218,6 @@ if it doesn't already exist. For example::
 As for the ``define`` statement, :ref:`lint` offers checks and optimizations
 related to the ``default`` statement.
 
-.. _init-offset-statement:
-
-Init Offset Statement
----------------------
-
-The ``init offset`` statement sets a priority offset for all statements
-that run at init time (init, init python, define, default, screen,
-transform, style, and more). The offset applies to all following
-statements in the current block and child blocks, up to the next
-init priority statement. The statement::
-
-    init offset = 42
-
-sets the priority offset to 42. In::
-
-    init offset = 2
-    define foo = 2
-
-    init offset = 1
-    define foo = 1
-
-    init offset = 0
-
-The first define statement is run at priority 2, which means it runs
-after the second define statement, and hence ``foo`` winds up with
-a value of 2.
-
 Names in the Store
 ------------------
 

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -111,6 +111,7 @@ in a block may be one of two things:
 * A property list.
 * A screen language statement.
 
+.. _screen-statement:
 
 Screen Statement
 ----------------

--- a/sphinx/source/splashscreen_presplash.rst
+++ b/sphinx/source/splashscreen_presplash.rst
@@ -12,7 +12,7 @@ code applies to a splashscreen located anywhere in your game under a different
 label.
 
 To add a textual splashscreen to your game, insert code like the below anywhere in
-your script files (as long as it is not itself in a block): ::
+your script files (as long as it is not itself in a block)::
 
     label splashscreen:
         scene black
@@ -27,7 +27,7 @@ your script files (as long as it is not itself in a block): ::
         return
 
 Here's another example of a splashscreen, this time using an image and
-sound: ::
+sound::
 
     image splash = "splash.png"
 
@@ -45,13 +45,15 @@ sound: ::
 
         return
 
-And finally, with a movie file: ::
+And finally, with a movie file::
 
     label splashscreen:
 
         $ renpy.movie_cutscene('movie.ogv')
 
         return
+
+.. _presplash:
 
 Adding a Presplash
 ------------------


### PR DESCRIPTION
A section where to include functions and classes would be cool, including at least `renpy.is_init_phase`.
I think we could add more flesh to it, but this could also be merged as it is.