### PR TITLE
Restore self-voicing notification callback

### DIFF
--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -624,6 +624,9 @@ init -1500 python:
         elif not _preferences.self_voicing and has_screen:
             renpy.hide_screen("_self_voicing")
 
+
+    config.interact_callbacks.append(__show_self_voicing)
+
     # Ignored.
     config.self_voicing_stops_afm = False
 


### PR DESCRIPTION
In current nightlies activating self-voicing mode doesn't display the screen saying it's active - regression introduced by 9366678fef7e83f4d59ec1aff1c0000965d1e52d.