### PR TITLE
Add the `in` keyword to show statements

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1312,7 +1312,10 @@ def predict_imspec(imspec, scene=False, atl=None):
     in imspec.
     """
 
-    if len(imspec) == 7:
+    if len(imspec) == 8:
+        name, expression, tag, at_expr_list, layer, _zorder, _behind, _sticky = imspec
+
+    elif len(imspec) == 7:
         name, expression, tag, at_expr_list, layer, _zorder, _behind = imspec
 
     elif len(imspec) == 6:
@@ -1355,12 +1358,17 @@ def predict_imspec(imspec, scene=False, atl=None):
 
 def show_imspec(imspec, atl=None):
 
-    if len(imspec) == 7:
+    if len(imspec) == 8:
+        name, expression, tag, at_list, layer, zorder, behind, sticky = imspec
+
+    elif len(imspec) == 7:
         name, expression, tag, at_list, layer, zorder, behind = imspec
+        sticky = False
 
     elif len(imspec) == 6:
         name, expression, tag, at_list, layer, zorder = imspec
         behind = [ ]
+        sticky = False
 
     else:
         name, at_list, layer = imspec
@@ -1368,6 +1376,7 @@ def show_imspec(imspec, atl=None):
         tag = None
         zorder = None
         behind = [ ]
+        sticky = False
 
     if zorder is not None:
         zorder = renpy.python.py_eval(zorder)
@@ -1389,7 +1398,8 @@ def show_imspec(imspec, atl=None):
                       zorder=zorder,
                       tag=tag,
                       behind=behind,
-                      atl=atl)
+                      atl=atl,
+                      sticky=sticky)
 
 
 class Show(Node):
@@ -1591,18 +1601,25 @@ class Hide(Node):
 
     def predict(self):
 
-        if len(self.imspec) == 7:
+        if len(self.imspec) == 8:
+            name, _expression, tag, _at_list, layer, _zorder, _behind, _sticky = self.imspec
+
+        elif len(self.imspec) == 7:
             name, _expression, tag, _at_list, layer, _zorder, _behind = self.imspec
+            _sticky = False
 
         elif len(self.imspec) == 6:
             name, _expression, tag, _at_list, layer, _zorder = self.imspec
             _behind = None
+            _sticky = False
+
         else:
             name, _at_list, layer = self.imspec
             tag = None
             _expression = None
             _zorder = None
             _behind = None
+            _sticky = False
 
         if tag is None:
             tag = name[0]
@@ -1618,7 +1635,9 @@ class Hide(Node):
         next_node(self.next)
         statement_name("hide")
 
-        if len(self.imspec) == 7:
+        if len(self.imspec) == 8:
+            name, _expression, tag, _at_list, layer, _zorder, _behind, _sticky = self.imspec
+        elif len(self.imspec) == 7:
             name, _expression, tag, _at_list, layer, _zorder, _behind = self.imspec
         elif len(self.imspec) == 6:
             name, _expression, tag, _at_list, layer, _zorder = self.imspec

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1079,7 +1079,8 @@ class SceneLists(renpy.object.Object):
             atl=None,
             default_transform=None,
             transient=False,
-            keep_st=False):
+            keep_st=False,
+            sticky=None):
         """
         Adds something to this scene list. Some of these names are quite a bit
         out of date.
@@ -1108,6 +1109,10 @@ class SceneLists(renpy.object.Object):
 
         `keep_st`
             If true, we preserve the shown time of a replaced displayable.
+
+        `sticky`
+            If not None, decides whether the the displayable sticks to the layer or not.
+            Otherwise, that's decided by the layer being in config.sticky_layers or not.
         """
 
         if not isinstance(thing, Displayable):
@@ -1120,7 +1125,7 @@ class SceneLists(renpy.object.Object):
             self.remove_hide_replaced(layer, key)
             self.at_list[layer][key] = at_list
 
-            if layer in renpy.config.sticky_layers:
+            if sticky or (layer in renpy.config.sticky_layers):
                 self.sticky_tags[key] = layer
 
         if key and name:

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -629,10 +629,10 @@ def set_tag_attributes(name, layer=None):
         renpy.game.context().images.predict_show(layer, name, False)
 
 
-def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind=[ ], atl=None, transient=False, munge_name=True):
+def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind=[ ], sticky=False, atl=None, transient=False, munge_name=True):
     """
     :doc: se_images
-    :args: (name, at_list=[], layer='master', what=None, zorder=0, tag=None, behind=[])
+    :args: (name, at_list=[], layer='master', what=None, zorder=0, tag=None, behind=[], sticky=False, **kwargs)
 
     Shows an image on a layer. This is the programmatic equivalent of the show
     statement.
@@ -667,6 +667,10 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
         A list of strings, giving image tags that this image is shown behind.
         The equivalent of the ``behind`` property.
 
