### PR TITLE
Or-augmented default statement

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2645,20 +2645,20 @@ class Default(Node):
         if self.varname in defaults_set:
             if start and renpy.config.developer:
                 raise Exception("{}.{} is being given a default a second time.".format(self.store, self.varname))
-            return
 
-        # do the variable shadowing if not in this case, for compatibility reasons
-        if start and (renpy.config.developer is True):
-            fullname = '.'.join((self.store, self.varname))
-            if fullname in renpy.python.store_dicts:
-                raise Exception("{} is being given a default, but a store with that name already exists.".format(fullname))
+        else:
+            # do the variable shadowing if not in this case, for compatibility reasons
+            if start and (renpy.config.developer is True):
+                fullname = '.'.join((self.store, self.varname))
+                if fullname in renpy.python.store_dicts:
+                    raise Exception("{} is being given a default, but a store with that name already exists.".format(fullname))
 
-        if start or (self.varname not in d.ever_been_changed):
-            d[self.varname] = renpy.python.py_eval_bytecode(self.code.bytecode)
+            if start or (self.varname not in d.ever_been_changed):
+                d[self.varname] = renpy.python.py_eval_bytecode(self.code.bytecode)
 
-        d.ever_been_changed.add(self.varname)
+            d.ever_been_changed.add(self.varname)
 
-        defaults_set.add(self.varname)
+            defaults_set.add(self.varname)
 
     def report_traceback(self, name, last):
         return [ (self.filename, self.linenumber, name, None) ]

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2660,6 +2660,9 @@ class Default(Node):
 
             defaults_set.add(self.varname)
 
+        if (not start) and (self.operator == "|="):
+            d[self.varname] = renpy.python.py_eval_bytecode(self.code.bytecode) | d[self.varname]
+
     def report_traceback(self, name, last):
         return [ (self.filename, self.linenumber, name, None) ]
 

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2589,19 +2589,22 @@ class Default(Node):
         'varname',
         'code',
         'store',
+        'operator',
         ]
 
     def __new__(cls, *args, **kwargs):
         self = Node.__new__(cls)
         self.store = 'store'
+        self.operator = '='
         return self
 
-    def __init__(self, loc, store, name, expr):
+    def __init__(self, loc, store, name, operator, expr):
 
         super(Default, self).__init__(loc)
 
         self.store = store
         self.varname = name
+        self.operator = operator
         self.code = PyCode(expr, loc=loc, mode='eval')
 
     def diff_info(self):

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1004,7 +1004,12 @@ def default_statement(l, loc):
         store = store + "." + name
         name = l.require(l.word)
 
-    l.require('=')
+    if l.match(r'\|='):
+        operator = "|="
+    else:
+        l.require('=')
+        operator = "="
+
     expr = l.rest()
 
     if not expr:
@@ -1012,7 +1017,7 @@ def default_statement(l, loc):
 
     l.expect_noblock('default statement')
 
-    rv = ast.Default(loc, store, name, expr)
+    rv = ast.Default(loc, store, name, operator, expr)
 
     if not l.init:
         rv = ast.Init(loc, [ rv ], priority + l.init_offset)


### PR DESCRIPTION
close #4976 

An inconvenience is that the | operation is done in the reverse order of the one readable : when `var` is already defined, we do `var = val | var` and not `var |= val` as it would appear. It could reveal to be a thorn later, I'll leave that to the judgement of others.