### PR TITLE
Fix compat using unknown config option.

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -250,14 +250,14 @@ init -1100 python:
             config.atl_function_always_blocks = True
 
         if version <= (7, 4, 11):
-            config.timer_blocks_pause = False
+            config.modal_blocks_timer = False
             config.modal_blocks_pause = False
         elif _compat_versions(version, (7, 5, 1), (8, 0, 1)):
-            config.timer_blocks_pause = True
+            config.modal_blocks_timer = True
             config.modal_blocks_pause = False
         elif _compat_versions(version, (7, 5, 2), (8, 0, 2)):
             config.modal_blocks_pause = True
-            config.timer_blocks_pause = True
+            config.modal_blocks_timer = True
 
         if _compat_versions(version, (7, 5, 3), (8, 0, 3)):
             config.quadratic_volumes = True


### PR DESCRIPTION
Fixes `Exception: config.timer_blocks_pause is not a known configuration variable.`

7d4610d13d6dc27440e9b5e235ab9992c55cb28d introduces `modal_blocks_timer` which is probably what was meant to be used here.