### PR TITLE
allow: `textsubsegment_callbacks` for `FontGroup`

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1285,6 +1285,10 @@ viewport_drag_radius = 10
 # function is run.
 scene_callbacks = [ ]
 
+# This is a dict of list with functions that accept the key to which is language,
+# (object of `text.TextSegment``, phrase by `font.FontGroup.segment``),
+# Only called when using `font.FontGroup` instead of a font.
+textsubsegment_callbacks = { }
 
 del os
 del collections

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -326,16 +326,25 @@ class TextSegment(object):
             return
 
         segs = { }
+        ts_callbacks = renpy.config.textsubsegment_callbacks.get(
+            renpy.game.preferences.language, []
+        )
 
         for f, ss in tf.segment(s):
 
-            seg = segs.get(f, None)
+            seg = segs.get(
+                (f, ss) if ts_callbacks else f,
+                None
+            )
 
             if seg is None:
                 seg = TextSegment(self)
                 seg.font = f
 
-                segs[f] = seg
+                for ts_callback in ts_callbacks:
+                    seg = ts_callback(seg, ss)
+
+                segs[(f, ss) if ts_callbacks else f] = seg
 
             yield seg, ss
 


### PR DESCRIPTION
This allows you to manipulate `text.TextSegment` relative to the fonts used in `font.FontGroup`.
Let's say one font in paragraphs may be larger than another, but simply changing the styles won't help here.
Example:
```python
def _ts_callback(segment, ss):
    if segment.font in ("example.ttf", ):
        segment.size *= 0.9
    return segment
```

Using a language for the key is justified by the fact that fonts are overwhelmingly used differently for each language.