### PR TITLE
Fix detection of multiple declarations of a style's parent

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -121,16 +121,7 @@ screen say(who, what):
 init python:
     config.character_id_prefixes.append('namebox')
 
-style window is default
-style say_label is default
-style say_dialogue is default
-style say_thought is say_dialogue
-
-style namebox is default
-style namebox_label is say_label
-
-
-style window:
+style window is default:
     xalign 0.5
     xfill True
     yalign gui.textbox_yalign
@@ -138,7 +129,7 @@ style window:
 
     background Image("gui/textbox.png", xalign=0.5, yalign=1.0)
 
-style namebox:
+style namebox is default:
     xpos gui.name_xpos
     xanchor gui.name_xalign
     xsize gui.namebox_width
@@ -148,12 +139,14 @@ style namebox:
     background Frame("gui/namebox.png", gui.namebox_borders, tile=gui.namebox_tile, xalign=gui.name_xalign)
     padding gui.namebox_borders.padding
 
-style say_label:
+style namebox_label is say_label
+
+style say_label is default:
     properties gui.text_properties("name", accent=True)
     xalign gui.name_xalign
     yalign 0.5
 
-style say_dialogue:
+style say_dialogue is default:
     properties gui.text_properties("dialogue")
 
     xpos gui.dialogue_xpos
@@ -161,6 +154,8 @@ style say_dialogue:
     ypos gui.dialogue_ypos
 
     adjust_spacing False
+
+style say_thought is say_dialogue
 
 ## Input screen ################################################################
 ##
@@ -213,11 +208,7 @@ screen choice(items):
             textbutton i.caption action i.action
 
 
-style choice_vbox is vbox
-style choice_button is button
-style choice_button_text is button_text
-
-style choice_vbox:
+style choice_vbox is vbox:
     xalign 0.5
     ypos gui.scale(270)
     yanchor 0.5
@@ -266,13 +257,10 @@ init python:
 
 default quick_menu = True
 
-style quick_button is default
-style quick_button_text is button_text
-
-style quick_button:
+style quick_button is default:
     properties gui.button_properties("quick_button")
 
-style quick_button_text:
+style quick_button_text is button_text:
     properties gui.button_text_properties("quick_button")
 
 
@@ -330,14 +318,11 @@ screen navigation():
             textbutton _("Quit") action Quit(confirm=not main_menu)
 
 
-style navigation_button is gui_button
-style navigation_button_text is gui_button_text
-
-style navigation_button:
+style navigation_button is gui_button:
     size_group "navigation"
     properties gui.button_properties("navigation_button")
 
-style navigation_button_text:
+style navigation_button_text is gui_button_text:
     properties gui.button_text_properties("navigation_button")
 
 
@@ -374,32 +359,26 @@ screen main_menu():
                 style "main_menu_version"
 
 
-style main_menu_frame is empty
-style main_menu_vbox is vbox
-style main_menu_text is gui_text
-style main_menu_title is main_menu_text
-style main_menu_version is main_menu_text
-
-style main_menu_frame:
+style main_menu_frame is empty:
     xsize gui.scale(280)
     yfill True
 
     background "gui/overlay/main_menu.png"
 
-style main_menu_vbox:
+style main_menu_vbox is vbox:
     xalign 1.0
     xoffset gui.scale(-20)
     xmaximum gui.scale(800)
     yalign 1.0
     yoffset gui.scale(-20)
 
-style main_menu_text:
+style main_menu_text is gui_text:
     properties gui.text_properties("main_menu", accent=True)
 
-style main_menu_title:
+style main_menu_title is main_menu_text:
     properties gui.text_properties("title")
 
-style main_menu_version:
+style main_menu_version is main_menu_text:
     properties gui.text_properties("version")
 
 
@@ -479,56 +458,47 @@ screen game_menu(title, scroll=None, yinitial=0.0):
         key "game_menu" action ShowMenu("main_menu")
 
 
-style game_menu_outer_frame is empty
-style game_menu_navigation_frame is empty
-style game_menu_content_frame is empty
-style game_menu_viewport is gui_viewport
-style game_menu_side is gui_side
-style game_menu_scrollbar is gui_vscrollbar
-
-style game_menu_label is gui_label
-style game_menu_label_text is gui_label_text
-
-style return_button is navigation_button
-style return_button_text is navigation_button_text
-
-style game_menu_outer_frame:
+style game_menu_outer_frame is empty:
     bottom_padding gui.scale(30)
     top_padding gui.scale(120)
 
     background "gui/overlay/game_menu.png"
 
