### PR TITLE
Various improvements around warpers

### DIFF
--- a/renpy/common/00definitions.rpy
+++ b/renpy/common/00definitions.rpy
@@ -127,10 +127,11 @@ init -1400 python:
         """
         :doc: transition_family
 
-        This defines a family of :class:`move transitions <MoveTransition>`, similar to the move and ease
-        transitions. For a given `prefix`, this defines the transitions:
+        This defines a family of :class:`move transitions <MoveTransition>`,
+        similar to the :var:`move` and :var:`ease` transitions. For a given
+        `prefix`, this defines the transitions:
 
-        * *prefix*- A transition that takes `delay` seconds to move images that
+        * *prefix* - A transition that takes `delay` seconds to move images that
           changed positions to their new locations.
 
         * *prefix*\ inleft, *prefix*\ inright, *prefix*\ intop, *prefix*\ inbottom - Transitions
@@ -143,11 +144,13 @@ init -1400 python:
           positions to their new locations, with newly hidden images leaving via
           the appropriate side.
 
+        The other parameters are as :class:`MoveTransition` takes them:
+
         `time_warp`, `in_time_warp`, `out_time_warp`
-            Time warp functions that are given a time from 0.0 to 1.0 representing
-            the fraction of the move that is complete, and return a value in the same
-            range giving the fraction of a linear move that is complete.
-            See :ref:`warpers <warpers>` for more information.
+            :ref:`Time warp functions <warpers>` that are given a time from 0.0
+            to 1.0 representing the fraction of the move that is complete, and
+            return a value in the same range giving the fraction of a linear
+            move that is complete.
 
             This can be used to define functions that ease the images around,
             rather than moving them at a constant speed.

--- a/renpy/display/movetransition.py
+++ b/renpy/display/movetransition.py
@@ -449,11 +449,12 @@ class MoveInterpolate(renpy.display.core.Displayable):
 def MoveTransition(delay, old_widget=None, new_widget=None, enter=None, leave=None, old=False, layers=[ 'master' ], time_warp=None, enter_time_warp=None, leave_time_warp=None):
     """
     :doc: transition function
-    :args: (delay, *, enter=None, leave=None, old=False, layers=['master'], time_warp=None, enter_time_warp=None, leave_time_warp=None)
+    :args: (delay, *, enter=None, leave=None, old=False, layers=['master'], time_warp=_warper.linear, enter_time_warp=_warper.linear, leave_time_warp=_warper.linear)
     :name: MoveTransition
 
-    Returns a transition that interpolates the position of images (with the
-    same tag) in the old and new scenes.
+    With these transitions, images changing position between the old and new
+    scenes will be interpolated, which means their movement will be smooth
+    instead of instantaneous.
 
     As only layers have tags, MoveTransitions can only be applied to a single
     layer or all layers at once, using the with statement. It will not work
