### PR TITLE
Add pass, at transform and image to the layeredimage language

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -972,7 +972,14 @@ python early in layeredimage:
                 if parse_property(l, a, LAYER_PROPERTIES):
                     continue
 
-                image = l.simple_expression()
+                if l.keyword("image"):
+                    l.require(":")
+                    l.expect_eol()
+                    l.expect_block("ATL block")
+                    image = renpy.atl.parse_atl(l.subblock_lexer())
+                else:
+                    image = l.simple_expression()
+
                 if image is not None:
 
                     if a.image is not None:
@@ -986,7 +993,7 @@ python early in layeredimage:
 
         line(l)
 
-        if a.atl_transform:
+        if count_blocks(a):
             l.expect_eol()
             return
         if not l.match(':'):
@@ -999,6 +1006,8 @@ python early in layeredimage:
 
         ll = l.subblock_lexer()
 
+        blocks_found = 0
+
         while ll.advance():
             if ll.keyword("pass"):
                 ll.expect_eol()
@@ -1006,8 +1015,13 @@ python early in layeredimage:
                 continue
 
             line(ll)
+            newblocks = count_blocks(a)
+
             ll.expect_eol()
-            if not a.atl_transform:
+            if blocks_found < newblocks:
+                # the last line() contained a block
+                blocks_found = newblocks
+            else:
                 ll.expect_noblock('always')
 
         if a.image is None:

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -922,10 +922,10 @@ python early in layeredimage:
 
         if not l.match(':'):
             l.expect_eol()
-            l.expect_noblock('attribute')
+            l.expect_noblock('always')
             return
 
-        l.expect_block('attribute')
+        l.expect_block('always')
         l.expect_eol()
 
         ll = l.subblock_lexer()
@@ -938,7 +938,7 @@ python early in layeredimage:
 
             line(ll)
             ll.expect_eol()
-            ll.expect_noblock('attribute')
+            ll.expect_noblock('always')
 
         if a.image is None:
             l.error("The always statement must have a displayable.")

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -1083,7 +1083,7 @@ python early in layeredimage:
                 ll.expect_eol()
                 ll.advance()
 
-            if ll.keyword('attribute'):
+            elif ll.keyword('attribute'):
 
                 parse_attribute(ll, rv)
                 ll.advance()

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -883,7 +883,7 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            if not l.keyword("pass"):
+            if not ll.keyword("pass"):
                 line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')
@@ -927,7 +927,7 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            if not l.keyword("pass"):
+            if not ll.keyword("pass"):
                 line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -99,7 +99,7 @@ python early in layeredimage:
 
         def __init__(self, if_all=[ ], if_any=[ ], if_not=[ ], at=[ ], group_args={}, atl_transform=None, **kwargs):
 
-            self.at = renpy.easy.to_list(at)
+            self.at = renpy.easy.to_list(at, copy=True)
             if atl_transform is not None:
                 self.at.append(atl_transform)
             self.if_all = renpy.easy.to_list(if_all)
@@ -617,7 +617,7 @@ python early in layeredimage:
             for i in attributes:
                 self.add(i)
 
-            self.at = renpy.easy.to_list(at)
+            self.at = renpy.easy.to_list(at, copy=True)
             if atl_transform is not None:
                 self.at.append(atl_transform)
 

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -883,8 +883,12 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            if not ll.keyword("pass"):
-                line(ll)
+            if ll.keyword("pass"):
+                ll.expect_eol()
+                ll.expect_noblock("pass")
+                continue
+
+            line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')
 
@@ -927,8 +931,12 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            if not ll.keyword("pass"):
-                line(ll)
+            if ll.keyword("pass"):
+                ll.expect_eol()
+                ll.expect_noblock("pass")
+                continue
+
+            line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')
 

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -90,6 +90,18 @@ python early in layeredimage:
 
         return image
 
