### PR TITLE
Add the screen property directive

### DIFF
--- a/sphinx/source/renpydoc.py
+++ b/sphinx/source/renpydoc.py
@@ -56,7 +56,6 @@ def parse_var_node(env, sig, signode):
 
 style_seen_ids = set()
 
-
 def parse_style_node(env, sig, signode):
     m = re.match(r'(\S+)(.*)', sig)
 
@@ -74,6 +73,25 @@ def parse_style_node(env, sig, signode):
         ref = ref + "_alt"
 
     style_seen_ids.add(ref)
+
+    return ref
+
+
+scpref_seen_ids = set()
+
+def parse_scpref_node(env, sig, signode):
+    m = re.match(r'(\S+)(.*)', sig)
+
+    signode += sphinx.addnodes.desc_name(m.group(1), m.group(1))
+    signode += docutils.nodes.Text(m.group(2), m.group(2))
+
+    ref = m.group(1)
+
+    while ref in scpref_seen_ids:
+        print("duplicate id:", ref)
+        ref = ref + "_alt"
+
+    scpref_seen_ids.add(ref)
 
     return ref
 
@@ -183,6 +201,7 @@ def setup(app):
     app.add_object_type("var", "var", "single: %s (variable)", parse_node=parse_var_node)
     app.add_object_type("style-property", "propref", "single: %s (style property)", parse_node=parse_style_node)
     app.add_object_type("transform-property", "tpref", "single: %s (transform property)")
+    app.add_object_type("screen-property", "scpref", "single: %s (screen property)", parse_node=parse_scpref_node)
     app.add_object_type("text-tag", "tt", "single: %s (text tag)")
 
     add_index(app, "std", "style-property", "Style Property Index")

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -160,40 +160,48 @@ common syntax.
 It takes one parameter, the name of the screen. This is a name, not an
 expression. It takes the following properties:
 
-`modal`
+.. screen-property:: modal
+
     If True, the screen is modal. A modal screen prevents the user
     from interacting with displayables below it, except
     for the default keymap. This is evaluated once, when the
     game starts.
 
-`sensitive`
+.. screen-property:: sensitive
+
     An expression that determines whether the screen is sensitive or not.
     This expression is evaluated at least once per interaction.
 
-`tag`
+.. screen-property:: tag
+
     Parsed as a name, not an expression. This specifies a tag
     associated with this screen. Showing a screen replaces other
     screens with the same tag. This can be used to ensure that only
     one screen of a menu is shown at a time, in the same context.
 
-`zorder`
+.. screen-property:: zorder
+
     This controls how close to the user a screen is displayed. The
     larger the number, the closer the screen is displayed to the
     user. It defaults to 0.
 
-`variant`
+.. screen-property:: variant
+
     If present, this should be a string or list of strings giving the
     variant of screen to be defined. See :ref:`screen-variants`.
 
-`style_prefix`
+.. screen-property:: style_prefix
+
     A string that's used to provide a prefix for the style for the
     children of this screen, as :ref:`described below <style-prefix>`.
 
-`layer`
+.. screen-property:: layer
+
     A string giving the name of the layer the screen is shown on by
     default.
 
-`roll_forward`
+.. screen-property:: roll_forward
+
     If true, roll forward will be enabled when the screen is used in a
     ``call screen`` statement. If false, roll forward is disabled, and
     if None or not given, the value of :var:`config.call_screen_roll_forward`
@@ -241,7 +249,8 @@ allow the game to react to various events.
 
 All user interface statements take the following common properties:
 
-`at`
+.. screen-property:: at
+
     This can be a transform, or a list of transforms, or an anonymous
     transform (a transform that is defined directly in at) ::
 
@@ -278,7 +287,8 @@ All user interface statements take the following common properties:
                     alpha 0.0
                     linear 0.5 alpha 1.0
 
-`default_focus`
+.. screen-property:: default_focus
+
     If given and true, the displayable is focused by default. When
     multiple displayables have this, the values are compared and the
     displayable with the greatest default focus becomes the default.
