### PR TITLE
fix: typo in common

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -268,7 +268,7 @@ init -1100 python:
             config.history_current_dialogue = False
 
             if version > (6, 99, 5):
-                config.search_path.append("images/")
+                config.search_prefixes.append("images/")
 
             config.top_layers.remove("top")
             config.bottom_layers.remove("bottom")

--- a/sphinx/source/changelog6.rst
+++ b/sphinx/source/changelog6.rst
@@ -1664,7 +1664,7 @@ but potentially not all, of the time. We strongly recommend upgrading from
 
 If a file is not found in the game directory, Ren'Py will search the
 images/ directory for that file. This behavior is controlled by
-the :var:`config.search_path` variable.
+the :var:`config.search_prefixes` variable.
 
 Screens now take the `style_group` property, which was previously only
 allowed on displayable statements.


### PR DESCRIPTION
I believe it was influenced by an even earlier commit:  b6d51b7b0bffb5ab1b08deeadfbea9cad273ceda