### PR TITLE
Differentiate DLC from other types of packages (Build)

### DIFF
--- a/launcher/game/distribute_gui.rpy
+++ b/launcher/game/distribute_gui.rpy
@@ -222,7 +222,13 @@ screen build_distributions:
                         for pkg in packages:
                             if not pkg["hidden"]:
                                 $ description = pkg["description"]
-                                textbutton "[description!q]" action PackageToggle(pkg["name"]) style "l_checkbox"
+                                button:
+                                    action PackageToggle(pkg["name"]) style "l_checkbox"
+                                    hbox:
+                                        spacing 3
+                                        text "[description!q]"
+                                        if pkg["dlc"]:
+                                            text "(DLC)"
 
                     add SPACER
                     add HALF_SPACER


### PR DESCRIPTION
I thought it would be a good idea to differentiate the type of package being built from the rest. This adds (DLC) if it is enabled in `build.package`

Example:
![imagen](https://user-images.githubusercontent.com/36079551/204686260-8e1a236c-aa58-4cba-a82d-15d7a64e441b.png)
