### PR TITLE
Avoid re-defining two config variables

### DIFF
--- a/sphinx/source/gui.rst
+++ b/sphinx/source/gui.rst
@@ -704,12 +704,10 @@ the save slots.
 
     The borders applied to each save slot.
 
-.. var:: config.thumbnail_width = 384
-.. var:: config.thumbnail_height = 216
-
-    The width and height of the save thumbnails. Note that these live in
-    the config namespace, not the gui namespace. These do not take effect
-    until the file is saved and loaded.
+:var:`config.thumbnail_width` = 384 and :var:`config.thumbnail_height` = 216
+set the width and height of the save thumbnails. Note that these live in
+the config namespace, not the gui namespace. These do not take effect
+until the file is saved and loaded.
 
 .. var:: gui.file_slot_cols = 3
 .. var:: gui.file_slot_rows = 2


### PR DESCRIPTION
This is an alternative to creating a single-use anonymous version of the `var` thing. I think this is simpler.