### PR TITLE
Add new config screenshot_name_callback

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -287,6 +287,9 @@ init -1600 python:
 
         pattern = renpy.store._screenshot_pattern or config.screenshot_pattern
 
+        if config.screenshot_name_callback is not None:
+            pattern = config.screenshot_name_callback(pattern)
+
         # Try to pick a filename.
         i = 1
         while True:

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1343,6 +1343,11 @@ after_default_callbacks = [ ]
 # A list of extra save directories. Strings giving the full paths.
 extra_savedirs = [ ]
 
+# A function that is expected to return a filename pattern for screenshot
+# It must take one argument: pattern selected by renpy
+# It may change it or return unchanged
+screenshot_name_callback = None
+
 del os
 del collections
 


### PR DESCRIPTION
I feel like only being able to use static pattern for screenshot filename isn't enough, there's a few cases where I'd want to dynamically select a name.
One usage example:
```py
import time

def _get_screenshot_name(fn: str) -> str:
    dt_str = time.strftime("%d-%m-%Y %H-%M-%S")
    return f"{dt_str} {fn}"

config.screenshot_name_callback = _get_screenshot_name
config.screenshot_pattern = "%04d.png"
```
which would give something like `01-01-1970 00-00-00 0001.png`.

But there's more: can add current chapter to filename, place screenshots into different folders based on the chapter, etc.