@@ -286,7 +296,8 @@ All user interface statements take the following common properties:
     The default focus is only used when the last interaction was not
     a mouse click, mouse movement, or touch.
 
-`id`
+.. screen-property:: id
+
     An identifier for the user-interface statement. When a screen is
     shown, property values can be supplied for the displayables with a
     given identifier. Some screens will require that a displayable
@@ -294,17 +305,20 @@ All user interface statements take the following common properties:
 
     By default, the ``id`` is automatically-generated.
 
-`prefer_screen_to_id`
+.. screen-property:: prefer_screen_to_id
+
     If true, when a property is provided by both the the screen and a
     displayble identifier, the screen property is used. If false, the
     default, the displayable property is used. (This can be used to
     decide if the screen overrides properties set by a Character.)
 
-`style`
+.. screen-property:: style
+
     A string giving the name of the style applied to this displayable. The
     style gives default values for style properties.
 
-`style_prefix`
+.. screen-property:: style_prefix
+
     .. _style-prefix:
 
     Provides a prefix to the style of this displayable and all of its
@@ -324,10 +338,12 @@ All user interface statements take the following common properties:
     does not exist. Setting a prefix of ``None`` removes the prefix from
     this displayable and its children.
 
-`style_group`
+.. screen-property:: style_group
+
     An alias for `style_prefix`, used in older versions of Ren'Py.
 
-`style_suffix`
+.. screen-property:: style_suffix
+
     Specifies the suffix that is combined with the `style_prefix` to
     generate a style name. If this is ``"small_button"`` and the
     style prefix is ``"pref"``, the style ``"pref_small_button"`` is
@@ -337,7 +353,8 @@ All user interface statements take the following common properties:
     the style. A style suffix applies to a single displayable only, not
     a displayable and all children.
 
-`focus`
+.. screen-property:: focus
+
     Takes a string or integer, and gives a name to the displayable
     for focus purposes. Ren'Py looks for structural similarity between
     focus names when deciding with displayable to give focus to at the
@@ -346,7 +363,8 @@ All user interface statements take the following common properties:
     the third button of a box with the same will be highlighted at
     the start of the next interaction.
 
-`tooltip`
+.. screen-property:: tooltip
+
     Assigns a tooltip to this displayable. When the displayable gains
     focus, the value of this property will be made available from the
     :func:`GetTooltip` function. See the :ref:`tooltips` section for
@@ -355,11 +373,13 @@ All user interface statements take the following common properties:
     Objects passed to tooltip must support equality. If equality is
     not supported, an infinite loop may occur.
 
-`arguments`
+.. screen-property:: arguments
+
     A tuple or list containing additional positional arguments that
     are given to the displayable.
 
-`properties`
+.. screen-property:: properties
+
     A dictionary containing additional properties given to the
     displayable.
 
@@ -382,28 +402,35 @@ Bar
 Creates a horizontally-oriented bar that can be used to view or adjust
 data. It takes the following properties:
 
-`value`
+.. screen-property:: value
+
     The current value of the bar. This can be either a :ref:`bar value <bar-values>`
     object, or a number.
 
-`range`
+.. screen-property:: range
+
     The maximum value of the bar. This is required if `value` is a
     number.
 
-`adjustment`
+.. screen-property:: adjustment
+
     A :func:`ui.adjustment` object that this bar adjusts.
 
-`changed`
+.. screen-property:: changed
+
     If given, this should be a Python function. The function is called
     with the value of the adjustment when the adjustment is changed.
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the bar gains focus.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the bar loses focus.
 
-`released`
+.. screen-property:: released
+
     An action to run when the bar button is released. This will be invoked
     even if the bar has not changed its value.
 
@@ -434,40 +461,48 @@ Button
 Creates an area of the screen that can be activated to run an
 action. A button takes no parameters, and the following properties.
 
