### PR TITLE
Edgecase with OneDrive vault

### DIFF
--- a/renpy.py
+++ b/renpy.py
@@ -207,7 +207,7 @@ def path_to_renpy_base():
     Returns the absolute path to the Ren'Py base directory.
     """
 
-    renpy_base = os.path.dirname(os.path.realpath(sys.argv[0]))
+    renpy_base = os.path.dirname(os.path.abspath(__file__))
     renpy_base = os.path.abspath(renpy_base)
 
     return renpy_base


### PR DESCRIPTION
Edgecase issue:

When lunching a renpy project from a OneDrive Vault `os.path.dirname(os.path.realpath(sys.argv[0]))` returns the Name of the virtualized file system Volume, but not the actual path. 
Changed it to `os.path.dirname(os.path.abspath(__file__))`, which in my limited test seems to work.