### PR TITLE
Mark renpy.split_properties as pure

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -132,6 +132,7 @@ renpy_pure("unelide_filename")
 renpy_pure("known_languages")
 renpy_pure("check_text_tags")
 renpy_pure("filter_text_tags")
+renpy_pure("split_properties")
 
 import time
 import sys


### PR DESCRIPTION
The returned dicts are mutable, but otherwise compare equal with equal inputs.

I'm using that in a dollar-line in a screen, seems like an optimization could be done there.