### PR TITLE
Fix TintMatrix to respect alpha

### DIFF
--- a/renpy/common/00matrixcolor.rpy
+++ b/renpy/common/00matrixcolor.rpy
@@ -167,17 +167,16 @@ init -1500 python:
                 b = oldb + (b - oldb) * done
                 a = olda + (a - olda) * done
 
-            # To properly handle premultiplied alpha, the color channels
-            # have to be multiplied by the alpha channel.
-            r *= a
-            g *= a
-            b *= a
+            # Update the tint with opacity from the alpha channel.
+            r = 1 - (1 - r) * a
+            g = 1 - (1 - g) * a
+            b = 1 - (1 - b) * a
 
             # Return a Matrix.
             return Matrix([ r, 0, 0, 0,
                             0, g, 0, 0,
                             0, 0, b, 0,
-                            0, 0, 0, a ])
+                            0, 0, 0, 1 ])
 
     class BrightnessMatrix(ColorMatrix, DictEquality):
         """


### PR DESCRIPTION
Per the documentation, the alpha shouldn't ever have been impacted.

This change instead treats the alpha in the supplied RGBA value as the tint opacity rather than applying the tint formula to the alpha channel. The result is the ability to use a colour value of `#FF000080` to apply a 50%-red tint to the target.

<details><summary>Control, before, and after screenshots.</summary>

![screenshot0000](https://user-images.githubusercontent.com/591257/225391748-11dfcd3a-1bd9-4564-a3e8-f02066ac835d.png)
![screenshot0001](https://user-images.githubusercontent.com/591257/225391756-0a21b416-a552-43b8-af20-df5b8a538fbb.png)
![screenshot0002](https://user-images.githubusercontent.com/591257/225391757-0fbd85d8-e169-4b2f-bdc5-e83d67d2176d.png)
</details>

<details><summary>Reproduction code.</summary>

```rpy
label main_menu:
    $ _confirm_quit = False
    return

image s = Solid('777', xysize=(320, 240))

label start:
    scene
    show s at Transform(align=(.5, .5))
    'Original'
    show s:
        matrixcolor TintMatrix('ff000080')
    'Test'
```
</details>

I did consider compat for this, but given the current behaviour directly conflicts with the documentation, and also doesn't align with the concept of tinting (when alpha is present) in most image editing software, decided against it.