### PR TITLE
web: Call prompt using JS on mobiles

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -932,9 +932,7 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
     rv = None
     if renpy.emscripten:
         # escape quotes in prompt and default for javascript usage
-        prompt = prompt.replace("'", "\'").replace('"', '\"')
-        default = default.replace("'", "\'").replace('"', '\"')
-        rv = emscripten.run_script_string("(function callMobilePrompt() { if (window.ontouchstart !== undefined) { return prompt('%s', '%s'); } return ''})()" % (prompt, default))
+        rv = emscripten.run_script_string("(function callMobilePrompt() { if (window.ontouchstart !== undefined) { return prompt(%r, %r); } return ''})()" % (prompt, default))
 
     if not rv:
         rv = renpy.ui.interact(mouse='prompt', type="input", roll_forward=roll_forward)

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -132,6 +132,9 @@ import sys
 import threading
 import fnmatch
 
+if renpy.emscripten:
+    import emscripten
+
 
 # The number of bits in the architecture.
 if sys.maxsize > (2 << 32):
@@ -926,7 +929,12 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
     if fixed:
         renpy.ui.saybehavior()
 
-    rv = renpy.ui.interact(mouse='prompt', type="input", roll_forward=roll_forward)
+    rv = None
+    if renpy.emscripten:
+        rv = emscripten.run_script_string("(function callMobilePrompt() { if (window.ontouchstart !== undefined) { return prompt('%s', '%s'); } return ''})()" % (prompt, default))
+
+    if not rv:
+        rv = renpy.ui.interact(mouse='prompt', type="input", roll_forward=roll_forward)
     renpy.exports.checkpoint(rv)
 
     if with_none is None:

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -931,6 +931,9 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
 
     rv = None
     if renpy.emscripten:
+        # escape quotes in prompt and default for javascript usage
+        prompt = prompt.replace("'", "\'").replace('"', '\"')
+        default = default.replace("'", "\'").replace('"', '\"')
         rv = emscripten.run_script_string("(function callMobilePrompt() { if (window.ontouchstart !== undefined) { return prompt('%s', '%s'); } return ''})()" % (prompt, default))
 
     if not rv:


### PR DESCRIPTION
When `renpy.input` is called, this code will execute JS (if available) to call the browser's default prompt window for input.
A user will be able to enter text using a keyboard or voice input instead of using the on-screen widget.

@renpytom, I wasn't sure where exactly the on-screen widget is being called in the code, it will be better to move the call of JS in this PR to where you think it will fit, to avoid drawing the mobile widget completely. Right now it shows up for a moment