### PR TITLE
Avoid undocumented config variables in examples

### DIFF
--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1294,6 +1294,12 @@ Rarely or Internally Used
     the selected direction of motion, when moving focus with the
     keyboard.
 
+.. var:: config.gamedir = ...
+
+    The full path leading to the game's ``game/`` directory. This is a
+    read-only variable. There is no guarantee that any file will be there,
+    typically on platforms such as android.
+
 .. var:: config.gl_resize = True
 
     Determines if the user is allowed to resize an OpenGL-drawn window.

--- a/sphinx/source/file_python.rst
+++ b/sphinx/source/file_python.rst
@@ -2,10 +2,10 @@ File Access
 ===========
 
 These Python functions allow you to access asset files, which may be found
-in the game directory, RPA archives, or as Android assets.
+in the game directory, RPA archives, or as Android assets. The :var:`config.gamedir`
+variable can be useful in order to create valid filepaths to pass to these functions.
 
 .. include:: inc/file
-
 
 Rarely Used
 -----------

--- a/sphinx/source/save_load_rollback.rst
+++ b/sphinx/source/save_load_rollback.rst
@@ -164,7 +164,7 @@ namespaces inside functions,  or ``python hide`` blocks.)
 
 For example, using a file object like::
 
-    $ monika_file = open(config.gamedir + "/monika.chr", "w")
+    $ monika_file = open("./monika.chr", "w")
     $ monika_file.write("Do not delete.\r\n")
     $ monika_file.close()
 
@@ -173,7 +173,7 @@ Putting this in a ``python hide`` block will work::
 
     python hide:
 
-        monika_file = open(config.gamedir + "/monika.chr", "w")
+        monika_file = open("./monika.chr", "w")
         monika_file.write("Do not delete.\r\n")
         monika_file.close()
 
@@ -181,7 +181,7 @@ Putting this in a ``python hide`` block will work::
 
     python hide:
 
-        with open(config.gamedir + "/monika.chr", "w") as monika_file:
+        with open("./monika.chr", "w") as monika_file:
             monika_file.write("Do not delete.\r\n")
 
 Coroutines, like those made with ``async``, ``await``, or the ``asyncio``

--- a/sphinx/source/save_load_rollback.rst
+++ b/sphinx/source/save_load_rollback.rst
@@ -164,7 +164,7 @@ namespaces inside functions,  or ``python hide`` blocks.)
 
 For example, using a file object like::
 
-    $ monika_file = open("./monika.chr", "w")
+    $ monika_file = open(config.gamedir + "/monika.chr", "w")
     $ monika_file.write("Do not delete.\r\n")
     $ monika_file.close()
 
@@ -173,7 +173,7 @@ Putting this in a ``python hide`` block will work::
 
     python hide:
 
-        monika_file = open("./monika.chr", "w")
+        monika_file = open(config.gamedir + "/monika.chr", "w")
         monika_file.write("Do not delete.\r\n")
         monika_file.close()
 
@@ -181,7 +181,7 @@ Putting this in a ``python hide`` block will work::
 
     python hide:
 
-        with open("./monika.chr", "w") as monika_file:
+        with open(config.gamedir + "/monika.chr", "w") as monika_file:
             monika_file.write("Do not delete.\r\n")
 
 Coroutines, like those made with ``async``, ``await``, or the ``asyncio``

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -1874,7 +1874,7 @@ statement. It supports the ``if``, ``elif``, and ``else`` clauses.
 ::
 
     screen skipping_indicator():
-        if config.skipping:
+        if renpy.get_skipping():
              text "Skipping."
         else:
              text "Not Skipping."

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -1874,7 +1874,7 @@ statement. It supports the ``if``, ``elif``, and ``else`` clauses.
 ::
 
     screen skipping_indicator():
-        if renpy.get_skipping():
+        if renpy.is_skipping():
              text "Skipping."
         else:
              text "Not Skipping."


### PR DESCRIPTION
`config.skipping` is undocumented, per #3773 and #1158.
`config.gamedir` is undocumented, and I suggest it stays so for the same reasons as config.skipping : it's not intended to be writeable.

Two examples were using those, now they don't.

Per #3600