+    def resolve_image(img):
+        """
+        Takes whatever the parser sets as the image attribute of Raw classes,
+        and returns None or a displayable-able.
+        """
+        if img is None:
+            return None
+        elif isinstance(img, renpy.atl.RawBlock):
+            return ATLTransform(img)
+        else:
+            return eval(img)
+
     class Layer(object):
         """
         Base class for our layers.
@@ -254,11 +266,6 @@ python early in layeredimage:
             if group_properties is None:
                 group_properties = {}
 
-            if self.image:
-                image = eval(self.image)
-            else:
-                image = None
-
             properties = { k : v for k, v in group_properties.items() if k not in ATL_PROPERTIES_SET }
             group_args = { k : v for k, v in group_properties.items() if k in ATL_PROPERTIES_SET }
             properties.update({ k : eval(v) for k, v in self.properties.items() })
@@ -267,7 +274,7 @@ python early in layeredimage:
             if atl_transform:
                 atl_transform = ATLTransform(atl_transform)
 
-            return [ Attribute(group, self.name, image, group_args=group_args, atl_transform=atl_transform, **properties) ]
+            return [ Attribute(group, self.name, resolve_image(self.image), group_args=group_args, atl_transform=atl_transform, **properties) ]
 
 
     class RawAttributeGroup(object):
@@ -406,7 +413,7 @@ python early in layeredimage:
             if atl_transform:
                 atl_transform = ATLTransform(atl_transform)
 
-            return [ Condition(self.condition, eval(self.image), atl_transform=atl_transform, **properties) ]
+            return [ Condition(self.condition, resolve_image(self.image), atl_transform=atl_transform, **properties) ]
 
 
     class ConditionGroup(Layer):
@@ -518,18 +525,13 @@ python early in layeredimage:
 
         def execute(self):
 
-            if self.image:
-                image = eval(self.image)
-            else:
-                image = None
-
             properties = { k : eval(v) for k, v in self.properties.items() }
 
             atl_transform = self.atl_transform
             if atl_transform:
                 atl_transform = ATLTransform(atl_transform)
 
-            return [ Always(image, atl_transform=atl_transform, **properties) ]
+            return [ Always(resolve_image(self.image), atl_transform=atl_transform, **properties) ]
 
     class LayeredImage(object):
         """

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -1094,7 +1094,7 @@ python early in layeredimage:
 
         rv = RawCondition(condition)
 
-        got_atl_transform = False
+        blocks_found = 0
 
         while ll.advance():
 
@@ -1108,7 +1108,13 @@ python early in layeredimage:
                 if parse_property(ll, rv, LAYER_PROPERTIES):
                     continue
 
-                image = ll.simple_expression()
+                if ll.keyword("image"):
+                    ll.require(":")
+                    ll.expect_eol()
+                    ll.expect_block("ATL block")
+                    image = renpy.atl.parse_atl(ll.subblock_lexer())
+                else:
+                    image = ll.simple_expression()
 
                 if image is not None:
 
@@ -1120,8 +1126,10 @@ python early in layeredimage:
 
                 break
 
-            if (not got_atl_transform) and rv.atl_transform:
-                got_atl_transform = True
+            newblocks = count_blocks(rv)
+
+            if blocks_found < newblocks:
+                blocks_found = newblocks
             else:
                 ll.expect_noblock("condition properties")
             ll.expect_eol()

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -956,14 +956,17 @@ python early in layeredimage:
             ll = l.subblock_lexer()
 
             while ll.advance():
-                if not ll.keyword("pass"):
+                if ll.keyword("pass"):
+                    ll.expect_eol()
+                    ll.expect_noblock("pass")
+                    continue
 
-                    if ll.keyword("attribute"):
-                        parse_attribute(ll, rv)
-                        continue
+                if ll.keyword("attribute"):
+                    parse_attribute(ll, rv)
+                    continue
 
-                    while parse_property(ll, rv, [ "auto" ] + LAYER_PROPERTIES):
-                        pass
+                while parse_property(ll, rv, [ "auto" ] + LAYER_PROPERTIES):
+                    pass
 
                 ll.expect_eol()
                 ll.expect_noblock('group property')
