### PR TITLE
Disable confirm-on-confirm when quitting

### DIFF
--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -213,6 +213,7 @@ init -1500 python:
             self.confirm = confirm
 
         def __call__(self):
+            global _confirm_quit
 
             confirm = self.confirm
 
@@ -223,7 +224,8 @@ init -1500 python:
                 if config.autosave_on_quit:
                     renpy.force_autosave()
 
-                layout.yesno_screen(layout.QUIT, Quit(False))
+                layout.yesno_screen(layout.QUIT, Quit(False), SetVariable("_confirm_quit", _confirm_quit))
+                _confirm_quit = False
 
             else:
                 renpy.quit(save=True)


### PR DESCRIPTION
I wanted to do a try/finally, which would be much more safe, but layout.yesno_screen returns immediately, before the click actually happens.

So, either we make a version of yesno_screen which waits for a click before returning - which is also the purpose of #4583 please do this it's over my head - or we do it that way and leak `_confirm_quit` to False if the player leaves the confirm quit without clicking "No". I didn't find any way to do it (opening the console and right-clicking/escape are safe) but I can't confirm for sure.