### PR TITLE
Make sticky layer behaviour consistent between layers

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -269,7 +269,7 @@ init -1100 python:
             config.context_clear_layers.remove("top")
             config.context_clear_layers.remove("bottom")
 
-            config.sticky_layers.remove("master")
+            config.sticky_layers = False
 
             store._errorhandling._constant = True
             store._gamepad._constant = True

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -169,8 +169,8 @@ top_layers = [ 'top' ]
 # Layers below all other layers, that do not participate in transitions.
 bottom_layers = [ 'bottom' ]
 
-# Layers which will override the default layer for a tag while shown.
-sticky_layers = [ 'master' ]
+# Which layer a showing tag was last displayed on will be used as it's default.
+sticky_layers = True
 
 # True if we want to show overlays during wait statements, or
 # false otherwise.

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1120,7 +1120,7 @@ class SceneLists(renpy.object.Object):
             self.remove_hide_replaced(layer, key)
             self.at_list[layer][key] = at_list
 
-            if layer in renpy.config.sticky_layers:
+            if renpy.config.sticky_layers and not isinstance(thing, renpy.display.screen.ScreenDisplayable):
                 self.sticky_tags[key] = layer
 
         if key and name:
@@ -1298,8 +1298,8 @@ class SceneLists(renpy.object.Object):
                 self.shown.predict_hide(layer, (tag,))
                 self.at_list[layer].pop(tag, None)
 
-                if layer in renpy.config.sticky_layers:
-                    self.sticky_tags.pop(tag, None)
+                if self.sticky_tags.get(tag, None) == layer:
+                    del self.sticky_tags[tag]
 
             self.hide_or_replace(layer, remove_index, prefix)
 
@@ -1325,10 +1325,9 @@ class SceneLists(renpy.object.Object):
                 self.hide_or_replace(layer, i, hide)
 
         self.at_list[layer].clear()
-        self.shown.predict_scene(layer)
+        self.sticky_tags = {k: v for k, v in self.sticky_tags.items() if v != layer}
 
-        if layer in renpy.config.sticky_layers:
-            self.sticky_tags = {k: v for k, v in self.sticky_tags.items() if v != layer}
+        self.shown.predict_scene(layer)
 
         if renpy.config.scene_clears_layer_at_list:
             self.layer_at_list[layer] = (None, [ ])

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3957,7 +3957,7 @@ def clear_line_log():
     renpy.game.context().line_log = [ ]
 
 
-def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
+def add_layer(layer, above=None, below=None, menu_clear=True):
     """
     :doc: image_func
 
@@ -3980,11 +3980,6 @@ def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
     `menu_clear`
         If true, this layer will be cleared when entering the game menu
         context, and restored when leaving it.
-
-    `sticky`
-        If true, any tags added to this layer will have it become their
-        default layer until they are hidden. If None, this layer will be
-        sticky only if other sticky layers already exist.
     """
 
     layers = renpy.config.layers
@@ -4014,9 +4009,6 @@ def add_layer(layer, above=None, below=None, menu_clear=True, sticky=None):
 
     if menu_clear:
         renpy.config.menu_clear_layers.append(layer) # type: ignore # Set in 00gamemenu.rpy.
-
-    if sticky or sticky is None and renpy.config.sticky_layers:
-        renpy.config.sticky_layers.append(layer)
 
 
 def maximum_framerate(t):

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -10,6 +10,23 @@ Changelog (Ren'Py 7.x-)
 8.1 / 7.6
 =========
 
+Sticky Layers
+-------------
+
+When a tag is shown, the layer it is shown on will be stored and treated as the
+tag's default layer until it is hidden. In practice that means when showing
+a tag on a layer besides its usual default it will continue to be updated with
+attributes set via a show or say statement without the need to respecify the
+layer. Once the tag is hidden then it's normal default layer will against take
+precedence.::
+
+    show eileen onlayer near
+    eileen happy "Hello there!"  # will now work, where previously it would not
+    show eileen excited          # implicit onlayer near
+    hide eileen                  # implicit onlayer near
+    show eileen                  # implicit onlayer master, eileen's default
+
+
 Mixer Volume Changes
 --------------------
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1760,11 +1760,11 @@ Rarely or Internally Used
     Ren'Py terminates. This is intended to free resources, such as
     opened files or started threads.
 
-.. var:: config.sticky_layers = [ "master", ... ]
+.. var:: config.sticky_layers = True
 
-    A list of layer names that will, when a tag is shown on them, take
-    precedence over that tag's entry in :var:`config.tag_layer` for the
-    duration of it being shown.
+    When True, the last layer a showing tag was displayed on will be
+    remembered and used in place of an entry in :var:`config.tag_layer`.
+    When the tag is hidden it is forgotten and will revert to normal.
 
 .. var:: config.top_layers = [ "top", ... ]
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -19,6 +19,17 @@ such changes only take effect when the GUI is regenerated.
 8.1.0 / 7.6.0
 -------------
 
+**Sticky layers** This release introduces sticky layer behaviour which
+helps automatically manage tags being placed on layers other than their
+default. In the rare case that a game requires multiple of the same tag,
+to be displayed at the same time, on different layers then this may not
+be desirable. This does not apply to screens.
+
+To disable sticky layers, add to your game::
+
+    define config.sticky_layers = False
+
+
 **Lenticular bracket ruby text** This release of Ren'Py introduces
 lenticular bracket ruby text, an easier way of writing ruby text. If
 a game included a literal 【, it needs to be doubled, to "【【", to


### PR DESCRIPTION
**tl;dr**: tags are sticky, screens are not... maybe. see https://github.com/renpy/renpy/pull/4210#issuecomment-1372665361 😛

---

After speaking with @Gouvernathor at length about this feature we reached what is hopefully a fairly sane and creator-friendly balance.

This PR has the feature adopt a take it or leave it stance, with the default being that it's turned on - a default that seeks to ensure that features like say-attributes "just work" and `onlayer` clauses need not be added to every subsequent `show` statement when displaying a tag on a layer not considered to be it's default.

In this implementation tag/screen conflicts are avoided via an explicit carve out for `ScreenDisplayables` which are never treated as sticky, which allows all layers to a share a consistent behaviour without needing to assess whether or not they are sticky.

This change does take the stance that there's no valid use for a mixture of sticky and non-sticky layers.

A summary of a code level changes:
- `config.sticky_layers` is now a compat boolean
- When a tag is hidden, the layer is checked before removing it from the `sticky_tags` dict.
  - This not only gives `hide` the same semantics as `clear`, but also avoids the need to check for screens - since they aren't sticky, and so if a screen is being removed from a layer, that layer could not contain a sticky tag of the same name.
- `sticky_tag` clean up is unconditional in both `hide` and `clear`.
  - The removal is cheap enough to not warrant a check on the grounds of performance, and has the side benefit of ensuring that anything placed there during development while the feature was enabled will still get cleaned up if it is later disabled which should provide a better creator experience if experimenting with the flag across reloads or saves.
- `sticky` argument is removed from `add_layer` as the feature is now an all or nothing proposition.
- Attempt to capture and explain feature in documentation with the expectation that it could be revisited prior to release.