### PR TITLE
Document platform-specific presplash images

### DIFF
--- a/sphinx/source/android.rst
+++ b/sphinx/source/android.rst
@@ -292,6 +292,7 @@ When generating the application, Ren'Py will convert these files to an
 appropriate size for each device, and will generate static icons for devices
 that do not support adaptive icons.
 
+.. _android-presplash:
 
 Presplash
 ---------

--- a/sphinx/source/splashscreen_presplash.rst
+++ b/sphinx/source/splashscreen_presplash.rst
@@ -66,6 +66,8 @@ into the game directory.
 presplash.png
     The image that's used when the game is loading.
 
+This will only work on computer platforms, not on android, ios or web.
+
 The :var:`config.minimum_presplash_time` variable sets a minimum time the
 presplash is shown for.
 
@@ -121,3 +123,12 @@ how things could look below:
 
         An slightly more elaborate example of how the progress bar foreground
         could look.
+
+Platform-specific presplashes
+-----------------------------
+
+The Web platform natively uses a default presplash image. To override it, you can supply
+an image named `web-presplash`, `.jpg`, `.png` or `.webp`, and it will replace
+the default.
+
+For the android platform, see :ref:`android-presplash`.


### PR DESCRIPTION
The Ios one is missing, but I don't have much infos about it.