### PR TITLE
Update the list of operators in the lexer

### DIFF
--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -609,6 +609,8 @@ OPERATORS = [
     '/',
     '%',
     '~',
+    '@',
+    ':=',
     ]
 
 ESCAPED_OPERATORS = [


### PR DESCRIPTION
[Source](https://docs.python.org/3/reference/lexical_analysis.html#operators)
Yes, these two operators can't be used in PY2, but the first operator in the list, <>, can't be used at all either and it didn't cause any issue, so it doesn't appear that a conditional is needed.