@@ -463,16 +464,6 @@ def MoveTransition(delay, old_widget=None, new_widget=None, enter=None, leave=No
     `delay`
         The time it takes for the interpolation to finish.
 
-    `enter`
-        If not None, images entering the scene will also be moved. The value
-        of `enter` should be a transform that is applied to the image to
-        get it in its starting position.
-
-    `leave`
-        If not None, images leaving the scene will also be moved. The value
-        of `leave` should be a transform that is applied to the image to
-        get it in its ending position.
-
     `old`
         If true, when a tag gets its image changed during the transition,
         the old image will be used in preference to the new one. Otherwise,
@@ -481,16 +472,62 @@ def MoveTransition(delay, old_widget=None, new_widget=None, enter=None, leave=No
     `layers`
         A list of layers that moves are applied to.
 
+    The two following parameters take transforms, which should not be animated
+    over time.
+
+    `enter`
+        If not None, images entering the scene will also be moved. The transform
+        will be applied to the image to get it in its starting position.
+
+    `leave`
+        If not None, images leaving the scene will also be moved. The transform
+        will be applied to the image to get it in its ending position.
+
+    The three following parameters take :ref:`time warp functions <warpers>`,
+    which take a number between 0.0 and 1.0, and should return a number in the
+    same range.
+
     `time_warp`
-        A :ref:`time warp function <warpers>` that's applied to the interpolation. This
-        takes a number between 0.0 and 1.0, and should return a number in
-        the same range.
+        A time warp function that's applied to the images changing position
+        between the old and new scenes.
 
     `enter_time_warp`
         A time warp function that's applied to images entering the scene.
 
     `leave_time_warp`
         A time warp function that's applied to images leaving the scene.
+
+    ::
+
+        define longer_easein = MoveTransition(3.0, enter=offscreenright, enter_time_warp=_warper.easein)
+
+    In the following code, "a" will be leaving the scene (using `leave` and
+    `leave_time_warp`), "b" will be changing position (using `time_warp`), and
+    "c" will be entering (using `enter` and `enter_time_warp`). Because the same
+    tag is applied before and after, "d" will not be counted as entering or
+    leaving, but as changing position.
+
+    ::
+
+        define some_move_trans = MoveTransition(...)
+
+        label start:
+            show a
+            show b at left
+            show ugly_eileen as d at right
+            e "This is a dialogue !"
+
+            hide a
+            show b at right
+            show c
+            show pretty_eileen as d at left
+            with some_move_trans
+
+    During the time when "d" is changing position, whether ugly or pretty eileen
+    will be shown depends on the value of `old` : if `old` is False, the
+    default, ugly_eileen will instantly turn into pretty_eileen and then move,
+    and if `old` is True, ugly_eileen will move and then instantly turn into
+    pretty_eileen.
     """
 
     if not (hasattr(old_widget, 'scene_list') or hasattr(old_widget, 'layers')):

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -331,9 +331,9 @@ class Dissolve(Transition):
         The time the dissolve will take.
 
     `time_warp`
-        A function that adjusts the timeline. If not None, this should be a
-        function that takes a fractional time between 0.0 and 1.0, and returns
-        a number in the same range.
+        A :ref:`function that adjusts the timeline <warpers>`. If not None, this
+        should be a function that takes a fractional time between 0.0 and 1.0,
+        and returns a number in the same range.
 
     `mipmap`
         When the dissolve will be scaled to less than half its natural size,
@@ -436,9 +436,9 @@ class ImageDissolve(Transition):
         If True, black pixels will dissolve in before white pixels.
 
     `time_warp`
-        A function that adjusts the timeline. If not None, this should be a
-        function that takes a fractional time between 0.0 and 1.0, and returns
-        a number in the same range.
+        A :ref:`function that adjusts the timeline <warpers>`. If not None, this
+        should be a function that takes a fractional time between 0.0 and 1.0,
+        and returns a number in the same range.
 
     `mipmap`
         When the dissolve will be scaled to less than half its natural size,

--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -643,21 +643,20 @@ amount of time. (If the statement has 0 duration, then t is 1.0 when it runs.)
 t' should start at 0.0 and end at 1.0, but can be greater or less.
 
 ``pause``
-    Pause, then jump to the new value. If t == 1.0, t' = 1.0. Otherwise, t'
-    = 0.0.
+    Pause, then jump to the new value. If ``t == 1.0``, ``t' = 1.0``. Otherwise,
+    ``t' = 0.0``.
 
 ``linear``
-    Linear interpolation. t' = t
+    Linear interpolation. ``t' = t``
 
 ``ease``
-    Start slow, speed up, then slow down. t' = .5 - math.cos(math.pi
-    * t) / 2.0
+    Start slow, speed up, then slow down. ``t' = .5 - math.cos(math.pi * t) / 2.0``
 
 ``easein``
-    Start fast, then slow down. t' = math.cos((1.0 - t) * math.pi / 2.0
+    Start fast, then slow down. ``t' = math.cos((1.0 - t) * math.pi / 2.0)``
 
 ``easeout``
-    Start slow, then speed up. t' = 1.0 - math.cos(t * math.pi / 2.0)
+    Start slow, then speed up. ``t' = 1.0 - math.cos(t * math.pi / 2.0)``
 
 In addition, most of Robert Penner's easing functions are supported. To
 make the names match those above, the functions have been renamed
@@ -667,7 +666,10 @@ http://www.easings.net/.
 .. include:: inc/easings
 
 These warpers can be accessed in the ``_warper`` read-only module, which contains
-the functions listed above.
+the functions listed above. It is useful for things in Ren'Py which take a
+time-warping function, such as :func:`Dissolve`, which you can use like::
+
+    with Dissolve(1, time_warp=_warper.easein_quad)
 
 New warpers can be defined using the ``renpy.atl_warper`` decorator, in a ``python
 early`` block. It should be placed in a file that is parsed before any file


### PR DESCRIPTION
Systematically link to Warpers when mentioning time-warping functions, at least in Transitions (it should be done everywhere).
Replace None with `_warper.linear` in a signature - which is a white lie, as it's how it behaves and gives a wink towards how to pass warpers. Maybe it should be generalized ?
Add examples and more explanations in MoveTransition.
Add an example with the simplest transition in the Warpers section, for those who don't intuitively understand what a "read-only module" is, also fix the math formulas and make them more readable.