### PR TITLE
Include an example of a proper usage of time_warp in the docs of ImageDissolve

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -442,8 +442,8 @@ class ImageDissolve(Transition):
 
     ::
 
-        define circirisout = ImageDissolve("circiris.png", 1.0)
-        define circirisin = ImageDissolve("circiris.png", 1.0, reverse=True)
+        define circirisout = ImageDissolve("circiris.png", 1.0, time_warp=_warper.easeout)
+        define circirisin = ImageDissolve("circiris.png", 1.0, reverse=True, time_warp=_warper.easein)
         define circiristbigramp = ImageDissolve("circiris.png", 1.0, ramplen=256)
 
     When the dissolve will be scaled to less than half its natural size, the


### PR DESCRIPTION
Even though time_warp is mentioned three times in the [transition classes document](https://www.renpy.org/doc/html/transitions.html#transition-classes), it's never shown how to actually use it. Since the idea of using the _warper module is not intuitive, and it's mentioned only once at the beginning of the section, I thought it would be best to at least include it in one of the examples.