### PR TITLE
Include functions intended to be documented

### DIFF
--- a/sphinx/source/android.rst
+++ b/sphinx/source/android.rst
@@ -358,7 +358,7 @@ interact with the Android permissions system.
     necessary to use renpy.check_permission and renpy.request_permission as necessary
     to request the permission.
 
-.. include: inc/android_permission
+.. include:: inc/android_permission
 
 
 Transferring Files to and From Android


### PR DESCRIPTION
This concerns the request_permission and check_permission functions, at the bottom of exports.py.

The JSONDB class in 00db_ren.py also has a docstring intending for it to be documented, but never included in the doc. Although in _that_ case, a bigger bunch of documentation remains to be done.