### PR TITLE
Enable the _layer parameter for the menu statement and add config.nvl_choice_layer

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -552,6 +552,9 @@ say_layer = "screens"
 # The layer the choice screen is shown on.
 choice_layer = "screens"
 
+# The layer the choice screen is shown on, when passed (nvl=True).
+nvl_choice_layer = "screens"
+
 # If true, we will not use the .report_traceback method to produced
 # prettier tracebacks.
 raw_tracebacks = ("RENPY_RAW_TRACEBACKS" in os.environ)

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1304,12 +1304,19 @@ def display_menu(items,
 
             item_actions.append(me)
 
+        if "_layer" in scope:
+            layer = scope.pop("_layer")
+        elif type == "nvl":
+            layer = renpy.config.nvl_choice_layer
+        else:
+            layer = renpy.config.choice_layer
+
         show_screen(
             screen,
             items=item_actions,
             _widget_properties=props,
             _transient=True,
-            _layer=renpy.config.choice_layer,
+            _layer=layer,
             *menu_args,
             **scope)
 


### PR DESCRIPTION
There is a config.nvl_layer for the nvl dialogue and a config.choice but no config for the nvl choice, that's unfair. Also, passing _layer to the menu as a menu parameter is now allowed, the display_menu function politely gives way and uses the config(s) as a default.

The _layer parameter is documented for show_screen, so I think it's acceptable to document it for [menu arguments](https://www.renpy.org/doc/html/menus.html#menu-arguments) too. I didn't do the documentation pass, I think it should be documented as "Menu arguments passed to the menu itself become arguments to the renpy.show_screen function which passes them to the screen" and the rest of the sentence unchanged.
I'll document when the purpose is accepted.
This has been requested by a creator.