-`action`
+.. screen-property:: action
+
     The action to run when the button is activated. A button is activated
     when it is clicked, or when the player selects it and hits enter on the
     keyboard. This also controls if the button is sensitive if `sensitive`
     is not provided or None, and if the button is selected if `selected` is not
     provided or None.
 
-`alternate`
+.. screen-property:: alternate
+
     An action that is run if the button is activated in an alternate manner.
     Alternate activation occurs when the player right-clicks on the button
     on a mouse-based platform, or when the player long presses the button
     on a touch-based platform.
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the button gains focus.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the button loses focus.
 
-`selected`
+.. screen-property:: selected
+
     An expression that determines whether the button is selected or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine selectedness.
 
-`sensitive`
+.. screen-property:: sensitive
+
     An expression that determines whether the button is sensitive or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine sensitivity.
 
-`keysym`
+.. screen-property:: keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the action of this button.
 
-`alternate_keysym`
+.. screen-property:: alternate_keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the alternate action of this button.
 
@@ -498,16 +533,19 @@ with a popup window.
 
 This takes the following properties:
 
-`action`
+.. screen-property:: action
+
     The action performed when the dismiss is activated. This property is
     required.
 
-`keysym`
+.. screen-property:: keysym
+
     A string giving a :doc:`keysym <keymap>` describing a key that,
     when pressed, invokes the action of this dismiss. This replaces the default
     "dismiss" keysym.
 
-`modal`
+.. screen-property:: modal
+
     By default, the dimiss is modal, preventing events from being processed
     by displayables "behind" it.
 
@@ -622,7 +660,8 @@ is not full, the remaining cells are filled with the ``null`` displayable.
 
 Grid takes one property:
 
-`transpose`
+.. screen-property:: transpose
+
     If False (the default), rows are filled before columns. If True,
     then columns are filled before rows.
 
@@ -679,7 +718,8 @@ Creates a button consisting of images, that change state when the user
 hovers over them. This takes no parameters, and the following
 properties:
 
-`auto`
+.. screen-property:: auto
+
     Used to automatically define the images used by this button. This
     should be a string that contains %s in it. If it is, and one of
     the image properties is omitted, %s is replaced with the name of
@@ -694,53 +734,66 @@ properties:
     :var:`config.imagemap_auto_function`.
 
 
-`insensitive`
+.. screen-property:: insensitive
+
     The image used when the button is insensitive.
 
-`idle`
+.. screen-property:: idle
+
     The image used when the button is not focused.
 
-`hover`
+.. screen-property:: hover
+
     The image used when the button is focused.
 
-`selected_idle`
+.. screen-property:: selected_idle
+
     The image used when the button is selected and idle.
 
-`selected_hover`
+.. screen-property:: selected_hover
+
     The image used when the button is selected and hovered.
 
-`action`
+.. screen-property:: action
+
     The action to run when the button is activated. This also controls if
     the button is sensitive if `sensitive` is not provided or None, and if the button
     is selected if `selected` is not provided or None.
 
-`alternate`
+.. screen-property:: alternate
+
     An action that is run if the button is activated in an alternate manner.
     Alternate activation occurs when the player right-clicks on the button
     on a mouse-based platform, or when the player long presses the button
     on a touch-based platform.
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the button gains focus.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the button loses focus.
 
-`selected`
+.. screen-property:: selected
+
     An expression that determines whether the button is selected or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine selectedness.
 
-`sensitive`
+.. screen-property:: sensitive
+
     An expression that determines whether the button is sensitive or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine sensitivity.
 
-`keysym`
+.. screen-property:: keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the action of this button.
 
-`alternate_keysym`
+.. screen-property:: alternate_keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the alternate action of this button.
 
@@ -778,7 +831,8 @@ the input displayable is limited to alphabetic characters.
 
 The input statement takes no parameters, and the following properties:
 
-`value`
+.. screen-property:: value
+
     An :ref:`input value <input-values>` object that this input uses.
     InputValue objects determine where the default value is taken from,
     what happens when the text is changed, what happens when enter is
