### PR TITLE
Fix occurrences of *args following a kwarg in calls

### DIFF
--- a/renpy/common/00action_control.rpy
+++ b/renpy/common/00action_control.rpy
@@ -196,7 +196,7 @@ init -1500 python:
         :func:`renpy.show_screen` function.
         """
 
-        return Show(screen, transition, _transient=True, *args, **kwargs)
+        return Show(screen, transition, *args, _transient=True, **kwargs)
 
     @renpy.pure
     class Hide(Action, DictEquality):

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -97,7 +97,7 @@ init -1500 python:
                 if renpy.has_screen(screen):
 
                     renpy.transition(transition)
-                    renpy.show_screen(screen, _transient=True, *self.args, **self.kwargs)
+                    renpy.show_screen(screen, *self.args, _transient=True, **self.kwargs)
                     renpy.restart_interaction()
 
                 elif renpy.has_label(screen):

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -423,7 +423,7 @@ python early in layeredimage:
             args.append(None)
             args.append(Null())
 
-            return ConditionSwitch(predict_all=predict_all, *args)
+            return ConditionSwitch(*args, predict_all=predict_all)
 
     class RawConditionGroup(object):
 

--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -416,7 +416,7 @@ def predict_say(who, what):
 
 def say(who, what, interact=True, *args, **kwargs):
     who = Character(who, kind=adv)
-    who(what, interact=interact, *args, **kwargs)
+    who(what, *args, interact=interact, **kwargs)
 
 # Used by renpy.reshow_say and extend.
 _last_say_who = None

--- a/renpy/display/anim.py
+++ b/renpy/display/anim.py
@@ -308,7 +308,7 @@ class SMAnimation(renpy.display.displayable.Displayable):
         for edges in self.edges.values():
             args.extend(edges)
 
-        return SMAnimation(self.initial, delay=self.delay, *args, **self.properties)
+        return SMAnimation(self.initial, *args, delay=self.delay, **self.properties)
 
 
 def Animation(*args, **kwargs):

--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -422,7 +422,7 @@ def before_interact(roots):
     grab = replaced_by.get(id(grab), None)
 
     if override is not None:
-        d = renpy.exports.get_displayable(base=True, *override) # type: ignore
+        d = renpy.exports.get_displayable(*override, base=True) # type: ignore
 
         if (d is not None) and (current is not d) and not grab:
             current = d

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2387,7 +2387,7 @@ def do_reshow_say(who, what, interact=False, *args, **kwargs):
     if who is not None:
         who = renpy.python.py_eval(who)
 
-    say(who, what, interact=interact, *args, **kwargs)
+    say(who, what, *args, interact=interact, **kwargs)
 
 
 curried_do_reshow_say = curry(do_reshow_say)
@@ -3340,7 +3340,7 @@ def call_screen(_screen_name, *args, **kwargs):
     if "_with_none" in kwargs:
         with_none = kwargs.pop("_with_none")
 
-    show_screen(_screen_name, _transient=True, *args, **kwargs)
+    show_screen(_screen_name, *args, _transient=True, **kwargs)
 
     roll_forward = renpy.exports.roll_forward_info()
 

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -2045,7 +2045,7 @@ class SLUse(SLNode):
             args = [ ]
             kwargs = { }
 
-        renpy.display.screen.use_screen(self.target, _name=name, _scope=context.scope, *args, **kwargs)
+        renpy.display.screen.use_screen(self.target, *args, _name=name, _scope=context.scope, **kwargs)
 
     def execute(self, context):
 


### PR DESCRIPTION
The `(kw=val, *args)` syntax _**in calls**_ (not in signatures) is the python equivalent of a default in the middle of a label : it's misleading, and if you think it changes anything then you're wrong about how things actually works.
That syntax was only kept in python (in and after [PEP 448](https://peps.python.org/pep-0448/)) due to backwards-compatibility concerns, but the interpreter internally does the exact same tweak I'm making here (an element of [proof](https://docs.python.org/3/library/ast.html#ast.Call)), and its peculiarity leads Python core devs to push to deprecate it.
I checked, this fix works in PY2.

Sources :
https://mail.python.org/archives/list/python-dev@python.org/thread/I6AUYV6DVEMP7XVYVDWC62N6PK6FHX3H/ https://discuss.python.org/t/rationale-for-supporting-foo-kw-1-args-keyword-arguments-before-positional-unpackings/26073/7