### PR TITLE
Add break and continue to the screen language for loop

### DIFF
--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -1711,12 +1711,19 @@ class SLFor(SLBlock):
 
             # Inline of SLBlock.execute.
 
-            for i in children_i:
-                try:
-                    i.execute(ctx)
-                except Exception:
-                    if not context.predicting:
+            try:
+                for i in children_i:
+                    try:
+                        i.execute(ctx)
+                    except SLForException:
                         raise
+                    except Exception:
+                        if not context.predicting:
+                            raise
+            except SLBreakException:
+                break
+            except SLContinueException:
+                continue
 
             if context.unlikely:
                 break
@@ -1745,6 +1752,38 @@ class SLFor(SLBlock):
 
         for i in self.children:
             i.dump_const(prefix + "  ")
+
+class SLForException(Exception): pass
+
+class SLBreakException(SLForException): pass
+
+class SLContinueException(SLForException): pass
+
+class SLBreak(SLNode):
+
+    def execute(self, context):
+        raise SLBreakException()
+
+    def copy(self, transclude):
+        rv = self.instantiate(transclude)
+
+        return rv
+
+    def dump_const(self, prefix):
+        self.dc(prefix, "break")
+
+class SLContinue(SLNode):
+
+    def execute(self, context):
+        raise SLContinueException()
+
+    def copy(self, transclude):
+        rv = self.instantiate(transclude)
+
+        return rv
+
+    def dump_const(self, prefix):
+        self.dc(prefix, "continue")
 
 class SLPython(SLNode):
 

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -812,7 +812,30 @@ class ForParser(Parser):
         return rv
 
 
-ForParser("for")
+for_parser = ForParser("for")
+
+
+class BreakParser(Parser):
+
+    def parse(self, loc, l, parent, keyword):
+
+        l.expect_eol()
+        l.expect_noblock('break statement')
+
+        return slast.SLBreak(loc)
+
+for_parser.add(BreakParser("break", False))
+
+class ContinueParser(Parser):
+
+    def parse(self, loc, l, parent, keyword):
+
+        l.expect_eol()
+        l.expect_noblock('continue statement')
+
+        return slast.SLContinue(loc)
+
+for_parser.add(ContinueParser("continue", False))
 
 
 class OneLinePythonParser(Parser):


### PR DESCRIPTION
SLBreak and SLContinue, apart from their respective execute methods, were shamelessly copied from SLPass. Same with BreakParser and ContinueParser wrt PassParser.
Test code :
```rpy
define colorlist = ["#f00", "#0f0", "#8400ff", "#00f"]

screen break:
    hbox:
        for color in colorlist:
            if len(color) > 5:
                # continue
                # break
                pass
            add Solid(color, xysize=(100, 100))
```

- Using pass should yield red, green, purple, blue
- Using continue should yield red, green, blue
- Using break should yield red, green