### PR TITLE
Python equivalent of layeredimage's Always layer

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -438,7 +438,7 @@ python early in layeredimage:
 
     class Always(Layer):
         """
-        :doc: li
+        :undocumented:
         :name: Always
 
         This is used for a displayable that is always shown.
@@ -515,11 +515,14 @@ python early in layeredimage:
         displayables associated with those attribute.
 
         `attributes`
-            This must be a list of Attribute objects. Each Attribute object
+            This must be a list of Attribute, Condition, ConditionGroup or
+            :func:`renpy.Displayable` objects. Each one
             reflects a displayable that may or may not be displayed as part
             of the image. The items in this list are in back-to-front order,
             with the first item further from the viewer and the last
             closest.
+            Passing a displayable directly is the equivalent of the `always`
+            layeredimage statement.
 
         `at`
             A transform or list of transforms that are applied to the displayable


### PR DESCRIPTION
I added `:doc: li` in Always as part of the global rewrite, but it didn't work because Always is not exported to the general store at the bottom of the file (unlike the others, Attribute, Condition, ConditionGroup and Layeredimage).
Since a displayable passed to LayeredImage gets converted to an Always in `Layeredimage.add()`, i think it's not necessary to add Always to the general store (where it may shadow things), and I included general displayables as being taken by Layeredimage too.

The additional properties taken by the always statement are not being given an equivalent (if_any, if_all and such) are not being given an equivalent, but people can always use Condition and the "True" condition.