### PR TITLE
MusicRoom: have queue_if_playing consider whether the currently playing track is in the playlist

### DIFF
--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -409,7 +409,7 @@ init -1500 python:
             if filename is None:
                 return
 
-            if self.single_track:
+            if self.single_track or filename not in self.filenames:
                 self.play(None, offset=0, queue=True)
             else:
                 self.play(None, offset=1, queue=True)


### PR DESCRIPTION
This change ensures that a MusicRoom queues up from the first track if the currently playing track is not part of the playlist. Enables the interjection of the MusicRoom into more complex scenarios (such as hotswapping MusicRooms to effect dynamic playlist changes).