### PR TITLE
Fix for 7.6 web

### DIFF
--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -128,7 +128,11 @@ init -1500 python in _console:
     import sys
     import traceback
     import store
-    import pydoc
+    try:
+        import pydoc
+    except ImportError:
+        # Web2 does not have pydoc, help() will fail but game will load at least
+        pass
 
     from reprlib import Repr
     class PrettyRepr(Repr):

--- a/renpy/compat/__init__.py
+++ b/renpy/compat/__init__.py
@@ -183,13 +183,14 @@ if PY2:
 # Chance the default for subprocess.Popen.
 if PY2:
     import subprocess
-    class Popen(subprocess.Popen):
-        def __init__(self, *args, **kwargs):
-            if ("stdout" not in kwargs) and ("stderr" not in kwargs) and ("stdin" not in kwargs):
-                kwargs.setdefault("close_fds", True)
-            super(Popen, self).__init__(*args, **kwargs)
+    if hasattr(subprocess, 'Popen'):  # Web2 does not have subprocess.Popen
+        class Popen(subprocess.Popen):
+            def __init__(self, *args, **kwargs):
+                if ("stdout" not in kwargs) and ("stderr" not in kwargs) and ("stdin" not in kwargs):
+                    kwargs.setdefault("close_fds", True)
+                super(Popen, self).__init__(*args, **kwargs)
 
-    subprocess.Popen = Popen
+        subprocess.Popen = Popen
 
 
 ################################################################################

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2857,7 +2857,7 @@ class WebInput(renpy.display.core.Displayable):
 
     @staticmethod
     def post_find_focusable():
-        if not renpy.emscripten:
+        if PY2 or not renpy.emscripten:
             return
 
         if WebInput.active is None:


### PR DESCRIPTION
Fix #4718.

On a side note, there are "bad mtime" warnings from Python when importing most of the PYO files on 7.6 Web, which forces Python to recompile the files and increases the load time. I'm not sure if this is specific to 7.6 and/or Web though.