### PR TITLE
Add path cleanup when reloading extensions and extension __file__ context

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -151,9 +151,10 @@ def load_rpe(fn):
     with zipfile.ZipFile(fn) as zfn:
         autorun = zfn.read("autorun.py")
 
+    if fn in sys.path:
+        sys.path.remove(fn)
     sys.path.insert(0, fn)
-    exec(autorun, {})
-
+    exec(autorun, {'__file__': os.path.join(fn, "autorun.py")})
 
 def choose_variants():
 


### PR DESCRIPTION
`sys.path` grows without limit at each reload, which quickly makes it unwieldy when working on a game with several extensions.

Also sets the __file__ global to make loading extension files that are not python modules more idiomatic (at the moment, the only way is to use sys.path[0], which relies on the way ren'py internally handles extension-loading to work, being able to do `os.path.dirname(__file__)` from a packaged extension seems more clear).
