### PR TITLE
Keep non-standard spaces in parsed strings

### DIFF
--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -907,7 +907,7 @@ class Lexer(object):
         if not raw:
 
             # Collapse runs of whitespace into single spaces.
-            s = re.sub(r'\s+', ' ', s)
+            s = re.sub(r'(\s)\s+', r'\1', s)
             s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s) # type: ignore
 
         return s
@@ -961,7 +961,6 @@ class Lexer(object):
 
         if not raw:
 
-            # Collapse runs of whitespace into single spaces.
             s = re.sub(r' *\n *', '\n', s)
 
             rv = [ ]
@@ -972,7 +971,8 @@ class Lexer(object):
                 if not s:
                     continue
 
-                s = re.sub(r'\s+', ' ', s)
+                # Collapse runs of whitespace into single spaces.
+                s = re.sub(r'(\s)\s+', r'\1', s)
                 s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s) # type: ignore
 
                 rv.append(s)


### PR DESCRIPTION
Instead of replacing any patch of whitespace with a standard one, this replaces it with the first space of the batch. The regex will also match less often, only on 2+ spaces instead of 1+ spaces, I guess this can save some computation time.
The result in any game only using standard whitespace should be exactly the same.

I still believe removing collapsing altogether would be a good thing, but this is a conservative way of keeping it while enabling non-standard single whitespaces.