### PR TITLE
Modernize the `inspect` module and fix subclasses of RevObject not overriding __init__

### DIFF
--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -283,22 +283,21 @@ def scan(name, o, prefix="", inclass=False):
             if not init:
                 return
 
-            init_doc = inspect.getdoc(init)
+            if init is not renpy.store.object.__init__:
 
-            if init_doc and (init_doc != objinidoc):
-                lines.append("")
-                lines.extend(init_doc.split("\n"))
+                init_doc = inspect.getdoc(init)
 
-            try:
-                args = inspect.getargspec(init)
-            except Exception:
-                args = None
+                if init_doc and (init_doc != objinidoc):
+                    lines.append("")
+                    lines.extend(init_doc.split("\n"))
 
-        elif inspect.isfunction(o):
-            args = inspect.getargspec(o)
+                try:
+                    args = inspect.signature(init)
+                except Exception:
+                    args = None
 
-        elif inspect.ismethod(o):
-            args = inspect.getargspec(o)
+        elif inspect.isfunction(o) or inspect.ismethod(o):
+            args = inspect.signature(o)
 
         else:
             print("Warning: %s has section but not args." % name)
@@ -308,7 +307,7 @@ def scan(name, o, prefix="", inclass=False):
         # Format the arguments.
         if args is not None:
 
-            args = inspect.formatargspec(*args)
+            args = str(args)
             args = args.replace("(self, ", "(")
         else:
             args = "()"

--- a/sphinx/game/doc.py
+++ b/sphinx/game/doc.py
@@ -283,18 +283,16 @@ def scan(name, o, prefix="", inclass=False):
             if not init:
                 return
 
-            if init is not renpy.store.object.__init__:
+            init_doc = inspect.getdoc(init)
 
-                init_doc = inspect.getdoc(init)
+            if init_doc and (init_doc != objinidoc):
+                lines.append("")
+                lines.extend(init_doc.split("\n"))
 
-                if init_doc and (init_doc != objinidoc):
-                    lines.append("")
-                    lines.extend(init_doc.split("\n"))
-
-                try:
-                    args = inspect.signature(init)
-                except Exception:
-                    args = None
+            try:
+                args = inspect.signature(init)
+            except Exception:
+                args = None
 
         elif inspect.isfunction(o) or inspect.ismethod(o):
             args = inspect.signature(o)

--- a/sphinx/game/script.rpy
+++ b/sphinx/game/script.rpy
@@ -2,11 +2,13 @@ init 1000000 python:
     import doc
     import shaderdoc
 
+    object.__init__ = lambda self:None
+
     srcdir = 'source'
     if os.path.isdir('sphinx') and os.path.split(os.getcwd())[-1] == 'renpy':
         srcdir = os.path.join('sphinx', 'source') # ran from renpy/. cwd using sphinx in-game project
 
-    incdir = os.path.join(srcdir, 'inc')        
+    incdir = os.path.join(srcdir, 'inc')
 
     shaderdoc.shaders(incdir=incdir)
 
@@ -45,5 +47,5 @@ init 1000000 python:
     console_commands = _console.help(None, True).replace("\n ", "\n\n* ")
     with open(os.path.join(incdir, "console_commands"), "w") as f:
         f.write(console_commands)
-    
+
     raise SystemExit


### PR DESCRIPTION
The only thing changed in doc.py (in fine) is the use of the `inspect` module, using the new methods instead of obsolete ones.
The only thing changed in script.rpy (apart from that linebreak thing) is the `object.__init__ = lambda self:None` line, which applies to the revertable object since it's in a rpy file. That is to fix #4317.