### PR TITLE
fix & changes: bypassing exception on `MP.save`, some functions, docs for `MP`

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -257,7 +257,7 @@ name_blacklist = {
     "renpy.audio.audio.lock",
     "renpy.audio.audio.periodic_condition",
     "renpy.webloader.queue_lock",
-    "renpy.persistent.save_MP_instances",
+    "renpy.persistent.MP_instances",
     "renpy.exports.sdl_dll",
     }
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -3168,7 +3168,7 @@ class Interface(object):
             renpy.loadsave.save("_reload-1")
 
         renpy.persistent.update(True)
-        renpy.persistent.save_MP()
+        renpy.persistent.save_on_quit_MP()
 
     def mobile_unlink(self):
         """

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -661,7 +661,7 @@ def main():
                 finally:
                     restart = (renpy.config.end_game_transition, "_invoke_main_menu", "_main_menu")
                     renpy.persistent.update(True)
-                    renpy.persistent.save_MP()
+                    renpy.persistent.save_on_quit_MP()
 
             except game.FullRestartException as e:
                 restart = e.reason

--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -461,16 +461,19 @@ class _MultiPersistent(object):
         return None
 
     def save(self):
-
-        fn = self._filename
-        with open(fn + ".new", "wb") as f:
-            dump(self, f)
-
         try:
-            os.rename(fn + ".new", fn)
-        except Exception:
-            os.unlink(fn)
-            os.rename(fn + ".new", fn)
+            fn = self._filename
+            with open(fn + ".new", "wb") as f:
+                dump(self, f)
+        except OSError as e:
+            if renpy.config.developer:
+                raise e
+        else:
+            try:
+                os.rename(fn + ".new", fn)
+            except Exception:
+                os.unlink(fn)
+                os.rename(fn + ".new", fn)
 
 
 def MultiPersistent(name, save_on_quit=False):


### PR DESCRIPTION
This poolrequest includes a workaround of the error when trying to save, and some changes and additions inside `renpy.persistent`, namely they deal with the interaction with objects of the `_MultiPersistent` class. 