### PR TITLE
Absolute compute

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -698,10 +698,8 @@ init -1500 python:
                 amount = delta * adjustment.step
             elif self.amount == "page":
                 amount = delta * adjustment.page
-            elif type(self.amount) is float:
-                amount = delta * self.amount * adjustment.range
             else:
-                amount = delta * self.amount
+                amount = absolute.compute_raw(delta*self.amount, adjustment.range)
 
             if self.delay == 0.0:
                 adjustment.change(adjustment.value + amount)

--- a/renpy/common/00splines.rpy
+++ b/renpy/common/00splines.rpy
@@ -24,8 +24,6 @@ init -1500 python:
             self.points = []
 
             for p in points:
-                length = len(p)
-
                 if isinstance(p[-1], float):
                     length = len(p) - 1
                     point = [ p[-1] ]
@@ -62,11 +60,7 @@ init -1500 python:
             self.initialized = None
 
         def init_values(self, sizes):
-            def to_abs_(value, size):
-                if type(value) is float:
-                    return value * size
-                else:
-                    return value
+            to_abs_ = absolute.compute_raw
 
             def coord_(c):
 

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -392,13 +392,13 @@ cdef class RenderTransform:
         ysize = state.ysize
 
         if xsize is not None:
-            if (type(xsize) is float) and renpy.config.relative_transform_size:
-                xsize *= self.widtho
+            if renpy.config.relative_transform_size:
+                xsize = absolute.compute_raw(xsize, self.widtho)
             self.widtho = xsize
 
         if ysize is not None:
-            if (type(ysize) is float) and renpy.config.relative_transform_size:
-                ysize *= self.heighto
+            if renpy.config.relative_transform_size:
+                ysize = absolute.compute_raw(ysize, self.heighto)
             self.heighto = ysize
 
         self.cr = render(child, self.widtho, self.heighto, st - self.transform.child_st_base, at)
@@ -753,12 +753,7 @@ cdef class RenderTransform:
                 manchory = height / 2.0
 
             else:
-                manchorx, manchory = state.matrixanchor
-
-                if type(manchorx) is float:
-                    manchorx *= width
-                if type(manchory) is float:
-                    manchory *= height
+                manchorx, manchory = map(absolute.compute_raw, state.matrixanchor, (width, height))
 
             m = Matrix.offset(-manchorx, -manchory, 0.0)
 
@@ -833,12 +828,7 @@ cdef class RenderTransform:
                 manchory = self.height / 2.0
 
             else:
-                manchorx, manchory = state.matrixanchor
-
-                if type(manchorx) is float:
-                    manchorx *= self.width
-                if type(manchory) is float:
-                    manchory *= self.height
+                manchorx, manchory = map(absolute.compute_raw, state.matrixanchor, (self.width, self.height))
 
             m = Matrix.offset(-manchorx, -manchory, 0.0)
             m = mt * m

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -210,7 +210,7 @@ class absolute(float):
     This represents an absolute float coordinate.
     """
 
-    slots = ()
+    __slots__ = ()
 
     def __repr__(self):
         return "absolute({})".format(float.__repr__(self))
@@ -220,6 +220,25 @@ class absolute(float):
 
     def __rdivmod__(self, value):
         return value//self, value%self
+
+    @staticmethod
+    def compute_raw(value, room):
+        """
+        Converts a position from one of the many supported position types
+        into an absolute number of pixels, without regard for the return type.
+        """
+        if isinstance(value, (absolute, int)):
+            return value
+        elif isinstance(value, float):
+            return value * room
+        raise TypeError("Value {} of type {} not recognized as a position.".format(value, type(value)))
+
+    @staticmethod
+    def compute(value, room):
+        """
+        Does the same, but converts the result to the absolute type.
+        """
+        return absolute(absolute.compute_raw(value, room))
 
 for fn in (
     '__coerce__', # PY2

--- a/renpy/display/displayable.py
+++ b/renpy/display/displayable.py
@@ -34,7 +34,7 @@ def place(width, height, sw, sh, placement):
         The width and height of the area the image will be
         placed in.
 
-    `size`
+    `sw`, `sh`
         The size of the image to be placed.
 
     `placement`
@@ -42,6 +42,8 @@ def place(width, height, sw, sh, placement):
     """
 
     xpos, ypos, xanchor, yanchor, xoffset, yoffset, _subpixel = placement
