### PR TITLE
Allow adding the current dialogue to history screen

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1313,9 +1313,10 @@ class ADVCharacter(object):
                 self.do_add(who, what)
 
             dtt = DialogueTextTags(what)
-
+            
+            if not renpy.config.history_current_dialogue:
             # Now, display the dialogue.
-            self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
+                self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
 
             # Indicate that we're done.
             if _call_done and not dtt.has_done:
@@ -1331,6 +1332,9 @@ class ADVCharacter(object):
 
                 renpy.exports.log(what)
                 renpy.exports.log("")
+                
+            if renpy.config.history_current_dialogue:
+                self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)                
 
         finally:
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -734,6 +734,9 @@ history_length = None
 # object.
 history_callbacks = [ ]
 
+# Should we add the current dialogue to the history?
+history_current_dialogue = False
+
 # Should we use the new order for translate blocks?
 new_translate_order = True
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -564,6 +564,10 @@ Occasionally Used
 
     The number of entries of dialogue history Ren'Py keeps. This is
     set to 250 by the default gui.
+    
+.. var:: config.history_current_dialogue = False
+
+    If true, The current dialogue will appear in the history screen.
 
 .. var:: config.hw_video = False
 


### PR DESCRIPTION
Attempt to implement https://github.com/renpy/renpy/issues/4018.

Added a configuration variable that allows adding the current dialogue to history screen.