### PR TITLE
Remove trailing space in hbox/xfill and vbox/yfill

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -947,6 +947,10 @@ class MultiBox(Container):
 
         spacings = [ first_spacing ] + [ spacing ] * (len(self.children) - 1)
 
+        # Suppress trailing space, as in practicality we want one fewer than
+        # the number of children.
+        spacings[-1] = 0
+
         box_wrap = self.style.box_wrap
         box_wrap_spacing = self.style.box_wrap_spacing
         xfill = self.style.xfill
@@ -962,9 +966,12 @@ class MultiBox(Container):
 
         # The children to layout.
         children = list(self.children)
+
         if self.style.box_reverse:
             children.reverse()
-            spacings.reverse()
+
+            # Leave the supressed trailing space in place.
+            spacings[:-1] = spacings[-2::-1]
 
         # a list of (child, x, y, w, h, surf) tuples that are turned into
         # calls to child.place().


### PR DESCRIPTION
Seeks to address some pain points closely related to #3666 — the use of `hbox` with `xfill` and `vbox` with `yfill`. This is intended as something like a stop-gap measure until such time that the spacing distribution issue can be looked at. It does two small things to hopefully make this a bit better:

1. It zeros the last spacer, shrinking any trailing space to consist only of the indivisible left overs.
2. Allows `first_spacing` to work with `box_reverse`. It'll be used between the penultimate and final items, rather ending up as a trailing space and making the xfill/yfill cases worse.