### PR TITLE
Classify actions as functions

### DIFF
--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -212,11 +212,16 @@ documented_list = [ ]
 def scan(name, o, prefix="", inclass=False):
 
     if inspect.isclass(o):
-        doc_type = "class"
-    elif not inclass:
-        doc_type = "function"
-    else:
+        if issubclass(o, (renpy.store.Action,
+                          renpy.store.BarValue,
+                          renpy.store.InputValue)):
+            doc_type = "function"
+        else:
+            doc_type = "class"
+    elif inclass:
         doc_type = "method"
+    else:
+        doc_type = "function"
 
     # The section it's going into.
     section = None


### PR DESCRIPTION
Due to #4143 

This reserves all `:doc: *action` as classifying actions, and categorizes those as functions regardless of their true nature.
Overrides like `:doc: somethingaction class` still take precedence over this added behavior.

This works well. Existing `:class:` references still work and link them properly just as before.

This does not cover Bar and Input Values however, which are still classified as classes. And some actions like Replay, EndReplay, gui.SetPreference, gui.TogglePreference and StylePreference are not covered, because their include name does not end with "action".
So either we don't care about them and leave them as classes, or we override them specifically with `:doc: something function`, or we rename their include name to end with "action", or we don't care at all and cancel this PR. But overriding them specifically is kinda the worst option in my opinion.