### PR TITLE
Implement AlphaMask using shader

### DIFF
--- a/renpy/common/_shaders.rpym
+++ b/renpy/common/_shaders.rpym
@@ -157,6 +157,23 @@ init python:
         gl_FragColor = vec4(src.r * mask.r, src.g * mask.r, src.b * mask.r, mask.r);
     """)
 
+    renpy.register_shader("renpy.mask", variables="""
+        uniform float u_lod_bias;
+        uniform sampler2D tex0;
+        uniform sampler2D tex1;
+        uniform float u_renpy_mask_multiplier;
+        uniform float u_renpy_mask_offset;
+        attribute vec2 a_tex_coord;
+        varying vec2 v_tex_coord;
+    """, vertex_200="""
+        v_tex_coord = a_tex_coord;
+    """, fragment_200="""
+        vec4 src = texture2D(tex0, v_tex_coord.st, u_lod_bias);
+        vec4 mask = texture2D(tex1, v_tex_coord.st, u_lod_bias);
+
+        gl_FragColor = src * (mask.a * u_renpy_mask_multiplier + u_renpy_mask_offset);
+    """)
+
 init python hide:
     from operator import mul
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2226,52 +2226,48 @@ class AlphaMask(Container):
     opaque where `child` and `mask` are both opaque.
 
     The `child` and `mask` parameters may be arbitrary displayables. The
-    size of the AlphaMask is the size of `child`.
+    size of the AlphaMask is the size of `child`. The `invert` parameter
+    can be used to invert the mask's alpha channel.
 
     Note that this takes different arguments from :func:`im.AlphaMask`,
     which uses the mask's red channel.
     """
 
-    def __init__(self, child, mask, **properties):
+    invert = False
+
+    def __init__(self, child, mask, invert=False, **properties):
         super(AlphaMask, self).__init__(**properties)
 
         self.mask = renpy.easy.displayable(mask)
         self.add(self.mask)
         self.add(child)
-        self.null = None
+        self.invert = invert
 
     def visit(self):
         return [ self.mask, self.child ]
 
     def render(self, width, height, st, at):
-
         cr = renpy.display.render.render(self.child, width, height, st, at)
+
         w, h = cr.get_size()
 
         mr = renpy.display.render.Render(w, h)
+        mr.add_property("color_mask", (False, False, False, True))
         mr.place(self.mask, main=False)
 
-        if self.null is None:
-            self.null = Fixed()
-
-        nr = renpy.display.render.render(self.null, w, h, st, at)
-
         rv = renpy.display.render.Render(w, h)
-
-        rv.operation = renpy.display.render.IMAGEDISSOLVE
-        rv.operation_alpha = True
-        rv.operation_complete = 256.0 / (256.0 + 256.0)
-        rv.operation_parameter = 256
+        rv.blit(cr, (0, 0))
+        rv.blit(mr, (0, 0), focus=False, main=False)
 
         rv.mesh = True
-        rv.add_shader("renpy.imagedissolve")
-        rv.add_uniform("u_renpy_dissolve_offset", 0)
-        rv.add_uniform("u_renpy_dissolve_multiplier", 1.0)
-        rv.add_property("mipmap", renpy.config.mipmap_dissolves if (self.style.mipmap is None) else self.style.mipmap)
+        rv.add_shader("renpy.mask")
 
-        rv.blit(mr, (0, 0))
-        rv.blit(nr, (0, 0), focus=False, main=False)
-        rv.blit(cr, (0, 0))
+        if self.invert:
+            rv.add_uniform("u_renpy_mask_multiplier", -1)
+            rv.add_uniform("u_renpy_mask_offset", 1)
+        else:
+            rv.add_uniform("u_renpy_mask_multiplier", 1)
+            rv.add_uniform("u_renpy_mask_offset", 0)
 
         self.offsets = [ (0, 0), (0, 0) ]
 


### PR DESCRIPTION
A second pass at this concept based upon the work done by @Elckarow in #4887.

The key differences are:
- Using the default BLIT operation rather than DISSOLVE.
- Discarding the mask's RGB via colour mask to (depending on which shader articles you read) possibly save some texture space.
- Simpler shader leveraging constants/uniforms and avoiding calculations and functions that can't be optimised by some hardware.