+    `sticky`
+        If True, the image will stick to the layer, making it the equivalent
+        of the ``in`` keyword rather than ``onlayer``.
+
     ::
         show a
         $ renpy.show("a")
@@ -680,6 +684,12 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
 
         show a at T, T2
         $ renpy.show("a", at_list=(T, T2))
+
+        show a onlayer b
+        $ renpy.show("a", layer="b")
+
+        show a in b
+        $ renpy.show("a", layer="b", sticky=True)
 
         show a onlayer b behind c zorder d as e
         $ renpy.show("a", layer="b", behind=["c"], zorder="d", tag="e")
@@ -698,6 +708,9 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
 
     sls = scene_lists()
     key = tag or name[0]
+
+    if not layer:
+        sticky = False
 
     layer = default_layer(layer, key)
 
@@ -757,7 +770,7 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
     if renpy.config.missing_hide:
         renpy.config.missing_hide(name, layer)
 
-    sls.add(layer, img, key, zorder, behind, at_list=at_list, name=name, atl=atl, default_transform=default_transform, transient=transient)
+    sls.add(layer, img, key, zorder, behind, at_list=at_list, name=name, atl=atl, default_transform=default_transform, transient=transient, sticky=sticky)
 
 
 def hide(name, layer=None):

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -646,8 +646,8 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
 
     `layer`
         A string, giving the name of the layer on which the image will be shown.
-        The equivalent of the ``onlayer`` property. If None, uses the default
-        layer associated with the tag.
+        The equivalent of the ``onlayer`` or ``in`` property. If None, uses the
+        default layer associated with the tag.
 
     `what`
         If not None, this is a displayable that will be shown in lieu of

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -129,6 +129,7 @@ def parse_image_specifier(l):
     at_list = [ ]
     zorder = None
     behind = [ ]
+    sticky = False
 
     if l.keyword("expression") or l.keyword("image"):
         expression = l.require(l.simple_expression)
@@ -139,11 +140,15 @@ def parse_image_specifier(l):
 
     while True:
 
-        if l.keyword("onlayer"):
+        ol = l.keyword("onlayer") or l.keyword("in") # either keyword, or the empty string
+        if ol:
             if layer:
-                l.error("multiple onlayer clauses are prohibited.")
+                l.error("multiple 'onlayer' or 'in' clauses are prohibited.")
             else:
                 layer = l.require(l.name)
+
+            if ol == "in":
+                sticky = True
 
             continue
 
@@ -189,7 +194,7 @@ def parse_image_specifier(l):
 
         break
 
-    return image_name, expression, tag, at_list, layer, zorder, behind
+    return image_name, expression, tag, at_list, layer, zorder, behind, sticky
 
 
 def parse_with(l, node):

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -800,7 +800,7 @@ def call_statement(l, loc):
 
 @statement("scene")
 def scene_statement(l, loc):
-    if l.keyword('onlayer'):
+    if l.keyword('onlayer') or l.keyword('in'):
         layer = l.require(l.name)
     else:
         layer = "master"

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1701,7 +1701,8 @@ Rarely or Internally Used
 
     A function that is used in place of :func:`renpy.show` by the :ref:`show
     <show-statement>` and :ref:`scene <scene-statement>` statements. This
-    should have the same signature as :func:`renpy.show`.
+    should have the same signature as :func:`renpy.show`, and ignore unknown
+    keyword arguments (or pass them unchanged).
 
 .. var:: config.skip_delay = 75
 

--- a/sphinx/source/displaying_images.rst
+++ b/sphinx/source/displaying_images.rst
@@ -243,6 +243,10 @@ The show statement takes the following properties:
 ``onlayer``
     Takes a name. Shows the image on the named layer.
 
+``in``
+    Same as ``onlayer``, but also makes the image sticky to the layer.
+    This can't be used at the same time as ``onlayer``.
+
 ``zorder``
     Takes an integer. The integer specifies the relative ordering of
     images within a layer, with larger numbers being closer to the


### PR DESCRIPTION
The objective is to encourage creators to use stickiness on a show-by-show basis and in a way that reflects in the script.
The rationale is that I don't see the first following example as being harder to understand or to use than the second one - in addition to the additional features it introduces.
```rpy
label start:
    show tag in c # sticky because in
```
```rpy
define config.sticky_layers += ["c"]

label start:
    show tag onlayer c # sticky because c
```

The reason for that is to make renpy script, and excerpts thereof, as unambiguous as possible.
That helps a great deal in the context of support channels, because you don't need to enquire about the state of the config variables or even to think about them, before knowing what a bit of code does.

Prediction was unchanged, I think there's no need for it. The exiting sticky layer implementation doesn't change it either, so 🤷 
Hide and scene-without-displayable also accept ``in`` in lieu of ``onlayer``, but that's not documented.
Just to state the obvious : the existing sticky-by-layer behavior related to the config variable was not altered, **nothing was removed**, even though undocumenting it would be fine by me.