### PR TITLE
Pylint - Avoid shadowing the function parameter

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2074,8 +2074,8 @@ def transition(trans, layer=None, always=False, force=False):
     """
 
     if isinstance(trans, dict):
-        for layer, t in trans.items():
-            transition(t, layer=layer, always=always, force=force)
+        for ly, t in trans.items():
+            transition(t, layer=ly, always=always, force=force)
         return
 
     if (not always) and not renpy.game.preferences.transitions: # type: ignore


### PR DESCRIPTION
From #3994