### PR TITLE
Undocument config.editor and document Shift+E

### DIFF
--- a/sphinx/source/developer_tools.rst
+++ b/sphinx/source/developer_tools.rst
@@ -41,11 +41,9 @@ The console can be used to:
 Shift+E Editor Support
 ----------------------
 
-The :var:`config.editor` variable allows a developer to specify an editor
-command that is run when the launch_editor keypress (by default, Shift+E)
-occurs.
-
-Please see :doc:`Text Editor Integration <editor>`.
+Shift+E opens the default text editor, as set in the launcher and customizable
+using :doc:`editor`, to open the script file in and line number at which the
+current statement is written.
 
 Shift+D Developer Menu
 ----------------------


### PR DESCRIPTION
`config.editor` was apparently never implemented, despite having been documented.
I removed the reference in the doc (missing a declaration, #3600) and described what Shift+E actually does.

I did _**not**_ remove `editor` from config.py, for fear of pickle-like consequences. And because a None-set variable has negligible memory impact.