### PR TITLE
Fix store.say's documentation

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1438,7 +1438,7 @@ def say(who, what, *args, **kwargs):
     `who`
         Either the character that will say something, None for the narrator,
         or a string giving the character name. In the latter case, the
-        :func:`say` is used to create the speaking character.
+        :var:`say` store function is called.
 
     `what`
         A string giving the line to say. Percent-substitutions are performed
@@ -1455,6 +1455,7 @@ def say(who, what, *args, **kwargs):
         e "Hello, world."
         $ renpy.say(e, "Hello, world.")
         $ e("Hello, world.") # when e is not a string
+        $ say(e, "Hello, world.") # when e is a string
     """
 
     if renpy.config.old_substitutions:

--- a/sphinx/source/store_variables.rst
+++ b/sphinx/source/store_variables.rst
@@ -122,16 +122,20 @@ and rolled-back when rollback occurs.
 
     Controls if rollback is allowed.
 
-.. var:: say = ...
+.. var:: say : Callable
 
-    A function that is called by Ren'Py to display dialogue. This is called
-    with three arguments. The first argument (`who`) is the character saying the
-    dialogue (or None for the narrator). The second argument (`what`) is what dialogue
-    is being said.
+    A function that is called by Ren'Py to display dialogue, when a string is
+    used in place of the speaking character::
 
-    The third argument must be a keyword argument named `interact` and defaulting
-    to True. If true, the say function will wait for a click. If false, it will
-    immediately return with the dialogue displayed on the screen.
+        define e = Character("Eileen", who_color="#0f0")
+
+        label start:
+            "Eileen" "My name is Eileen." # will call the say function
+            e "I like trains !" # will not call the say function
+
+    This function should have the same signature as :func:`renpy.say`.
+    It should not call :func:`renpy.say` but rather use the other
+    :doc:`say statement equivalents <statement_equivalents>`.
 
     It's rare to call this function directly, as one can simply call a character
     with dialogue. This variable mostly exists to be redefined, as a way of


### PR DESCRIPTION
It was documented as an override of renpy.say, and while that would be useful, it's not at all what the function does.

Also, this function is defined twice for some reason ? In [defaultstore](https://github.com/renpy/renpy/blob/80ea555ad61e484c96a5fedb91f0a432cd34efad/renpy/defaultstore.py#L418) and in [00library](https://github.com/renpy/renpy/blob/80ea555ad61e484c96a5fedb91f0a432cd34efad/renpy/common/00library.rpy#L319)