### PR TITLE
Fix: alternate translation

### DIFF
--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -204,7 +204,7 @@ class ScriptTranslator(object):
             tl = self.language_translates.get((identifier, language), None)
 
             if (tl is None) and alternate:
-                tl = self.language_translates.get((identifier, language), None)
+                tl = self.language_translates.get((identifier, alternate), None)
 
         else:
             tl = None


### PR DESCRIPTION
The alternate variable wasn't used where it should.
Instead there are two indentical `self.language_translates.get((identifier, language), None)` lines.