### PR TITLE
Pylint - Remove overriden slot name

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1020,7 +1020,6 @@ class Label(Node):
 
     translation_relevant = True
     __slots__ = [
-        'name',
         'parameters',
         'block',
         'hide',


### PR DESCRIPTION
From #3994
Wastes memory and may break in a future version of python, see point 6 of this : https://docs.python.org/3/reference/datamodel.html#notes-on-using-slots