### PR TITLE
RenpyImporter.get_data fix

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 import renpy
 import os
+import os.path
 import sys
 import types
 import threading
@@ -1048,8 +1049,14 @@ class RenpyImporter(object):
         return self.load_module(fullname, "get_code")
 
     def get_data(self, filename):
-        if filename.startswith(renpy.config.gamedir + "/"):
-            filename = filename[len(renpy.config.gamedir) + 1:]
+
+        filename = os.path.normpath(filename).replace('\\', '/')
+
+        _check_prefix = "{0}/".format(
+            os.path.normpath(renpy.config.gamedir).replace('\\', '/')
+        )
+        if filename.startswith(_check_prefix):
+            filename = filename[len(_check_prefix):]
 
         return load(filename).read()
 


### PR DESCRIPTION
When trying to call method `get_data` of class `RenpyImporter` (for example through `pkgutil.get_data`) on Windows OS there can be situations when path with mixed delimiters is passed to function.
I consider it necessary, before checking and passing the path to the loader, to bring the delimiters into a single format (with straight slashes), to avoid errors. 

For example, such a path was passed to a method in the game I was running:
`D:\Novels\MyGame\game/python-packages/my_module\some_file.txt`

After that I got an error:
```
Exception: Backslash in filename ...
```

Also the path `renpy.config.gamedir` on Windows contains backslashes. And if, before passing to `RenpyImporter.get_data` method, the path will be normalized, then deletion of `renpy.config.gamedir` will not happen.