### PR TITLE
Improve and secure the documented signature of renpy.show

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -632,7 +632,7 @@ def set_tag_attributes(name, layer=None):
 def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind=[ ], atl=None, transient=False, munge_name=True):
     """
     :doc: se_images
-    :args: (name, at_list=[], layer='master', what=None, zorder=0, tag=None, behind=[])
+    :args: (name, at_list=[], layer=None, what=None, zorder=0, tag=None, behind=[], **kwargs)
 
     Shows an image on a layer. This is the programmatic equivalent of the show
     statement.

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1721,7 +1721,8 @@ Rarely or Internally Used
 
     A function that is used in place of :func:`renpy.show` by the :ref:`show
     <show-statement>` and :ref:`scene <scene-statement>` statements. This
-    should have the same signature as :func:`renpy.show`.
+    should have the same signature as :func:`renpy.show`, and pass unknown
+    keyword arguments unchanged.
 
 .. var:: config.skip_delay = 75
 


### PR DESCRIPTION
There are undocumented keyword arguments (they are at least 7 years old) which would already break existing uses of config.show with a function which would only take the documented arguments. This warns about them, and tell creators to pass them unchanged.
Also, the layer argument is worded as "if not None..." while the displayed default value is "master". I find that putting None in the signature is more clear, because the explanation is clear enough.