### PR TITLE
Optimize allow_underfull for non-developer mode

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -549,19 +549,23 @@ class Grid(Container):
         super(Grid, self).per_interact()
 
         delta = (self.cols * self.rows) - len(self.children)
-        if delta > 0:
+
+        if not delta:
+            return
+
+        if renpy.config.developer:
             allow_underfull = self.allow_underfull
+
             if allow_underfull is None:
                 allow_underfull = renpy.config.allow_underfull_grids
 
-            if not renpy.config.developer:
-                allow_underfull = True
-
             if not allow_underfull:
                 raise Exception("Grid not completely full.")
-            else:
-                for _ in range(delta):
-                    self.add(Null())
+
+        null = Null()
+
+        for _ in range(delta):
+            self.add(null)
 
 
 class IgnoreLayers(Exception):


### PR DESCRIPTION
Bit of potential optimisation after looking into https://github.com/renpy/renpy/issues/4153.

The main change is that only in the event that the grid is underfull and developer mode is active will it bother to:
- Resolve the `allow_underfull` value,
- Construct of exception instances.

This is very much a same-behaviour refactor, which I appreciate we're not always looking for, so completely understand if it's not desired. :)