### PR TITLE
fix: upper case letter

### DIFF
--- a/launcher/game/tl/japanese/launcher.rpy
+++ b/launcher/game/tl/japanese/launcher.rpy
@@ -669,7 +669,7 @@
 
     # ios.rpy:37
     old "Creates an Xcode project corresponding to the current Ren'Py project."
-    new "現在の Ren'PY プロジェクトに対応する Xcode プロジェクトを作成します。"
+    new "現在の Ren'Py プロジェクトに対応する Xcode プロジェクトを作成します。"
 
     # ios.rpy:38
     old "Updates the Xcode project with the latest game files. This must be done each time the Ren'Py project changes."


### PR DESCRIPTION
In the Japanese UI, the notation `Ren'PY` was used in the description text of `Create Xcode Project` in the iOS build settings section, but `Ren'Py` is believed to be the correct notation.