@@ -992,24 +995,27 @@ python early in layeredimage:
 
         while ll.advance():
 
-            if not ll.keyword("pass"):
+            if ll.keyword("pass"):
+                ll.expect_eol()
+                ll.expect_noblock("pass")
+                continue
 
-                while True:
+            while True:
 
-                    if parse_property(ll, rv, LAYER_PROPERTIES):
-                        continue
+                if parse_property(ll, rv, LAYER_PROPERTIES):
+                    continue
 
-                    image = ll.simple_expression()
+                image = ll.simple_expression()
 
-                    if image is not None:
+                if image is not None:
 
-                        if rv.image is not None:
-                            ll.error('A condition can only have one displayable, two found.')
+                    if rv.image is not None:
+                        ll.error('A condition can only have one displayable, two found.')
 
-                        rv.image = image
-                        continue
+                    rv.image = image
+                    continue
 
-                    break
+                break
 
             ll.expect_noblock("condition properties")
             ll.expect_eol()

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -883,7 +883,8 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            line(ll)
+            if not l.keyword("pass"):
+                line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')
 
@@ -926,7 +927,8 @@ python early in layeredimage:
         ll = l.subblock_lexer()
 
         while ll.advance():
-            line(ll)
+            if not l.keyword("pass"):
+                line(ll)
             ll.expect_eol()
             ll.expect_noblock('attribute')
 
@@ -954,12 +956,14 @@ python early in layeredimage:
             ll = l.subblock_lexer()
 
             while ll.advance():
-                if ll.keyword("attribute"):
-                    parse_attribute(ll, rv)
-                    continue
+                if not ll.keyword("pass"):
 
-                while parse_property(ll, rv, [ "auto" ] + LAYER_PROPERTIES):
-                    pass
+                    if ll.keyword("attribute"):
+                        parse_attribute(ll, rv)
+                        continue
+
+                    while parse_property(ll, rv, [ "auto" ] + LAYER_PROPERTIES):
+                        pass
 
                 ll.expect_eol()
                 ll.expect_noblock('group property')
@@ -988,23 +992,24 @@ python early in layeredimage:
 
         while ll.advance():
 
+            if not ll.keyword("pass"):
 
-            while True:
+                while True:
 
-                if parse_property(ll, rv, LAYER_PROPERTIES):
-                    continue
+                    if parse_property(ll, rv, LAYER_PROPERTIES):
+                        continue
 
-                image = ll.simple_expression()
+                    image = ll.simple_expression()
 
-                if image is not None:
+                    if image is not None:
 
-                    if rv.image is not None:
-                        ll.error('A condition can only have one displayable, two found.')
+                        if rv.image is not None:
+                            ll.error('A condition can only have one displayable, two found.')
 
-                    rv.image = image
-                    continue
+                        rv.image = image
+                        continue
 
-                break
+                    break
 
             ll.expect_noblock("condition properties")
             ll.expect_eol()
@@ -1058,6 +1063,11 @@ python early in layeredimage:
         rv = RawLayeredImage(name)
 
         while not ll.eob:
+
+            if ll.keyword("pass"):
+                ll.expect_noblock("pass")
+                ll.expect_eol()
+                ll.advance()
 
             if ll.keyword('attribute'):
 


### PR DESCRIPTION
```rpy
layeredimage dummy:
    pass
    always image:
        "eileen happy"
        0.5
        "lucy concerned"
        0.5
        repeat
    always:
        image:
            "eileen happy"
            rotate 0
            linear 2.0 rotate 360.0
            repeat
```
I didn't showcase it just above but you can do the same with attribute, and with if/elif/else but only inside their blocks ; and you can do `at transform:` in all these places plus inside and inline groups, and inside layeredimages directly (meaning everywhere you could use the at clause).

I imagine a parser master could improve over my implementation, I fear it's getting a little spaghettified or at least intricate.

This PR contains #4812 for ease of use, but I'm keeping the other open in case this one's implem is not good enough.