### PR TITLE
Reform the Render.blit API

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -268,6 +268,7 @@ init -1100 python:
             config.history_current_dialogue = False
             config.scry_extend = False
             config.fadeout_audio = 0.0
+            config.int_render_blit = True
 
             if version > (6, 99, 5):
                 config.search_prefixes.append("images/")

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1373,6 +1373,9 @@ check_translate_none = True
 # Like developer, but available at the end of python early blocks.
 early_developer = False
 
+# Does Render.blit round down its pos parameter ?
+int_render_blit = False
+
 
 del os
 del collections

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -799,10 +799,15 @@ cdef class Render:
 
         (xo, yo) = pos
 
-        if type(xo) is float:
-            xo = renpy.display.core.absolute(xo * self.width)
-        if type(yo) is float:
-            yo = renpy.display.core.absolute(yo * self.height)
+        if renpy.config.int_render_blit:
+            xo = int(xo)
+            yo = int(yo)
+        else:
+            if type(xo) is float:
+                xo *= self.width
+            if type(yo) is float:
+                yo *= self.height
+            # no need to convert to absolute
 
         if index is None:
             self.children.append((source, xo, yo, focus, main))
@@ -814,18 +819,6 @@ cdef class Render:
             source.parents.add(self)
 
         return 0
-
-    cpdef int integer_blit(Render self, source, tuple pos, *args, **kwargs):
-        """
-        An proxy for _blit that blits on integer pixel boundaries.
-        """
-
-        (xo, yo) = pos
-
-        xo = round(xo)
-        yo = round(yo)
-
-        return self._blit(source, (xo, yo), *args, **kwargs)
 
     cpdef int absolute_blit(Render self, source, tuple pos, *args, **kwargs):
         """

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -822,7 +822,7 @@ cdef class Render:
 
     cpdef int absolute_blit(Render self, source, tuple pos, *args, **kwargs):
         """
-        An proxy for _blit that blits at fractional pixel boundaries.
+        An proxy for blit that blits at fractional pixel boundaries.
         """
 
         (xo, yo) = pos
@@ -830,7 +830,7 @@ cdef class Render:
         xo = renpy.display.core.absolute(xo)
         yo = renpy.display.core.absolute(yo)
 
-        return self._blit(source, (xo, yo), *args, **kwargs)
+        return self.blit(source, (xo, yo), *args, **kwargs)
 
     subpixel_blit = absolute_blit # legacy
 

--- a/sphinx/source/cdd.rst
+++ b/sphinx/source/cdd.rst
@@ -257,9 +257,11 @@ the implicit `self` parameter.
             The render object to draw.
 
         `pos`
-            The location to draw into. This is an (x, y) tuple
-            with the coordinates being pixels relative to the
-            upper-left corner of the target render.
+            The location to draw into. This is an (x, y) tuple of
+            :ref:`positions <style-property-values>` : integers and
+            ``absolute``\ s are a number of pixels relative to the upper-left
+            corner of the target render, and floats are interpreted as a
+            fraction of the width or height of the target render.
 
         `main`
             A keyword-only parameter. If true, `source` will be displayed

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -465,6 +465,10 @@ safer to use.
 When Ren'Py used to normalize every whitespaces into standard spaces, it now
 supports non-standard spaces such as \\u3000, the full-width ideographic space.
 
+:meth:`renpy.Render.blit` now takes :ref:`positions <style-property-values>`
+for its `pos` parameter, allowing one to pass values relative to the size of
+the Render.
+
 
 .. _renpy-7.5.3:
 .. _renpy-8.0.3:

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -139,6 +139,11 @@ Alternatively, you can determine new default volumes for :var:`config.default_mu
 :var:`config.default_sfx_volume`, and :var:`config.default_voice_volume` variables. If any
 of these is 0.0 or 1.0, it can be left unchanged.
 
+**Render.blit** : this method now takes :ref:`positions <style-property-values>` as `pos` values,
+and will not round them down to integers. To revert to the old behavior::
+
+    define config.int_render_blit = True
+
 
 .. _incompatible-8.0.2:
 .. _incompatible-7.5.2:

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -94,6 +94,8 @@ text.::
          selected_color "#ff0"
 
 
+.. _style-property-values:
+
 Style Property Values
 =====================
 


### PR DESCRIPTION
The first commit may be cherrypicked on its own.
I initially planned to have `blit = _blit` in the class body and have the compat edit the class with `blit = integer_blit`, but unfortunately you can't edit classes out of pyx files.
This also needs to be tested.

There is also the issue that the blit method is used a lot internally, and was used in the perspective of the pos being rounded to int.
These need to be checked, and I believe the simplest way forward would be to add an integer_blit method and massively rename dubious entries in the repo to using that one. (dubious meaning not calling it with literal `(0, 0)` as the pos or other simple cases)
I'll wait for confirmation before doing that though.

An argument could be made (and easily won, in my opinion) to drop subpixel_blit, since it's now replaced with absolute_blit.