### PR TITLE
Apply path prefixes when loading movies for web

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -80,7 +80,7 @@ def load(fn):
         elif exception.rtype == 'video':
             # Video files are downloaded by the browser, so return
             # the file name instead of a file-like object
-            return 'url:' + renpy.config.web_video_base + "/" + fn
+            return 'url:' + renpy.config.web_video_base + "/" + exception.relpath
 
         # temporary 1s placeholder, will retry loading when looping:
         rv = open(os.path.join(renpy.config.commondir, '_dl_silence.ogg'), 'rb') # type: ignore


### PR DESCRIPTION
Using `exception.relpath` instead of `fn` makes sure the search prefixes are applied to the final path (when `config.search_prefixes` is used for instance).