### PR TITLE
fix drag drop screen example

### DIFF
--- a/sphinx/source/drag_drop.rst
+++ b/sphinx/source/drag_drop.rst
@@ -41,7 +41,7 @@ Examples
 An example of a say screen that allows the user to choose the location
 of the window by dragging it around the screen.::
 
-    screen say:
+    screen say(who, what):
 
         drag:
             drag_name "say"


### PR DESCRIPTION
the `say` screen was missing the `who` and `what` parameters