@@ -786,47 +840,59 @@ The input statement takes no parameters, and the following properties:
 
     This should not be given at the same time as `default` and `changed`.
 
-`default`
+.. screen-property:: default
+
     The default text in this input.
 
-`length`
+.. screen-property:: length
+
     The maximum length of the text in this input.
 
-`pixel_width`
+.. screen-property:: pixel_width
+
     The maximum pixel width of the input. If typing a character would
     cause the input to exceed this width, the keypress is ignored.
 
-`allow`
+.. screen-property:: allow
+
     A string containing characters that are allowed to be typed into
     this input. (By default, allow all characters.)
 
-`exclude`
+.. screen-property:: exclude
+
     A string containing characters that are disallowed from being
     typed into this input. (By default, "{}".)
 
-`copypaste`
+.. screen-property:: copypaste
+
     If True, it becomes possible to copy and paste
     into this input. (By default, disabled.)
 
-`prefix`
+.. screen-property:: prefix
+
     An immutable string to prepend to what the user has typed.
 
-`suffix`
+.. screen-property:: suffix
+
     An immutable string to append to what the user has typed.
 
-`changed`
+.. screen-property:: changed
+
     A Python function that is called with what the user has typed,
     when the string changes.
 
-`mask`
+.. screen-property:: mask
+
     If given, a string that replaces each displayable character in
     the text. This can be used to mask out a password.
 
-`caret_blink`
+.. screen-property:: caret_blink
+
     If not False, the blinking period of the default caret.
     Overrides :var:`config.input_caret_blink`.
 
-`multiline`
+.. screen-property:: multiline
+
     If true, it becomes possible to move caret on the next line
     using keyboard (Shift+Enter by default,
     can be changed by modifying config.keymap['input_next_line']).
@@ -863,11 +929,13 @@ Key takes one positional parameter, a string giving the key to
 bind. See the :doc:`keymap` section for a description of available
 keysyms. It takes two properties:
 
-`action`
+.. screen-property:: action
+
     This gives an action that is run when the key is pressed. This
     property is mandatory.
 
-`capture`
+.. screen-property:: capture
+
     If true, the default, the event will capture, and will not be
     processed by other displayables. If false and the action does
     not end the interaction, the event will be procssed by other
@@ -895,12 +963,14 @@ frame.
 It takes one positional argument, the text of the label. It takes
 the property:
 
-`text_style`
+.. screen-property:: text_style
+
     The name of the style to use for the button text. If not supplied,
     and the `style` property is a string, then ``"_text"`` is appended
     to that string to give the default text style.
 
-`text_`-
+.. screen-property:: text_-
+
    Other properties prefixed with text_ have this prefix stripped, and
    are then passed to the text displayable.
 
@@ -934,13 +1004,16 @@ entering or leaving it. Unlike a button, a mouse area does not take
 focus, so it's possible to have a mouse area with buttons inside it.
 The ``mousearea`` statement takes no parameters, and the following properties:
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the mouse enters the mouse area.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the mouse leaves the mouse area.
 
