### PR TITLE
Make extension load order reliable

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -393,7 +393,7 @@ def main():
 
     # Load Ren'Py extensions.
     for dir in renpy.config.searchpath: # @ReservedAssignment
-        for fn in os.listdir(dir):
+        for fn in sorted(os.listdir(dir)):
             if fn.lower().endswith(".rpe"):
                 load_rpe(dir + "/" + fn)
 


### PR DESCRIPTION
I know ren'py extensions are considered unused, but I have a few use-cases for Ren'Py augmentations/core changes/non-intrusive features and not being able to re-use code without copy-pasting because I can't rely on the extensions' load order is a pain. Could this be merged to make them more reliable ?