### PR TITLE
Tag the callables properly when generating sphinx from docstrings

### DIFF
--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -209,9 +209,14 @@ documented = collections.defaultdict(list)
 documented_list = [ ]
 
 
-def scan(name, o, prefix=""):
+def scan(name, o, prefix="", inclass=False):
 
-    doc_type = "function"
+    if inspect.isclass(o):
+        doc_type = "class"
+    elif not inclass:
+        doc_type = "function"
+    else:
+        doc_type = "method"
 
     # The section it's going into.
     section = None
@@ -313,7 +318,7 @@ def scan(name, o, prefix=""):
     if inspect.isclass(o):
         if (name not in [ "Matrix", "OffsetMatrix", "RotateMatrix", "ScaleMatrix" ]):
             for i in dir(o):
-                scan(i, getattr(o, i), prefix + "    ")
+                scan(i, getattr(o, i), prefix + "    ", inclass=True)
 
     if name == "identity":
         raise Exception("identity")


### PR DESCRIPTION
Every python class, function or method which currently gets documented from its docstring is incorrectly tagged as a function.
This reads fine-ish visually - although the class lack the `class` keyword - but there's a problem with autolinks : the A.b() method will be considered as the b function, and therefore will collide with the C.b() method.
Now, every class is declared as a class, and the functions found inside classes are declared as methods.

I explained it better in the linked issue.