### PR TITLE
Add a type check on data saved in persistent

### DIFF
--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -58,6 +58,8 @@ if PY2:
         else:
             return pickle.dumps(o, PROTOCOL)
 
+    persistent_dumps = dumps
+
 else:
 
     import functools
@@ -92,6 +94,18 @@ else:
 
             return super().find_class(module, name)
 
+    class PersistentPickler(pickle.Pickler):
+        def reducer_override(self, obj):
+            if renpy.persistent.safe_types is not None:
+                t = obj
+                if not isinstance(obj, type):
+                    t = type(obj)
+
+                if t.__module__.startswith("store") and (t not in renpy.persistent.safe_types):
+                    raise TypeError("Cannot save {} : Type {} is not safe for persistent saving.".format(obj, t))
+
+            return NotImplemented # lets normal reducing take place
+
     def load(f):
         up = Unpickler(f, fix_imports=True, encoding="utf-8", errors="surrogateescape")
         return up.load()
@@ -104,3 +118,11 @@ else:
 
     def dumps(o, highest=False):
         return pickle.dumps(o, pickle.HIGHEST_PROTOCOL if highest else PROTOCOL)
+
+    def persistent_dumps(o, highest=False):
+        if renpy.config.developer:
+            b = io.BytesIO()
+            PersistentPickler(b, pickle.HIGHEST_PROTOCOL if highest else PROTOCOL).dump(o)
+            return b.getvalue()
+        else:
+            return dumps(o, highest)


### PR DESCRIPTION
This checks whether the type of the object being pickled into persistent is of a supported type (defined `early` enough), or the object itself if the object is a type.

This probably adds some amount of execution time at loading, and possibly at saving, but I don't know how the check could really be done more quickly than this.
For some reason I did not fully investigate, `renpy.config.developer` is not set to True when init() executes, so the creation of `safe_types` cannot be done on that condition. It would save some time in distributed games, if it could. The computation cannot be made any later, since the only call to persistent.init() happens right at the time when it's too late to define new persistable types.

If the check was done in `safe_deepcopy` as the issue suggests, the creator could see easily which persistent entry is faulty ; however it wouldn't check the type of elements of lists, or attributes of objects.