### PR TITLE
Fix RENPY_DEPS_INSTALL docs for armhf, ppc64, and ppc64le

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Next, set RENPY_DEPS_INSTALL To a \:-separated (\;-separated on Windows)
 list of paths containing the dependencies, and RENPY_CYTHON to the name
 of the cython command::
 
-    export RENPY_DEPS_INSTALL="/usr:/usr/lib/$(uname -m)-linux-gnu/"
+    export RENPY_DEPS_INSTALL="/usr:/usr/lib/$(gcc -dumpmachine)/"
     export RENPY_CYTHON=cython
 
 Finally, use setup.py in the Ren'Py ``module`` directory to compile and


### PR DESCRIPTION
The correct triplets for various arches are:

- `x86_64-linux-gnu`
- `arm-linux-gnueabihf`
- `powerpc64-linux-gnu`
- `powerpc64le-linux-gnu`

The `uname`-based instructions produced the following:

- `x86_64-linux-gnu` (correct)
- `armv7l-linux-gnu` (wrong)
- `ppc64-linux-gnu` (wrong)
- `ppc64le-linux-gnu` (wrong)

`gcc` produces the correct results for all four.  I suspect this will also fix non-GNU triplets such as musl, but didn't test those.