### PR TITLE
Make sticky layers always an opt-in for existing games

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3951,7 +3951,7 @@ def clear_line_log():
     renpy.game.context().line_log = [ ]
 
 
-def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
+def add_layer(layer, above=None, below=None, menu_clear=True, sticky=False):
     """
     :doc: image_func
 
@@ -3977,8 +3977,7 @@ def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
 
     `sticky`
         If true, any tags added to this layer will have it become their
-        default layer until they are hidden. If None, this layer will be
-        sticky only if other sticky layers already exist.
+        default layer until they are hidden.
     """
 
     layers = renpy.config.layers
@@ -4009,7 +4008,7 @@ def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
     if menu_clear:
         renpy.config.menu_clear_layers.append(layer) # type: ignore # Set in 00gamemenu.rpy.
 
-    if sticky or sticky is None and renpy.config.sticky_layers:
+    if sticky:
         renpy.config.sticky_layers.append(layer)
 
 


### PR DESCRIPTION
This allows creators who use custom layers not to have to change their code in any way in order to keep the current behavior.
What was initially discussed in #4149 was to make stickiness a global opt-in, and then to make it an opt-in for all layers except detached layers (which don't exist yet).
This PR re-establishes the behavior that was discussed.