### PR TITLE
Fix inertial viewport dragging

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1984,7 +1984,7 @@ class Adjustment(renpy.object.Object):
             self.end_animation()
         else:
             self.animation_amplitude = amplitude
-            self.animation_target = self.round_value(self._value + amplitude, release=True)
+            self.animation_target = self._value + amplitude
 
             self.animation_delay = delay
             self.animation_start = None
@@ -1995,8 +1995,8 @@ class Adjustment(renpy.object.Object):
         self.animate(amplitude, time_constant * 6.0, self.inertia_warper)
         self.periodic(st)
 
-    def end_animation(self):
-        if self.animation_target is not None:
+    def end_animation(self, instantly=False):
+        if self.animation_target is not None or instantly:
             value = self.animation_target
 
             self.animation_amplitude = None
@@ -2005,7 +2005,8 @@ class Adjustment(renpy.object.Object):
             self.animation_delay = None
             self.animation_warper = None
 
-            self.change(value, end_animation=False)
+            if not instantly:
+                self.change(value, end_animation=False)
 
     def periodic(self, st):
 
@@ -2022,7 +2023,10 @@ class Adjustment(renpy.object.Object):
 
         self.change(value, end_animation=False)
 
-        if st > self.animation_start + self.animation_delay: # type: ignore
+        if value < 0 or value > self._range:
+            self.end_animation(instantly=True)
+            return 0
+        elif st > self.animation_start + self.animation_delay: # type: ignore
             self.end_animation()
             return None
         else:

--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -527,8 +527,8 @@ class Viewport(renpy.display.layout.Container):
                     self.drag_position_time = st
                     self.drag_speed = (0.0, 0.0)
 
-                    self.xadjustment.end_animation()
-                    self.yadjustment.end_animation()
+                    self.xadjustment.end_animation(instantly=True)
+                    self.yadjustment.end_animation(instantly=True)
 
         if inside and self.edge_size and ev.type in [ pygame.MOUSEMOTION, pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP ]:
 


### PR DESCRIPTION
This fixes inertial viewport dragging. Namely, it adds an `instantly` parameter to the Adjustment `end_animation` method such that the relevant Adjustment parameters can be reset for the animation to instantly stop where it is. This is used 1) when the user touches down again, so the viewport stops when they press down, and 2) when the drag hits one of the viewport limits (so it can't be dragged any further). You may also consider using it in other circumstances, such as stopping the animation when the viewport scrollbar is grabbed.