### PR TITLE
Tool to view and copy translation identifiers

### DIFF
--- a/renpy/common/_developer/developer.rpym
+++ b/renpy/common/_developer/developer.rpym
@@ -65,6 +65,13 @@ screen _developer:
                 textbutton _("Image Attributes"):
                     action ui.callsinnewcontext("_image_attributes")
 
+                if not renpy.get_screen("_translation_identifier"):
+                    textbutton _("Show Translation Identifiers"):
+                        action Show("_translation_identifier")
+                else:
+                    textbutton _("Hide Translation Identifiers"):
+                        action Hide("_translation_identifier")
+
                 if bubble.active:
 
                     textbutton _("Speech Bubble Editor (Shift+B)"):
@@ -527,6 +534,58 @@ screen _image_load_log():
 
             if show_help:
                 text _("\n{color=#cfc}✔ predicted image (good){/color}\n{color=#fcc}✘ unpredicted image (bad){/color}\n{color=#fff}Drag to move.{/color}"):
+                    size 14
+
+    timer 10.0 action SetScreenVariable("show_help", False)
+
+
+screen _translation_identifier():
+    zorder 1500
+
+    default show_copy = False
+    default show_help = True
+
+    style_prefix ""
+
+    python:
+        identifier = renpy.get_translation_identifier()
+        copy = None
+
+        if identifier:
+            copy = (SetScreenVariable("show_copy", True),
+                    Function(pygame_sdl2.scrap.put,
+                             pygame_sdl2.scrap.SCRAP_TEXT,
+                             identifier.encode("utf8")))
+
+    drag:
+        draggable True
+        focus_mask None
+        xpos 0
+        ypos 0
+
+        frame:
+            style "empty"
+            background "#0004"
+            xpadding 5
+            ypadding 5
+
+            has vbox
+
+            textbutton "[identifier]":
+                action copy
+                padding (0, 0)
+                text_color "#fff"
+                text_hover_color "#bdf"
+                text_size 14
+
+            if show_copy:
+                text _("\n{color=#fff}Copied to clipboard.{/color}"):
+                    size 14
+
+                timer 2.0 action SetScreenVariable("show_copy", False)
+
+            elif show_help:
+                text _("\n{color=#fff}Click to copy.\nDrag to move.{/color}"):
                     size 14
 
     timer 10.0 action SetScreenVariable("show_help", False)


### PR DESCRIPTION
Inspired by #4865.

Adds a screen (toggled via the developer menu) which displays the current translation identifier and, on click, copies the value to the clipboard.