### PR TITLE
Encode the save directory as bytes on py2

### DIFF
--- a/renpy/common/00sync.rpy
+++ b/renpy/common/00sync.rpy
@@ -354,8 +354,11 @@ init -1100 python in _sync:
 
             total_size = 0
 
-            if renpy.config.save_directory:
-                zf.writestr("save_directory", renpy.config.save_directory)
+            sd = renpy.config.save_directory
+            if sd:
+                if PY2:
+                    sd = sd.encode("utf-8")
+                zf.writestr("save_directory", sd)
 
             persistent = location.path("persistent")[1]
 


### PR DESCRIPTION
PY3 zipfile accepts bytes and unicode, and encodes unicode using utf-8 (as the doc says), but py2 zipfile only accepts bytes.
On PY2, bytes still have the .encode method, so whatever the type of save_directory, my `if` shouldn't fail.