### PR TITLE
Restore return values from time-adjusted widgets

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2067,7 +2067,7 @@ class AdjustTimes(Container):
 
     def event(self, ev, x, y, st):
         st, _ = self.adjusted_times()
-        Container.event(self, ev, x, y, st)
+        return Container.event(self, ev, x, y, st)
 
     def get_placement(self):
         return self.child.get_placement()


### PR DESCRIPTION
I don't believe the current behaviour of swallowing return values here is intentional, so hopefully this falls into the "obvious fix" category. 🤞