### PR TITLE
Parse (ignore) typing annotations for define and default

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -963,6 +963,9 @@ def define_statement(l, loc):
     elif l.match(r'\|='):
         operator = "|="
     else:
+        if l.match(":"):
+            l.match(r"[^=\n]*")
+
         l.require('=')
         operator = "="
 
@@ -998,6 +1001,9 @@ def default_statement(l, loc):
     while l.match(r'\.'):
         store = store + "." + name
         name = l.require(l.word)
+
+    if l.match(":"):
+        l.match(r"[^=\n]*")
 
     l.require('=')
     expr = l.rest()


### PR DESCRIPTION
The following is now allowed :
```py
define a : str = "Hello World"
default b : str = "Hello World"
# define c : int # fails
# default d : int # fails

init python:
    def adj_eileen(attributes):
        return attributes

define config.adjust_attributes["eileen"] : Callable[tuple, tuple] = adj_eileen
define config.adjust_attributes : Dict[str, Callable[tuple, tuple]] |= {"eileen2" : adj_eileen}
define config.after_default_callbacks : List[Callable] += [print]
```
The annotations are completely ignored, and taking them into account falls solely on the IDE syntax analyzer. I think this is also how it works in Python for non-return and non-parameter annotations ?

This was particularly easy to implement, I'm not sure it's worth it though - if the burden of support falls on the IDE extensions anyway, it might as well use the `typing :` comments.