### PR TITLE
Persistent improvements and fixes

### DIFF
--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -36,7 +36,6 @@ from renpy.compat.pickle import dump, dumps, loads
 
 # The class that's used to hold the persistent data.
 
-
 class Persistent(object):
 
     def __init__(self):
@@ -55,6 +54,16 @@ class Persistent(object):
 
         return None
 
+    def __contains__(self, key):
+        return key in self.__dict__
+
+    def _keys(self):
+        """
+        Returns a list of the persistent variables,
+        but only those the creators should be aware of, not renpy's internals.
+        """
+        return [key for key in self.__dict__ if (not key.startswith("_")) or key.startswith("__") and not key.startswith("__00")]
+
     def _clear(self, progress=False):
         """
         Resets the persistent data.
@@ -63,12 +72,7 @@ class Persistent(object):
             If true, also resets progress data that Ren'Py keeps.
         """
 
-        keys = list(self.__dict__)
-
-        for i in keys:
-            if i[0] == "_":
-                continue
-
+        for i in self._keys():
             del self.__dict__[i]
 
         if progress:

--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -54,15 +54,8 @@ class Persistent(object):
 
         return None
 
-    def __contains__(self, key):
-        return key in self.__dict__
-
-    def _keys(self):
-        """
-        Returns a list of the persistent variables,
-        but only those the creators should be aware of, not renpy's internals.
-        """
-        return [key for key in self.__dict__ if (not key.startswith("_")) or key.startswith("__") and not key.startswith("__00")]
+    def _hasattr(self, field_name):
+        return field_name in self.__dict__
 
     def _clear(self, progress=False):
         """
@@ -72,7 +65,12 @@ class Persistent(object):
             If true, also resets progress data that Ren'Py keeps.
         """
 
-        for i in self._keys():
+        keys = list(self.__dict__)
+
+        for i in keys:
+            if i[0] == "_":
+                continue
+
             del self.__dict__[i]
 
         if progress:

--- a/sphinx/source/language_basics.rst
+++ b/sphinx/source/language_basics.rst
@@ -164,6 +164,8 @@ structure without overwhelming the script text.
    "This is part of the first block, again."
 
 
+.. _elements-of-statements:
+
 Elements of Statements
 ======================
 

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -18,14 +18,11 @@ the :ref:`default <default-statement>` statement should be used::
 
     default persistent.main_background = "princess_not_saved"
 
-To test whether a given persistent field has been set, use the ``in`` syntax.
-This allows to tell apart the fields manually set to None, and the unset fields.
+.. function:: persistent._hasattr(field_name):
 
-A list of all registered fields can also be generated:
-
-.. function:: persistent._keys():
-
-    Returns a list of the registered persistent entries.
+    Tests whether the `field_name` persistent field has been set or not.
+    This allows you to distinguish fields that have been explicitly set
+    to None from fields that have never been set.
 
 An example use of persistent is the creation of an unlockable image gallery.
 This is done by storing a flag in persistent that determines if the gallery has

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -18,6 +18,15 @@ the :ref:`default <default-statement>` statement should be used::
 
     default persistent.main_background = "princess_not_saved"
 
+To test whether a given persistent field has been set, use the ``in`` syntax.
+This allows to tell apart the fields manually set to None, and the unset fields.
+
+A list of all registered fields can also be generated:
+
+.. function:: persistent._keys():
+
+    Returns a list of the registered persistent entries.
+
 An example use of persistent is the creation of an unlockable image gallery.
 This is done by storing a flag in persistent that determines if the gallery has
 been unlocked, as in ::
@@ -40,6 +49,11 @@ As persistent data is loaded before ``init python`` blocks are run, persistent d
 should only contain types that are native to Python or Ren'Py. Alternatively,
 classes that are defined in ``python early`` blocks can be used, provided
 those classes can be pickled and implement equality.
+
+Fields starting with ``__`` are supported, but will have the name-mangling effect
+described in :ref:`this section <elements-of-statements>`, which means they will be
+specific to the file they're defined in. This means that when renaming the file,
+access to that field will be broken.
 
 Merging Persistent Data
 -----------------------
@@ -79,7 +93,6 @@ Persistent Functions
 
     Note that this will delete all persistent data, and will not re-apply
     defaults until Ren'Py restarts.
-
 
 .. include:: inc/persistent
 

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -47,10 +47,14 @@ should only contain types that are native to Python or Ren'Py. Alternatively,
 classes that are defined in ``python early`` blocks can be used, provided
 those classes can be pickled and implement equality.
 
-Fields starting with ``__`` are supported, but will have the name-mangling effect
-described in :ref:`this section <elements-of-statements>`, which means they will be
-specific to the file they're defined in. This means that when renaming the file,
-access to that field will be broken.
+Fields starting with two underscores (``__``) are supported, but will receive the
+name-mangling effect described in :ref:`this section <elements-of-statements>`,
+which means they will be specific to the file they're defined in. This means that
+when renaming the file, access to that field will be broken. In addition to this,
+these fields are not affected by the :meth:`persistent._clear` method.
+
+As a reminder, fields starting with a single underscore ``_`` are reserved and
+should not be used.
 
 Merging Persistent Data
 -----------------------
@@ -83,7 +87,7 @@ Persistent Functions
 
 .. function:: persistent._clear(progress=False)
 
-    Resets the persistent data.
+    Resets the persistent data, except for fields starting with ``__``.
 
     `progress`
         If true, also resets progress data that Ren'Py keeps.

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -82,7 +82,7 @@ union of that set when merging data. ::
 Persistent Functions
 --------------------
 
-.. function:: persistent._hasattr(field_name):
+.. function:: persistent._hasattr(field_name)
 
     Tests whether the `field_name` persistent field has been set or not.
     This allows you to distinguish fields that have been explicitly set

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -18,12 +18,6 @@ the :ref:`default <default-statement>` statement should be used::
 
     default persistent.main_background = "princess_not_saved"
 
-.. function:: persistent._hasattr(field_name):
-
-    Tests whether the `field_name` persistent field has been set or not.
-    This allows you to distinguish fields that have been explicitly set
-    to None from fields that have never been set.
-
 An example use of persistent is the creation of an unlockable image gallery.
 This is done by storing a flag in persistent that determines if the gallery has
 been unlocked, as in ::
@@ -49,9 +43,12 @@ those classes can be pickled and implement equality.
 
 Fields starting with two underscores (``__``) are supported, but will receive the
 name-mangling effect described in :ref:`this section <elements-of-statements>`,
-which means they will be specific to the file they're defined in. This means that
-when renaming the file, access to that field will be broken. In addition to this,
-these fields are not affected by the :meth:`persistent._clear` method.
+which means they will be specific to the file they're defined in. This implies that
+if the file is renamed between two releases, access to the value that field had in
+the previous release will be broken.
+
+In addition to this, these fields are not affected by the :meth:`persistent._clear`
+method.
 
 As a reminder, fields starting with a single underscore ``_`` are reserved and
 should not be used.
@@ -84,6 +81,12 @@ union of that set when merging data. ::
 
 Persistent Functions
 --------------------
+
+.. function:: persistent._hasattr(field_name):
+
+    Tests whether the `field_name` persistent field has been set or not.
+    This allows you to distinguish fields that have been explicitly set
+    to None from fields that have never been set.
 
 .. function:: persistent._clear(progress=False)
 


### PR DESCRIPTION
- The new _hasattr method, and its documentation
- document the __-starting names : warn about them not being affected by _clear, and general limitations over these names in renpy