### PR TITLE
Fix absolute.slots to __slots__

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -211,7 +211,7 @@ class absolute(float):
     This represents an absolute float coordinate.
     """
 
-    slots = ()
+    __slots__ = ()
 
     def __repr__(self):
         return "absolute({})".format(float.__repr__(self))


### PR DESCRIPTION
My rewrite of the change propagated the error into the fix branch, when it was originally contained in master.
I tested a save-load cycle on an instance of absolute before and after this very fix, it passed without problem. But if someone added arbitrary attributes on an absolute instance, that will now fail.