### PR TITLE
better implementation of `AlphaMask`

### DIFF
--- a/renpy/common/_shaders.rpym
+++ b/renpy/common/_shaders.rpym
@@ -143,6 +143,7 @@ init python:
         gl_FragColor = texture2D(tex0, v_tex_coord.xy, -1.0);
     """)
 
+    # used by Movie
     renpy.register_shader("renpy.alpha_mask", variables="""
         uniform sampler2D tex0;
         uniform sampler2D tex1;
@@ -157,6 +158,7 @@ init python:
         gl_FragColor = vec4(src.r * mask.r, src.g * mask.r, src.b * mask.r, mask.r);
     """)
 
+    # used by AlphaMask
     renpy.register_shader("renpy.alphamask", variables="""
         uniform float u_alpha_over;
         uniform sampler2D tex0;

--- a/renpy/common/_shaders.rpym
+++ b/renpy/common/_shaders.rpym
@@ -157,6 +157,25 @@ init python:
         gl_FragColor = vec4(src.r * mask.r, src.g * mask.r, src.b * mask.r, mask.r);
     """)
 
+    renpy.register_shader("renpy.alphamask", variables="""
+        uniform float u_alpha_over;
+        uniform sampler2D tex0;
+        uniform sampler2D tex1;
+        attribute vec2 a_tex_coord;
+        varying vec2 v_tex_coord;
+    """, vertex_200="""
+        v_tex_coord = a_tex_coord;
+    """, fragment_500="""
+        vec4 source = texture2D(tex0, v_tex_coord.xy);
+        vec4 mask = texture2D(tex1, v_tex_coord.xy);
+
+        float alpha = source.a * mask.a;
+        float reversed_alpha = 1.0 - alpha;
+        float final_alpha = mix(alpha, reversed_alpha, u_alpha_over);
+
+        gl_FragColor = vec4(source.rgb * final_alpha, final_alpha);
+    """)
+
 init python hide:
     from operator import mul
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2229,7 +2229,8 @@ class AlphaMask(Container):
     size of the AlphaMask is the size of `child`.
 
     `alpha_over` is a float that ranges from 0.0 to 1.0.
-    At `0.0`, nothing changes. At `1.0`, the behavior is swapped (`child` is opaque where `mask` is transparent).
+    At `0.0`, the behavior stays the same and the child gets masked.
+    At `1.0`, the behavior is swapped (`child` is opaque where `mask` is transparent).
 
     Note that this takes different arguments from :func:`im.AlphaMask`,
     which uses the mask's red channel.


### PR DESCRIPTION
-use `DISSOLVE` as render operation rather than `IMAGEDISSOLVE`. that way, no need to create and render a `Fixed` to get a third texture (since only two are needed)
-use its own shader `renpy.alphamask`. i know `renpy.alpha_mask` is also a shader, but it's only used for `Movie`s. maybe it could be renamed to `renpy.movie_mask`?
-new parameter `alpha_over` (not sure about the name tho). a float that ranges from 0.0 to 1.0. at 0.0, nothing changes. at 1.0, the behavior is swapped (the child is opaque where the mask is transparent). allows for more customization (for instance, 1.0 creates a "reversed" alphamask).