### PR TITLE
fix: missed iteration arg in `SLIf.keywords`

### DIFF
--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -1450,7 +1450,7 @@ class SLIf(SLNode):
 
     def keywords(self, context):
 
-        for cond, block in self.prepared_entries:
+        for cond, block, _cond_const in self.prepared_entries:
             if cond is None or eval(cond, context.globals, context.scope):
                 block.keywords(context)
                 return


### PR DESCRIPTION
This pull request fixed https://github.com/renpy/renpy/issues/4331.

As there was a missed point in the iteration in this change (https://github.com/renpy/renpy/commit/03d37d24dc912e091490c27d02af75449336ddf6)