### PR TITLE
Convert build.itch_channels to a true dict

### DIFF
--- a/launcher/game/itch.rpy
+++ b/launcher/game/itch.rpy
@@ -98,7 +98,7 @@ label itch:
 
         for fn in os.listdir(destination):
 
-            for pattern, channel in reversed(build['itch_channels']):
+            for pattern, channel in reversed(build['itch_channels'].items()):
                 if fnmatch.fnmatch(fn, pattern):
                     break
             else:

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -457,15 +457,15 @@ init -1500 python in build:
     itch_project = None
 
     # Maps from files to itch.io channels.
-    itch_channels = [
-        ( "*-all.zip", "win-osx-linux" ),
-        ( "*-market.zip", "win-osx-linux" ),
-        ( "*-pc.zip", "win-linux" ),
-        ( "*-win.zip", "win" ),
-        ( "*-mac.zip", "osx" ),
-        ( "*-linux.tar.bz2", "linux" ),
-        ( "*-release.apk", "android" ),
-    ]
+    itch_channels = {
+        "*-all.zip" : "win-osx-linux",
+        "*-market.zip" : "win-osx-linux",
+        "*-pc.zip" : "win-linux",
+        "*-win.zip" : "win",
+        "*-mac.zip" : "osx",
+        "*-linux.tar.bz2" : "linux",
+        "*-release.apk" : "android",
+    }
 
     # Should we include the old Ren'Py themes?
     include_old_themes = True

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -295,6 +295,7 @@ init -1100 python:
 
         if _compat_versions(version, (7, 6, 99), (8, 1, 99)):
             config.simple_box_reverse = True
+            build.itch_channels = list(build.itch_channels.items())
 
     # The version of Ren'Py this script is intended for, or
     # None if it's intended for the current version.

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -51,6 +51,22 @@ add to your game::
     define config.simple_box_reverse = True
 
 
+**build.itch_channels** That variable was always documented as a dict but was
+mistakenly implemented as a list of tuples. It's now truly a dict. If you
+were using list operations on it, you'll need to change your code::
+
+    # formerly
+    $ build.itch_channels.append(("pattern", "channel"))
+    $ build.itch_channels.extend([("pattern", "channel")])
+    define build.itch_channels += [("pattern", "channel")]
+
+    # now
+    $ build.itch_channels["pattern"] = "channel"
+    $ build.itch_channels.update({"pattern": "channel"})
+    define build.itch_channels["pattern"] = "channel"
+    define build.itch_channels |= {"pattern": "channel"}
+
+
 .. _incompatible-8.1.1:
 .. _incompatible-7.6.1:
 


### PR DESCRIPTION
The compat works as follows :
- The games already distributed and doing list operations on it (from creators who disregarded the doc) will still work when launched from a more recent launcher, the build.itch_channels will still support list operations.
- Distributing a game after this update will need the code to be updated, otherwise it will fail, but I think that's acceptable. The required change to code is very light, the feature is very recent and it is probably not widely used.

I chose to target master because with the caveats above, it's an incompatible change (albeit a fix in purpose).