-style game_menu_navigation_frame:
+style game_menu_navigation_frame is empty:
     xsize gui.scale(280)
     yfill True
 
-style game_menu_content_frame:
+style game_menu_content_frame is empty:
     left_margin gui.scale(40)
     right_margin gui.scale(20)
     top_margin gui.scale(10)
 
-style game_menu_viewport:
+style game_menu_viewport is gui_viewport:
     xsize gui.scale(920)
 
 style game_menu_vscrollbar:
     unscrollable gui.unscrollable
 
-style game_menu_side:
+style game_menu_side is gui_side:
     spacing gui.scale(10)
 
-style game_menu_label:
+style game_menu_scrollbar is gui_vscrollbar
+
+style game_menu_label is gui_label:
     xpos gui.scale(50)
     ysize gui.scale(120)
 
-style game_menu_label_text:
+style game_menu_label_text is gui_label_text:
     size gui.title_text_size
     color gui.accent_color
     yalign 0.5
 
-style return_button:
+style return_button is navigation_button:
     xpos gui.navigation_xpos
     yalign 1.0
     yoffset gui.scale(-30)
+
+style return_button_text is navigation_button_text
 
 
 ## About screen ################################################################
@@ -563,11 +533,11 @@ screen about():
 
 
 style about_label is gui_label
-style about_label_text is gui_label_text
-style about_text is gui_text
 
-style about_label_text:
+style about_label_text is gui_label_text:
     size gui.label_text_size
+
+style about_text is gui_text
 
 
 ## Load and Save screens #######################################################
@@ -682,36 +652,30 @@ screen file_slots(title):
                             xalign 0.5
 
 
-style page_label is gui_label
-style page_label_text is gui_label_text
-style page_button is gui_button
-style page_button_text is gui_button_text
-
-style slot_button is gui_button
-style slot_button_text is gui_button_text
-style slot_time_text is slot_button_text
-style slot_name_text is slot_button_text
-
-style page_label:
+style page_label is gui_label:
     xpadding gui.scale(50)
     ypadding gui.scale(3)
 
-style page_label_text:
+style page_label_text is gui_label_text:
     textalign 0.5
     layout "subtitle"
     hover_color gui.hover_color
 
-style page_button:
+style page_button is gui_button:
     properties gui.button_properties("page_button")
 
-style page_button_text:
+style page_button_text is gui_button_text:
     properties gui.button_text_properties("page_button")
 
-style slot_button:
+style slot_button is gui_button:
     properties gui.button_properties("slot_button")
 
-style slot_button_text:
+style slot_button_text is gui_button_text:
     properties gui.button_text_properties("slot_button")
+
+style slot_time_text is slot_button_text
+
+style slot_name_text is slot_button_text
 
 
 ## Preferences screen ##########################################################
@@ -802,75 +766,68 @@ screen preferences():
                             style "mute_all_button"
 
 
-style pref_label is gui_label
-style pref_label_text is gui_label_text
-style pref_vbox is vbox
 
-style radio_label is pref_label
-style radio_label_text is pref_label_text
-style radio_button is gui_button
-style radio_button_text is gui_button_text
-style radio_vbox is pref_vbox
-
-style check_label is pref_label
-style check_label_text is pref_label_text
-style check_button is gui_button
-style check_button_text is gui_button_text
-style check_vbox is pref_vbox
-
-style slider_label is pref_label
-style slider_label_text is pref_label_text
-style slider_slider is gui_slider
-style slider_button is gui_button
-style slider_button_text is gui_button_text
-style slider_pref_vbox is pref_vbox
-
-style mute_all_button is check_button
-style mute_all_button_text is check_button_text
-
-style pref_label:
+style pref_label is gui_label:
     top_margin gui.pref_spacing
     bottom_margin gui.scale(2)
 
-style pref_label_text:
+style pref_label_text is gui_label_text:
     yalign 1.0
 
-style pref_vbox:
+style pref_vbox is vbox:
     xsize gui.scale(225)
 
-style radio_vbox:
+style radio_vbox is pref_vbox:
     spacing gui.pref_button_spacing
 
