### PR TITLE
fix to_unlink changes size during iteration error

### DIFF
--- a/renpy/webloader.py
+++ b/renpy/webloader.py
@@ -250,8 +250,8 @@ def process_downloaded_resources():
     # Due to search-path dups and derived images (including image-based animations)
     # files can't be removed right after actual load
     ttl = 60  # remove after 1mn - if your animation is longer than that, use a video
-    for fullpath in to_unlink.copy():
-        delta = time.time() - to_unlink[fullpath]
+    for fullpath, value in tuple(to_unlink.items()):
+        delta = time.time() - value
         if delta > ttl:
             os.unlink(fullpath)
             del to_unlink[fullpath]

--- a/renpy/webloader.py
+++ b/renpy/webloader.py
@@ -250,7 +250,7 @@ def process_downloaded_resources():
     # Due to search-path dups and derived images (including image-based animations)
     # files can't be removed right after actual load
     ttl = 60  # remove after 1mn - if your animation is longer than that, use a video
-    for fullpath in to_unlink:
+    for fullpath in to_unlink.copy():
         delta = time.time() - to_unlink[fullpath]
         if delta > ttl:
             os.unlink(fullpath)

--- a/renpy/webloader.py
+++ b/renpy/webloader.py
@@ -250,8 +250,10 @@ def process_downloaded_resources():
     # Due to search-path dups and derived images (including image-based animations)
     # files can't be removed right after actual load
     ttl = 60  # remove after 1mn - if your animation is longer than that, use a video
+    current_time = time.time()
     for fullpath, value in tuple(to_unlink.items()):
-        delta = time.time() - value
+        # Get the number of seconds that passed since the item was pushed into the to_unlink
+        delta = current_time - value
         if delta > ttl:
             os.unlink(fullpath)
             del to_unlink[fullpath]


### PR DESCRIPTION
When checking for outdated media in the to_unlink variable, if you click through images fast enough, sometimes it throws an error `RuntimeError: dictionary changed size during iteration` because of new items being pushed to the dictionary. Iterating through the copy of to_unlink prevents this error.