### PR TITLE
Update layeredimage.predict_all to None

### DIFF
--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -15,7 +15,7 @@ python early in layeredimage:
     FIXED_PROPERTIES = renpy.sl2.slproperties.position_property_names + renpy.sl2.slproperties.box_property_names
 
     # This is the default value for predict_all given to conditions.
-    predict_all = False
+    predict_all = None
 
     def format_function(what, name, group, variant, attribute, image, image_format, **kwargs):
         """


### PR DESCRIPTION
It was always documented as None (I checked), which means deferring to config.predict_all (which itself is False by default), but its actual default value is False, which means not predicting even if config.predict_all says we should.

I don't think this deserves a compat, but that's arguable, maybe the safer solution would be to change the doc.