### PR TITLE
Allow comments in shader variables lists

### DIFF
--- a/renpy/gl2/gl2shadercache.py
+++ b/renpy/gl2/gl2shadercache.py
@@ -105,7 +105,7 @@ class ShaderPart(object):
                 used.add(m.group(0))
 
         for l in variables.split("\n"):
-            l = l.strip(' ;')
+            l = l.partition("//")[0].strip(' ;')
 
             a = l.split()
             if not a:


### PR DESCRIPTION
Just like in any code, C-style (or GLSL-style) single-line comments, starting with //, are allowed.
This applies to the `variables` parameter of renpy.register_shader.