### PR TITLE
Pylint - Use literals instead of builtin types constructors

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -2058,7 +2058,7 @@ class Interface(object):
                     )
 
             else:
-                self.layer_properties[layer] = dict()
+                self.layer_properties[layer] = {}
 
         # A stack giving the values of self.transition and self.transition_time
         # for contexts outside the current one. This is used to restore those

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1230,7 +1230,7 @@ class SizeGroup(renpy.object.Object):
         return maxwidth
 
 
-size_groups = dict()
+size_groups = {}
 
 
 class Window(Container):

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -935,7 +935,7 @@ def get_menu_args():
     """
 
     if menu_args is None:
-        return tuple(), dict()
+        return (), {}
 
     return menu_args, menu_kwargs
 
@@ -951,8 +951,8 @@ def menu(items, set_expr, args=None, kwargs=None, item_arguments=None):
     global menu_args
     global menu_kwargs
 
-    args = args or tuple()
-    kwargs = kwargs or dict()
+    args = args or ()
+    kwargs = kwargs or {}
 
     nvl = kwargs.pop("nvl", False)
 
@@ -970,7 +970,7 @@ def menu(items, set_expr, args=None, kwargs=None, item_arguments=None):
             return s
 
     if item_arguments is None:
-        item_arguments = [ (tuple(), dict()) ] * len(items)
+        item_arguments = [ ((), {}) ] * len(items)
 
     # Filter the list of items on the set_expr:
     if set_expr:

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -897,7 +897,7 @@ def transfn(name):
     raise Exception("Couldn't find file '%s'." % name)
 
 
-hash_cache = dict()
+hash_cache = {}
 
 
 def get_hash(name): # type: (str) -> int

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -152,7 +152,7 @@ def load_rpe(fn):
         autorun = zfn.read("autorun.py")
 
     sys.path.insert(0, fn)
-    exec(autorun, dict())
+    exec(autorun, {})
 
 
 def choose_variants():

--- a/renpy/text/font.py
+++ b/renpy/text/font.py
@@ -748,7 +748,7 @@ class FontGroup(object):
     """
 
     # For compatibility with older instances.
-    char_map = dict()
+    char_map = {}
 
     def __init__(self):
 


### PR DESCRIPTION
From #3994
Generates simpler executable code, I think (it's recommended anyway)