### PR TITLE
fix: periodic animate

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2037,6 +2037,9 @@ class Adjustment(renpy.object.Object):
         if self.animation_start is None:
             self.animation_start = st
 
+        if st < self.animation_start:
+            st += self.animation_start + self.animation_delay # type: ignore
+
         done = (st - self.animation_start) / self.animation_delay
         done = self.animation_warper(done)
 


### PR DESCRIPTION
When creating `adjustment` via `default | define adj = ui.adjustment()`, if you wait some time (so that the animation start time is long) and then run the scroll animation and close the screen, then after opening the screen again - since `st` will start its countdown from zero, it causes an exception - `OverflowError: math range error` at the time of calculating `def inertia_warper`