### PR TITLE
Fix star-import of substores

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -225,8 +225,7 @@ def create_store(name):
     pyname = pystr(name)
 
     # Set the name.
-    d["__name__"] = pyname
-    d["__package__"] = pyname
+    d.update(__name__=pyname, __package__=pyname)
 
     # Set up the default contents of the store.
     eval("1", d)


### PR DESCRIPTION
`from module import *`
In python 2, when `b"__name__"` is found in the module's inner dict, it is not imported. _**However**_, if `u"__name__"` is found, it _is_ imported and replaces the local `__name__`.
Given the `from __future__ import unicode_literals`, `d["__name__"] = pyname` stored the name in the unicode key on both py2 and py3, whereas the key needed to be `pystr("__name__")` - unicode in py3, bytes in py2, just like the pyname variable itself.
Using the update method does the same thing as using pystr on the keys : it interprets the keys as unicode in py3 and as bytes in py2.