### PR TITLE
Better director toggle variable

### DIFF
--- a/renpy/common/00director.rpy
+++ b/renpy/common/00director.rpy
@@ -79,9 +79,6 @@ init python in director:
     # The maximum height of viewports containing scrolling information.
     viewport_height = 280
 
-    # Is the director enabled? Used by the tutorial to protect itself.
-    enable = True
-
     state = renpy.session.get("director", None)
 
     # A list of statements we find too uninteresting to present to the
@@ -704,7 +701,7 @@ init python in director:
                 if not config.developer:
                     return None
 
-                if not enable:
+                if not getattr(store, "_director_enable", True):
                     renpy.notify(_("The interactive director is not enabled here."))
                     return None
 

--- a/tutorial/game/01director_support.rpy
+++ b/tutorial/game/01director_support.rpy
@@ -1,5 +1,5 @@
 # Disable the director until the director example enables it.
-default director.enable = False
+default _director_enable = False
 
 python early hide:
 

--- a/tutorial/game/tutorial_director.rpym
+++ b/tutorial/game/tutorial_director.rpym
@@ -37,7 +37,7 @@ label director:
     scene
     with dissolve
 
-    $ director.enable = not director_readonly
+    $ _director_enable = not director_readonly
 
     e "To get started, let's go back to a blank slate, with no images on the screen."
 
@@ -54,7 +54,7 @@ label director:
     e "Finally, you can use the play, queue, stop, and voice statements to manage audio. Try adding 'play', 'music', 'sunflower-slow-drag.ogg'."
 
     $ director.state.show_director = False
-    $ director.enable = False
+    $ _director_enable = False
 
     if renpy.showing("lucy"):
 
@@ -73,5 +73,3 @@ label director:
     e "I hope these tools make developing your visual novel that much easier."
 
     return
-
-


### PR DESCRIPTION
The tutorial needs to disable the interactive director in a variable manner.
This replaces a variable meant to change over time but placed in a constant store (which lead to bugs), with a query made on a variable in the general store.
I think this is cleaner than #4307.