### PR TITLE
fix fonts linting

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -683,7 +683,7 @@ def check_style(name, s):
                     for f in set(v.map.values()):
                         check_file(name, f, directory="fonts")
                 else:
-                    check_file(name, v, directory="images")
+                    check_file(name, v, directory="fonts")
 
             if isinstance(v, renpy.display.core.Displayable):
                 check_style_property_displayable(name, k, v)


### PR DESCRIPTION
Fixes an issue where fonts located in the fonts/ directory and referenced in .rpy files with just their filename and not the fonts/ prefix would be falsely claimed to be unloadable by the linter despite working just fine in-game. Also fixes the converse issue, where fonts located in images/ directory and referenced without the images/ prefix weren't caught by the linter despite the game crashing when actually attempting to load them.