### PR TITLE
Disable empty keywords in screen parsing

### DIFF
--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -271,6 +271,8 @@ class Parser(object):
                 return
 
             expr = l.comma_expression()
+            if expr is None:
+                l.error("the {} keyword argument was not given a value.".format(name))
 
             if (not keyword) and (not renpy.config.keyword_after_python):
                 try:


### PR DESCRIPTION
I don't think this deserves a compat, because there's no use to the syntax hereby disabled. And if one is found, thiis shouldn't be merged at all.