### PR TITLE
Revert removal of `loop_only` to fix `if_changed` loop seam issue

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -668,7 +668,7 @@ class Channel(object):
             renpysound.dequeue(self.number, True)
             renpysound.stop(self.number)
 
-    def enqueue(self, filenames, loop=True, synchro_start=False, fadein=0, tight=None, relative_volume=1.0):
+    def enqueue(self, filenames, loop=True, synchro_start=False, fadein=0, tight=None, loop_only=False, relative_volume=1.0):
 
         with lock:
 
@@ -676,20 +676,22 @@ class Channel(object):
                 filename, _, _ = self.split_filename(filename, False)
                 renpy.game.persistent._seen_audio[str(filename)] = True # type: ignore
 
-            if tight is None:
-                tight = self.tight
+            if not loop_only:
 
-            self.keep_queue += 1
-
-            for filename in filenames:
-                qe = QueueEntry(filename, fadein, tight, False, relative_volume)
-                self.queue.append(qe)
-
-                # Only fade the first thing in.
-                fadein = 0
-
-            self.wait_stop = synchro_start
-            self.synchro_start = synchro_start
+                if tight is None:
+                    tight = self.tight
+    
+                self.keep_queue += 1
+    
+                for filename in filenames:
+                    qe = QueueEntry(filename, fadein, tight, False, relative_volume)
+                    self.queue.append(qe)
+    
+                    # Only fade the first thing in.
+                    fadein = 0
+    
+                self.wait_stop = synchro_start
+                self.synchro_start = synchro_start
 
             if loop:
                 self.loop = list(filenames)

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -116,11 +116,13 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
 
             if if_changed and c.get_playing() in filenames:
                 fadein = 0
+                loop_only = loop_is_filenames
                 if not loop_is_filenames:
                     c.dequeue()
             else:
                 c.dequeue()
                 c.fadeout(fadeout)
+                loop_only = False
 
             if renpy.config.skip_sounds and renpy.config.skipping and (not loop):
                 enqueue = False
@@ -128,7 +130,7 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=Fals
                 enqueue = True
 
             if enqueue:
-                c.enqueue(filenames, loop=loop, synchro_start=synchro_start, fadein=fadein, tight=tight, relative_volume=relative_volume)
+                c.enqueue(filenames, loop=loop, synchro_start=synchro_start, fadein=fadein, tight=tight, loop_only=loop_only, relative_volume=relative_volume)
 
             t = get_serial()
             ctx.last_changed = t


### PR DESCRIPTION
Fixes #4872 by restoring the `loop_only` parameter of `enqueue()` in audio.py.

After commit `b0b096b`, calling `play` on a music track with the `if_changed` parameter would *always* add it to the queue, even if the same track was already currently playing on loop. This newly queued 'loop' would always begin at the very start of the track, **ignoring any user-defined `loop` point parameters** that were added by the user to allow the track to seamlessly loop. This caused the looping track to abruptly 'restart' the next time it would normally loop whenever a player visited a label that wanted that track to play if it wasn't already looping (for example, the 'market' example in Ren'Py's audio documentation page for `if_changed`).

This change restores the `loop_only` parameter and functionality to `enqueue()` and `play()` to avoid a track from being added to the queue and potentially abruptly restarting the track if it is currently already playing on loop. To attempt to preserve the fix the change `b0b096b` accomplished for #4695, the position/logic of the `c.dequeue()` calls in `music.play()` has not been reverted to it's previous behaviour.

Documentation wise, the Audio documentation page mentions that `if_changed` queues 'an additional loop' of the currently playing track when this situation is reached, which is only an accurate description if the currently looping track does not have a user defined `loop` point (or if the loop point was 0.0). A more accurate description is that the track is queued to play again from the very beginning after the current loop is complete, discarding any user-defined `loop` points. The issue mentioned above is reproducible using the code present in the `if_changed` section of the audio page, provided the 'market' track has a non-zero `loop` parameter.