### PR TITLE
Bring list operator dunders in accordance with the datamodel

### DIFF
--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -203,6 +203,8 @@ class RevertableList(list):
         @_method_wrapper(method)
         def newmethod(*args, **kwargs):
             l = method(*args, **kwargs) # type: ignore
+            if l is NotImplemented:
+                return l
             return RevertableList(l)
 
         return newmethod
@@ -210,6 +212,8 @@ class RevertableList(list):
     __add__ = wrapper(list.__add__) # type: ignore
     if PY2:
         __getslice__ = wrapper(list.__getslice__) # type: ignore
+    __mul__ = wrapper(list.__mul__) # type: ignore
+    __rmul__ = wrapper(list.__rmul__) # type: ignore
 
     del wrapper
 
@@ -220,14 +224,6 @@ class RevertableList(list):
             return RevertableList(rv)
         else:
             return rv
-
-    def __mul__(self, other):
-        if not isinstance(other, int):
-            raise TypeError("can't multiply sequence by non-int of type '{}'.".format(type(other).__name__))
-
-        return RevertableList(list.__mul__(self, other))
-
-    __rmul__ = __mul__ # type: ignore
 
     def copy(self):
         return self[:]

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -193,7 +193,7 @@ class RevertableList(list):
     append = mutator(list.append)
     extend = mutator(list.extend)
     insert = mutator(list.insert)
-    pop = mutator(list.pop) # type: ignore
+    pop = mutator(list.pop)
     remove = mutator(list.remove)
     reverse = mutator(list.reverse)
     sort = mutator(list.sort)
@@ -229,7 +229,7 @@ class RevertableList(list):
         return self[:]
 
     def clear(self):
-        self[:] = []
+        del self[:]
 
     def _clean(self):
         """


### PR DESCRIPTION
Simplification and separation from #4604. This is arguably more risky than the dict stuff which is new, so it can wait for 8.1.1 or something.