### PR TITLE
Enable ClearFocus and renpy.clear_capture_focus to clear all focuses at once

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -806,6 +806,7 @@ init -1500 python:
         :doc: focus_action
 
         Clears a stored focus rectangle captured with :func:`CaptureFocus`.
+        If `name` is None, all focus rectangles are cleared.
         """
 
         def __init__(self, name="default"):

--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -65,9 +65,13 @@ def clear_capture_focus(name="default"):
     :doc: other
 
     Clear the captured focus with `name`.
+    If `name` is None, clear all captured focuses.
     """
 
-    focus_storage.pop(name, None)
+    if name is None:
+        focus_storage.clear()
+    else:
+        focus_storage.pop(name, None)
 
 
 def get_focus_rect(name="default"):


### PR DESCRIPTION
fixes #4381
It's a bit weird to have that and None not being the default value, though.