### PR TITLE
Oversampling for image manipulators

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -886,6 +886,9 @@ class Composite(ImageBase):
         self.positions = args[0::2]
         self.images = [ image(i) for i in args[1::2] ]
 
+        # Only supports all the images having the same oversample factor
+        self.oversample = self.images[0].get_oversample()
+
     def get_hash(self):
         rv = 0
 
@@ -901,10 +904,13 @@ class Composite(ImageBase):
         else:
             size = cache.get(self.images[0]).get_size()
 
+        os = self.oversample
+        size = [s*os for s in size]
+
         rv = renpy.display.pgrender.surface(size, True)
 
         for pos, im in zip(self.positions, self.images):
-            rv.blit(cache.get(im), pos)
+            rv.blit(cache.get(im), [p*os for p in pos])
 
         return rv
 
@@ -1894,6 +1900,9 @@ class AlphaMask(ImageBase):
 
         self.base = image(base)
         self.mask = image(mask)
+
+        # The two images already need to be the same size, they now also need the same oversample.
+        self.oversample = self.base.get_oversample()
 
     def get_hash(self):
         return self.base.get_hash() + self.mask.get_hash()

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -702,14 +702,11 @@ class Image(ImageBase):
             base = filename.rpartition(".")[0]
             extras = base.partition("@")[2].split(",")
 
-            for i in extras:
-                try:
+            try:
+                for i in extras:
                     oversample = float(i)
                     properties.setdefault('oversample', oversample)
-                    continue
-                except Exception:
-                    pass
-
+            except Exception:
                 raise Exception("Unknown image modifier %r in %r." % (i, filename))
 
         super(Image, self).__init__(filename, **properties)
@@ -786,8 +783,6 @@ class Image(ImageBase):
                     raise e
                 else:
                     return Image("_missing_image.png").load()
-
-            raise e
 
     def predict_files(self):
 


### PR DESCRIPTION
Each committed change was tested on my end.
Among the subclasses of im.ImageBase :

- im.Data, and im.ZipFileImage aren't subject to oversampling, as they aren't "im transforms" - taking an im and returning another
- Composite takes several im parameters, so computing the oversampling of the whole is not trivial. I chose only to support all the images having the same oversampling factor - which is better than nothing, for obsolete functions
- Alphamask already had the constrant of the two images having the same size, they now also must have the same oversampling - seems fair enough to me. If you try it, it will most likely glitch, but that's only if and because #4083 is not merged
- All others have been converted.