### PR TITLE
Textalign renaming

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -684,7 +684,7 @@ style page_label:
     ypadding gui.scale(3)
 
 style page_label_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
     hover_color gui.hover_color
 
@@ -932,7 +932,7 @@ style history_name:
 
 style history_name_text:
     min_width gui.history_name_width
-    text_align gui.history_name_xalign
+    textalign gui.history_name_xalign
 
 style history_text:
     xpos gui.history_text_xpos
@@ -940,7 +940,7 @@ style history_text:
     xanchor gui.history_text_xalign
     xsize gui.history_text_width
     min_width gui.history_text_width
-    text_align gui.history_text_xalign
+    textalign gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
 
 style history_label:
@@ -1109,7 +1109,7 @@ style help_label:
 style help_label_text:
     size gui.text_size
     xalign 1.0
-    text_align 1.0
+    textalign 1.0
 
 
 
@@ -1171,7 +1171,7 @@ style confirm_frame:
     yalign .5
 
 style confirm_prompt_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
 
 style confirm_button:
@@ -1365,7 +1365,7 @@ style nvl_label:
     yanchor 0.0
     xsize gui.nvl_name_width
     min_width gui.nvl_name_width
-    text_align gui.nvl_name_xalign
+    textalign gui.nvl_name_xalign
 
 style nvl_dialogue:
     xpos gui.nvl_text_xpos
@@ -1373,7 +1373,7 @@ style nvl_dialogue:
     ypos gui.nvl_text_ypos
     xsize gui.nvl_text_width
     min_width gui.nvl_text_width
-    text_align gui.nvl_text_xalign
+    textalign gui.nvl_text_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_thought:
@@ -1382,7 +1382,7 @@ style nvl_thought:
     ypos gui.nvl_thought_ypos
     xsize gui.nvl_thought_width
     min_width gui.nvl_thought_width
-    text_align gui.nvl_thought_xalign
+    textalign gui.nvl_thought_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_button:
@@ -1440,12 +1440,12 @@ style bubble_namebox:
 
 style bubble_who:
     xalign 0.5
-    text_align 0.5
+    textalign 0.5
     color "#000"
 
 style bubble_what:
     align (0.5, 0.5)
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
     color "#000"
 

--- a/launcher/game/interface.rpy
+++ b/launcher/game/interface.rpy
@@ -170,7 +170,7 @@ screen common:
             has vbox
 
             text message:
-                text_align 0.5
+                textalign 0.5
                 xalign 0.5
                 layout "subtitle"
 
@@ -211,7 +211,7 @@ screen common:
                 add SPACER
 
                 text submessage:
-                    text_align 0.5
+                    textalign 0.5
                     xalign 0.5
                     layout "subtitle"
 
@@ -250,7 +250,7 @@ screen launcher_input:
             has vbox
 
             text message:
-                text_align 0.5
+                textalign 0.5
                 xalign 0.5
                 layout "subtitle"
 

--- a/launcher/game/navigation.rpy
+++ b/launcher/game/navigation.rpy
@@ -249,7 +249,7 @@ screen navigation:
                         if persistent.navigation == "todo":
 
                             text _("No TODO comments found.\n\nTo create one, include \"# TODO\" in your script."):
-                                text_align 0.5
+                                textalign 0.5
                                 xalign 0.5
                                 yalign 0.5
 
@@ -279,4 +279,3 @@ label navigation_loop:
 label navigation_refresh:
     $ project.current.update_dump(True)
     jump navigation_loop
-

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -343,7 +343,7 @@ screen choose_language():
                 style "l_label_text"
 
                 size 36
-                text_align .5
+                textalign .5
                 layout "subtitle"
 
         add SPACER
@@ -377,7 +377,7 @@ screen choose_language():
                 text_style "l_default"
 
                 text_size 30
-                text_text_align .5
+                text_textalign .5
                 text_layout "subtitle"
 
 

--- a/launcher/game/style.rpy
+++ b/launcher/game/style.rpy
@@ -402,7 +402,7 @@ style l_alternate is l_default:
 style l_alternate_text is l_default:
     size size(14)
     font light_font()
