### PR TITLE
Add a warning when creating new projects in renpy 7

### DIFF
--- a/launcher/game/new_project.rpy
+++ b/launcher/game/new_project.rpy
@@ -62,6 +62,9 @@ label new_project:
     if persistent.projects_directory is None:
         $ interface.error(_("The projects directory could not be set. Giving up."))
 
+    if PY2:
+        $ interface.info(_("Warning : you are using Ren'Py 7. It is recommended to start new projects using Ren'Py 8 instead."))
+
     python:
         if persistent.legacy:
 


### PR DESCRIPTION
Not disabled, because it still makes sense for test purposes or to update default files of an older game (that last part can be done in renpy 8 but it's not obvious that it works and having to update to 8, generate the files and downgrade after is not obvious either).
This can be reworded (I'll add translation when it's fixed), and has been made fix-compatible.
Obviously it's meant for the transition period before the end of renpy7.