### PR TITLE
web: auto mute video for autoplay

### DIFF
--- a/renpy/common/00webvideo.rpy
+++ b/renpy/common/00webvideo.rpy
@@ -2,7 +2,7 @@ init -1100 python hide:
 
     config.web_video_base = "./game"
 
-    config.web_video_prompt = _("Touch to play the video.")
+    config.web_video_prompt = _("Touch to turn on volume.")
 
     if renpy.emscripten:
 
@@ -91,13 +91,14 @@ videoPlay = (properties) => {
         setTimeout(unblockVideo, 1000);
     }).catch( (e) => {
         console.log("Video rejected: " + e);
-        videoPlayPrompt(properties.prompt);
         video.style.pointerEvents = "auto";
+        video.muted = true;
+        video.play();
 
         video.addEventListener("click", () => {
             console.log("Video click!");
-            videoPlayPromptHide();
             setTimeout(unblockVideo, 1000);
+            video.muted = false;
             video.play();
         });
     });


### PR DESCRIPTION
Usually if a game starts with a video, the video is just a series of logos without sound. So why not auto mute the video if no user click instead of show a prompt to request user click? This can provide a better experience.
This change have no impact on in-game videos since in-game videos must be played after at least one click interaction so won't be muted. Only splash videos may be muted for autoplay. If user clicked video in muted status, the sound will be enabled again.

(I have already applied this change to my site and works well, u can test this feature at https://zhijiang.qinlili.bid/play ,which is a game starts with a splash video)