### PR TITLE
Add renpy.is_pixel_opaque

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3098,16 +3098,16 @@ render = renpy.display.render.render
 IgnoreEvent = renpy.display.core.IgnoreEvent
 redraw = renpy.display.render.redraw
 
-def is_pixel_opaque(d, x, y, *args):
+def is_pixel_opaque(d, width, height, st, at, x, y):
     """
     :doc: udd_utility
 
-    Returns whether the pixel at (x, y) is opaque, when this displayable
-    is rendered by ``renpy.render(d, *args)``.
+    Returns whether the pixel at (x, y) is opaque when this displayable
+    is rendered by ``renpy.render(d, width, height, st, at)``.
     """
 
     # Uses the caching features of renpy.render, as opposed to d.render.
-    return bool(render(renpy.easy.displayable(d), *args).is_pixel_opaque(x, y))
+    return bool(render(renpy.easy.displayable(d), width, height, st, at).is_pixel_opaque(x, y))
 
 
 class Displayable(renpy.display.core.Displayable, renpy.revertable.RevertableObject):

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -3098,6 +3098,17 @@ render = renpy.display.render.render
 IgnoreEvent = renpy.display.core.IgnoreEvent
 redraw = renpy.display.render.redraw
 
+def is_pixel_opaque(d, x, y, *args):
+    """
+    :doc: udd_utility
+
+    Returns whether the pixel at (x, y) is opaque, when this displayable
+    is rendered by ``renpy.render(d, *args)``.
+    """
+
+    # Uses the caching features of renpy.render, as opposed to d.render.
+    return bool(render(renpy.easy.displayable(d), *args).is_pixel_opaque(x, y))
+
 
 class Displayable(renpy.display.core.Displayable, renpy.revertable.RevertableObject):
     pass


### PR DESCRIPTION
Replaces calls to undocumented method Render.is_pixel_opaque.
renpy.render is preferred to Displayable.render because of its caching effects, saving potentially lots of computation time.