### PR TITLE
Reachability update for UserStatements

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2169,7 +2169,6 @@ class UserStatement(Node):
         return self
 
     def __init__(self, loc, line, block, parsed):
-
         super(UserStatement, self).__init__(loc)
         self.code_block = None # type: Optional[list]
         self.parsed = parsed
@@ -2225,12 +2224,7 @@ class UserStatement(Node):
         return (UserStatement, self.line)
 
     def call(self, method, *args, **kwargs):
-
-        parsed = self.parsed
-
-        if parsed is None:
-            parsed = renpy.statements.parse(self, self.line, self.block)
-            self.parsed = parsed
+        parsed = self.get_parsed()
 
         return renpy.statements.call(method, parsed, *args, **kwargs)
 
@@ -2279,11 +2273,7 @@ class UserStatement(Node):
         return [ self.next ]
 
     def get_name(self):
-        parsed = self.parsed
-
-        if parsed is None:
-            parsed = renpy.statements.parse(self, self.line, self.block)
-            self.parsed = parsed
+        parsed = self.get_parsed()
 
         return renpy.statements.get_name(parsed)
 
@@ -2298,6 +2288,15 @@ class UserStatement(Node):
             return renpy.game.script.lookup(rv)
         else:
             return self.next
+
+    def get_parsed(self):
+        parsed = self.parsed
+
+        if parsed is None:
+            parsed = renpy.statements.parse(self, self.line, self.block)
+            self.parsed = parsed
+
+        return parsed
 
     def scry(self):
         rv = Node.scry(self)

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -157,11 +157,14 @@ python early hide:
                     pass
 
     renpy.register_statement('play music',
-                              parse=parse_play_music,
-                              execute=execute_play_music,
-                              predict=predict_play_music,
-                              lint=lint_play_music,
-                              warp=warp_audio)
+                             parse=parse_play_music,
+                             execute=execute_play_music,
+                             predict=predict_play_music,
+                             lint=lint_play_music,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     # From here on, we'll steal bits of other statements when defining other
     # statements.
@@ -225,10 +228,13 @@ python early hide:
 
 
     renpy.register_statement('queue music',
-                              parse=parse_queue_music,
-                              execute=execute_queue_music,
-                              lint=lint_play_music,
-                              warp=warp_audio)
+                             parse=parse_queue_music,
+                             execute=execute_queue_music,
+                             lint=lint_play_music,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     def parse_stop_music(l):
         channel = None
@@ -263,9 +269,12 @@ python early hide:
         renpy.music.stop(fadeout=eval(p["fadeout"]), channel=channel)
 
     renpy.register_statement('stop music',
-                              parse=parse_stop_music,
-                              execute=execute_stop_music,
-                              warp=warp_audio)
+                             parse=parse_stop_music,
+                             execute=execute_stop_music,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
     # Sound statements. They share alot with the equivalent music
@@ -308,10 +317,13 @@ python early hide:
         return lint_play_music(p, channel="sound")
 
     renpy.register_statement('play sound',
-                              parse=parse_play_music,
-                              execute=execute_play_sound,
-                              lint=lint_play_sound,
-                              warp=warp_sound)
+                             parse=parse_play_music,
+                             execute=execute_play_sound,
+                             lint=lint_play_sound,
+                             warp=warp_sound,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     def execute_queue_sound(p):
         if p["channel"] is not None:
@@ -334,10 +346,13 @@ python early hide:
 
 
     renpy.register_statement('queue sound',
-                              parse=parse_queue_music,
-                              execute=execute_queue_sound,
-                              lint=lint_play_sound,
-                              warp=warp_sound)
+                             parse=parse_queue_music,
+                             execute=execute_queue_sound,
+                             lint=lint_play_sound,
+                             warp=warp_sound,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     def execute_stop_sound(p):
         if p["channel"] is not None:
@@ -350,9 +365,12 @@ python early hide:
         renpy.sound.stop(fadeout=fadeout, channel=channel)
 
     renpy.register_statement('stop sound',
-                              parse=parse_stop_music,
-                              execute=execute_stop_sound,
-                              warp=warp_sound)
+                             parse=parse_stop_music,
+                             execute=execute_stop_sound,
+                             warp=warp_sound,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
     # Generic play/queue/stop statements. These take a channel name as
@@ -409,23 +427,32 @@ python early hide:
             renpy.error("channel %r is not defined" % channel)
 
     renpy.register_statement('play',
-                              parse=parse_play_generic,
-                              execute=execute_play_music,
-                              predict=predict_play_music,
-                              lint=lint_play_generic,
-                              warp=warp_audio)
+                             parse=parse_play_generic,
+                             execute=execute_play_music,
+                             predict=predict_play_music,
+                             lint=lint_play_generic,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement('queue',
-                              parse=parse_queue_generic,
-                              execute=execute_queue_music,
-                              lint=lint_play_generic,
-                              warp=warp_audio)
+                             parse=parse_queue_generic,
+                             execute=execute_queue_music,
+                             lint=lint_play_generic,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement('stop',
-                              parse=parse_stop_generic,
-                              execute=execute_stop_music,
-                              lint=lint_stop_generic,
-                              warp=warp_audio)
+                             parse=parse_stop_generic,
+                             execute=execute_stop_music,
+                             lint=lint_stop_generic,
+                             warp=warp_audio,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
 
