### PR TITLE
web: Generate catalog of all media content for caching in PWA

### DIFF
--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -371,7 +371,19 @@ init python:
 
         :return: None
         """
-        catalog = {"files": {}, "version": version}
+        catalog = {
+            "core": {
+                "index.html": "",
+                "game.zip": "",
+                "renpy-pre.js": "",
+                "renpy.js": "",
+                "renpy.data": "",
+                "renpy.wasm": "",
+                "web-presplash.jpg": "",
+            },
+            "files": {},
+            "version": version
+        }
         # Walk through the game folder
         for root, dirs, files in os.walk(os.path.join(destination, "game")):
             for file in files:
@@ -385,6 +397,14 @@ init python:
                 file_hash = get_md5_hash(file_path)
                 # Add the file to the catalog
                 catalog["files"][file_name] = file_hash
+
+        # Generate md5 hashes for core files
+        for key, value in catalog["core"].items():
+            file_path = os.path.join(destination, key)
+            file_path = file_path.replace("\\", "/")
+            file_hash = get_md5_hash(file_path)
+            catalog["core"][key] = file_hash
+
         with io.open(os.path.join(destination, "pwa_catalog.json"), 'w', encoding='utf-8') as f:
             # Write the JSON file without spaces and new lines, so it's as small as possible
             f.write(json.dumps(catalog, separators=(',', ':')))
@@ -479,9 +499,6 @@ init python:
             os.unlink(os.path.join(destination, "web-presplash.jpg"))
             shutil.copy(os.path.join(project.current.path, presplash), os.path.join(destination, presplash))
 
-        generate_pwa_icons(p, destination)
-        prepare_pwa_files(p, destination)
-
         # Copy over index.html.
         with io.open(os.path.join(WEB_PATH, "index.html"), encoding='utf-8') as f:
             html = f.read()
@@ -496,6 +513,9 @@ init python:
 
         with io.open(os.path.join(destination, "index.html"), "w", encoding='utf-8') as f:
             f.write(html)
+
+        generate_pwa_icons(p, destination)
+        prepare_pwa_files(p, destination)
 
         # Zip up the game.
 

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -326,7 +326,7 @@ init python:
         icon72_maskable = renpy.display.pgrender.transform_scale(icon512_maskable, (72, 72))
         pygame_sdl2.image.save(icon72_maskable, os.path.join(icons_dir, 'icon-72x72-maskable.png'), best_compression)
 
-    def get_md5_hash(file_path: str) -> str:
+    def get_md5_hash(file_path):
         """
         Generates MD5 hash sum of the given file.
 

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -384,7 +384,7 @@ init python:
                 # Get the MD5 hash of the file
                 file_hash = get_md5_hash(file_path)
                 # Add the file to the catalog
-                catalog["files"][file_hash] = file_name
+                catalog["files"][file_name] = file_hash
         with io.open(os.path.join(destination, "pwa_catalog.json"), 'w', encoding='utf-8') as f:
             # Write the JSON file without spaces and new lines, so it's as small as possible
             f.write(json.dumps(catalog, separators=(',', ':')))

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -346,7 +346,7 @@ init python:
                 catalog["files"].append(file_name)
         with io.open(os.path.join(destination, "pwa_catalog.json"), 'w', encoding='utf-8') as f:
             # Write the JSON file without spaces and new lines, so it's as small as possible
-            f.write(json.dumps(catalog, separators=(',', ':'), sort_keys=True))
+            f.write(json.dumps(catalog, separators=(',', ':')))
 
 
     def prepare_pwa_files(p, destination):

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -331,8 +331,10 @@ init python:
         Generates a JSON file with information about the game files.
         This file is used by the service worker to cache the game files.
 
-        :param destination: The destination path where the files will be copied to and where
+        :param destination: string, The destination path where the files will be copied to and where
         game folder is located.
+        :param version: string, the version of the game. Should be the same as the version in the
+        manifest.json file.
 
         :return: None
         """


### PR DESCRIPTION
The first step on working on [https://github.com/renpy/renpy-build/issues/53](https://github.com/renpy/renpy-build/issues/53).
This code creates a minified `pwa_catalog.json` file in the destination build that has the following structure:
```
{"files": { "<file_path>": "<hash>", ... }, "version": "your-game-<timestamp>"}
```
`files` contains all paths in the `game` folder, and will allow us to download all files at once, for offline use.
The `version` will let us track if the catalog is updated to the current version of the service worker. If not, we'll create a warning in the console, to let the dev know that it needs to be updated