### PR TITLE
Make absolute a float again

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -232,7 +232,7 @@ for fn in (
     '__ceil__',
     # '__divmod__', # special-cased above, tuple of floats
     # '__eq__', # non-float
-    '__floordiv__', # not sure about this one
+    '__floordiv__',
     # '__format__', # non-float
     # '__ge__', # non-float
     # '__gt__', # non-float

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -190,17 +190,13 @@ class EndInteraction(Exception):
         self.value = value
 
 
-def absolute_wrap(func_name):
+def absolute_wrap(func):
     """
     Wraps func_name into a method of absolute. The wrapped method
-    converts any absolute arguments to floats, and then converts
-    a float result back to absolute.
+    converts a float result back to absolute.
     """
 
-    func = getattr(float, func_name)
-
     def wrapper(*args):
-        args = (i.value if type(i) is absolute else i for i in args)
         rv = func(*args)
 
         if type(rv) is float:
@@ -210,120 +206,74 @@ def absolute_wrap(func_name):
 
     return wrapper
 
-
-class absolute(object):
+class absolute(float):
     """
-    This represents a class that can be used to represent absolute
-    positions on the screen. It emulates float, except that all operations
-    that would return a float return an absolute instead.
-
-    In a previous version of Ren'Py, this was a subclass of float,
-    hence why new is needed to create an instance.
+    This represents an absolute float coordinate.
     """
 
-    slots = [ 'value' ]
+    slots = ()
 
-    def __new__(cls, value):
-        self = object.__new__(cls)
-        self.value = float(value)
-        return self
+    def __repr__(self):
+        return "absolute({})".format(float.__repr__(self))
 
-    def __getnewargs__(self):
-        return (self.value, ) #type: ignore
+    def __divmod__(self, value):
+        d, r = float.__divmod__(self, value)
+        return absolute(d), absolute(r)
 
-    def __repr__(self, *args, **kwargs):
-        return "absolute({})".format(self.value) # type: ignore
+to_wrap = (
+    '__coerce__', # PY2
+    '__div__', # PY2
+    '__long__', # PY2
+    '__nonzero__', # PY2
+    '__rdiv__', # PY2
 
-    def __float__(self):
-        return self.value # type: ignore
+    '__abs__',
+    '__add__',
+    # '__bool__', # non-float
+    '__ceil__',
+    # '__divmod__', # special-cased above, tuple of floats
+    # '__eq__', # non-float
+    '__floordiv__',
+    # '__format__', # non-float
+    # '__ge__', # non-float
+    # '__gt__', # non-float
+    # '__hash__', # non-float
+    # '__int__', # non-float
+    # '__le__', # non-float
+    # '__lt__', # non-float
+    '__mod__',
+    '__mul__',
+    # '__ne__', # non-float
+    '__neg__',
+    '__pos__',
+    '__pow__',
+    '__radd__',
+    '__rdivmod__',
+    '__rfloordiv__',
+    '__rmod__',
+    '__rmul__',
+    '__round__',
+    '__rpow__',
+    '__rsub__',
+    '__rtruediv__',
+    # '__str__', # non-float
+    '__sub__',
+    '__truediv__',
+    # '__trunc__', # non-float
 
-    if not PY2:
+    # 'as_integer_ratio', # tuple of non-floats
+    'conjugate',
+    'fromhex',
+    # 'hex', # non-float
+    # 'is_integer', # non-float
+)
 
-        __abs__ = absolute_wrap('__abs__') # type: ignore
-        __add__ = absolute_wrap('__add__') # type: ignore
-        __bool__ = absolute_wrap('__bool__') # type: ignore
-        __ceil__ = absolute_wrap('__ceil__') # type: ignore
-        __divmod__ = absolute_wrap('__divmod__') # type: ignore
-        __eq__ = absolute_wrap('__eq__') # type: ignore
-        __floordiv__ = absolute_wrap('__floordiv__') # type: ignore
-        __format__ = absolute_wrap('__format__') # type: ignore
-        __ge__ = absolute_wrap('__ge__') # type: ignore
-        __gt__ = absolute_wrap('__gt__') # type: ignore
-        __hash__ = absolute_wrap('__hash__') # type: ignore
-        __int__ = absolute_wrap('__int__') # type: ignore
-        __le__ = absolute_wrap('__le__') # type: ignore
-        __lt__ = absolute_wrap('__lt__') # type: ignore
-        __mod__ = absolute_wrap('__mod__') # type: ignore
-        __mul__ = absolute_wrap('__mul__') # type: ignore
-        __ne__ = absolute_wrap('__ne__') # type: ignore
-        __neg__ = absolute_wrap('__neg__') # type: ignore
-        __pos__ = absolute_wrap('__pos__') # type: ignore
-        __pow__ = absolute_wrap('__pow__') # type: ignore
-        __radd__ = absolute_wrap('__radd__') # type: ignore
-        __rdivmod__ = absolute_wrap('__rdivmod__') # type: ignore
-        __rfloordiv__ = absolute_wrap('__rfloordiv__') # type: ignore
-        __rmod__ = absolute_wrap('__rmod__') # type: ignore
-        __rmul__ = absolute_wrap('__rmul__') # type: ignore
-        __round__ = absolute_wrap('__round__') # type: ignore
-        __rpow__ = absolute_wrap('__rpow__') # type: ignore
-        __rsub__ = absolute_wrap('__rsub__') # type: ignore
-        __rtruediv__ = absolute_wrap('__rtruediv__') # type: ignore
-        __str__ = absolute_wrap('__str__') # type: ignore
-        __sub__ = absolute_wrap('__sub__') # type: ignore
-        __truediv__ = absolute_wrap('__truediv__') # type: ignore
-        __trunc__ = absolute_wrap('__trunc__') # type: ignore
+for fn in to_wrap:
+    f = getattr(float, fn, None)
+    if f is not None: # for PY2-only and PY3-only methods
+        setattr(absolute, fn, absolute_wrap(f))
 
-    else:
-
-        __abs__ = absolute_wrap('__abs__') # type: ignore
-        __add__ = absolute_wrap('__add__') # type: ignore
-        __coerce__ = absolute_wrap('__coerce__') # type: ignore
-        __div__ = absolute_wrap('__div__') # type: ignore
-        __divmod__ = absolute_wrap('__divmod__') # type: ignore
-        __eq__ = absolute_wrap('__eq__') # type: ignore
-        __floordiv__ = absolute_wrap('__floordiv__') # type: ignore
-        __format__ = absolute_wrap('__format__') # type: ignore
-        __ge__ = absolute_wrap('__ge__') # type: ignore
-        __gt__ = absolute_wrap('__gt__') # type: ignore
-        __hash__ = absolute_wrap('__hash__') # type: ignore
-        __int__ = absolute_wrap('__int__') # type: ignore
-        __le__ = absolute_wrap('__le__') # type: ignore
-        __long__ = absolute_wrap('__long__') # type: ignore
-        __lt__ = absolute_wrap('__lt__') # type: ignore
-        __mod__ = absolute_wrap('__mod__') # type: ignore
-        __mul__ = absolute_wrap('__mul__') # type: ignore
-        __ne__ = absolute_wrap('__ne__') # type: ignore
-        __neg__ = absolute_wrap('__neg__') # type: ignore
-        __nonzero__ = absolute_wrap('__nonzero__') # type: ignore
-        __pos__ = absolute_wrap('__pos__') # type: ignore
-        __pow__ = absolute_wrap('__pow__') # type: ignore
-        __radd__ = absolute_wrap('__radd__') # type: ignore
-        __rdiv__ = absolute_wrap('__rdiv__') # type: ignore
-        __rdivmod__ = absolute_wrap('__rdivmod__') # type: ignore
-        __rfloordiv__ = absolute_wrap('__rfloordiv__') # type: ignore
-        __rmod__ = absolute_wrap('__rmod__') # type: ignore
-        __rmul__ = absolute_wrap('__rmul__') # type: ignore
-        __rpow__ = absolute_wrap('__rpow__') # type: ignore
-        __rsub__ = absolute_wrap('__rsub__') # type: ignore
-        __rtruediv__ = absolute_wrap('__rtruediv__') # type: ignore
-        __str__ = absolute_wrap('__str__') # type: ignore
-        __sub__ = absolute_wrap('__sub__') # type: ignore
-        __truediv__ = absolute_wrap('__truediv__') # type: ignore
-        __trunc__ = absolute_wrap('__trunc__') # type: ignore
-
-    as_integer_ratio = absolute_wrap('as_integer_ratio')
-    conjugate = absolute_wrap('conjugate')
-    fromhex = absolute_wrap('fromhex')
-    hex = absolute_wrap('hex')
-    is_integer = absolute_wrap('is_integer')
-
-    @property
-    def imag(self):
-        return self.value.imag # type: ignore
-
-    @property
-    def real(self):
-        return self.value.real # type: ignore
+del absolute_wrap, to_wrap, fn, f # type: ignore
 
 
 def place(width, height, sw, sh, placement):

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -217,8 +217,7 @@ class absolute(float):
         return "absolute({})".format(float.__repr__(self))
 
     def __divmod__(self, value):
-        d, r = float.__divmod__(self, value)
-        return absolute(d), absolute(r)
+        return self//value, self%value
 
 to_wrap = (
     '__coerce__', # PY2
@@ -233,7 +232,7 @@ to_wrap = (
     '__ceil__',
     # '__divmod__', # special-cased above, tuple of floats
     # '__eq__', # non-float
-    '__floordiv__',
+    '__floordiv__', # not sure about this one
     # '__format__', # non-float
     # '__ge__', # non-float
     # '__gt__', # non-float

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -219,7 +219,7 @@ class absolute(float):
     def __divmod__(self, value):
         return self//value, self%value
 
-to_wrap = (
+for fn in (
     '__coerce__', # PY2
     '__div__', # PY2
     '__long__', # PY2
@@ -265,14 +265,12 @@ to_wrap = (
     'fromhex',
     # 'hex', # non-float
     # 'is_integer', # non-float
-)
-
-for fn in to_wrap:
+):
     f = getattr(float, fn, None)
     if f is not None: # for PY2-only and PY3-only methods
         setattr(absolute, fn, absolute_wrap(f))
 
-del absolute_wrap, to_wrap, fn, f # type: ignore
+del absolute_wrap, fn, f # type: ignore
 
 
 def place(width, height, sw, sh, placement):


### PR DESCRIPTION
Multiple advantages over the wrapper-class implementation : lighter in memory, don't wrap methods that don't need too, don't spend time converting their parameters, avoid a two-version pickling and unpickling mechanism (with slots), shorter code with less warning silencing.

I'm not certain how pickled instances of the wrapper-class implementation will work, but if this is merged shortly it won't be a problem - saves made on a nightly have limited support.