### PR TITLE
NVL flexibility

### DIFF
--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -118,9 +118,9 @@ init -1500 python:
 
     def __nvl_screen_dialogue():
         """
-         Returns widget_properties and dialogue for the current NVL
-         mode screen.
-         """
+        Returns widget_properties and dialogue for the current NVL
+        mode screen.
+        """
 
         dialogue = [ ]
         kwargs = { }
@@ -189,8 +189,8 @@ init -1500 python:
 
     def __nvl_show_screen(screen_name, **scope):
         """
-         Shows an nvl-mode screen. Returns the "what" widget.
-         """
+        Shows an nvl-mode screen. Returns the "what" widget.
+        """
 
         widget_properties, dialogue, show_args = __nvl_screen_dialogue()
         scope.update(show_args)
@@ -202,7 +202,7 @@ init -1500 python:
 
     def nvl_show_core(who=None, what=None, multiple=None):
 
-         # Screen version.
+        # Screen version.
         if renpy.has_screen("nvl"):
             return __nvl_show_screen("nvl", items=[ ])
 
@@ -381,12 +381,56 @@ init -1500 python:
             renpy.display_say(
                 who,
                 what,
-                nvl_show_core,
+                self.do_show,
                 checkpoint=checkpoint,
                 multiple=multiple,
                 **display_args)
 
             self.pop_nvl_list()
+
+        def do_show(self, who, what, multiple=None, extra_properties=None, retain=None):
+            screen, show_args, who_args, what_args, window_args, properties = self.get_show_properties(extra_properties)
+
+            show_args = dict(show_args)
+
+            if multiple is not None:
+                show_args["multiple"] = multiple
+
+            if retain:
+                show_args["retain"] = retain
+
+            # Screen version.
+            if screen and renpy.has_screen(screen):
+                return __nvl_show_screen(screen, items=[ ])
+            elif renpy.has_screen("nvl"):
+                return __nvl_show_screen("nvl", items=[ ])
+
+            if renpy.in_rollback():
+                nvl_window = __s(style.nvl_window)['rollback']
+                nvl_vbox = __s(style.nvl_vbox)['rollback']
+            else:
+                nvl_window = __s(style.nvl_window)
+                nvl_vbox = __s(style.nvl_vbox)
+
+            ui.window(style=nvl_window)
+            ui.vbox(style=nvl_vbox)
+
+            rv = None
+
+            for i in nvl_list:
+                if not i:
+                    continue
+
+                who, what, kw = i
+                kw = dict(kw)
+                kw.setdefault("show_say_vbox_properties",  { 'box_layout' : 'horizontal' }),
+                rv = config.nvl_show_display_say(who, what, variant=nvl_variant, **kw)
+
+            ui.close()
+
+            renpy.shown_window()
+
+            return rv
 
         def do_done(self, who, what, multiple=None):
 

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1023,10 +1023,10 @@ def menu(items, set_expr, args=None, kwargs=None, item_arguments=None):
     args = args or ()
     kwargs = kwargs or {}
 
-    nvl = kwargs.pop("nvl", False)
-
     if renpy.config.menu_arguments_callback is not None:
         args, kwargs = renpy.config.menu_arguments_callback(*args, **kwargs)
+
+    nvl = kwargs.pop("nvl", False)
 
     if renpy.config.old_substitutions:
 


### PR DESCRIPTION
This is the start of a PR intended to add functionality to NVL which is already included for ADV mode - namely, the ability to specify a particular screen for NVL choice menus and characters. The idea behind this is so people can style NVL in multiple ways across their game.

Included in the PR at the moment:

- The ability to use the `config.menu_arguments_callback` to specify the `nvl` argument to menus.
- The ability for NVLCharacter definitions to use their own NVL screen when speaking. This will also show all previous NVL dialogue on whatever screen the speaker uses, but I consider this behaviour fine. The intention is so people can use NVL to style both regular NVL dialogue and also things like messenger/phone dialogue, where they will be responsible for clearing the screen.
  - That said, I wouldn't be opposed to an approach where different NVL screens had separate `dialogue` lists, but this is likely out of the scope of this PR

Things I would like assistance with before this PR is merged:
- The empty_window/`nvl_show_core` should be refactored to show the screen associated with the last NVL dialogue speaker. I achieved a close-to-desired result with the following code:
(In `push_nvl_list`)
```renpy
kwargs["properties"]["screen"] = self.screen
```
(In `nvl_show_core`)
```renpy
if store.nvl_list:
    last_screen = store.nvl_list[-1][2]["properties"].get("screen", "nvl")
else:
    last_screen = "nvl"
if renpy.has_screen(last_screen):
    return __nvl_show_screen(last_screen, items=[ ])
```

I wasn't sure if this was the right approach however, so I've omitted it from the PR. I'd still like the ability to specify an NVL screen even without this functionality, so long as dialogue window management can prevent other NVL screens from flashing (which it currently cannot; the original NVL will always flash either at the start of a `window show` statement or between choice menus unless `window show` is active).