### PR TITLE
Variables documentation

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1182,7 +1182,7 @@ def display_menu(items,
     """
     :doc: se_menu
     :name: renpy.display_menu
-    :args: (items, *, interact=True, screen="choice")
+    :args: (items, *, interact=True, screen="choice", **kwargs)
 
     This displays a menu to the user. `items` should be a list of 2-item tuples.
     In each tuple, the first item is a textual label, and the second item is

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -350,8 +350,8 @@ Occasionally Used
 
 .. var:: config.context_callback = None
 
-    This is a callback that is called when Ren'Py enters a new context,
-    such as a menu context.
+    This is a callback that is called with no arguments when Ren'Py enters a
+    new context, such as a menu context.
 
 .. var:: config.context_copy_remove_screens = [ 'notify', ... ]
 
@@ -488,7 +488,7 @@ Occasionally Used
 
 .. var:: config.empty_window : Callable
 
-    This is called when _window is True, and no window has been shown
+    This is called with no arguments when _window is True, and no window has been shown
     on the screen. (That is, no call to :func:`renpy.shown_window` has
     occurred.) It's expected to show an empty window on the screen, and
     return without causing an interaction.
@@ -1484,8 +1484,9 @@ Rarely or Internally Used
 .. var:: config.missing_image_callback = None
 
     If not None, this function is called when an attempt to load an
-    image fails. It may return None, or it may return an image
-    manipulator. If an image manipulator is returned, that image
+    image fails. The callback is passed the filename of the missing image.
+    It may return None, or it may return an :doc:`image manipulator <im>`.
+    If an image manipulator is returned, that image
     manipulator is loaded in the place of the missing image.
 
     One may want to also define a :var:`config.loadable_callback`,

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -310,9 +310,9 @@ Occasionally Used
 
 .. var:: config.autosave_callback = None
 
-    A callback or list of callbacks that will be called after each time a
-    background autosave happens. The callbacks are called during an interaction,
-    and so actions may be used, though the Return action will not function.
+    A callback or list of callbacks or Actions that will be called after
+    each time a background autosave happens. Although actions may be used,
+    the Return action will not function.
 
     If a non-Action callback shows a displayable or screen,
     :func:`renpy.restart_interaction` should be called.
@@ -418,6 +418,8 @@ Occasionally Used
     If not None, this should be a string giving the default language
     that the game is translated into by the translation framework.
 
+    See :doc:`translation` for more details.
+
 .. var:: config.default_tag_layer = "master"
 
     The layer an image is shown on if its tag is not found in :var:`config.tag_layer`.
@@ -512,9 +514,9 @@ Occasionally Used
 
 .. var:: config.fix_rollback_without_choice = False
 
-    This option determines how the built in menus or imagemaps behave
+    This option determines how the built-in menus or imagemaps behave
     during fixed rollback. The default value is False, which means that
-    menu only the previously selected option remains clickable. If set
+    only the previously selected menu option remains clickable. If set
     to True, the selected option is marked but no options are clickable.
     The user can progress forward through the rollback buffer by
     clicking.
@@ -733,6 +735,8 @@ Occasionally Used
     The frames are played back at 20Hz, and the animation loops after
     all frames have been shown.
 
+    See :doc:`mouse` for more information.
+
 .. var:: config.mouse_displayable = None
 
     If not None, this should either be a displayable, or a callable that
@@ -744,6 +748,8 @@ Occasionally Used
     responsible for positioning and drawing a sythetic mouse
     cursor, and so should probably be a :func:`MouseDisplayable`
     or something very similar.
+
+    See :doc:`mouse` for more information.
 
 .. var:: config.narrator_menu = True
 
@@ -827,7 +833,7 @@ Occasionally Used
 .. var:: config.quit_action : Action
 
     The action that is called when the user clicks the quit button on
-    a window. The default action prompts the user to see if he wants
+    a window. The default action prompts the user to see if they want
     to quit the game.
 
 .. var:: config.reload_modules = [ ... ]
@@ -1129,7 +1135,7 @@ Rarely or Internally Used
 
     A list of callbacks that are called by all characters. This list
     is prepended to the list of character-specific callbacks. Ren'Py
-    includes it's own callbacks at the start of this list.
+    includes its own callbacks at the start of this list.
 
 .. var:: config.allow_skipping = True
 
@@ -1214,7 +1220,7 @@ Rarely or Internally Used
 
 .. var:: config.character_callback = None
 
-    The default value of the callback parameter of Character.
+    The default value of the `callback` parameter of :class:`Character`.
 
 .. var:: config.choice_empty_window = None
 

--- a/sphinx/source/custom_text_tags.rst
+++ b/sphinx/source/custom_text_tags.rst
@@ -12,13 +12,13 @@ Custom text tags are created by assigning a text tag function to an
 entry in the config.custom_text_tags dictionary or the
 config.self_closing_custom_tags dictionary.
 
-.. var:: config.custom_text_tags
+.. var:: config.custom_text_tags = { }
 
     Maps text tag names to text tag functions, when the text tag can
     wrap other text.
 
 
-.. var:: config.self_closing_custom_text_tags
+.. var:: config.self_closing_custom_text_tags = { }
 
     Maps text tag names to a self-closing text tag functions, when the text tag
     does not wrap other text.

--- a/sphinx/source/gesture.rst
+++ b/sphinx/source/gesture.rst
@@ -26,11 +26,10 @@ a touchscreen device.
 
     A map from gesture to the event activated by the gesture.
 
-.. var:: config.dispatch_gesture = None
+.. var:: config.dispatch_gesture : Callable
 
     The function that is used to dispatch gestures. This function is
     passed the raw gesture string. If it returns non-None, the
-    interaction ends. If this variable is None, a default dispatch
-    function is used.
+    interaction ends.
 
 .. include:: inc/gesture

--- a/sphinx/source/preferences.rst
+++ b/sphinx/source/preferences.rst
@@ -60,6 +60,8 @@ can then change it again.)
     the current language. The :func:`Language` action can be used to change
     the language.
 
+    See :doc:`translation` for more information.
+
 .. var:: preferences.emphasize_audio = False
 
     If True, Ren'Py will emphasize the audio channels found in :var:`config.emphasize_audio_channels`

--- a/sphinx/source/side_image.rst
+++ b/sphinx/source/side_image.rst
@@ -85,10 +85,10 @@ using config variables.
 .. var:: _side_image_tag = None
 .. var:: config.side_image_tag = None
 
-    If _side_image_tag is not None, it takes preference over config.side_image_tag.
+    If _side_image_tag is not None, it takes precedence over config.side_image_tag.
 
     If this is given, then the side image will track the given image tag,
-    rather than the image associated with currently speaking character. For example,
+    rather than the image associated with the currently speaking character. For example,
 
     ::
 

--- a/sphinx/source/store_variables.rst
+++ b/sphinx/source/store_variables.rst
@@ -33,6 +33,8 @@ and rolled-back when rollback occurs.
     when the current cursor does not exist, or is the default. This is used by
     :var:`config.mouse` and :func:`MouseDisplayable`.
 
+    See :doc:`mouse` for more information.
+
 .. var:: _dismiss_pause = True
 
     If True, the player can dismiss pauses and transitions.

--- a/sphinx/source/store_variables.rst
+++ b/sphinx/source/store_variables.rst
@@ -78,8 +78,8 @@ and rolled-back when rollback occurs.
 .. var:: menu = renpy.display_menu
 
     The function that's called to display the in-game menu. It should take the same
-    arguments as :func:`renpy.display_menu`. Assigning :func:`nvl_menu` to this
-    will display an nvl-mode menu.
+    arguments as :func:`renpy.display_menu`, and pass unknown keyword arguments
+    unchanged. Assigning :func:`nvl_menu` to this will display an nvl-mode menu.
 
 .. var:: mouse_visible = True
 


### PR DESCRIPTION
Various tweaks, in particular to how callbacks are documented, so that creators always know what parameter they can be passed.

I'm not sure why gesture and side_image appear as entirely replaced, I suppose it's a problem of LF/CRLF and git or vscode replaced all line endings automatically ? That, or they had trailing whitespace on all lines.
If it's a problem I can try to recommit that differently.