### PR TITLE
Parse argument keywords as words instead of names

### DIFF
--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -501,7 +501,7 @@ def parse_arguments(l):
         state = l.checkpoint()
 
         if not (expect_starred or expect_doublestarred):
-            name = l.name()
+            name = l.word()
 
             if name and l.match(r'='):
                 if name in names:


### PR DESCRIPTION
- renpy statement names are authorized in python blocks, in function and method signatures, so they should be authorized in the calls parsed by renpy which end up calling a python thing (more about that nuance later)
- `r"stringu"` still cannot be mistaken for a keyword in this context : `r` will be recognized as a word, but since there is no `=` afterwards it will be discarded afterwards
- python statement names are still allowed as keywords, as they currently are. It makes little sense per se, but barring them is not necessary in order to fix #4874 and I fear unnecessary incompatibilities - for example a `label a(def)` and `call a(def="abc")`.

This change is necessary for when parsing the arguments to a say statement, where the call is forwarded to a Python callable, first to the potential config function then to a Character object or a proxy thereof. It is not necessary for `call screen` or `call` statements with parameters, so we could make the parsing of word vs name optional depending on that. But I think it's simpler this way.