### PR TITLE
web: Generate PWA icons and prepare files

### DIFF
--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -351,6 +351,10 @@ init python:
 
         # Replace the project name with the ones in the game
         manifest = manifest.replace("Ren'Py Web Game", p.dump['build']['display_name'])
+        screen_size = p.dump.get("size")
+        # If width are smaller than height, set the orientation to portrait. If not, leave it as is.
+        if screen_size[0] < screen_size[1]:
+            manifest = manifest.replace("landscape-primary", "portrait-primary")
 
         # Write the file
         with io.open(os.path.join(destination, "manifest.json"), 'w', encoding='utf-8') as f:

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -255,7 +255,7 @@ init python:
         if icon_width < 512:
             raise RuntimeError("The icon must be at least 512x512 pixels")
 
-        best_compression = 5
+        best_compression = 9
         # Generate 512x512 icon, if needed
         if icon_width != 512:
             icon512 = renpy.display.pgrender.transform_scale(icon, (512, 512))
@@ -290,6 +290,40 @@ init python:
         # Generate 72x72 icon
         icon72 = renpy.display.pgrender.transform_scale(icon, (72, 72))
         pygame_sdl2.image.save(icon72, os.path.join(icons_dir, 'icon-72x72.png'), best_compression)
+
+        # Add 128 pixels to the 384x384 icon to generate 512x512 icon maskable
+        icon512_maskable = pygame_sdl2.Surface((512, 512), pygame_sdl2.SRCALPHA)
+        icon512_maskable.blit(icon384, (64, 64))
+        pygame_sdl2.image.save(icon512_maskable, os.path.join(icons_dir, 'icon-512x512-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 384x384 to generate 384x384 icon maskable
+        icon384_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (384, 384))
+        pygame_sdl2.image.save(icon384_maskable, os.path.join(icons_dir, 'icon-384x384-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 192x192 to generate 192x192 icon maskable
+        icon192_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (192, 192))
+        pygame_sdl2.image.save(icon192_maskable, os.path.join(icons_dir, 'icon-192x192-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 152x152 to generate 152x152 icon maskable
+        icon152_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (152, 152))
+        pygame_sdl2.image.save(icon152_maskable, os.path.join(icons_dir, 'icon-152x152-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 144x144 to generate 144x144 icon maskable
+        icon144_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (144, 144))
+        pygame_sdl2.image.save(icon144_maskable, os.path.join(icons_dir, 'icon-144x144-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 128x128 to generate 128x128 icon maskable
+        icon128_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (128, 128))
+        pygame_sdl2.image.save(icon128_maskable, os.path.join(icons_dir, 'icon-128x128-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 96x96 to generate 96x96 icon maskable
+        icon96_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (96, 96))
+        pygame_sdl2.image.save(icon96_maskable, os.path.join(icons_dir, 'icon-96x96-maskable.png'), best_compression)
+
+        # Resize icon512_maskable to 72x72 to generate 72x72 icon maskable
+        icon72_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (72, 72))
+        pygame_sdl2.image.save(icon72_maskable, os.path.join(icons_dir, 'icon-72x72-maskable.png'), best_compression)
+
 
     def build_web(p, gui=True):
 

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -225,6 +225,72 @@ init python:
                 return f_rule
         return False
 
+    def generate_pwa_icons(p, destination):
+        """
+        Checks if the pwa_icon.png file exists in the game folder and generates
+        required icons for PWA in subdirectory icons/ in the destination folder.
+        If no pwa_icon.png is found, the default Ren'Py icon is used instead in
+        the web folder, if exists.
+        """
+        # Check if there's a custom icon in the game directory
+        icon_path = os.path.join(p.path, 'pwa_icon.png')
+        # Generate a default icon if there isn't
+        if not os.path.exists(icon_path):
+            icon_path = os.path.join(WEB_PATH, 'pwa_icon.png')
+
+        # Check if path is a valid image
+        if not os.path.exists(icon_path):
+            # Skip pwa support if no icon is found
+            return
+        # Create icons directory
+        icons_dir = os.path.join(destination, 'icons')
+        if not os.path.isdir(icons_dir):
+            os.makedirs(icons_dir, 0o777) 
+        # Check the height and width of the icon
+        icon = pygame_sdl2.image.load(icon_path)
+        icon_width = icon.get_width()
+        icon_height = icon.get_height()
+        if icon_width != icon_height:
+            raise RuntimeError("The icon must be square")
+        if icon_width < 512:
+            raise RuntimeError("The icon must be at least 512x512 pixels")
+
+        best_compression = 5
+        # Generate 512x512 icon, if needed
+        if icon_width != 512:
+            icon512 = renpy.display.pgrender.transform_scale(icon, (512, 512))
+            pygame_sdl2.image.save(icon512, os.path.join(icons_dir, 'icon-512x512.png'), best_compression)
+        else:
+            pygame_sdl2.image.save(icon, os.path.join(icons_dir, 'icon-512x512.png'), best_compression)
+        
+        # Generate 384x384 icon
+        icon384 = renpy.display.pgrender.transform_scale(icon, (384, 384))
+        pygame_sdl2.image.save(icon384, os.path.join(icons_dir, 'icon-384x384.png'), best_compression)
+
+        # Generate 192x192 icon
+        icon192 = renpy.display.pgrender.transform_scale(icon, (192, 192))
+        pygame_sdl2.image.save(icon192, os.path.join(icons_dir, 'icon-192x192.png'), best_compression)
+
+        # Generate 152x152 icon
+        icon152 = renpy.display.pgrender.transform_scale(icon, (152, 152))
+        pygame_sdl2.image.save(icon152, os.path.join(icons_dir, 'icon-152x152.png'), best_compression)
+
+        # Generate 144x144 icon
+        icon144 = renpy.display.pgrender.transform_scale(icon, (144, 144))
+        pygame_sdl2.image.save(icon144, os.path.join(icons_dir, 'icon-144x144.png'), best_compression)
+
+        # Generate 128x128 icon
+        icon128 = renpy.display.pgrender.transform_scale(icon, (128, 128))
+        pygame_sdl2.image.save(icon128, os.path.join(icons_dir, 'icon-128x128.png'), best_compression)
+
+        # Generate 96x96 icon
+        icon96 = renpy.display.pgrender.transform_scale(icon, (96, 96))
+        pygame_sdl2.image.save(icon96, os.path.join(icons_dir, 'icon-96x96.png'), best_compression)
+
+        # Generate 72x72 icon
+        icon72 = renpy.display.pgrender.transform_scale(icon, (72, 72))
+        pygame_sdl2.image.save(icon72, os.path.join(icons_dir, 'icon-72x72.png'), best_compression)
+
     def build_web(p, gui=True):
 
         # Figure out the reporter to use.
@@ -275,6 +341,8 @@ init python:
         if presplash:
             os.unlink(os.path.join(destination, "web-presplash.jpg"))
             shutil.copy(os.path.join(project.current.path, presplash), os.path.join(destination, presplash))
+
+        generate_pwa_icons(p, destination)
 
         # Copy over index.html.
         with io.open(os.path.join(WEB_PATH, "index.html"), encoding='utf-8') as f:


### PR DESCRIPTION
Support of Progressive Web Application (PWA) in RenPy requires the generation of a bunch of icons for a variety of devices.
This code needs a single icon image (in png format) of 512x512 or bigger. It looks for a file called `pwa_icon.png` in the project directory. If such an icon does not exist, it will look for the default one from the web folder (ref: https://github.com/renpy/renpyweb), which is also optional because it requires an additional pull request to the renpyweb repository to add this file. Then this file is scaled down progressively to all required sizes and saves everything into the icons subfolder in the build directory, so we can use it later for actually building PWA in the `index.html` file.

To test this code, you can use this image:
![pwa_icon](https://user-images.githubusercontent.com/26556210/205438895-fa50c6fd-0dee-4336-bdff-ffb22889cdd0.png)

