### PR TITLE
Attempt to implement #4018 and #4019

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1314,8 +1314,9 @@ class ADVCharacter(object):
 
             dtt = DialogueTextTags(what)
 
+            if not renpy.config.history_current_dialogue:
             # Now, display the dialogue.
-            self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
+                self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
 
             # Indicate that we're done.
             if _call_done and not dtt.has_done:
@@ -1331,6 +1332,9 @@ class ADVCharacter(object):
 
                 renpy.exports.log(what)
                 renpy.exports.log("")
+                
+            if renpy.config.history_current_dialogue:
+                self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
 
         finally:
 

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -429,7 +429,8 @@ init -1500 python hide:
             return
 
         if getattr(renpy.context(), "_menu", False):
-            renpy.sound.stop(channel="voice")
+            if config.voice_stop_menu:
+                renpy.sound.stop(channel="voice")
             return
 
         if _preferences.voice_sustain and not _voice.sustain:

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -513,6 +513,9 @@ key_repeat = (.3, .03)
 # A callback that is called with the character's voice_tag.
 voice_tag_callback = None
 
+# Should we make the voice stop when we enter the menu?
+voice_stop_menu = True
+
 # A list of callbacks that can be used to add JSON to save files.
 save_json_callbacks = [ ]
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -734,6 +734,9 @@ history_length = None
 # object.
 history_callbacks = [ ]
 
+# Should we add the current dialogue to the history?
+history_current_dialogue = False
+
 # Should we use the new order for translate blocks?
 new_translate_order = True
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -301,6 +301,11 @@ Occasionally Used
 
     See :ref:`Automatic Voice <automatic-voice>` for more details.
 
+.. var:: config.voice_stop_menu = True
+
+    If False, The voice does not stop playing when entering menus
+    (navigation and history screens).
+    
 .. var:: config.autosave_callback = None
 
     A callback or list of callbacks that will be called after each time a

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -564,6 +564,10 @@ Occasionally Used
 
     The number of entries of dialogue history Ren'Py keeps. This is
     set to 250 by the default gui.
+    
+.. var:: config.history_current_dialogue = False
+  
+    If true, The current dialogue will appear in the history screen.
 
 .. var:: config.hw_video = False
 


### PR DESCRIPTION
Attempted to add configuration variables
to the history screen to show the current conversation https://github.com/renpy/renpy/issues/4018
and the voice will not stop when entering the menu.  https://github.com/renpy/renpy/issues/4019
