### PR TITLE
Better detect when the console should expect a new line before executing the block

### DIFF
--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -1,4 +1,4 @@
-﻿# console.rpy
+# console.rpy
 # Ren'Py console
 # Copyright (C) 2012-2017 Shiz, C, delta, PyTom
 #
@@ -593,7 +593,7 @@ init -1500 python in _console:
                     else:
                         break
 
-                if s.rstrip().endswith(":"):
+                if s.partition("#")[0].rstrip().endswith(":"):
                     rv += "    "
 
                 if not s.rstrip():

--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -612,7 +612,7 @@ init -1500 python in _console:
             self.lines.append(line)
 
             indent = get_indent(line)
-            if indent or line.startswith("@"):
+            if indent or line.startswith("@") or line.endswith("\\"):
                 self.lines.append(indent)
                 return
 
@@ -1109,7 +1109,7 @@ screen _console:
                 hbox:
                     spacing 4
 
-                    if (line[:1] != " ") and (last_line[:1] != "@"):
+                    if (line[:1] != " ") and (last_line[:1] != "@") and (last_line[-1:] != "\\"):
                         text "> " style "_console_prompt"
                     else:
                         text "... " style "_console_prompt"
@@ -1121,7 +1121,7 @@ screen _console:
             hbox:
                 spacing 4
 
-                if (default[:1] != " ") and (last_line[:1] != "@"):
+                if (default[:1] != " ") and (last_line[:1] != "@") and (last_line[-1:] != "\\"):
                     text "> " style "_console_prompt"
                 else:
                     text "... " style "_console_prompt"

--- a/renpy/common/00console.rpy
+++ b/renpy/common/00console.rpy
@@ -612,7 +612,7 @@ init -1500 python in _console:
             self.lines.append(line)
 
             indent = get_indent(line)
-            if indent:
+            if indent or line.startswith("@"):
                 self.lines.append(indent)
                 return
 
@@ -1103,21 +1103,25 @@ screen _console:
 
             has vbox
 
+            $ last_line = ""
+
             for line in lines:
                 hbox:
                     spacing 4
 
-                    if line[:1] != " ":
+                    if (line[:1] != " ") and (last_line[:1] != "@"):
                         text "> " style "_console_prompt"
                     else:
                         text "... " style "_console_prompt"
 
                     text "[line!q]" style "_console_input_text"
 
+                $ last_line = line
+
             hbox:
                 spacing 4
 
-                if default[:1] != " ":
+                if (default[:1] != " ") and (last_line[:1] != "@"):
                     text "> " style "_console_prompt"
                 else:
                     text "... " style "_console_prompt"


### PR DESCRIPTION
When starting a line with @, you're using a decorator so the line can't work just by itself, and it would if you let the user write a def or a class underneath.
Same when ending a line with `\` : it's expecting the python line to continue on the next text line.
A colon should start a block, even if it's followed by a comment (less likely to be an issue in practice).