### PR TITLE
renpy: Make version PEP440-compatible

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -105,9 +105,9 @@ else:
 version_only = ".".join(str(i) for i in version_tuple)
 
 if not official:
-    version_only += "u"
+    version_only += "+unofficial"
 elif nightly:
-    version_only += "n"
+    version_only += "+nightly"
 
 # A verbose string giving the version.
 version = "Ren'Py " + version_only


### PR DESCRIPTION
Starting with 67.2.0 setuptools enforces PEP440 compliance.
