### PR TITLE
`copy_properties` method for custom screen statements

### DIFF
--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -578,6 +578,10 @@ def register_sl_displayable(*args, **kwargs):
 
         These correspond to groups of :doc:`style_properties`. Group can
         also be "ui", in which case it adds the :ref:`common ui properties <common-properties>`.
+    
+    .. method:: :: copy_properties(name)
+
+        Adds all styles and positional/keyword arguments that can be passed to the `name` screen statement.
     """
 
     kwargs.setdefault("unique", False)

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -52,7 +52,8 @@ STYLE_PREFIXES = [
 parser = None
 
 # The names of all statements known to SL.
-statement_names = set()
+# a map of "parser_name": Parser
+statements = dict()
 
 # A list of statements that are valid anywhere a child can be placed.
 all_child_statements = [ ]
@@ -153,7 +154,7 @@ class Parser(object):
         self.keyword = { }
         self.children = { }
 
-        statement_names.add(name)
+        statements[name] = self
 
         # True if this parser takes "as".
         self.variable = False
@@ -277,7 +278,7 @@ class Parser(object):
             if name not in self.keyword:
                 if name == "continue" or name == "break":
                     l.error("The %s statement may only appear inside a for statement, or an if statement inside a for statement." % name)
-                elif name in statement_names:
+                elif name in statements:
                     l.error('The %s statement is not a valid child of the %s statement.' % (name, self.name))
                 else:
                     l.error('%r is not a keyword argument or valid child of the %s statement.' % (name, self.name))
@@ -445,6 +446,29 @@ class Parser(object):
                 Keyword(prefix + prop.name)
             else:
                 PrefixStyle(prefix, prop.name)
+
+        return self
+    
+    def copy_properties(self, name):
+        global parser
+        parser = self
+
+        parser_to_copy = statements.get(name, None)
+        if parser_to_copy is None:
+            raise Exception("{!r} is not a known screen statement".format(name))
+    
+        for p in parser_to_copy.positional:
+            Positional(p.name)
+        
+        for v in set(parser_to_copy.keyword.values()):
+            if isinstance(v, Keyword):
+                Keyword(v.name)
+
+            elif isinstance(v, Style):
+                Style(v.name)
+
+            elif isinstance(v, PrefixStyle):
+                PrefixStyle(v.prefix, v.name)
 
         return self
 

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -579,7 +579,7 @@ def register_sl_displayable(*args, **kwargs):
         These correspond to groups of :doc:`style_properties`. Group can
         also be "ui", in which case it adds the :ref:`common ui properties <common-properties>`.
     
-    .. method:: :: copy_properties(name)
+    .. method:: copy_properties(name)
 
         Adds all styles and positional/keyword arguments that can be passed to the `name` screen statement.
     """


### PR DESCRIPTION
_i'll take what i did for a project as a use case_

i created a custom vpgrid that does some alpha operation depending on how much a displayable is showing (if 60% of its surface is showing, set its alpha to 0.6).
then i created a custom screen displayable with `renpy.register_sl_displayable`:
```rpy
renpy.register_sl_displayable("gradient_alpha_vpgrid", GradientAlphaVPGrid, "vpgrid", "many", replaces=True) \
    .add_property("rows") \
    .add_property("cols") \
    .add_property("allow_underfull") \
    .add_property("child_size") \
    .add_property("mousewheel") \
    .add_property("arrowkeys") \
    .add_property("pagekeys") \
    .add_property("draggable") \
    .add_property("edgescroll") \
    .add_property("xadjustment") \
    .add_property("yadjustment") \
    .add_property("initial") \
    .add_property("yinitial") \
    .add_property("scrollbars") \
    .add_property("spacing") \
    .add_property("transpose") \
    .add_style_property("spacing") \
    .add_style_property("xminimum") \
    .add_style_property("yminimum") \
    .add_prefix_style_property("side_", "spacing")
```

- first of all, if you don't know **every** style / property, you won't be able to add them all.
- second of all, you can't replicate those lines:
![image](https://github.com/renpy/renpy/assets/101005497/f7ca844b-7d39-4cc4-9700-c96dbda4f704)
- thridly, if something else is added in a new renpy version, it won't necessarily be added here

with this pr, everything can be condensed down to one single line:
```rpy
renpy.register_sl_displayable("gradient_alpha_vpgrid", GradientAlphaVPGrid, "vpgrid", "many", replaces=True).copy_properties("vpgrid")
``` 