-style radio_button:
+style radio_label is pref_label
+
+style radio_label_text is pref_label_text
+
+style radio_button is gui_button:
     properties gui.button_properties("radio_button")
     foreground "gui/button/radio_[prefix_]foreground.png"
 
-style radio_button_text:
+style radio_button_text is gui_button_text:
     properties gui.button_text_properties("radio_button")
 
-style check_vbox:
+style check_vbox is pref_vbox:
     spacing gui.pref_button_spacing
 
-style check_button:
+style check_label is pref_label
+
+style check_label_text is pref_label_text
+
+style check_button is gui_button:
     properties gui.button_properties("check_button")
     foreground "gui/button/check_[prefix_]foreground.png"
 
-style check_button_text:
+style check_button_text is gui_button_text:
     properties gui.button_text_properties("check_button")
 
-style slider_slider:
+style slider_slider is gui_slider:
     xsize gui.scale(350)
 
-style slider_button:
+style slider_label is pref_label
+
+style slider_label_text is pref_label_text
+
+style slider_button is gui_button:
     properties gui.button_properties("slider_button")
     yalign 0.5
     left_margin gui.scale(10)
 
-style slider_button_text:
+style slider_button_text is gui_button_text:
     properties gui.button_text_properties("slider_button")
+
+style slider_pref_vbox is pref_vbox
 
 style slider_vbox:
     xsize gui.scale(450)
+
+style mute_all_button is check_button
+
+style mute_all_button_text is check_button_text
 
 
 ## History screen ##############################################################
@@ -924,30 +881,21 @@ screen history():
 define gui.history_allow_tags = { "alt", "noalt", "rt", "rb", "art" }
 
 
-style history_window is empty
-
-style history_name is gui_label
-style history_name_text is gui_label_text
-style history_text is gui_text
-
-style history_label is gui_label
-style history_label_text is gui_label_text
-
-style history_window:
+style history_window is empty:
     xfill True
     ysize gui.history_height
 
-style history_name:
+style history_name is gui_label:
     xpos gui.history_name_xpos
     xanchor gui.history_name_xalign
     ypos gui.history_name_ypos
     xsize gui.history_name_width
 
-style history_name_text:
+style history_name_text is gui_label_text:
     min_width gui.history_name_width
     textalign gui.history_name_xalign
 
-style history_text:
+style history_text is gui_text:
     xpos gui.history_text_xpos
     ypos gui.history_text_ypos
     xanchor gui.history_text_xalign
@@ -956,10 +904,10 @@ style history_text:
     textalign gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
 
-style history_label:
+style history_label is gui_label:
     xfill True
 
-style history_label_text:
+style history_label_text is gui_label_text:
     xalign 0.5
 
 
@@ -1102,27 +1050,23 @@ screen gamepad_help():
     textbutton _("Calibrate") action GamepadCalibrate()
 
 
-style help_button is gui_button
-style help_button_text is gui_button_text
-style help_label is gui_label
-style help_label_text is gui_label_text
-style help_text is gui_text
-
-style help_button:
+style help_button is gui_button:
     properties gui.button_properties("help_button")
     xmargin gui.scale(8)
 
-style help_button_text:
+style help_button_text is gui_button_text:
     properties gui.button_text_properties("help_button")
 
-style help_label:
+style help_label is gui_label:
     xsize gui.scale(250)
     right_padding gui.scale(20)
 
-style help_label_text:
+style help_label_text is gui_label_text:
     size gui.text_size
     xalign 1.0
     textalign 1.0
+
+style help_text is gui_text
 
 
 
@@ -1171,26 +1115,22 @@ screen confirm(message, yes_action, no_action):
     key "game_menu" action no_action
 
 
-style confirm_frame is gui_frame
-style confirm_prompt is gui_prompt
-style confirm_prompt_text is gui_prompt_text
-style confirm_button is gui_medium_button
-style confirm_button_text is gui_medium_button_text
-
-style confirm_frame:
+style confirm_frame is gui_frame:
     background Frame([ "gui/confirm_frame.png", "gui/frame.png"], gui.confirm_frame_borders, tile=gui.frame_tile)
     padding gui.confirm_frame_borders.padding
     xalign .5
     yalign .5
 
-style confirm_prompt_text:
+style confirm_prompt is gui_prompt
+
+style confirm_prompt_text is gui_prompt_text:
     textalign 0.5
     layout "subtitle"
 
-style confirm_button:
+style confirm_button is gui_medium_button:
     properties gui.button_properties("confirm_button")
 
