### PR TITLE
Update revertable types according to Python's datamodel

### DIFF
--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -203,6 +203,8 @@ class RevertableList(list):
         @_method_wrapper(method)
         def newmethod(*args, **kwargs):
             l = method(*args, **kwargs) # type: ignore
+            if l == NotImplemented:
+                return l
             return RevertableList(l)
 
         return newmethod
@@ -222,10 +224,9 @@ class RevertableList(list):
             return rv
 
     def __mul__(self, other):
-        if not isinstance(other, int):
-            raise TypeError("can't multiply sequence by non-int of type '{}'.".format(type(other).__name__))
-
-        return RevertableList(list.__mul__(self, other))
+        if isinstance(other, int):
+            return RevertableList(list.__mul__(self, other))
+        return NotImplemented
 
     __rmul__ = __mul__ # type: ignore
 
@@ -335,11 +336,15 @@ class RevertableDict(dict):
 
         # https://peps.python.org/pep-0584 methods
         def __or__(self, other):
+            if not isinstance(other, dict):
+                return NotImplemented
             rv = RevertableDict(self)
             rv.update(other)
             return rv
 
         def __ror__(self, other):
+            if not isinstance(other, dict):
+                return NotImplemented
             rv = RevertableDict(other)
             rv.update(self)
             return rv

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -203,9 +203,7 @@ class RevertableList(list):
         @_method_wrapper(method)
         def newmethod(*args, **kwargs):
             l = method(*args, **kwargs) # type: ignore
-            if type(l) is list:
-                return RevertableList(l)
-            return l
+            return RevertableList(l)
 
         return newmethod
 
@@ -224,9 +222,10 @@ class RevertableList(list):
             return rv
 
     def __mul__(self, other):
-        if isinstance(other, int):
-            return RevertableList(list.__mul__(self, other))
-        return NotImplemented
+        if not isinstance(other, int):
+            raise TypeError("can't multiply sequence by non-int of type '{}'.".format(type(other).__name__))
+
+        return RevertableList(list.__mul__(self, other))
 
     __rmul__ = __mul__ # type: ignore
 

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -203,9 +203,9 @@ class RevertableList(list):
         @_method_wrapper(method)
         def newmethod(*args, **kwargs):
             l = method(*args, **kwargs) # type: ignore
-            if l == NotImplemented:
-                return l
-            return RevertableList(l)
+            if type(l) is list:
+                return RevertableList(l)
+            return l
 
         return newmethod
 


### PR DESCRIPTION
Follow-up to #4598 using PEP 584's recommendations and [datamodel](https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types) support.