### PR TITLE
Layer displayable and detached layers

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -169,6 +169,10 @@ bottom_layers = [ 'bottom' ]
 # Layers which will override the default layer for a tag while shown.
 sticky_layers = [ 'master' ]
 
+# Layers not automatically added to a scene and inherently sticky,
+# primarily for use with the Layer displayable.
+detached_layers = [ ]
+
 # True if we want to show overlays during wait statements, or
 # false otherwise.
 overlay_during_with = True

--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -161,6 +161,7 @@ DynamicDisplayable = renpy.display.layout.DynamicDisplayable
 ConditionSwitch = renpy.display.layout.ConditionSwitch
 ShowingSwitch = renpy.display.layout.ShowingSwitch
 AlphaMask = renpy.display.layout.AlphaMask
+Layer = renpy.display.layout.Layer
 
 Transform = renpy.display.motion.Transform
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -110,9 +110,20 @@ enabled_events = {
 # The number of msec between periodic events.
 PERIODIC_INTERVAL = 50
 
+# Layer management.
+layers = frozenset(renpy.config.layers)
+sticky_layers = frozenset()
+
 # Time management.
 time_base = 0.0
 time_mult = 1.0
+
+
+def init_layers():
+    global layers, sticky_layers
+
+    layers = frozenset(renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers)
+    sticky_layers = frozenset(renpy.config.sticky_layers)
 
 
 def init_time():
@@ -829,11 +840,10 @@ class SceneLists(renpy.object.Object):
     __version__ = 8
 
     def after_setstate(self):
-
         self.camera_list = getattr(self, "camera_list", { })
         self.camera_transform = getattr(self, "camera_transform", { })
 
-        for i in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+        for i in layers:
             if i not in self.layers:
                 self.layers[i] = [ ]
                 self.at_list[i] = { }
@@ -849,7 +859,7 @@ class SceneLists(renpy.object.Object):
             self.at_list = { }
             self.layer_at_list = { }
 
-            for i in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+            for i in layers:
                 self.at_list[i] = { }
                 self.layer_at_list[i] = (None, [ ])
 
@@ -918,7 +928,7 @@ class SceneLists(renpy.object.Object):
 
         if oldsl:
 
-            for i in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+            for i in layers:
 
                 try:
                     self.layers[i] = oldsl.layers[i][:]
@@ -948,7 +958,7 @@ class SceneLists(renpy.object.Object):
             self.sticky_tags.update(oldsl.sticky_tags)
 
         else:
-            for i in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+            for i in layers:
                 self.layers[i] = [ ]
                 self.at_list[i] = { }
                 self.layer_at_list[i] = (None, [ ])
@@ -1120,7 +1130,7 @@ class SceneLists(renpy.object.Object):
             self.remove_hide_replaced(layer, key)
             self.at_list[layer][key] = at_list
 
-            if layer in renpy.config.sticky_layers:
+            if layer in sticky_layers:
                 self.sticky_tags[key] = layer
 
         if key and name:
@@ -2057,7 +2067,10 @@ class Interface(object):
         # Is our audio paused?
         self.audio_paused = False
 
-        for layer in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+        # Init layers.
+        init_layers()
+
+        for layer in layers:
             if layer in renpy.config.layer_clipping:
                 x, y, w, h = renpy.config.layer_clipping[layer]
                 self.layer_properties[layer] = dict(
@@ -3023,7 +3036,7 @@ class Interface(object):
         raw = { }
         rv = { }
 
-        for layer in renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers:
+        for layer in layers:
             raw[layer] = d = scene_lists.make_layer(layer, self.layer_properties[layer])
             rv[layer] = scene_lists.transform_layer(layer, d)
 

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -124,8 +124,11 @@ time_mult = 1.0
 def init_layers():
     global layers, sticky_layers, null
 
-    layers = frozenset(renpy.config.layers + renpy.config.top_layers + renpy.config.bottom_layers)
-    sticky_layers = frozenset(renpy.config.sticky_layers)
+    layers = frozenset(
+        renpy.config.layers + renpy.config.detached_layers +
+        renpy.config.top_layers + renpy.config.bottom_layers)
+    sticky_layers = frozenset(
+        renpy.config.sticky_layers + renpy.config.detached_layers)
 
     null = renpy.display.layout.Null()
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2445,3 +2445,22 @@ class Layer(AdjustTimes):
         self.anim_time = at
 
         super(Layer, self).add(d)
+
+    def visit_all(self, callback, seen=None):
+        # Call on self first, as it could be replacing the child.
+        callback(self)
+
+        d = self.child
+
+        if d is None:
+            return
+
+        if seen is None:
+            seen = set()
+
+        id_d = id(d)
+        if id_d in seen:
+            return
+
+        seen.add(id_d)
+        d.visit_all(callback, seen)

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2418,6 +2418,8 @@ class NearRect(Container):
 
 class Layer(AdjustTimes):
     """
+    :doc: disp_layer
+
     This allows a layer to be shown as a displayable on another layer.
     Intended for use with detached layers.
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2414,3 +2414,34 @@ class NearRect(Container):
             return self._tts_common()
         else:
             return ""
+
+
+class Layer(AdjustTimes):
+    """
+    This allows a layer to be shown as a displayable on another layer.
+    Intended for use with detached layers.
+
+    Trying to display a layer on itself is not supported.
+
+    `layer`
+        The layer to display.
+
+    `clipping`
+        If False, the layer's contents may exceed its bounds, otherwise
+        anything exceeding the bounds will be trimmed.
+    """
+
+    def __init__(self, layer, **properties):
+        self.layer = layer
+        self._clipping = properties.pop('clipping', True)
+
+        # Intentionally skip over the AdjustTimes constructor.
+        super(AdjustTimes, self).__init__(**properties)
+
+    def add(self, d, st=None, at=None):
+        self._clear()
+
+        self.start_time = st
+        self.anim_time = at
+
+        super(Layer, self).add(d)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -35,6 +35,24 @@ well as any layers created with :func:`renpy.add_layer` unless passed
 the new parameter ``sticky=False``.
 
 
+Detached Layers & Layer Displayable
+-----------------------------------
+
+Detached layers are creator-defined layers which are not automatically added to
+a scene. They are instead displayed using a new :class:`Layer` displayable
+which can be show on other layers.
+
+One of the driving factors behind this is that it allows shaders and other
+transform effects to be applied to a group of tags while still allowing them to
+operate normally with other systems such as show and say statements. It also
+also allows the same layer to be shown multiple times, for instance in
+reflections or several TV showing the same channel.
+
+As detached layers don't participate in scene building in the same way as
+typical layers, they are defined directly in :var:`config.detached_layers`
+rather than through :func:`add_layer`, and are inherently sticky.
+
+
 Mixer Volume Changes
 --------------------
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1277,6 +1277,12 @@ Rarely or Internally Used
     returns False, the built-in exception handler is use. This function may also call
     :func:`renpy.jump` to transfer control to some other label.
 
+.. var:: config.detached_layers = [ ]
+
+    These are layers which do not get automatically added to scenes.
+    They are always treated as :var:`sticky <config.sticky_layers>` and
+    intended for use with the :ref:`Layer` displayable for embedding.
+
 .. var:: config.fade_music = 0.0
 
     This is the amount of time in seconds to spend fading the old

--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -141,6 +141,53 @@ change frequently, such as character emotions.
 .. include:: inc/disp_dynamic
 
 
+Layer Displayables
+------------------
+
+Layer displayables display the contents of a layer based on the state of the
+game. They are intended for use with :var:`config.detached_layers`.
+
+Note that similar to dynamic displayables, the layers shown within always
+display their current state. Because of this, the contents of a layer
+displayable will not participate in a transition, unless that transition is
+targeted at the layer being displayed.
+
+.. include:: inc/disp_layer
+
+::
+
+   # A new detached layer to hold the contents of a broadcast.
+   define config.detached_layers += [ "broadcast" ]
+
+   # A layer displayable to represent a TV and watch the broadcast layer.
+   image tv = Window(Layer("broadcast"), background='#000', padding=(10, 10))
+
+   image living_room = Placeholder('bg', text='living_room')
+   image studio = Solid('7c7')
+   image eileen = Placeholder('girl')
+
+   label example:
+       pause
+
+       # Set up the broadcast scene.
+       scene studio onlayer broadcast
+       with None
+
+       # Begin a new scene in the living room.
+       scene living_room
+
+       # Show the TV in the lower right corner of ths screen.
+       show tv:
+         align (.75, .75) zoom .3
+
+       # Show Eileen in the broadcast.
+       show eileen onlayer broadcast
+
+       # Dissolve into the living room, as Eileen enters the TV from the right.
+       with {'master': dissolve, 'broadcast': moveinright}
+       pause
+
+
 Applying Transforms to Displayables
 -----------------------------------
 


### PR DESCRIPTION
The second half of https://github.com/renpy/renpy/issues/4149.

This is intended as a feature for more advanced creators and comes with minimal hand holding. Docs to follow Tom's approval.

**Key points**
- The `Layer` displayable has been added to represent one layer inside another.
- `config.detached_layers` has been added to allow declaration of layers that will not be automatically added to a scene, but rather used via the `Layer` displayable on an as-needed basis.
- `layers` and `sticky_layers` have been created to help manage layer configuration and optimize some of their operations.

---

This feature underwent significant changes during development, with a substantial portion of the original code backed out. The original PR body can be viewed below to contextualise the comment thread, but is largely obsolete as it pertains to the current changes.

<details><summary>Original PR body</summary>
**Key points**
- The `show layer` statement can now be used to add new "detached" layers when used with an unrecognised layer name.
- A corresponding `hide layer` statement has been added to destroy "detached" layers - and _only_ detached layers.
- Python equivalents `renpy.show_layer` and `renpy.hide_layer` have been added - intentionally undocumented for now.
- The `Layer` displayable has been added to represent one layer inside another.
- `layers_static` and `layers_non_stick` have been created to help manage layer configuration and optimize some of their operations.

<details><summary>Demo script using tutorial assets.</summary>

```rpy
image tv = Layer('tv')

screen inspect():
    frame:
        background '#0007'
        text ', '.join(sorted(renpy.scene_lists().layers.keys()))

label demo:
    show screen inspect

    scene bg washington
    show eileen happy
    e "Hi! I'm excited to tell you about the new detached layers feature in Ren'Py!"
    e "But don't take my word for it, let's check in with Lucy's news broadcast."
    e "Let me just add a new layer for the TV ..."

    show layer tv
    show tv:
        align (0.9, 0.1)
        zoom 0.3

    e "There we are, now we can turn it on."

    show bg whitehouse as whitehouse onlayer tv
    show lucy happy onlayer tv
    with {'tv': CropMove(0.2, 'irisout')}

    l "For those just joining us, we're reporting on the new detached layers feature, live from the Whitehouse!"

    show eileen:
        ease 1 xalign 0.25
    show tv zorder 1:
        ease 2 align (0.9, 0.7)

    l "As you can see, this brings new possibilities to Ren'Py ..."

    show lucy:
        ease 1 xalign 0.25
    show tv as tv2:
        anchor (.5, .5) pos (0.75, 0.25) zoom 0
        ease .3 zoom .3
    with dissolve

    l "... Many, many possibilities."

    show lucy:
        ease 1 xalign 0.75
    show tv as tv3:
        anchor (.5, .5) pos (0.65, 0.45) zoom 0
        ease .3 zoom .3

    e "Wow, Lucy! There are so many of you, and all in sync!"
    l "That's right, Eileen, and they're all the same me."
    e "We've got to go, bye for now, Lucy!"
    l "Okay, bye."

    play music "renpyallstars.ogg" noloop

    scene concert onlayer tv
    with {'tv': fade}
    pause 1

    e "Woah! Too loud!" with vpunch

    stop music

    scene onlayer tv
    with {'tv': CropMove(0.2, 'irisin')}

    e "That's just some of what's possible with detached images."
    e "And now the TV is off, we don't need that extra layer anymore ..."

    hide layer tv

    e "All done!"

    return
```
</details></details>