### PR TITLE
Avoid cropping widgets during a dissolve

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -378,8 +378,8 @@ class Dissolve(Transition):
         bottom = render(self.old_widget, width, height, st, at)
         top = render(self.new_widget, width, height, st, at)
 
-        width = min(top.width, bottom.width)
-        height = min(top.height, bottom.height)
+        width = max(top.width, bottom.width)
+        height = max(top.height, bottom.height)
 
         rv = renpy.display.render.Render(width, height)
 


### PR DESCRIPTION
It's rare, but sometimes it's desirable to dissolve between two differently sized widgets - most typically when the size of one or other is not known or easily computable by the creator (dynamic input text and user-chosen displayables are good example of these).

Currently the dissolved area is the smallest possible, rather than one that will be able to encompass both old and new widgets. This change ensures enough space is rendered to be able to dissolve cleanly between the two widgets.

There's a trade off that we'll dissolve more pixels in these cases, but A) they are probably fairly rare, and B) the current visual behaviour is unlikely to be desirable in any scenario.

<details><summary>Testcase</summary>

```rpy
image r = Solid('f773', xysize=(160, 240))
image b = Solid('7ff3', xysize=(320, 120))

label main_menu:
    $ _confirm_quit = False
    return

label start:
    scene
    'Ready'
    show test at reset
    'Crops to smallest width/height combination of both displayables during dissolve.'
    return

image test:
    'r'
    1
    'b' with Dissolve(1)
```
</details>