### PR TITLE
Use the regular way of testing py's version

### DIFF
--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -31,12 +31,11 @@ init python in distribute:
     import sys
     import threading
 
-    from renpy import six
     from zipfile import crc32
 
 
     # Since the long type doesn't exist on py3, define it here
-    if six.PY3:
+    if not PY2:
         long = int
 
     zlib.Z_DEFAULT_COMPRESSION = 5


### PR DESCRIPTION
This is the last use of the six module across the repo - other than `__init__.py` importing it. Maybe we can remove it from the requirements ?