### PR TITLE
use `zorder 0` for the gl test

### DIFF
--- a/renpy/common/00gltest.rpy
+++ b/renpy/common/00gltest.rpy
@@ -383,14 +383,14 @@ label _gl_test:
         return
 
     # Show the test image.
-    scene black
+    scene black zorder 0
     show expression config.gl_test_image
     with None
 
     $ __gl_test()
 
     # Hide the test image.
-    scene black
+    scene black zorder 0
 
     return
 


### PR DESCRIPTION
something i noticed is that this bit of code:
```
image black = Solid("#000")
image white = Solid("#fff")

define config.gl_test_image = "white"
define config.tag_zorder["black"] = 5
```
will cause the gl_test_image to not show up due to its zorder being lower than black's.

this is annoying when a `splashscreen` that uses a white solid is used:
```
label splashscreen:
    show white
    pause 1.0
    return
```
the game will "flicker" from black to white, when only white is supposed to be showing