### PR TITLE
Sensitiveness and selectedness of action lists

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -73,6 +73,7 @@ init -1500 python:
     class SelectedIf(Action, DictEquality):
         """
         :doc: other_action
+        :args: (action, /)
 
         This indicates that one action in a list of actions should be used
         to determine if a button is selected. This only makes sense
@@ -106,6 +107,7 @@ init -1500 python:
     class SensitiveIf(Action, DictEquality):
         """
         :doc: other_action
+        :args: (action, /)
 
         This indicates that one action in a list of actions should be used
         to determine if a button is sensitive. This only makes sense

--- a/sphinx/source/screen_actions.rst
+++ b/sphinx/source/screen_actions.rst
@@ -19,7 +19,10 @@ invoked. If the action returns a value, then the value is returned
 from an interaction.
 
 A list of actions can usually be provided in lieu of a single action,
-in which case the actions in the list are run in order.
+in which case the actions in the list are run in order. A list of
+actions is sensitive if all of the actions are sensitive, and selected
+if any of them are ; that unless :func:`SensitiveIf` or :func:`SelectedIf`,
+respectively, is part of the list.
 
 Control Actions
 ---------------


### PR DESCRIPTION
Documents how and when action lists are sensitive and selected.
Also changes the **documented** signature (not the actual one) of SensitiveIf and SelectedIf actions, because "expression" is a misleading name when we want people to only pass actions.