### PR TITLE
Update Portuguese Translations

### DIFF
--- a/launcher/game/tl/portuguese/ios.rpy
+++ b/launcher/game/tl/portuguese/ios.rpy
@@ -66,11 +66,11 @@
 
     # game/ios.rpy:257
     old "Create Xcode Project"
-    new "Crear Proyecto de Xcode"
+    new "Criar Projeto Xcode"
 
     # game/ios.rpy:261
     old "Update Xcode Project"
-    new "Criar Projeto Xcode"
+    new "Atualizar Projeto Xcode"
 
     # game/ios.rpy:266
     old "Launch Xcode"
@@ -95,4 +95,3 @@
     # game/ios.rpy:348
     old "Ren'Py has set the Xcode Projects Directory to:"
     new "Ren'Py definiu o Diretório de Projetos Xcode para: "
-

--- a/launcher/game/tl/portuguese/preferences.rpy
+++ b/launcher/game/tl/portuguese/preferences.rpy
@@ -54,7 +54,7 @@
 
     # game/preferences.rpy:169
     old "Open launcher project"
-    new "Abrir o launcher"
+    new "Abrir projeto do launcher"
 
     # game/preferences.rpy:183
     old "Language:"
@@ -79,4 +79,3 @@
     # game/preferences.rpy:176
     old "Generate empty strings for translations"
     new "Gerar strings vazias para as traduções"
-


### PR DESCRIPTION
ios - Fixed a broken string which was in Spanish and changed a duplicate string.
preferences - Fixed a typo which said "Open launcher" instead of "Open launcher project".