### PR TITLE
Use the say_menu_text_filter when linting

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -444,6 +444,9 @@ def quote_text(s):
 
 def text_checks(s):
 
+    if renpy.config.say_menu_text_filter is not None:
+        s = renpy.config.say_menu_text_filter(s)
+
     msg = renpy.text.extras.check_text_tags(s)
     if msg:
         report("%s (in %s)", msg, quote_text(s))


### PR DESCRIPTION
In the event that a user is using the say_menu_text_filter to clean up some of their text, lint should take this into account so it doesn't report errors that the filter fixes.