### PR TITLE
Ban object's __init__ docstring from our documentation

### DIFF
--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -208,6 +208,9 @@ documented = collections.defaultdict(list)
 # This keeps all objectsd we see alive, to prevent duplicates in documented.
 documented_list = [ ]
 
+# The docstring for object.__init__ - which we don't want to pass for one of our classes's
+objinidoc = inspect.getdoc(object.__init__)
+
 
 def scan(name, o, prefix="", inclass=False):
 
@@ -277,7 +280,7 @@ def scan(name, o, prefix="", inclass=False):
 
             init_doc = inspect.getdoc(init)
 
-            if init_doc and not init_doc.startswith("x.__init__("):
+            if init_doc and (init_doc != objinidoc):
                 lines.append("")
                 lines.extend(init_doc.split("\n"))
 


### PR DESCRIPTION
In py3, `class A: pass` then `A.__init__.__doc__` returns the docstring of `object.__init__`, which babbles about help(type(o)).
This part of code I edited looks for the `__init__` docstring to add it to the extracted docstring of the class, but we don't want object's docstrings, we only want ours.

This works by memorizing the forbidden docstring (for efficiency). I removed a previous test which _seemed_ to do a similar test but I'm **not sure what it was about**. It was added in 3b6c9bde63333d28bd9b20caae591a35d45116a3 without much explanation, and seems outdated.