### PR TITLE
Wait for audio files to be downloaded before queuing them (web)

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -71,6 +71,7 @@ def load(fn):
     except renpy.webloader.DownloadNeeded as exception:
         if exception.rtype == 'music':
             renpy.webloader.enqueue(exception.relpath, 'music', None)
+            return False  # Try again later
         elif exception.rtype == 'voice':
             # prediction failed, too late
             pass
@@ -523,6 +524,10 @@ class Channel(object):
                     topf = io.BytesIO(topq.filename.data)
                 else:
                     topf = load(filename)
+                    if topf is False:
+                        # File is not ready, try again later
+                        self.queue.insert(0, topq)
+                        break
 
                 if renpysound.is_webaudio and self.movie != renpy.audio.renpysound.NO_VIDEO:
                     # Let the browser handle the video loop if any

--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -73,8 +73,8 @@ def load(fn):
             renpy.webloader.enqueue(exception.relpath, 'music', None)
             return False  # Try again later
         elif exception.rtype == 'voice':
-            # prediction failed, too late
-            pass
+            renpy.webloader.enqueue(exception.relpath, 'voice', None)
+            return False  # Try again later
         elif exception.rtype == 'video':
             # Video files are downloaded by the browser, so return
             # the file name instead of a file-like object


### PR DESCRIPTION
When audio files need to be downloaded and they have not been yet, the current behavior for Web is to queue the download and play a silence audio file instead. This is the root cause for #4113 and it also prevents some audio effects/voices to be played at all if prediction failed.

These changes make queueing the audio files wait for the files to be downloaded to prevent that. I kept [the silence file playback code](https://github.com/renpy/renpy/blob/8668e3c986f4aaf0b35c7a7c404ec6138558eee5/renpy/audio/audio.py#L83) but it is probably a dead code now.