### PR TITLE
Unmixup config.language and config.default_language

### DIFF
--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -402,6 +402,11 @@ Occasionally Used
     As this function may be called during prediction, it must not rely on any
     state.
 
+.. var:: config.default_language = None
+
+    If not None, this should be a string giving the default language
+    that the game is translated into by the translation framework.
+
 .. var:: config.default_tag_layer = "master"
 
     The layer an image is shown on if its tag is not found in :var:`config.tag_layer`.
@@ -602,11 +607,6 @@ Occasionally Used
 .. var:: config.input_caret_blink = 1.0
 
     If not False, sets the blinking period of the default caret, in seconds.
-
-.. var:: config.language = None
-
-    If not None, this should be a string giving the default language
-    that the game is translated into by the translation framework.
 
 .. var:: config.lint_character_statistics = True
 
@@ -1921,3 +1921,7 @@ variables. You can locate them there, in their context.
 * :var:`config.side_image_prefix_tag`
 * :var:`config.side_image_same_transform`
 * :var:`config.side_image_tag`
+
+:doc:`translation`:
+
+* :var:`config.language`

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -406,15 +406,15 @@ The default language is chosen using the following method:
 
 * If the RENPY_LANGUAGE environment variable is set, that language is
   used.
-* If :var:`config.language` is set, that language is used.
+* If :var:`config.language` is set, that language is used, overriding
+  all of the following.
 * If the game has ever chosen a language in the past, that language is
   used.
 * If this is the first time the game has been run and
   :var:`config.enable_language_autodetect` is True, Ren'Py tries to
   autodetect the language using :var:`config.locale_to_language_function`.
 * If this is the first time the game has been run,
-  :var:`config.default_language` is used. (This defaults to the None
-  language.)
+  :var:`config.default_language` is used.
 * Otherwise, the None language is used.
 
 Translation Actions, Functions, and Variables
@@ -462,7 +462,7 @@ translation:
 .. include:: inc/translate_string
 
 There are two language-related variables. One is
-:var:`config.language`, which is used to change the default language
+:var:`config.default_language`, which is used to change the default language
 of the game.
 
 .. var:: _preferences.language
@@ -503,6 +503,11 @@ translation template that contains all of the strings in it.
 If a game doesn't include support for changing the language, it may be
 appropriate to use an ``init python`` block to set :var:`config.language`
 to the target language.
+
+.. var:: config.language = None
+
+    If not None, sets the language to use at game launch, overriding
+    any memorized choice made by the user.
 
 Along with the use of string translations for dialogue, unsanctioned
 translators may be interested in using the techniques described above


### PR DESCRIPTION
`default_language` is a default
`language` is an override, only topped by an environ variable

`config.language` was documented using language actually describing `config.default_language`, except at the rundown of the language choice in translation.rst which is actually correct. `config.default_language` was referred to there, but missing an entry (per #3600).
Both are now fixed.