### PR TITLE
Extend the system cursor preference to config.mouse_displayable

### DIFF
--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -211,8 +211,8 @@ init -1500 python:
         * Preference("font size", 1.0) - Sets the accessibility font size scaling factor.
         * Preference("font line spacing", 1.0) - Sets the accessibility font vertical spacing scaling factor.
 
-        * Preference("system cursor", "enable") - Use system cursor ignoring :var:`config.mouse`.
-        * Preference("system cursor", "disable") - Use cursor defined in :var:`config.mouse`.
+        * Preference("system cursor", "disable") - Use the cursor defined in :var:`config.mouse` or :var:`config.mouse_displayable`.
+        * Preference("system cursor", "enable") - Use the system cursor, ignoring :var:`config.mouse`.
         * Preference("system cursor", "toggle") - Toggle system cursor.
 
         * Preference("high contrast text", "enable") - Enables white text on a black background.

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -4005,13 +4005,16 @@ class Interface(object):
         for i in renpy.display.emulator.overlay:
             root_widget.add(i)
 
-        mouse_displayable = renpy.config.mouse_displayable
-        if mouse_displayable is not None:
-            if not isinstance(mouse_displayable, Displayable):
-                mouse_displayable = mouse_displayable()
-
+        if renpy.game.preferences.system_cursor:
+            mouse_displayable = None
+        else:
+            mouse_displayable = renpy.config.mouse_displayable
             if mouse_displayable is not None:
-                root_widget.add(mouse_displayable, 0, 0)
+                if not isinstance(mouse_displayable, Displayable):
+                    mouse_displayable = mouse_displayable()
+
+                if mouse_displayable is not None:
+                    root_widget.add(mouse_displayable, 0, 0)
 
         self.prediction_coroutine = renpy.display.predict.prediction_coroutine(root_widget)
         self.prediction_coroutine.send(None)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -18,6 +18,9 @@ the file and all parent directories for git lock files. The autoreload will
 be deferred until the lock files are removed when the git operation
 completes.
 
+The "system cursor" :func:`Preference` now applies to :var:`config.mouse_displayable`,
+when it used to only disable :var:`config.mouse`.
+
 
 .. _renpy-8.1.1:
 .. _renpy-7.6.1:

--- a/sphinx/source/preferences.rst
+++ b/sphinx/source/preferences.rst
@@ -149,9 +149,9 @@ can then change it again.)
 
 .. var:: preferences.system_cursor = False
 
-    If True, the system cursor is forced to be used, ignoring the
-    :var:`config.mouse` value. If False, it will not. The equivalent of the
-    "system cursor" preference.
+    If True, the system cursor is forced to be used, ignoring the value of
+    :var:`config.mouse` and :var:`config.mouse_displayable`. If False, it
+    will not. The equivalent of the "system cursor" preference.
 
 .. var:: preferences.audio_when_minimized = True
 


### PR DESCRIPTION
May require a compat, though I think it's probably not worth it due to the nature of the preference here.
Mentioning Andy as he authored the preference in the first place.
Code by @the66f95 (can't co-commit it since I don't know the no-reply email).