### PR TITLE
revert the applyment order of poi,orientation,xyzrotate and zpos

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -690,6 +690,9 @@ cdef class RenderTransform:
                 ypoi = math.degrees(ypoi)
                 zpoi = math.degrees(zpoi)
 
+        if xplacement or yplacement or state.zpos:
+            self.reverse = Matrix.offset(-xplacement, -yplacement, -state.zpos) * self.reverse
+
         if poi or orientation or xyz_rotate:
             m = Matrix.offset(-width / 2, -height / 2, -z11)
 
@@ -706,9 +709,6 @@ cdef class RenderTransform:
             m = Matrix.offset(width / 2, height / 2, z11) * m
 
             self.reverse = m * self.reverse
-
-        if xplacement or yplacement or state.zpos:
-            self.reverse = Matrix.offset(-xplacement, -yplacement, -state.zpos) * self.reverse
 
         if state.rotate is not None:
             m = Matrix.offset(-width / 2, -height / 2, 0.0)


### PR DESCRIPTION
The order of the camera point_to/orientation/x,y,zrotate and x,yplacement,zpos matrix was reversed at 7c082f0fb5ed6516b776c93209e97d7cec90e283.

Currently, above rotations don't rotate around the camera when x, y, zpos aren't 0.