### PR TITLE
Allow control exceptions as pause roll forward

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1594,7 +1594,7 @@ def pause(delay=None, music=None, with_none=None, hard=False, predict=False, che
 
     roll_forward = renpy.exports.roll_forward_info()
 
-    if roll_forward not in [ True, False ]:
+    if type(roll_forward) not in (bool, renpy.game.CallException, renpy.game.JumpException):
         roll_forward = None
 
     if (delay is not None) and renpy.game.after_rollback and not renpy.config.pause_after_rollback:


### PR DESCRIPTION
Fixes #4807.

Despite correctly recording control exceptions in the rollback log, the `pause` statement wasn't permitting them to be used (it was clearing any roll-forward info that wasn't `True` or `False`. The fix is to allow `roll_forward` to be of type `bool` or one of the expected control exceptions (`CallException` and `JumpException`).