### PR TITLE
Let Transforms benefit from style optimisation

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -449,14 +449,15 @@ class Transform(Container):
                  focus=None,
                  default=False,
                  _args=None,
-                 alt=None,
 
                  **kwargs):
+
+        properties = {k: kwargs.pop(k) for k in style_properties if k in kwargs}
 
         self.kwargs = kwargs
         self.style_arg = style
 
-        super(Transform, self).__init__(style=style, focus=focus, default=default, _args=_args, alt=alt)
+        super(Transform, self).__init__(style=style, focus=focus, default=default, _args=_args, **properties)
 
         self.function = function
 
@@ -976,6 +977,9 @@ class ATLTransform(renpy.atl.ATLTransformBase, Transform):
     def _repr_info(self):
         return repr((self.child, self.atl.loc))
 
+
+# Names of style properties that should be sent to the parent.
+style_properties = {'alt'}
 
 # Names of transform properties, and if the property should be handled with
 # diff2 or diff4.


### PR DESCRIPTION
In ef6173de4f93d3b45c2ea2d393f3d3f9a16f9e7c we added the facility for alt text to be passed through `Transform` to allow its use in SL2. A side effect of this was to always pass alt text, meaning that the underlying `Displayable`'s `properties` could never be empty (they'd contain `alt=None`). This has been preventing `Transform` benefiting from the optimised code path in `Displayable` that avoids creating a new anonymous style.

In order to address this, we now filter out arguments passed to `Transform` that ought to be propagated up to the parent class, sending them only when defined, thus re-enabling the optimisation for the vast majority of `Transform` instances.