### PR TITLE
Sticky layer tweaks

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1298,8 +1298,8 @@ class SceneLists(renpy.object.Object):
                 self.shown.predict_hide(layer, (tag,))
                 self.at_list[layer].pop(tag, None)
 
-                if layer in renpy.config.sticky_layers:
-                    self.sticky_tags.pop(tag, None)
+                if self.sticky_tags.get(tag, None) == layer:
+                    del self.sticky_tags[tag]
 
             self.hide_or_replace(layer, remove_index, prefix)
 
@@ -1325,10 +1325,9 @@ class SceneLists(renpy.object.Object):
                 self.hide_or_replace(layer, i, hide)
 
         self.at_list[layer].clear()
-        self.shown.predict_scene(layer)
+        self.sticky_tags = {k: v for k, v in self.sticky_tags.items() if v != layer}
 
-        if layer in renpy.config.sticky_layers:
-            self.sticky_tags = {k: v for k, v in self.sticky_tags.items() if v != layer}
+        self.shown.predict_scene(layer)
 
         if renpy.config.scene_clears_layer_at_list:
             self.layer_at_list[layer] = (None, [ ])

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -10,6 +10,31 @@ Changelog (Ren'Py 7.x-)
 8.1 / 7.6
 =========
 
+Sticky Layers
+-------------
+
+A sticky layer is defined as one that, when a tag is shown upon it, will
+be treated as that tag's default layer until it is either hidden, or
+shown on another sticky layer.
+
+In practice, that means showing a tag on a layer other than its default,
+and assuming that layer is sticky, it will be updated with attributes
+set via a show or say statement without the need to respecify the layer.
+
+The following example assumes that the default layer for ``eileen`` is
+``master``, and that ``near`` is a sticky layer::
+
+    show eileen onlayer near
+    eileen happy "Hello there!"  # will now work, where previously it would not
+    show eileen excited          # implicit onlayer near
+    hide eileen                  # implicit onlayer near
+    show eileen                  # implicit onlayer master, eileen's default
+
+The default for this feature is for the ``master`` layer to be sticky, as
+well as any layers created with :func:`renpy.add_layer` unless passed
+the new parameter ``sticky=False``.
+
+
 Mixer Volume Changes
 --------------------
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -19,6 +19,23 @@ such changes only take effect when the GUI is regenerated.
 8.1.0 / 7.6.0
 -------------
 
+**Sticky layers** This release introduces the concept of sticky layers
+which help automatically manage tags being placed on layers other than
+their default. In the rare case that a game requires multiple of the
+same tag, to be displayed at the same time, on different layers then
+this may not be desirable.
+
+To disable sticky layers entirely, add to your game::
+
+    define config.sticky_layers = [ ]
+
+Alternatively, to prevent only specific layers from being sticky, update
+their definitions to include ``sticky=False``::
+
+    init python:
+        renpy.add_layer("ptfe", sticky=False)
+
+
 **Lenticular bracket ruby text** This release of Ren'Py introduces
 lenticular bracket ruby text, an easier way of writing ruby text. If
 a game included a literal 【, it needs to be doubled, to "【【", to


### PR DESCRIPTION
Code-wise, this change ensures that tags are only unstuck when being removed from the layer to which they were stuck, and as they could only have been stuck to a sticky layer in the first place, there is no need to check if the layer is sticky.

Aside from that is a pass at documenting the feature, explaining its purpose, function, and how it can be avoided, along with a small nod to all the chemists in the audience. 😁 🧪 🥼