### PR TITLE
Fix sync download for web

### DIFF
--- a/renpy/common/00sync.rpy
+++ b/renpy/common/00sync.rpy
@@ -233,7 +233,7 @@ init -1100 python in _sync:
                 return None
 
 
-        def download_content(hashed, url):
+        def download_content(url):
             import emscripten
             import time
             import os


### PR DESCRIPTION
`download_content()` only takes 1 argument, I guess the `hashed` argument is from obsolete code.