### PR TITLE
Improve savedump

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -40,7 +40,7 @@ import sys
 import renpy
 from json import dumps as json_dumps
 
-from renpy.compat.pickle import dump, loads
+from renpy.compat.pickle import PROTOCOL, dump, loads
 
 
 # This is used as a quick and dirty way of versioning savegame
@@ -118,7 +118,7 @@ def save_dump(roots, log):
         else:
 
             try:
-                reduction = o.__reduce_ex__(2)
+                reduction = o.__reduce_ex__(PROTOCOL)
             except Exception:
                 reduction = [ ]
                 o_repr_cache[ido] = "BAD REDUCTION " + o_repr

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -121,7 +121,7 @@ def save_dump(roots, log):
                 reduction = o.__reduce_ex__(2)
             except Exception:
                 reduction = [ ]
-                o_repr = "BAD REDUCTION " + o_repr
+                o_repr_cache[ido] = "BAD REDUCTION " + o_repr
 
             if isinstance(reduction, basestring):
                 o_repr_cache[ido] = o.__module__ + '.' + reduction

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -86,6 +86,14 @@ def save_dump(roots, log):
             else:
                 o_repr = "<method {0}.{1}>".format(o.__self__.__class__.__name__, o.__name__)
 
+        elif isinstance(o, types.FunctionType):
+            if PY2:
+                name = o.__name__
+            else:
+                name = o.__qualname__ or o.__name__
+
+            o_repr = o.__module__ + '.' + name
+
         elif isinstance(o, object):
             o_repr = "<{0}>".format(type(o).__name__)
 
@@ -114,6 +122,9 @@ def save_dump(roots, log):
 
         elif isinstance(o, types.MethodType):
             size = 1 + visit(o.__self__, path + ".im_self")
+
+        elif isinstance(o, types.FunctionType):
+            size = 1
 
         else:
 


### PR DESCRIPTION
- Adds handling for the case where the output of `__reduce_ex__` is a string representing a singleton.
- Makes sure "BAD REDUCTION" warnings make it into output.
- Grabs the protocol to use from `renpy.pickle.compat.PROTOCOL`.
- Adds support for functions, which can be pickled but don't support the `__reduce__`/`__reduce_ex__` APIs.

Recommend [viewing changes without whitespace](https://github.com/renpy/renpy/pull/4444/files?w=1) as a chunk of code had to be indented but was otherwise untouched. Each commit corresponds to an entry in the list above.