### PR TITLE
simplify renpy.dynamic calls

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1072,9 +1072,7 @@ class Label(Node):
 
         values = apply_arguments(self.parameters, renpy.store._args, renpy.store._kwargs)
 
-        for k, v in values.items():
-            renpy.exports.dynamic(k)
-            setattr(renpy.store, k, v)
+        renpy.exports.dynamic(**values)
 
         renpy.store._args = None
         renpy.store._kwargs = None

--- a/renpy/common/00start.rpy
+++ b/renpy/common/00start.rpy
@@ -172,12 +172,9 @@ label _splashscreen:
     python:
 
         if config.splashscreen_suppress_overlay:
-            renpy.dynamic("suppress_overlay", "_confirm_quit")
-            suppress_overlay = True
-            _confirm_quit = False
+            renpy.dynamic(suppress_overlay=True, _confirm_quit=False)
 
-        renpy.dynamic("_autosave")
-        _autosave = False
+        renpy.dynamic(_autosave=False)
 
     jump expression "splashscreen"
 
@@ -297,8 +294,7 @@ label _main_menu(_main_menu_screen="_main_menu_screen"):
 
         _enter_menu()
 
-        renpy.dynamic("_load_prompt")
-        _load_prompt = False
+        renpy.dynamic(_load_prompt=False)
 
         renpy.context()._main_menu = True
         store.main_menu = True


### PR DESCRIPTION
The ast.py use is quicker now, the others are probably unchanged but prettier.