### PR TITLE
Class decorator version of renpy.register_statement

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -102,7 +102,7 @@ from renpy.character import show_display_say, predict_show_display_say, display_
 import renpy.audio.sound as sound
 import renpy.audio.music as music
 
-from renpy.statements import register as register_statement
+from renpy.statements import register as register_statement, register_decorator
 from renpy.text.extras import check_text_tags
 
 from renpy.memory import profile_memory, diff_memory, profile_rollback

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -309,6 +309,60 @@ def register(
 
     parsers.add(name, parse_data)
 
+# import inspect # only works in py3
+# register_params = frozenset(inspect.signature(renpy.register_statement).parameters) - {"name", "parse", "execute"}
+register_params = frozenset((
+    # "name", # special-cased
+    # "parse", # special-cased
+    "lint",
+    # "execute", # special-cased
+    "predict",
+    "next",
+    "scry",
+    "block",
+    "init",
+    "translatable",
+    "execute_init",
+    "init_priority",
+    "label",
+    "warp",
+    "translation_strings",
+    "force_begin_rollback",
+    "post_execute",
+    "post_label",
+    "predict_all",
+    "predict_next",
+    "execute_default",
+    "reachable",
+))
+def register_decorator(cls):
+    """
+    (documented in sphinx)
+
+    A class decorator which registers a new Creator-defined statement.
+
+    The "parse" parameter of renpy.register_statement should be either the
+    class constructor itself or a method named "parse" (likely a classmethod
+    or a staticmethod) returning an instance of the class. The name of the
+    statement will be the class name unless a "name" class attribute is
+    present, which should be a string. Instead of the "execute" parameter,
+    Ren'Py will look for a method named "execute", or in its absence, the
+    class's `__call__` method to call the object like a function.
+
+    All other parameters to the register_statement function can be set as
+    class attributes or functions with the same name.
+    """
+    name = getattr(cls, "name", cls.__name__)
+    parse = getattr(cls, "parse", cls)
+    execute = getattr(cls, "execute", None) or cls.__call__
+    register(
+        name,
+        parse=parse,
+        execute=execute,
+        **{k:getattr(cls, k) for k in register_params.intersection(vars(cls))}
+    )
+    return cls
+
 
 def parse(node, line, subblock):
     """

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -310,7 +310,7 @@ def register(
     parsers.add(name, parse_data)
 
 # import inspect # only works in py3
-# register_params = frozenset(inspect.signature(renpy.register_statement).parameters) - {"name", "parse", "execute"}
+# register_params = frozenset(inspect.signature(register).parameters) - {"name", "parse", "execute"}
 register_params = frozenset((
     # "name", # special-cased
     # "parse", # special-cased
@@ -337,20 +337,25 @@ register_params = frozenset((
 ))
 def register_decorator(cls):
     """
-    (documented in sphinx)
+    :doc: statement_register decorator
+    :args:
 
-    A class decorator which registers a new Creator-defined statement.
+    A class decorator which registers a new statement.
 
-    The "parse" parameter of renpy.register_statement should be either the
-    class constructor itself or a method named "parse" (likely a classmethod
-    or a staticmethod) returning an instance of the class. The name of the
-    statement will be the class name unless a "name" class attribute is
-    present, which should be a string. Instead of the "execute" parameter,
-    Ren'Py will look for a method named "execute", or in its absence, the
-    class's `__call__` method to call the object like a function.
+    The name of the statement will be the class name unless a ``name``
+    class attribute is present, which should be a string.
 
-    All other parameters to the register_statement function can be set as
-    class attributes or functions with the same name.
+    The `parse` parameter to :func:`renpy.register_statement` should
+    either be the class constructor itself, or a method named ``parse``
+    (likely a class method or static method) returning an instance of
+    the class.
+
+    For the `execute` parameter, Ren'Py will look for a method named
+    ``execute`` on the class, or if it is not found, will use the class's
+    ``__call__`` method to call like a function the object created by `parse`.
+
+    All other parameters to :func:`renpy.register_statement` should be set as
+    class attributes or methods with the same name.
     """
     name = getattr(cls, "name", cls.__name__)
     parse = getattr(cls, "parse", cls)

--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -140,25 +140,6 @@ API Reference
 
 .. include:: inc/statement_register
 
-.. decorator:: renpy.register_decorator
-
-    A class decorator which registers a new statement.
-
-    The name of the statement will be the class name unless a ``name``
-    class attribute is present, which should be a string.
-
-    The `parse` parameter to :func:`renpy.register_statement` should
-    either be the class constructor itself, or a method named ``parse``
-    (likely a class method or static method) returning an instance of
-    the class.
-
-    For the `execute` parameter, Ren'Py will look for a method named
-    ``execute`` on the class, or if it is not found, will use the class's
-    ``__call__`` method to call like a function the object created by `parse`.
-
-    All other parameters to :func:`renpy.register_statement` should be set as
-    class attributes or methods with the same name.
-
 
 Lexer object
 ~~~~~~~~~~~~

--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -144,17 +144,17 @@ API Reference
 
     A class decorator which registers a new statement.
 
-    The name of the statement will be the class name unless a `name`
+    The name of the statement will be the class name unless a ``name``
     class attribute is present, which should be a string.
 
     The `parse` parameter to :func:`renpy.register_statement` should
-    either be the class constructor itself, or a method named "parse"
+    either be the class constructor itself, or a method named ``parse``
     (likely a class method or static method) returning an instance of
     the class.
 
     For the `execute` parameter, Ren'Py will look for a method named
-    "execute" on the class, or if it is not found, will use the class's
-    ``__call__`` method to call the object created by `parse` like a function.
+    ``execute`` on the class, or if it is not found, will use the class's
+    ``__call__`` method to call like a function the object created by `parse`.
 
     All other parameters to :func:`renpy.register_statement` should be set as
     class attributes or methods with the same name.

--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -140,6 +140,25 @@ API Reference
 
 .. include:: inc/statement_register
 
+.. decorator:: renpy.register_decorator
+
+    A class decorator which registers a new statement.
+
+    The name of the statement will be the class name unless a `name`
+    class attribute is present, which should be a string.
+
+    The `parse` parameter to :func:`renpy.register_statement` should
+    either be the class constructor itself, or a method named "parse"
+    (likely a class method or static method) returning an instance of
+    the class.
+
+    For the `execute` parameter, Ren'Py will look for a method named
+    "execute" on the class, or if it is not found, will use the class's
+    ``__call__`` method to call the object created by `parse` like a function.
+
+    All other parameters to :func:`renpy.register_statement` should be set as
+    class attributes or methods with the same name.
+
 
 Lexer object
 ~~~~~~~~~~~~


### PR DESCRIPTION
There is some code duplication as it comes to the accepted parameters to register_statement, because the inspect module does that in py3 only. I suggest using it as soon as we pass to py3-only (the code has been left commented-out), or to wait until then for merging this.

The doc entry looks like this
![image](https://github.com/renpy/renpy/assets/44340603/995f0a86-7a2a-4169-ae43-f398bdeaf232)
