### PR TITLE
move: Transformed-layer specific Move transition

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1449,6 +1449,7 @@ class SceneLists(renpy.object.Object):
             f = renpy.display.layout.MultiBox(layout='fixed')
             f.add(rv, time, time)
             f.layer_name = layer
+            f.raw_child = d
 
             rv = f
 
@@ -1477,6 +1478,7 @@ class SceneLists(renpy.object.Object):
             f = renpy.display.layout.MultiBox(layout='fixed')
             f.add(rv, time, time)
             f.layer_name = layer
+            f.raw_child = d
 
             rv = f
 
@@ -3040,20 +3042,17 @@ class Interface(object):
         name to a Fixed containing that layer.
         """
 
-        raw = { }
         rv = { }
 
         for layer in layers:
-            raw[layer] = d = scene_lists.make_layer(layer, self.layer_properties[layer])
+            d = scene_lists.make_layer(layer, self.layer_properties[layer])
             rv[layer] = scene_lists.transform_layer(layer, d)
 
         root = renpy.display.layout.MultiBox(layout='fixed')
         root.layers = { }
-        root.raw_layers = { }
 
         for layer in renpy.config.layers:
             root.layers[layer] = rv[layer]
-            root.raw_layers[layer] = raw[layer]
             root.add(rv[layer])
 
         rv[None] = root
@@ -3776,7 +3775,6 @@ class Interface(object):
         # The root widget of all of the layers.
         layers_root = renpy.display.layout.MultiBox(layout='fixed')
         layers_root.layers = { }
-        layers_root.raw_layers = scene[None].raw_layers
 
         def add_layer(where, layer):
 
@@ -3816,7 +3814,6 @@ class Interface(object):
 
             old_root = renpy.display.layout.MultiBox(layout='fixed')
             old_root.layers = { }
-            old_root.raw_layers = self.transition_from[None].raw_layers
 
             for layer in renpy.config.layers:
                 d = self.transition_from[None].layers[layer]

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -619,7 +619,6 @@ class MultiBox(Container):
     _layer_at_list = None # type: list|None
     _camera_list = None # type: list|None
     layers = None # type: dict|None
-    raw_layers = None # type: dict|None
 
 
     def __init__(self, spacing=None, layout=None, style='default', **properties):
@@ -642,9 +641,6 @@ class MultiBox(Container):
         # that layer.
         self.layers = None
 
-        # The same, but for the raw layers.
-        self.raw_layers = None
-
         # The scene list for this widget.
         self.scene_list = None
 
@@ -654,7 +650,6 @@ class MultiBox(Container):
         self.start_times = [ ]
         self.anim_times = [ ]
         self.layers = None
-        self.raw_layers = None
         self.scene_list = None
 
     def _in_current_store(self):
@@ -689,15 +684,14 @@ class MultiBox(Container):
         elif self.layers:
             rv = MultiBox(layout=self.default_layout)
             rv.layers = { }
-            rv.raw_layers = { }
 
             changed = False
 
             for layer in renpy.config.layers:
-                old_d = self.raw_layers[layer]
-                new_d = old_d._in_current_store()
+                old_d = self.layers[layer]
+                old_d = getattr(old_d, 'raw_child', old_d)
 
-                rv.raw_layers[layer] = new_d
+                new_d = old_d._in_current_store()
 
                 if new_d is not old_d:
                     changed = True

--- a/renpy/display/movetransition.py
+++ b/renpy/display/movetransition.py
@@ -513,31 +513,40 @@ def MoveTransition(delay, old_widget=None, new_widget=None, enter=None, leave=No
 
             rv = renpy.display.layout.MultiBox(layout='fixed')
 
-            rv.raw_layers = { }
             rv.layers = { }
 
             for layer in renpy.config.layers:
 
-                f = new.layers[layer]
-                d = new.raw_layers[layer]
+                d = merge_slide(old.layers[layer], new.layers[layer], merge_slide)
 
-                if (isinstance(d, renpy.display.layout.MultiBox)
-                    and layer in layers
-                    and d.scene_list is not None):
+                rv.layers[layer] = d
+                rv.add(d, True, True)
 
-                    d = merge_slide(old.raw_layers[layer], new.raw_layers[layer], merge_slide)
+            return rv
 
-                    adjust = renpy.display.layout.AdjustTimes(d, None, None)
-                    f = renpy.game.context().scene_lists.transform_layer(layer, adjust)
+        # Unpack old if needs be.
+        old = getattr(old, 'raw_child', old)
 
-                    if f is adjust:
-                        f = d
-                    else:
-                        f = renpy.display.layout.MatchTimes(f, adjust)
+        # If we're dealing with a wrapped layer widget, merge the raw
+        # children then re-apply the transform.
+        if hasattr(new, 'raw_child'):
+            rv = new
 
-                rv.raw_layers[layer] = d
-                rv.layers[layer] = f
-                rv.add(f, True, True)
+            new = new.raw_child
+            layer = new.layer_name
+
+            if (isinstance(new, renpy.display.layout.MultiBox) and
+                layer in layers and new.scene_list is not None):
+
+                d = merge_slide(old, new, merge_slide)
+
+                adjust = renpy.display.layout.AdjustTimes(d, None, None)
+                rv = renpy.game.context().scene_lists.transform_layer(layer, adjust)
+
+                if rv is adjust:
+                    rv = d
+                else:
+                    rv = renpy.display.layout.MatchTimes(rv, adjust)
 
             return rv
 


### PR DESCRIPTION
Proposed fix for #4264. I don't pretend to have worked with `MoveTransition` enough to know if this is truly the right approach, it seems sane, but given how often issues in this area have come up before - #2560, #2821, #2995 - it should probably be vetted comprehensively.

---

This alters how the Move transition deals with layers that have been wrapped in a transform by the "show layer" statement.

Previously raw layers were hung on the layers_root widget, so that the Move transition could unwrap them when needed. Unfortunately this meant that it was only possible to do this unwrapping if it was the layers_root widget being transitioned, rather than individual layers.

The change is to instead hang the raw layer on its transformation directly, allowing it to be accessed both in the case of transitioning the layers_root widget and also transitioning a layer in isolation. It also makes the concept of raw_layers on the root widget redundant, and so they have been cleaned up.

---

<details><summary>Basic test case</summary>

```rpy
image b = Solid('7ff3', xysize=(320, 240))

label main_menu:
    $ _confirm_quit = False
    return

label start:
    show b
    "Start."

    show b:
        align (.75, .25) subpixel True
    with {'master': move}
    "Move transition applied to master layer only."

    show layer master:
        blur 5
    "Show layer at blur applied."

    show b:
        align (.25, .25)
    with {'master': move}
    "Move transition applied to master layer only with transformed layer."

    show layer master # reset
    "Reset layer at."

    show b:
        align (.5, 1.)
    with {'master': move}
    "Move transition applied to master layer without transformed layer."
    pause

    show b:
        align (.75, .25)
    with move
    "Generic move transition."

    show layer master:
        blur 5
    "Show layer at blur applied."

    show b:
        align (.25, .25)
    with move
    "Generic move transition with transformed layer."

    show layer master # reset
    "Reset layer at."

    show b:
        align (.5, 1.)
    with {'master': move}
    "Generic move transition without transformed layer."

    jump start

```
</details>