-    text_align 1.0
+    textalign 1.0
 
 style l_small_button is l_button
 
@@ -488,7 +488,7 @@ style l_info_button is l_button:
     xmargin 50
 
 style l_info_button_text is l_button_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
 
 # Progress bar.

--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -56,7 +56,7 @@ init -1500:
 
     style _console_prompt is _console_text:
         minwidth gui._scale(22)
-        text_align 1.0
+        textalign 1.0
 
     style _console_input_text is _console_text:
         color "#000000"

--- a/renpy/common/00director.rpy
+++ b/renpy/common/00director.rpy
@@ -1550,7 +1550,7 @@ screen director_lines(state):
                     text "[line_pos]":
                         xpos (gui._scale(300) - 10)
                         xanchor 1.0
-                        text_align 1.0
+                        textalign 1.0
                         style "director_text"
 
                     if change_action:

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -351,7 +351,7 @@ init -1150 python in gui:
         :propref:`xalign`
             To gui.kind_text_xalign, if it exists.
 
-        :propref:`text_align`
+        :propref:`textalign`
             To gui.kind_text_xalign, if it exists.
 
         :propref:`layout`
@@ -413,6 +413,7 @@ init -1150 python in gui:
             if xalign is not None:
                 rv["xalign"] = xalign
                 rv["text_align"] = xalign
+                rv["textalign"] = xalign
 
                 if (xalign > 0) and (xalign < 1):
                     rv["layout"] = "subtitle"

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -693,7 +693,7 @@ python early in layeredimage:
                     size=16,
                     xalign=0.5,
                     yalign=0.5,
-                    text_align=0.5,
+                    textalign=0.5,
                     color="#fff",
                     outlines=[ (1, "#0008", 0, 0) ],
                 )

--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -62,7 +62,7 @@ init -1500 python:
 
     # Set up nvl mode styles.
     style.nvl_label.minwidth = 150
-    style.nvl_label.text_align = 1.0
+    style.nvl_label.textalign = 1.0
 
     style.nvl_window.background = "#0008"
     style.nvl_window.yfill = True

--- a/renpy/common/00placeholder.rpy
+++ b/renpy/common/00placeholder.rpy
@@ -67,9 +67,9 @@ init -1500 python:
                 If true, the sprite is flipped horizontally.
 
             `text`
