### PR TITLE
Fix _ren.py format changelog example

### DIFF
--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -222,7 +222,7 @@ in a valid Python file. For example::
 
     """renpy
     init python:
-    """"
+    """
 
     flag = True
 


### PR DESCRIPTION
This fixes the changelog example for _ren.py code sections.

>A Ren'Py section is introduced with """renpy on a line by itself, and is terminated with """ on a line by itself.