### PR TITLE
Do not max default focus on user events

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -396,7 +396,7 @@ def before_interact(roots):
         max_default_screen = None
 
     # Should we do the max_default logic?
-    should_max_default = (renpy.display.interface.last_event is None) or (renpy.display.interface.last_event.type not in [ pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION ])
+    should_max_default = (renpy.display.interface.last_event is None) or (renpy.display.interface.last_event.type not in [ pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP, pygame.MOUSEMOTION, pygame.USEREVENT ])
 
     # Is this an explicit change, using the override operation?
     explicit = False


### PR DESCRIPTION
Should fix #4092, might also be a partial regression though.
This is probably not the way it should be fixed, I mostly wanted to open the PR to help pinpoint the issue and provide a quick alternative.