-`focus_mask`
+.. screen-property:: focus_mask
+
     The :propref:`focus_mask` style property, which may be a Displayable
     or None. If a displayable, the mousearea will only be hovered if the
     mouse is over an opaque portion of the displayable. (The displayable
@@ -994,11 +1067,13 @@ pulldown menus.
 
 Nearrect takes the following properties:
 
-`rect`
+.. screen-property:: rect
+
     If given, this should be an (x, y, w, h) rectangle that the child is
     positioned relative to, as described below.
 
-`focus`
+.. screen-property:: focus
+
     If given, this should be a string. This string is passed to the equivalent of
     :func:`GetFocusRect` to find the rectangle. If a focus rectangle with that
     name is found, the child is rendered.
@@ -1006,7 +1081,8 @@ Nearrect takes the following properties:
     Passing "tooltip" to this uses the location of the last displayable that
     was focused while displaying a tooltip.
 
-`prefer_top`
+.. screen-property:: prefer_top
+
     If given, positioning the child above the focus rect is preferred.
 
 It also takes:
@@ -1101,10 +1177,12 @@ The null statement inserts an empty area on the screen. This can be
 used to space things out. The null statement takes no parameters, and
 the following properties:
 
-`width`
+.. screen-property:: width
+
     The width of the empty area, in pixels.
 
-`height`
+.. screen-property:: height
+
     The height of the empty area, in pixels.
 
 It also takes:
@@ -1139,7 +1217,8 @@ one of:
 
 A side takes the following properties:
 
-`spacing`
+.. screen-property:: spacing
+
     The spacing between the rows and columns of the grid.
 
 
@@ -1197,47 +1276,57 @@ Creates a button containing a text label. The button takes a single
 parameter, the text to include as part of the button. It takes the
 following properties:
 
-`action`
+.. screen-property:: action
+
     The action to run when the button is activated. This also controls if
     the button is sensitive if `sensitive` is not provided or None, and if the button
     is selected if `selected` is not provided or None.
 
-`alternate`
+.. screen-property:: alternate
+
     An action that is run if the button is activated in an alternate manner.
     Alternate activation occurs when the player right-clicks on the button
     on a mouse-based platform, or when the player long presses the button
     on a touch-based platform.
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the button gains focus.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the button loses focus.
 
-`selected`
+.. screen-property:: selected
+
     An expression that determines whether the button is selected or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine selectedness.
 
-`sensitive`
+.. screen-property:: sensitive
+
     An expression that determines whether the button is sensitive or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine sensitivity.
 
-`keysym`
+.. screen-property:: keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the action of this button.
 
-`alternate_keysym`
+.. screen-property:: alternate_keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the alternate action of this button.
 
-`text_style`
+.. screen-property:: text_style
+
     The name of the style to use for the button text. If not supplied,
     and the `style` property is a string, then ``"_text"`` is appended
     to that string to give the default text style.
 
-`text_`-
+.. screen-property:: text_-
+
     Other properties prefixed with text_ have this prefix stripped, and are
     then passed to the text displayable.
 
@@ -1267,14 +1356,17 @@ This creates a timer that runs an action when time runs out. It takes
 one positional parameter, giving the timeout time, in seconds. It
 takes the properties:
 
-`action`
+.. screen-property:: action
+
     This gives an action that is run when the timer expires. This
     property is mandatory.
 
-`repeat`
+.. screen-property:: repeat
+
     If True, the timer repeats after it times out.
 
-`modal`
+.. screen-property:: modal
+
     If True, the timer will not fire if it is blocked by a modal
     screen. If false or not given, the timer will fire even if it
     is blocked by a modal screen.
@@ -1357,13 +1449,15 @@ with the mouse wheel, or with scrollbars. It can be used to display
 part of something that is bigger than the screen. It takes the
 following properties:
 
-`child_size`
+.. screen-property:: child_size
+
     The size that is offered to the child for rendering. An (`xsize`,
     `ysize`) tuple. This can usually be omitted, when the child can
     compute it's own size. If either component is None, the child's
     size is used.
 
-`mousewheel`
+.. screen-property:: mousewheel
+
     This should be one of:
 
     False
@@ -1382,12 +1476,14 @@ following properties:
     "horizontal-change"
         Combines horizontal scrolling with change mode.
 
-`draggable`
+.. screen-property:: draggable
+
     If True, dragging the mouse will scroll the viewport. This can also be
     a :ref:`variant <screen-variants>`, in which case the viewport will be draggable
     if the variant is in place. (For example, ``draggable "touch"``.)
 
-`edgescroll`
+.. screen-property:: edgescroll
+
     Controlls scrolling when the mouse reaches the edge of the
     viewport. If not None, this should be a two- or three-element
     tuple:
@@ -1407,25 +1503,30 @@ following properties:
       that returned -1.0 or 1.0 based on the sign of its input would
       implement constant-speed scrolling.
 
-`xadjustment`
+.. screen-property:: xadjustment
+
     The :func:`ui.adjustment` used for the x-axis of the
     viewport. When omitted, a new adjustment is created.
 
-`yadjustment`
+.. screen-property:: yadjustment
+
     The :func:`ui.adjustment` used for the y-axis of the
     viewport. When omitted, a new adjustment is created.
 
-`xinitial`
+.. screen-property:: xinitial
+
     The initial horizontal offset of the viewport. This may be an integer
     giving the number of pixels, or a float giving a fraction of the
     possible offset.
 
-`yinitial`
+.. screen-property:: yinitial
+
     The initial vertical offset of the viewport. This may be an integer
     giving the number of pixels, or a float giving a fraction of the
     possible offset.
 
-`scrollbars`
+.. screen-property:: scrollbars
+
     If not None, scrollbars are added along with this viewport.
     This works by creating a side layout, and placing the created
     viewport in the center of the side. If `scrollbars` is "horizontal",
@@ -1445,13 +1546,15 @@ following properties:
     passed to the side, while other unprefixed properties are supplied to the
     viewport.
 
-`arrowkeys`
+.. screen-property:: arrowkeys
+
     If true, the viewport can be scrolled with the left, right, up, and down
     arrow keys. This takes precedence over the usual function of these keys,
     which is changing focus. However, the arrow keys will change focus when the
     viewport reaches its limits.
 
-`pagekeys`
+.. screen-property:: pagekeys
+
     If true, the viewport can be scrolled up and down by the pageup and
     pagedown keys. This disables the usual functionality of these keys,
     which is to cause rollback and rollforward.
@@ -1504,13 +1607,16 @@ size, spacing, and number of children. If a row or column would be underfull,
 
 Vpgrids take the the following properties:
 
-`cols`
+.. screen-property:: cols
+
     The number of columns in the grid.
 
-`rows`
+.. screen-property:: rows
+
     The number of rows in the grid.
 
-`transpose`
+.. screen-property:: transpose
+
     If true, columns are filled before rows. The default of this depends
     on the `cols` and `rows` properties. If `cols` is given, columns
     are filled before rows, otherwise rows are filled before columns.
@@ -1618,7 +1724,8 @@ Imagemap
 The imagemap statement is used to specify an imagemap. It takes no
 parameters, and the following properties:
 
-`auto`
+.. screen-property:: auto
+
     Used to automatically define the images used by this imagemap. This
     should be a string that contains %s in it. If it is, and one of
     the image properties is omitted, %s is replaced with the name of
@@ -1632,35 +1739,43 @@ parameters, and the following properties:
     The behavior of `auto` can be customized by changing
     :var:`config.imagemap_auto_function`.
 
-`ground`
+.. screen-property:: ground
+
     The image used for portions of the imagemap that are not part of a
     hotspot or hotbar.
 
-`insensitive`
+.. screen-property:: insensitive
+
     The image used when a hotspot or hotbar is insensitive.
 
-`idle`
+.. screen-property:: idle
+
     The image used when a hotspot is not selected and not focused, and
     for the empty portion of unfocused hotbars.
 
-`hover`
+.. screen-property:: hover
+
     The image used when a hotspot is not selected and focused, and
     for the empty portion of focused hotbars.
 
-`selected_idle`
+.. screen-property:: selected_idle
+
     The image used when a hotspot is selected and not focused, and
     for the full portion of unfocused hotbars.
 
-`selected_hover`
+.. screen-property:: selected_hover
+
     The image used when a hotspot is selected and focused, and
     for the full portion of focused hotbars.
 
-`alpha`
+.. screen-property:: alpha
+
     If true, the default, a hotspot only gains focus when the mouse is
     in an area of the hover image that is opaque. If false, the hotspot
     gains focus whenever the mouse is within its rectangular boundary.
 
-`cache`
+.. screen-property:: cache
+
     If true, the default, hotspot data is cached in to improve performance
     at the cost of some additional disk space.
 
@@ -1684,37 +1799,45 @@ contains it. It takes a single parameter, a (x, y, width, height)
 tuple giving the area of the imagemap that makes up the button. It
 also takes the following properties:
 
-`action`
+.. screen-property:: action
+
     The action to run when the button is activated. This also controls
     if the button is sensitive, and if the button is selected.
 
-`alternate`
+.. screen-property:: alternate
+
     An action that is run if the hotspot is activated in an alternate manner.
     Alternate activation occurs when the player right-clicks on the hotspot
     on a mouse-based platform, or when the player long presses the hotspot
     on a touch-based platform.
 
-`hovered`
+.. screen-property:: hovered
+
     An action to run when the button gains focus.
 
-`unhovered`
+.. screen-property:: unhovered
+
     An action to run when the button loses focus.
 
-`selected`
+.. screen-property:: selected
+
     An expression that determines whether the button is selected or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine selectedness.
 
-`sensitive`
+.. screen-property:: sensitive
+
     An expression that determines whether the button is sensitive or not.
     This expression is evaluated at least once per interaction.
     If not provided or None, the action will be used to determine sensitivity.
 
-`keysym`
+.. screen-property:: keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the action of this button.
 
-`alternate_keysym`
+.. screen-property:: alternate_keysym
+
     A string giving a :doc:`keysym <keymap>` describing a keyboard key that,
     when pressed, invokes the alternate action of this button.
 
@@ -1740,15 +1863,18 @@ contains it. It takes a single parameter, a (x, y, width, height)
 tuple giving the area of the imagemap that makes up the button. It
 also takes the following properties:
 
-`value`
+.. screen-property:: value
+
     The current value of the bar. This can be either a :ref:`bar value <input-values>`
     object, or a number.
 
-`range`
+.. screen-property:: range
+
     The maximum value of the bar. This is required if `value` is a
     number.
 
-`adjustment`
+.. screen-property:: adjustment
+
     A :func:`ui.adjustment` object that this bar adjusts.
 
 One of `value` or `adjustment` must be given. In addition, this
@@ -1811,28 +1937,34 @@ Areapicker
 Intended for use in development tools, this lets the user select a
 rectangular area on the screen. It takes the following properties:
 
-`cols`
+.. screen-property:: cols
+
     If not None, the defaut, this divides the screen up into a grid
     with this many columns.
 
-`rows`
+.. screen-property:: rows
+
     If not None, the defaut, this divides the screen up into a grid
     with this many rows.
 
-`position`
+.. screen-property:: position
+
     If not None, the default, this is a function called with the
     x and y coordinates of the location the user first clicked,
     rounded to the grid.
 
-`changed`
+.. screen-property:: changed
+
     This is called with the rectangle, an (x, y, width, height) tuple,
     whenever the user changes the selected area.
 
-`finished`
+.. screen-property:: finished
+
     This is called with the rectangle, an (x, y, width, height) tuple,
     when the user finishes selecting an area.
 
-`persist`
+.. screen-property:: persist
+
     If true, the child will be shown in the selected area when the
     selection is complete. If false, the default, the child will be
     hidden once the selection is complete.


### PR DESCRIPTION
![image](https://github.com/renpy/renpy/assets/44340603/95b869f4-df4f-465d-991b-db7e78633def)

(the new one is on the left)

The internal issue with this is the massive amount of duplicate screen (element/displayable) properties : "action", "unhovered", "keysym", "modal" and others which are shared between several displayables.
For comparison, style properties only have two pairs of duplicates : "mouse" and "spacing".

To mitigate that we could only linkify the first 8 properties, those applying directly to the screens and not the screen displayables, from "modal" to "roll_forward". Possibly add to those the 12 properties shared by all screen elements, from "at" to "properties".

The reason I didn't just reuse the style property directive is that they would end up in the style property index, and that some may imply they can be put in style definition blocks - and I think that doesn't work.

Fixes #4774