-style confirm_button_text:
+style confirm_button_text is gui_medium_button_text:
     properties gui.button_text_properties("confirm_button")
 
 
@@ -1232,19 +1172,15 @@ transform delayed_blink(delay, cycle):
         repeat
 
 
-style skip_frame is empty
-style skip_text is gui_text
-style skip_triangle is skip_text
-
-style skip_frame:
+style skip_frame is empty:
     ypos gui.skip_ypos
     background Frame("gui/skip.png", gui.skip_frame_borders, tile=gui.frame_tile)
     padding gui.skip_frame_borders.padding
 
-style skip_text:
+style skip_text is gui_text:
     size gui.notify_text_size
 
-style skip_triangle:
+style skip_triangle is skip_text:
     ## We have to use a font that has the BLACK RIGHT-POINTING SMALL TRIANGLE
     ## glyph in it.
     font "DejaVuSans.ttf"
@@ -1276,16 +1212,13 @@ transform notify_appear:
         linear .5 alpha 0.0
 
 
-style notify_frame is empty
-style notify_text is gui_text
-
-style notify_frame:
+style notify_frame is empty:
     ypos gui.notify_ypos
 
     background Frame("gui/notify.png", gui.notify_frame_borders, tile=gui.frame_tile)
     padding gui.notify_frame_borders.padding
 
-style notify_text:
+style notify_text is gui_text:
     properties gui.text_properties("notify")
 
 
@@ -1351,27 +1284,18 @@ screen nvl_dialogue(dialogue):
 ## at once.
 define config.nvl_list_length = gui.nvl_list_length
 
-style nvl_window is default
-style nvl_entry is default
-
-style nvl_label is say_label
-style nvl_dialogue is say_dialogue
-
-style nvl_button is button
-style nvl_button_text is button_text
-
-style nvl_window:
+style nvl_window is default:
     xfill True
     yfill True
 
     background "gui/nvl.png"
     padding gui.nvl_borders.padding
 
-style nvl_entry:
+style nvl_entry is default:
     xfill True
     ysize gui.nvl_height
 
-style nvl_label:
+style nvl_label is say_label:
     xpos gui.nvl_name_xpos
     xanchor gui.nvl_name_xalign
     ypos gui.nvl_name_ypos
@@ -1380,7 +1304,7 @@ style nvl_label:
     min_width gui.nvl_name_width
     textalign gui.nvl_name_xalign
 
-style nvl_dialogue:
+style nvl_dialogue is say_dialogue:
     xpos gui.nvl_text_xpos
     xanchor gui.nvl_text_xalign
     ypos gui.nvl_text_ypos
@@ -1398,12 +1322,12 @@ style nvl_thought:
     textalign gui.nvl_thought_xalign
     layout ("subtitle" if gui.nvl_text_xalign else "tex")
 
-style nvl_button:
+style nvl_button is button:
     properties gui.button_properties("nvl_button")
     xpos gui.nvl_button_xpos
     xanchor gui.nvl_button_xalign
 
-style nvl_button_text:
+style nvl_button_text is button_text:
     properties gui.button_text_properties("nvl_button")
 
 
@@ -1435,28 +1359,22 @@ screen bubble(who, what):
             id "what"
 
 
-style bubble_window is empty
-style bubble_namebox is empty
-style bubble_who is default
-style bubble_what is default
-
-
-style bubble_window:
+style bubble_window is empty:
     background Frame("gui/bubble.png", 15, 15, 15, 15)
     padding (15, 10)
 
-style bubble_namebox:
+style bubble_namebox is empty:
     background Frame("gui/bubble.png", 15, 15, 15, 15)
     pos (-15, -5)
     anchor (0.0, 1.0)
     padding (15, 10)
 
-style bubble_who:
+style bubble_who is default:
     xalign 0.5
     textalign 0.5
     color "#000"
 
-style bubble_what:
+style bubble_what is default:
     align (0.5, 0.5)
     textalign 0.5
     layout "subtitle"


### PR DESCRIPTION
* Fix an issue that caused multiple declarations of a style's parent in a single statement to not trigger an error in `renpy/parser.py`.
* Update `gui/game/screens.rpy` to declare parents with the style content's declaration to improve style readability and avoid undetected multiple-definition of parents in the default project file (e.g.: at the moment, the `choice_button` style inherits from `button`, which is later silently erased in favor of `default`)
