### PR TITLE
Toggle expect_noblock's colon message based on a new parameter

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -849,7 +849,7 @@ python early in layeredimage:
 
         if not l.match(':'):
             l.expect_eol()
-            l.expect_noblock('attribute')
+            l.expect_noblock('attribute', colon_possible=True)
             return
 
 
@@ -893,7 +893,7 @@ python early in layeredimage:
 
         if not l.match(':'):
             l.expect_eol()
-            l.expect_noblock('attribute')
+            l.expect_noblock('attribute', colon_possible=True)
             return
 
         l.expect_block('attribute')
@@ -942,7 +942,7 @@ python early in layeredimage:
 
         else:
             l.expect_eol()
-            l.expect_noblock("group")
+            l.expect_noblock("group", colon_possible=True)
 
     def parse_condition(l, need_expr):
 

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -804,16 +804,22 @@ class Lexer(object):
         if not self.eol():
             self.error('end of line expected.')
 
-    def expect_noblock(self, stmt):
+    def expect_noblock(self, stmt, colon_possible=False):
         """
         Called to indicate this statement does not expect a block.
         If a block is found, raises an error.
+        `colon_possible` indicates that a block could be accepted if a colon were added.
         """
 
         if self.subblock:
             ll = self.subblock_lexer()
             ll.advance()
-            ll.error("Line is indented, but the preceding %s statement does not expect a block. Please check this line's indentation." % stmt)
+            error = "Line is indented, but the preceding {} statement does not expect a block.".format(stmt)
+            if colon_possible:
+                error += " You may have forgotten a colon (:)."
+            else:
+                error += " Please check this line's indentation."
+            ll.error(error)
 
     def expect_block(self, stmt):
         """

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -757,7 +757,7 @@ def jump_statement(l, loc):
 
 @statement("call")
 def call_statement(l, loc):
-    l.expect_noblock('call statment')
+    l.expect_noblock('call statement')
 
     if l.keyword('expression'):
         expression = True
@@ -812,7 +812,7 @@ def scene_statement(l, loc):
     if l.match(':'):
         stmt.atl = renpy.atl.parse_atl(l.subblock_lexer())
     else:
-        l.expect_noblock('scene statement')
+        l.expect_noblock('scene statement', colon_possible=True)
 
     l.expect_eol()
     l.advance()
@@ -829,7 +829,7 @@ def show_statement(l, loc):
     if l.match(':'):
         stmt.atl = renpy.atl.parse_atl(l.subblock_lexer())
     else:
-        l.expect_noblock('show statement')
+        l.expect_noblock('show statement', colon_possible=True)
 
     l.expect_eol()
     l.advance()
@@ -851,7 +851,7 @@ def show_layer_statement(l, loc):
         atl = renpy.atl.parse_atl(l.subblock_lexer())
     else:
         atl = None
-        l.expect_noblock('show layer statement')
+        l.expect_noblock('show layer statement', colon_possible=True)
 
     l.expect_eol()
     l.advance()
@@ -875,7 +875,7 @@ def camera_statement(l, loc):
         atl = renpy.atl.parse_atl(l.subblock_lexer())
     else:
         atl = None
-        l.expect_noblock('camera statement')
+        l.expect_noblock('camera statement', colon_possible=True)
 
     l.expect_eol()
     l.advance()
@@ -1412,7 +1412,7 @@ def style_statement(l, loc):
         pass
 
     if not l.match(':'):
-        l.expect_noblock("style statement")
+        l.expect_noblock("style statement", colon_possible=True)
         l.expect_eol()
     else:
         l.expect_block("style statement")

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -300,7 +300,7 @@ class Parser(object):
                     break
 
                 if l.eol():
-                    l.expect_noblock(self.name)
+                    l.expect_noblock(self.name, colon_possible=True)
                     block = False
                     break
 
@@ -892,7 +892,7 @@ class UseParser(Parser):
 
         else:
             l.expect_eol()
-            l.expect_noblock("use statement")
+            l.expect_noblock("use statement", colon_possible=True)
 
             block = None
 


### PR DESCRIPTION
Alternative way of fixing #4140 by checking each individual call (except ATL parsing, I have a life to tend to) and treating them as either likely being an indentation mistake, the default, or a colon mistake.