@@ -461,9 +488,12 @@ python early hide:
             renpy.pause()
 
     renpy.register_statement('pause',
-                              parse=parse_pause,
-                              lint=lint_pause,
-                              execute=execute_pause)
+                             parse=parse_pause,
+                             lint=lint_pause,
+                             execute=execute_pause,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
 ##############################################################################
@@ -710,21 +740,30 @@ python early hide:
 
 
     renpy.register_statement("show screen",
-                              parse=parse_show_call_screen,
-                              execute=execute_show_screen,
-                              predict=predict_screen,
-                              lint=lint_show_call_screen,
-                              warp=warp_true)
+                             parse=parse_show_call_screen,
+                             execute=execute_show_screen,
+                             predict=predict_screen,
+                             lint=lint_show_call_screen,
+                             warp=warp_true,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement("call screen",
-                              parse=parse_show_call_screen,
-                              execute=execute_call_screen,
-                              predict=predict_screen,
-                              lint=lint_show_call_screen,
-                              force_begin_rollback=True)
+                             parse=parse_show_call_screen,
+                             execute=execute_call_screen,
+                             predict=predict_screen,
+                             lint=lint_show_call_screen,
+                             force_begin_rollback=True,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement("hide screen",
-                              parse=parse_hide_screen,
-                              execute=execute_hide_screen,
-                              lint=lint_hide_screen,
-                              warp=warp_true)
+                             parse=parse_hide_screen,
+                             execute=execute_hide_screen,
+                             lint=lint_hide_screen,
+                             warp=warp_true,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )

--- a/renpy/common/000window.rpy
+++ b/renpy/common/000window.rpy
@@ -201,18 +201,27 @@ python early hide:
 
 
     renpy.register_statement('window show',
-                              parse=parse_window,
-                              execute=execute_window_show,
-                              lint=lint_window,
-                              warp=warp_true)
+                             parse=parse_window,
+                             execute=execute_window_show,
+                             lint=lint_window,
+                             warp=warp_true,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement('window hide',
-                              parse=parse_window,
-                              execute=execute_window_hide,
-                              lint=lint_window,
-                              warp=warp_true)
+                             parse=parse_window,
+                             execute=execute_window_hide,
+                             lint=lint_window,
+                             warp=warp_true,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
     renpy.register_statement('window auto',
                              parse=parse_window_auto,
                              execute=execute_window_auto,
-                             warp=warp_true)
+                             warp=warp_true,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -182,6 +182,9 @@ def register(
     if label:
         force_begin_rollback = True
 
+    if block not in (True, False, "script", "possible"):
+        raise Exception("Unknown \"block\" argument value: {}".format(block))
+
     registry[name] = dict(
         parse=parse,
         lint=lint,
@@ -200,9 +203,6 @@ def register(
         predict_next=predict_next,
         execute_default=execute_default,
     )
-
-    if block not in [True, False, "script", "possible" ]:
-        raise Exception("Unknown \"block\" argument value: {}".format(block))
 
     # The function that is called to create an ast.UserStatement.
     def parse_user_statement(l, loc):

--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -1,5 +1,3 @@
-.. _cds:
-
 Creator-Defined Statements
 ==========================
 

--- a/tutorial/game/01example.rpy
+++ b/tutorial/game/01example.rpy
@@ -257,7 +257,16 @@ python early:
     def execute_init_example(data):
         read_example(data["name"], data["filename"], data["number"], data.get("outdent", "auto"))
 
-    renpy.register_statement("example", parse=parse_example, execute=execute_example, execute_init=execute_init_example, next=next_example, block="script")
+    renpy.register_statement("example",
+                             parse=parse_example,
+                             execute=execute_example,
+                             execute_init=execute_init_example,
+                             next=next_example,
+                             block="script",
+                             statement_reachable=False,
+                             block_reachable="Always",
+                             next_reachable="RIR",
+                             )
 
 
     # The show example statement.
@@ -303,7 +312,12 @@ python early:
             "showtrans" : showtrans,
             }
 
-    renpy.register_statement("show example", parse=parse_show_example, execute=execute_example)
+    renpy.register_statement("show example",
+                             parse=parse_show_example,
+                             execute=execute_example,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
     # The hide example statement.
@@ -331,7 +345,12 @@ python early:
             hide_example_screen()
             renpy.with_statement(example_transition)
 
-    renpy.register_statement("hide example", parse=parse_hide_example, execute=execute_hide_example)
+    renpy.register_statement("hide example",
+                             parse=parse_hide_example,
+                             execute=execute_hide_example,
+                             statement_reachable=True,
+                             next_reachable="RIR",
+                             )
 
 
 # A preference that controls if translations are shown.


### PR DESCRIPTION
TODO:
- check PostUserStatement for possible complications
- check the case where block != "script" but the parsed content still includes renpy statements (the "random" example in the doc, for one)
- change the nomenclature of the passed values, RIR is probably illegible ("flow" ?), and Always is terrible ("innate" ?)
- add examples and more explanation in the doc ?