### PR TITLE
Make it possible to pass rpyc version value as an argument

### DIFF
--- a/renpy/arguments.py
+++ b/renpy/arguments.py
@@ -33,6 +33,7 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 import argparse
 import os
 import sys
+import time
 
 import renpy
 
@@ -117,6 +118,10 @@ class ArgumentParser(argparse.ArgumentParser):
         self.add_argument(
             "--compile", action='store_true', dest='compile',
             help='Forces all .rpy scripts to be recompiled before proceeding.')
+
+        self.add_argument(
+            "--rpyc-version", action='store', type=int, default=int(time.time()),
+            help='The integer version number to use when compiling .rpyc files. Defaults to the current epoch time.')
 
         self.add_argument(
             "--keep-orphan-rpyc", action="store_true",

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -369,7 +369,7 @@ class Script(object):
 
         all_stmts = collapse_stmts(stmts)
 
-        version = int(time.time())
+        version = renpy.game.args.rpyc_version
 
         for s in all_stmts:
             if s.name is None:


### PR DESCRIPTION
Main use-case for that is to run `renpy --compile --rpyc-version int(HEAD_COMMIT_SHA, 16)` in Git environment (by git pull/checkout hook or other means), so we have the same rpycs content between members without involving of old-game (I used that approach and it wasn't very convenient).

I don't think it makes old-game obsolete, because for non-techie it is easier to copy and paste folders with rpycs then playing with console.