### PR TITLE
Allow slow text to be used in screens while TTS is active

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1632,7 +1632,7 @@ class Text(renpy.display.core.Displayable):
         # Sets the text we're showing, and performs substitutions.
         self.set_text(text, scope, substitute) # type: ignore
 
-        if renpy.game.less_updates or renpy.game.preferences.self_voicing:
+        if renpy.game.less_updates:
             slow = False
 
         # True if we're using slow text mode.


### PR DESCRIPTION
This relaxes the restriction on using slow text in screens while self-voicing is enabled. As say dialogue is handled by Character it is unaffected by this change.

The use-case for slow text while TTS is active is that it can be in some cases an effective visual story-telling aid for first person PoV typing and writing, and so on. Many TTS users still have partial sight, and so are able to appreciate this visual effect despite not being able to read the text for themselves directly.