+
+    compute_raw = renpy.display.core.absolute.compute_raw
 
     if xpos is None:
         xpos = 0
@@ -56,20 +58,15 @@ def place(width, height, sw, sh, placement):
     if yoffset is None:
         yoffset = 0
 
-    # We need to use type, since isinstance(absolute(0), float).
-    if xpos.__class__ is float:
-        xpos *= width
+    xpos = compute_raw(xpos, width)
 
-    if xanchor.__class__ is float:
-        xanchor *= sw
+    xanchor = compute_raw(xanchor, sw)
 
     x = xpos + xoffset - xanchor
 
-    if ypos.__class__ is float:
-        ypos *= height
+    ypos = compute_raw(ypos, height)
 
-    if yanchor.__class__ is float:
-        yanchor *= sh
+    yanchor = compute_raw(yanchor, sh)
 
     y = ypos + yoffset - yanchor
 

--- a/renpy/display/dragdrop.py
+++ b/renpy/display/dragdrop.py
@@ -424,11 +424,11 @@ class Drag(renpy.display.displayable.Displayable, renpy.revertable.RevertableObj
         linear move.
         """
 
-        if (type(x) is float) and self.parent_width is not None:
-            x = int(x * self.parent_width)
+        if self.parent_width is not None:
+            x = int(absolute.compute_raw(x, self.parent_width))
 
-        if (type(y) is float) and self.parent_height is not None:
-            y = int(y * self.parent_height)
+        if self.parent_height is not None:
+            y = int(absolute.compute_raw(y, self.parent_height))
 
         self.target_x = x
         self.target_y = y
@@ -609,18 +609,10 @@ class Drag(renpy.display.displayable.Displayable, renpy.revertable.RevertableObj
         if self.draggable or self.clicked is not None:
 
             fx, fy, fw, fh = self.drag_handle
-
-            if type(fx) is float:
-                fx = int(fx * cw)
-
-            if type(fy) is float:
-                fy = int(fy * ch)
-
-            if type(fw) is float:
-                fw = int(fw * cw)
-
-            if type(fh) is float:
-                fh = int(fh * ch)
+            fx = int(absolute.compute_raw(fx, cw))
+            fy = int(absolute.compute_raw(fy, ch))
+            fw = int(absolute.compute_raw(fw, cw))
+            fh = int(absolute.compute_raw(fh, ch))
 
             mask = self.style.focus_mask
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -31,16 +31,7 @@ import renpy
 from renpy.display.render import render, Render
 
 
-def scale(num, base):
-    """
-    If num is a float, multiplies it by base and returns that. Otherwise,
-    returns num unchanged.
-    """
-
-    if type(num) is float:
-        return num * base
-    else:
-        return num
+compute_raw = renpy.display.core.absolute.compute_raw
 
 
 def xyminimums(style, width, height):
@@ -58,7 +49,7 @@ def xyminimums(style, width, height):
         if (type(xmaximum) is float) and xmaximum and renpy.config.adjust_minimums:
             xminimum = xminimum / xmaximum
 
-        xminimum = xminimum * width
+    xminimum = compute_raw(xminimum, width)
 
     if type(yminimum) is float:
         ymaximum = style.ymaximum
@@ -66,7 +57,7 @@ def xyminimums(style, width, height):
         if (type(ymaximum) is float) and ymaximum and renpy.config.adjust_minimums:
             yminimum = yminimum / ymaximum
 
-        yminimum = yminimum * height
+    yminimum = compute_raw(yminimum, height)
 
     return xminimum, yminimum
 
@@ -467,13 +458,13 @@ class Grid(Container):
             yspacing = self.style.spacing
 
         if renpy.config.relative_spacing:
-            xspacing = renpy.display.layout.scale(xspacing, width)
-            yspacing = renpy.display.layout.scale(yspacing, height)
+            xspacing = compute_raw(xspacing, width)
+            yspacing = compute_raw(yspacing, height)
 
-        left_margin = scale(self.style.left_margin, width)
-        right_margin = scale(self.style.right_margin, width)
-        top_margin = scale(self.style.top_margin, height)
-        bottom_margin = scale(self.style.bottom_margin, height)
+        left_margin = compute_raw(self.style.left_margin, width)
+        right_margin = compute_raw(self.style.right_margin, width)
+        top_margin = compute_raw(self.style.top_margin, height)
+        bottom_margin = compute_raw(self.style.bottom_margin, height)
 
         # For convenience and speed.
         cols = self.cols
@@ -815,11 +806,11 @@ class MultiBox(Container):
 
         minx = self.style.xminimum
         if minx is not None:
-            width = max(width, scale(minx, width))
+            width = max(width, compute_raw(minx, width))
 
         miny = self.style.yminimum
         if miny is not None:
-            height = max(height, scale(miny, height))
+            height = max(height, compute_raw(miny, height))
 
         if self.first and adjust_times:
             self.update_times()
@@ -1302,17 +1293,17 @@ class Window(Container):
         width = max(xminimum, width)
         height = max(yminimum, height)
 
-        left_margin = scale(style.left_margin, width)
-        left_padding = scale(style.left_padding, width)
+        left_margin = compute_raw(style.left_margin, width)
+        left_padding = compute_raw(style.left_padding, width)
 
-        right_margin = scale(style.right_margin, width)
-        right_padding = scale(style.right_padding, width)
+        right_margin = compute_raw(style.right_margin, width)
+        right_padding = compute_raw(style.right_padding, width)
 
-        top_margin = scale(style.top_margin, height)
-        top_padding = scale(style.top_padding, height)
+        top_margin = compute_raw(style.top_margin, height)
+        top_padding = compute_raw(style.top_padding, height)
 
-        bottom_margin = scale(style.bottom_margin, height)
-        bottom_padding = scale(style.bottom_padding, height)
+        bottom_margin = compute_raw(style.bottom_margin, height)
+        bottom_padding = compute_raw(style.bottom_padding, height)
 
         # c for combined.
         cxmargin = left_margin + right_margin
@@ -2390,11 +2381,8 @@ class NearRect(Container):
             layout_y = py - ch
 
         # Initial x positioning - using a variant of the layout algorithm.
-        if isinstance(xpos, float):
-            xpos = xpos * pw
-
-        if isinstance(xanchor, float):
-            xanchor = xanchor * cw
+        xpos = compute_raw(xpos, pw)
+        xanchor = compute_raw(xanchor, cw)
 
         layout_x = px + xpos - xanchor
 

--- a/renpy/display/motion.py
+++ b/renpy/display/motion.py
@@ -319,6 +319,7 @@ class Revolver(object):
         self.child = child
 
     def __call__(self, t, rect):
+        absolute = renpy.display.core.absolute
 
         (w, h, cw, ch) = rect
 
@@ -328,10 +329,7 @@ class Revolver(object):
             if x is None:
                 x = 0
 
-            if type(x) is float:
-                return int(x * r)
-            else:
-                return x
+            return absolute.compute_raw(x, r)
 
         if self.pos is None:
             pos = self.child.get_placement()
@@ -370,7 +368,7 @@ class Revolver(object):
         nx = nx - xcor + xaround
         ny = ny - ycor + yaround
 
-        return (renpy.display.core.absolute(nx), renpy.display.core.absolute(ny), 0, 0)
+        return (absolute(nx), absolute(ny), 0, 0)
 
 
 def Revolve(start, end, time, child, around=(0.5, 0.5), cor=(0.5, 0.5), pos=None, **properties):

--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -227,16 +227,10 @@ cpdef render(d, object widtho, object heighto, double st, double at):
         width, height = d._offer_size
 
     if xmaximum is not None:
-        if type(xmaximum) is float:
-            width = min(width * xmaximum, width)
-        else:
-            width = min(xmaximum, width)
+        width = min(renpy.display.core.absolute.compute_raw(xmaximum, width), width)
 
     if ymaximum is not None:
-        if type(ymaximum) is float:
-            height = min(height * ymaximum, height)
-        else:
-            height = min(ymaximum, height)
+        height = min(renpy.display.core.absolute.compute_raw(ymaximum, height), height)
 
     if width < 0:
         width = 0

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -222,16 +222,14 @@ class TransformState(renpy.object.Object):
 
     yalign = property(get_yalign, set_yalign)
 
-    def scale(self, value, available):
+    @staticmethod
+    def scale(value, available):
         """
         Converts value to a float, scaled by the available area, if
         required.
         """
 
-        if type(value) is float:
-            return value * available
-
-        return 1.0 * value
+        return float(absolute.compute_raw(value, available))
 
     def cartesian_to_polar_pos(self, x, y):
         """
@@ -371,8 +369,7 @@ class TransformState(renpy.object.Object):
     def set_radius(self, radius):
         self.radius_type = type(radius)
 
-        if type(radius) is float:
-            radius = self.scale(radius, min(self.available_width, self.available_height))
+        radius = self.scale(radius, min(self.available_width, self.available_height))
 
         xpos = first_not_none(self.xpos, self.inherited_xpos, 0)
         ypos = first_not_none(self.ypos, self.inherited_ypos, 0)
@@ -1027,10 +1024,8 @@ class Transform(Container):
                 cw, ch = self.child_size
                 rw, rh = self.render_size
 
-                if xanchor.__class__ is float:
-                    xanchor *= cw
-                if yanchor.__class__ is float:
-                    yanchor *= ch
+                xanchor = absolute.compute_raw(xanchor, cw)
+                yanchor = absolute.compute_raw(yanchor, ch)
 
                 xanchor -= cw / 2.0
                 yanchor -= ch / 2.0
@@ -1040,8 +1035,8 @@ class Transform(Container):
                 xanchor += rw / 2.0
                 yanchor += rh / 2.0
 
-                xanchor = renpy.display.core.absolute(xanchor)
-                yanchor = renpy.display.core.absolute(yanchor)
+                xanchor = absolute(xanchor)
+                yanchor = absolute(yanchor)
 
                 rv = (xpos, ypos, xanchor, yanchor, xoffset, yoffset, subpixel)
 

--- a/renpy/gl2/live2d.py
+++ b/renpy/gl2/live2d.py
@@ -28,6 +28,7 @@ from typing import Any
 import renpy
 import renpy.gl2.live2dmotion
 from renpy.gl2.gl2shadercache import register_shader
+from renpy.display.core import absolute
 
 try:
     import renpy.gl2.live2dmodel as live2dmodel
@@ -941,15 +942,9 @@ class Live2D(renpy.display.displayable.Displayable):
 
         zoom = self.zoom
 
-        def s(n):
-            if type(n) is float:
-                return n * sh
-            else:
-                return n
-
         if zoom is None:
-            top = s(self.top)
-            base = s(self.base)
+            top = absolute.compute_raw(self.top, sh)
+            base = absolute.compute_raw(self.base, sh)
 
             size = max(base - top, 1.0)
 


### PR DESCRIPTION
Second part of segmenting #3214 into subtasks.
This time, adds the `absolute.compute_raw` function and the `absolute.compute` counterpart, which assembles all these similar computations in one place, which avoids the need for future #4709s in the future should we ever add position types or change their behavior (wink wink).