### PR TITLE
Upgrade toctrees for the new doc theme

### DIFF
--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -21,19 +21,17 @@ To find out more about Ren'Py, please visit the Ren'Py home page:
 
         https://renpy.cn/doc-tw/
 
-Getting Started
----------------
 .. toctree::
     :maxdepth: 3
+    :caption: Getting Started
 
     quickstart
     gui
 
-The Ren'Py Language
--------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: The Ren'Py Language
 
    language_basics
    label
@@ -46,11 +44,10 @@ The Ren'Py Language
    movie
    voice
 
-Text, Displayables, Transforms, and Transitions
------------------------------------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Text, Displayables, Transforms, and Transitions
 
    text
    translation
@@ -63,11 +60,10 @@ Text, Displayables, Transforms, and Transitions
    3dstage
    live2d
 
-Customizing Ren'Py
-------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Customizing Ren'Py
 
    style
    style_properties
@@ -80,21 +76,19 @@ Customizing Ren'Py
    store_variables
    mouse
 
-Tools
------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Tools
 
    launcher
    developer_tools
    director
 
-Other Functionality
--------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Other Functionality
 
    nvl_mode
    input
@@ -109,11 +103,10 @@ Other Functionality
    splashscreen_presplash
    lifecycle
 
-Python and Ren'Py
------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Python and Ren'Py
 
    statement_equivalents
    save_load_rollback
@@ -133,11 +126,10 @@ Python and Ren'Py
    other
    ren_py
 
-Building, Updating, and Other Platforms
----------------------------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Building, Updating, and Other Platforms
 
    build
    android
@@ -149,32 +141,29 @@ Building, Updating, and Other Platforms
    updater
    gesture
 
-End-User Documentation
-----------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: End-User Documentation
 
    security
    problems
    environment_variables
    self_voicing
 
-Engine Developer Documentation
-------------------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Engine Developer Documentation
 
    editor
    skins
    translating_renpy
 
-Changes, License, and Credits
------------------------------
 
 .. toctree::
    :maxdepth: 1
+   :caption: Changes, License, and Credits
 
    changelog
    changelog6
@@ -197,8 +186,5 @@ Indices
 Example Scripts
 ---------------
 
-.. toctree::
-   :maxdepth: 1
-
-   thequestion
-   thequestion_nvl
+* :doc:`thequestion`
+* :doc:`thequestion_nvl`

--- a/sphinx/source/thequestion.txt
+++ b/sphinx/source/thequestion.txt
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _thequestion:
 
 Script of The Question

--- a/sphinx/source/thequestion_nvl.rst
+++ b/sphinx/source/thequestion_nvl.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 NVL-mode script for The Question
 ================================
 


### PR DESCRIPTION
The toctrees now take the :caption: instead of a heading, so that the caption appears in the left side list.
The last toctree was dismantled and changed to a simple bullet list so that it disappears from the left column list.