-                 If provided, no other text than this will be displayed on the
-                 placeholder. If not, the text will reflect the show
-                 instruction that was used to display it.
+                If provided, no other text than this will be displayed on the
+                placeholder. If not, the text will reflect the show
+                instruction that was used to display it.
             """
 
             super(Placeholder, self).__init__(**properties)
@@ -149,7 +149,7 @@ init -1500 python:
             if base == "bg":
                 rv = Fixed(
                     Solid("#aaa"),
-                    Text(" ".join(self.name), style="_default", color="#333333", text_align=0.5, xalign=0.5, ypos=5),
+                    Text(" ".join(self.name), style="_default", color="#333333", textalign=0.5, xalign=0.5, ypos=5),
                     alt="",
                 )
 
@@ -190,7 +190,7 @@ init -1500 python:
 
             rv = Fixed(
                 Transform(image, crop=crop, size=size, xzoom=xzoom),
-                Text(text, pos=textpos, xanchor=0.5, yanchor=0.5, style="_default", color="#aaa", text_align=0.5),
+                Text(text, pos=textpos, xanchor=0.5, yanchor=0.5, style="_default", color="#aaa", textalign=0.5),
                 xysize=size,
                 alt="",
             )

--- a/renpy/common/00style.rpy
+++ b/renpy/common/00style.rpy
@@ -152,7 +152,7 @@ init -1800:
         outlines [ ]
         outline_scaling "linear"
         minwidth 0
-        text_align 0
+        textalign 0
         justify False
         text_y_fudge 0
         first_indent 0

--- a/renpy/common/00sync.rpy
+++ b/renpy/common/00sync.rpy
@@ -516,7 +516,7 @@ init -1100:
 
                 text _("This will upload your saves to the {a=https://sync.renpy.org}Ren'Py Sync Server{/a}.\nDo you want to continue?"):
                     xalign 0.5
-                    text_align 0.5
+                    textalign 0.5
 
                 hbox:
                     xalign 0.5
@@ -548,7 +548,7 @@ init -1100:
 
                 text prompt:
                     xalign 0.5
-                    text_align 0.5
+                    textalign 0.5
 
                 input:
                     id "input"
@@ -556,7 +556,7 @@ init -1100:
 
                 text _("This will contact the {a=https://sync.renpy.org}Ren'Py Sync Server{/a}."):
                     xalign 0.5
-                    text_align 0.5
+                    textalign 0.5
 
                 textbutton _("Cancel"):
                     action Return("")
@@ -592,7 +592,7 @@ init -1100:
 
                 text _("You can use this ID to download your save on another device.\nThis sync will expire in an hour.\nRen'Py Sync is supported by {a=https://www.renpy.org/sponsors.html}Ren'Py's Sponsors{/a}."):
                     xalign 0.5
-                    text_align 0.5
+                    textalign 0.5
 
                 textbutton _("Continue"):
                     action Return(True)

--- a/renpy/common/00themes.rpy
+++ b/renpy/common/00themes.rpy
@@ -155,7 +155,7 @@ init -1110 python hide:
 
             style.button_text.xalign = 0.5
             style.button_text.yalign = 0.5
-            style.button_text.text_align = 0.5
+            style.button_text.textalign = 0.5
 
         setattr(theme, name + "_buttons", buttons)
 
@@ -215,7 +215,7 @@ init -1110 python hide:
             style.prompt_text.color = label
 
             style.prompt.xalign = 0.5
-            style.prompt_text.text_align = 0.5
+            style.prompt_text.textalign = 0.5
             style.prompt_text.layout = "subtitle"
 
         setattr(theme, name + "_prompts", prompts)
@@ -455,7 +455,7 @@ init -1110 python hide:
         style.button_text.selected_hover_color = bright_red
 
         style.button_text.xalign = 0.5
-        style.button_text.text_align = 0.5
+        style.button_text.textalign = 0.5
 
         style.bar.ymaximum = 22
         style.bar.left_bar = Solid(bright_cyan)
@@ -509,7 +509,7 @@ init -1110 python hide:
         style.large_button_text.size = 16
         style.large_button_text.drop_shadow = (1, 1)
         style.large_button_text.xalign = 0
-        style.large_button_text.text_align = 0
+        style.large_button_text.textalign = 0
 
         style.label_text.size = 24
         style.label_text.color = green
@@ -519,7 +519,7 @@ init -1110 python hide:
         style.prompt_text.size = 24
         style.prompt_text.color = green
         style.prompt_text.layout = "subtitle"
-        style.prompt_text.text_align = 0.5
+        style.prompt_text.textalign = 0.5
         style.prompt_text.drop_shadow = (1, 1)
         style.prompt_text.drop_shadow_color = "#000"
 
@@ -872,7 +872,7 @@ init -1110 python hide:
 
         style.button_text.xalign = 0.5
         style.button_text.yalign = 0.5
-        style.button_text.text_align = 0.5
+        style.button_text.textalign = 0.5
 
         # Radio Buttons
 
@@ -912,7 +912,7 @@ init -1110 python hide:
 
 
             s.xalign = 0.0
-            s.text_align = 0.0
+            s.textalign = 0.0
 
         set_radio_style(style.radio_button, widget)
         set_radio_text_style(style.radio_button_text)
@@ -981,7 +981,7 @@ init -1110 python hide:
 
         style.large_button_text.xalign = 0.5
         style.large_button_text.yalign = 0.5
-        style.large_button_text.text_align = 0.5
+        style.large_button_text.textalign = 0.5
 
     @theme
     def a_white_tulip_labels(
@@ -1014,7 +1014,7 @@ init -1110 python hide:
         style.prompt_text.color = label
 
         style.prompt.xalign = 0.5
-        style.prompt_text.text_align = 0.5
+        style.prompt_text.textalign = 0.5
         style.prompt_text.layout = "subtitle"
 
     @theme

--- a/renpy/common/00touchkeyboard.rpy
+++ b/renpy/common/00touchkeyboard.rpy
@@ -100,7 +100,7 @@ init -1500:
         outlines [ (absolute(3), "#000", absolute(0), absolute(0)) ]
         size gui._scale(55)
         min_width gui._scale(55)
-        text_align 0.5
+        textalign 0.5
 
     screen _touch_keyboard:
         zorder 1100

--- a/renpy/common/_compat/styles.rpym
+++ b/renpy/common/_compat/styles.rpym
@@ -218,8 +218,8 @@ init python:
     style.file_picker_new.minwidth = 40
     style.file_picker_old.minwidth = 40
 
-    style.file_picker_new.text_align = 1.0
-    style.file_picker_old.text_align = 1.0
+    style.file_picker_new.textalign = 1.0
+    style.file_picker_old.textalign = 1.0
 
 
     ######################################################################

--- a/renpy/common/_compat/themes.rpym
+++ b/renpy/common/_compat/themes.rpym
@@ -422,8 +422,8 @@ init -1100:
             style.file_picker_old.minwidth = 40
             style.file_picker_new.minwidth = 40
 
-            style.file_picker_old.text_align = 1.0
-            style.file_picker_new.text_align = 1.0
+            style.file_picker_old.textalign = 1.0
+            style.file_picker_new.textalign = 1.0
 
             if config.script_version is None or config.script_version > (6, 0, 0):
                 style.file_picker_text.insensitive_color = disabled_text
@@ -481,20 +481,20 @@ init -1100:
                 style.launcher_text.xanchor = 0.5
                 style.launcher_text.xmaximum = 240
                 style.launcher_text.color = label
-                style.launcher_text.text_align = 0.5
+                style.launcher_text.textalign = 0.5
 
 
                 style.launcher_label.xpos = 140
                 style.launcher_label.xanchor = 0.5
                 style.launcher_label.xmaximum = 240
                 style.launcher_label.color = label
-                style.launcher_label.text_align = 0.5
+                style.launcher_label.textalign = 0.5
 
                 style.launcher_input.xpos = 140
                 style.launcher_input.xanchor = 0.5
                 style.launcher_input.xmaximum = 240
                 style.launcher_input.color = widget
-                style.launcher_input.text_align = 0.5
+                style.launcher_input.textalign = 0.5
 
                 store._launcher_per_page = 9
 
@@ -517,4 +517,3 @@ init -1100:
             theme.roundrect(**args)
 
         theme.roundrect_red = theme_roundrect_red
-

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -72,7 +72,7 @@ init label _errorhandling:
         outlines [ ]
         outline_scaling "step"
         minwidth 0
-        text_align 0
+        textalign 0
         justify False
         text_y_fudge 0
         first_indent 0
@@ -592,7 +592,7 @@ screen _exception:
         side "c r":
             xfill True
             label _("An exception has occurred.") text_size gui._scale(40)
-            text "{size=-3}[config.version!q]\n[renpy.version_only!q]\n[renpy.platform!q]{/size}" text_align 1.0 yalign 0.5
+            text "{size=-3}[config.version!q]\n[renpy.version_only!q]\n[renpy.platform!q]{/size}" textalign 1.0 yalign 0.5
 
         viewport:
             id "viewport"

--- a/renpy/sl2/slproperties.py
+++ b/renpy/sl2/slproperties.py
@@ -98,6 +98,7 @@ text_property_names = [
     "slow_cps_multiplier",
     "slow_abortable",
     "strikethrough",
+    "textalign",
     "text_align",
     "text_y_fudge",
     "underline",

--- a/sphinx/source/oshs/game/screens.rpy
+++ b/sphinx/source/oshs/game/screens.rpy
@@ -681,7 +681,7 @@ style page_label:
     ypadding 5
 
 style page_label_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
     hover_color gui.hover_color
 
@@ -935,7 +935,7 @@ style history_name:
 
 style history_name_text:
     min_width gui.history_name_width
-    text_align gui.history_name_xalign
+    textalign gui.history_name_xalign
 
 style history_text:
     xpos gui.history_text_xpos
@@ -943,7 +943,7 @@ style history_text:
     xanchor gui.history_text_xalign
     xsize gui.history_text_width
     min_width gui.history_text_width
-    text_align gui.history_text_xalign
+    textalign gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
 
 style history_label:
@@ -1107,7 +1107,7 @@ style help_label:
 style help_label_text:
     size gui.text_size
     xalign 1.0
-    text_align 1.0
+    textalign 1.0
 
 
 
@@ -1169,7 +1169,7 @@ style confirm_frame:
     yalign .5
 
 style confirm_prompt_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
 
 style confirm_button:
@@ -1363,7 +1363,7 @@ style nvl_label:
     yanchor 0.0
     xsize gui.nvl_name_width
     min_width gui.nvl_name_width
-    text_align gui.nvl_name_xalign
+    textalign gui.nvl_name_xalign
 
 style nvl_dialogue:
     xpos gui.nvl_text_xpos
@@ -1371,7 +1371,7 @@ style nvl_dialogue:
     ypos gui.nvl_text_ypos
     xsize gui.nvl_text_width
     min_width gui.nvl_text_width
-    text_align gui.nvl_text_xalign
+    textalign gui.nvl_text_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_thought:
@@ -1380,7 +1380,7 @@ style nvl_thought:
     ypos gui.nvl_thought_ypos
     xsize gui.nvl_thought_width
     min_width gui.nvl_thought_width
-    text_align gui.nvl_thought_xalign
+    textalign gui.nvl_thought_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_button:

--- a/sphinx/source/screen_special.rst
+++ b/sphinx/source/screen_special.rst
@@ -755,7 +755,7 @@ If no ``confirm`` screen is present, ``yesno_prompt`` is used instead.
                 spacing 25
 
                 text _(message):
-                    text_align 0.5
+                    textalign 0.5
                     xalign 0.5
 
                 hbox:

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -477,7 +477,7 @@ Here's an example of dismiss being used::
 
             text "This is a very important message.":
                 xalign 0.5
-                text_align 0.5
+                textalign 0.5
 
             # Dismiss can be confusing on its own, so we'll add a button as well.
             textbutton "Dismiss":

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -585,7 +585,7 @@ Text Style Properties
 .. style-property:: min_width int
 
     Sets the minimum width of each line of that. If a line is shorter
-    than this, it is padded to this length, with ``text_align`` used to
+    than this, it is padded to this length, with ``textalign`` used to
     specify where such padding is placed.
 
 .. style-property:: newline_indent boolean
@@ -675,7 +675,7 @@ Text Style Properties
 
     If True, a line is drawn through the text.
 
-.. style-property:: text_align float
+.. style-property:: textalign float
 
     This is used when a line is shorter than the width of the text
     displayable. It determines how much of the extra space is placed

--- a/testcases/game/screens.rpy
+++ b/testcases/game/screens.rpy
@@ -495,4 +495,4 @@ screen yesno_prompt:
 
 init -2 python:
     style.yesno_button.size_group = "yesno"
-    style.yesno_label_text.text_align = 0.5
+    style.yesno_label_text.textalign = 0.5

--- a/testcases/game/script.rpy
+++ b/testcases/game/script.rpy
@@ -138,14 +138,14 @@ screen text1:
             language "korean-with-spaces"
             layout "subtitle"
             xalign 0.5
-            text_align 0.5
+            textalign 0.5
 
         text "ビジュアルノベル、ヴィジュアルノベル（visual novel）とは、コンピュータゲームの一ジャンルである。ビジュアルノベルそれ自体もアドベンチャーゲームの一種に分類される。ノベルゲームやサウンドノベルと呼ばれることもある。":
             font JAPANESE
 
-        text "Min-width & Text_align":
+        text "Min-width & Textalign":
             min_width 400
-            text_align 1.0
+            textalign 1.0
 
         text "This will be typed out slowly.":
             slow_cps 40

--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -606,7 +606,7 @@ style about_label_text:
 style about_small:
     size 20
     minwidth 260
-    text_align 1.0
+    textalign 1.0
     yalign 0.9
 
 
@@ -724,7 +724,7 @@ style page_label:
     ypadding 3
 
 style page_label_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
     hover_color gui.hover_color
 
@@ -999,7 +999,7 @@ style history_name:
 
 style history_name_text:
     min_width gui.history_name_width
-    text_align gui.history_name_xalign
+    textalign gui.history_name_xalign
 
 style history_text:
     xpos gui.history_text_xpos
@@ -1007,7 +1007,7 @@ style history_text:
     xanchor gui.history_text_xalign
     xsize gui.history_text_width
     min_width gui.history_text_width
-    text_align gui.history_text_xalign
+    textalign gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
 
 style history_label:
@@ -1175,7 +1175,7 @@ style help_label:
 style help_label_text:
     size gui.text_size
     xalign 1.0
-    text_align 1.0
+    textalign 1.0
 
 
 
@@ -1237,7 +1237,7 @@ style confirm_frame:
     yalign .5
 
 style confirm_prompt_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
 
 style confirm_button:
@@ -1431,7 +1431,7 @@ style nvl_label:
     yanchor 0.0
     xsize gui.nvl_name_width
     min_width gui.nvl_name_width
-    text_align gui.nvl_name_xalign
+    textalign gui.nvl_name_xalign
 
 style nvl_dialogue:
     xpos gui.nvl_text_xpos
@@ -1439,7 +1439,7 @@ style nvl_dialogue:
     ypos gui.nvl_text_ypos
     xsize gui.nvl_text_width
     min_width gui.nvl_text_width
-    text_align gui.nvl_text_xalign
+    textalign gui.nvl_text_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_thought:
@@ -1448,7 +1448,7 @@ style nvl_thought:
     ypos gui.nvl_thought_ypos
     xsize gui.nvl_thought_width
     min_width gui.nvl_thought_width
-    text_align gui.nvl_thought_xalign
+    textalign gui.nvl_thought_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_button:

--- a/tutorial/game/01example.rpy
+++ b/tutorial/game/01example.rpy
@@ -546,7 +546,7 @@ screen example(blocks, small=False, bottom=False, showtrans=False):
             textbutton _("copy"):
                 style "empty"
                 text_style "quick_button_text"
-                text_text_align 0.5
+                text_textalign 0.5
                 text_minwidth 180
 
                 text_size 16

--- a/tutorial/game/indepth_style.rpy
+++ b/tutorial/game/indepth_style.rpy
@@ -726,7 +726,7 @@ screen vbar(style):
 
         text "[measure:.0f]/100":
             xalign 0.5
-            text_align 0.5
+            textalign 0.5
             min_width 100
 
 
@@ -1092,5 +1092,3 @@ label style_inspector:
     e "You can try the inspector right now, by hovering this text and hitting shift+I."
 
     return
-
-

--- a/tutorial/game/indepth_style.rpy
+++ b/tutorial/game/indepth_style.rpy
@@ -436,23 +436,23 @@ label style_text:
 
     example:
         style center_text:
-            text_align 0.5
+            textalign 0.5
 
     show screen text("center_text")
 
-    e "The text_align property controls the positioning of multiple lines of text inside the text displayable. For example, 0.5 means centered."
+    e "The textalign property controls the positioning of multiple lines of text inside the text displayable. For example, 0.5 means centered."
 
-    e "It doesn't change the position of the text displayable itself. For that, you'll often want to set the text_align and xalign to the same value."
+    e "It doesn't change the position of the text displayable itself. For that, you'll often want to set the textalign and xalign to the same value."
 
 
     example:
         style right_text:
-            text_align 1.0
+            textalign 1.0
             yalign 1.0
 
     show screen text("right_text")
 
-    e "When both text_align and xalign are set to 1.0, the text is properly right-justified."
+    e "When both textalign and xalign are set to 1.0, the text is properly right-justified."
 
 
     example:
@@ -509,7 +509,7 @@ label style_text:
         style layout_subtitle_text:
             layout "subtitle"
             xalign 0.5
-            text_align 0.5
+            textalign 0.5
 
     show screen text("layout_subtitle_text")
 

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -692,7 +692,7 @@ style page_label:
     ypadding 3
 
 style page_label_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
     hover_color gui.hover_color
 
@@ -980,7 +980,7 @@ style history_name:
 
 style history_name_text:
     min_width gui.history_name_width
-    text_align gui.history_name_xalign
+    textalign gui.history_name_xalign
 
 style history_text:
     xpos gui.history_text_xpos
@@ -988,7 +988,7 @@ style history_text:
     xanchor gui.history_text_xalign
     xsize gui.history_text_width
     min_width gui.history_text_width
-    text_align gui.history_text_xalign
+    textalign gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
 
 style history_label:
@@ -1156,7 +1156,7 @@ style help_label:
 style help_label_text:
     size gui.text_size
     xalign 1.0
-    text_align 1.0
+    textalign 1.0
 
 
 
@@ -1218,7 +1218,7 @@ style confirm_frame:
     yalign .5
 
 style confirm_prompt_text:
-    text_align 0.5
+    textalign 0.5
     layout "subtitle"
 
 style confirm_button:
@@ -1412,7 +1412,7 @@ style nvl_label:
     yanchor 0.0
     xsize gui.nvl_name_width
     min_width gui.nvl_name_width
-    text_align gui.nvl_name_xalign
+    textalign gui.nvl_name_xalign
 
 style nvl_dialogue:
     xpos gui.nvl_text_xpos
@@ -1420,7 +1420,7 @@ style nvl_dialogue:
     ypos gui.nvl_text_ypos
     xsize gui.nvl_text_width
     min_width gui.nvl_text_width
-    text_align gui.nvl_text_xalign
+    textalign gui.nvl_text_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_thought:
@@ -1429,7 +1429,7 @@ style nvl_thought:
     ypos gui.nvl_thought_ypos
     xsize gui.nvl_thought_width
     min_width gui.nvl_thought_width
-    text_align gui.nvl_thought_xalign
+    textalign gui.nvl_thought_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
 style nvl_button:

--- a/tutorial/game/tutorial_screens.rpy
+++ b/tutorial/game/tutorial_screens.rpy
@@ -76,7 +76,7 @@ default stat_chutzpah = 75
 # These styles are used to style the various stats.
 style stat_text is default:
     min_width 200
-    text_align 1.0
+    textalign 1.0
     yalign 0.5
 
 style stat_hbox is hbox:


### PR DESCRIPTION
The use of `textalign` in style blocks, and as assignments to field-like properties of a Style object, already works.
The different commits do incremental changes.
- be95fa74127261f37b8b0e398e4a3f52049fd21d enables the use of textalign in screen language
- ad2e80f90029783a61f68ecb54e3194ee47220cc updates the documentation
- 6c89fcb29d28a7b48d01679a27aa3d6d4083c771 seeks to address gui.text_properties, first by correcting the reference to the style property changed in the preceding commit, and then by doubling the key of the returned dict (the old key is kept for compatibilty, and the new one is the one documented now). I don't fully understand what the function does so this should be checked.
- a0dba5ca1d81a6493fdf90ffc44f2fba08f11162 updates examples in the doc and in the tutorial game, to show people examples of the new syntax rather than the old
- 194cacf7f2e631b9bc3cf87b44ffda0905a870f0 updates all occurrences of text_align into textalign in internal style definitions (I may have made mistakes but the list has been curated, it's not a simple Shift+Ctrl+H). This is less necessary than the others, but can be useful for consistency. It also has the drawback of flagging entire files as changed, presumably because of LF/CRLF trouble...

The keywords.py files will need to be regenerated, but they will be correct due to be95fa74127261f37b8b0e398e4a3f52049fd21d.

If you don't want the last commit changing every occurrence of the property, you can `git merge a0dba5c` in CLI.