### PR TITLE
Cancel long press wait when user stops touching the screen

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1115,11 +1115,10 @@ class Button(renpy.display.layout.Window):
 
                 renpy.game.interface.timeout(renpy.config.longpress_duration)
 
-            elif ev.type == pygame.MOUSEBUTTONUP and ev.button == 1:
-                self.longpress_start = None
-
             if self.longpress_start is not None:
-                if math.hypot(x - self.longpress_x, y - self.longpress_y) > renpy.config.longpress_radius:
+                if ev.type == pygame.MOUSEBUTTONUP and ev.button == 1:
+                    self.longpress_start = None
+                elif math.hypot(x - self.longpress_x, y - self.longpress_y) > renpy.config.longpress_radius:
                     self.longpress_start = None
                 elif st >= (self.longpress_start + renpy.config.longpress_duration):
                     renpy.exports.vibrate(renpy.config.longpress_vibrate)

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1115,6 +1115,9 @@ class Button(renpy.display.layout.Window):
 
                 renpy.game.interface.timeout(renpy.config.longpress_duration)
 
+            elif ev.type == pygame.MOUSEBUTTONUP and ev.button == 1:
+                self.longpress_start = None
+
             if self.longpress_start is not None:
                 if math.hypot(x - self.longpress_x, y - self.longpress_y) > renpy.config.longpress_radius:
                     self.longpress_start = None


### PR DESCRIPTION
Either choosing to cancel the long press detection when focus is lost was a bad decision, or something is broken in the focus logic for touch devices. Checking for a mouse up event to cancel the long press detection as this PR does is a more obvious way to do it.

I've kept the detection logic based on focus just in case it makes sense for other platforms.

Fix #4482.