### PR TITLE
Disable empty keywords in screen parsing - with compat

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2393,6 +2393,7 @@ EARLY_CONFIG = {
     "name",
     "version",
     "save_token_keys",
+    "allow_empty_slkeywords",
 }
 
 define_statements = [ ]

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -265,6 +265,7 @@ init -1100 python:
             config.lenticular_bracket_ruby = False
             config.preserve_volume_when_muted = True
             config.history_current_dialogue = False
+            config.allow_empty_slkeywords = True
 
             config.top_layers.remove("top")
             config.bottom_layers.remove("bottom")

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1346,6 +1346,9 @@ extra_savedirs = [ ]
 # The text-to-speech dictionary. A list of [ (RegeEx|String, String) ] pairs.
 tts_substitutions = [ ]
 
+# Whether to allow value-less keyword arguments in screen parsing.
+allow_empty_slkeywords = False
+
 del os
 del collections
 

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -271,6 +271,8 @@ class Parser(object):
                 return
 
             expr = l.comma_expression()
+            if expr is None:
+                l.error("the {} keyword argument was not given a value.".format(name))
 
             if (not keyword) and (not renpy.config.keyword_after_python):
                 try:

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -94,6 +94,26 @@ Alternatively, you can determine new default volumes for :var:`config.default_mu
 :var:`config.default_sfx_volume`, and :var:`config.default_voice_volume` variables. If any
 of these is 0.0 or 1.0, it can be left unchanged.
 
+**Parsing changes** Some parsing changes were made in this version.
+For one, while screen elements taking keyword arguments allowed for
+these to be passed without a value, this never made sense and is no
+longer allowed. An example::
+
+    screen a():
+        vpgrid:
+            cols 3
+            rows # here, the rows keyword argument is passed without a value
+            add "#f00"
+            add "#0f0"
+            add "#00f"
+
+To restore the old behavior, in which the line would have no meaning or
+consequence, you need to add::
+
+    define config.allow_empty_slkeywords = True
+
+Every compat for a parsing change needs to be added in a file named
+01compat.rpy in your game's game directory.
 
 .. _incompatible-8.0.2:
 .. _incompatible-7.5.2:


### PR DESCRIPTION
I don't think this should be the one to be merged, but it's a good example of how a compated syntax change could be implemented.