### PR TITLE
Use flag to govern callable conversion in interpolation

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -299,7 +299,6 @@ init -1100 python:
             config.simple_box_reverse = True
             build.itch_channels = list(build.itch_channels.items())
             style.default.shaper = "freetype"
-            config.interpolate_calls_functions = False
 
     # The version of Ren'Py this script is intended for, or
     # None if it's intended for the current version.

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1401,9 +1401,6 @@ simple_box_reverse = False
 # A map from font name to the hinting for the font.
 font_hinting = { None : "auto" }
 
-# Should interpolated functions be called for a value?
-interpolate_calls_functions = True
-
 del os
 del collections
 

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -178,8 +178,16 @@ class Formatter(string.Formatter):
         if not conversion:
             raise ValueError("Conversion specifier can't be empty.")
 
-        if set(conversion) - set("rstqulci!"):
-            raise ValueError("Unknown symbols in conversion specifier, this must use only the \"rstqulci\".")
+        if set(conversion) - set("frstqulci!"):
+            raise ValueError("Unknown symbols in conversion specifier, this must use only the \"frstqulci\".")
+
+        if "f" in conversion:
+            try:
+                value = value()
+                conversion = conversion.replace("f", "")
+            except Exception:
+                if renpy.config.developer:
+                    raise
 
         if "r" in conversion:
             value = repr(value)

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -172,12 +172,6 @@ class Formatter(string.Formatter):
     def convert_field(self, value, conversion):
         value, kwargs = value
 
-        if callable(value) and renpy.config.interpolate_calls_functions:
-            try:
-                value = value()
-            except Exception:
-                pass
-
         if conversion is None:
             return value
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -82,12 +82,6 @@ control hinting per-use. For example::
 
 enables bytecode hinting for MyFont.ttf.
 
-Text Interpolation Improvements
--------------------------------
-
-When the text interpolation system is given a callable, it will now call
-that function with no arguments, and interpolate the result.
-
 Speech Bubble Improvements
 --------------------------
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -82,6 +82,17 @@ control hinting per-use. For example::
 
 enables bytecode hinting for MyFont.ttf.
 
+Text Interpolation Improvements
+-------------------------------
+
+The text interpolation system can now be told to evaluate callables by
+providing the ``f`` conversion flag. It will call the function with no
+arguments, and interpolate the result. For example::
+
+    e "I'm talking to you from [renpy.version!f]!"
+
+would interpolate the result of ``renpy.version()`` into the dialogue.
+
 Speech Bubble Improvements
 --------------------------
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -33,13 +33,6 @@ report any issues. When reporting issues, please determine the hardware
 8.2.0 / 7.7.0
 --------------
 
-**Interpolation Changes** Ren'Py will now automatically call a function
-that's being interpolated with no arguments. To prevent this, add
-
-    define config.interpolate_calls_functions = False
-
-to your game.
-
 **Text Changes** Ren'Py uses harfbuzz for shaping, which may produce
 different glyphs than would have been produced differently, and may change
 the spacing of text. The positioning of vertical text has also been

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -105,9 +105,25 @@ formatting syntax. Ren'Py uses [ to introduce string formatting
 because { was taken by text tags.
 
 Along with the ``!s`` and ``!r`` conversion flags supported by Python, Ren'Py
-supports several more flags. The ``!q`` conversion flag ensures that
-text tags are properly quoted, so that displaying a string will not
-introduce unwanted formatting constructs. For example::
+supports several more flags.
+
+The ``!f`` conversion flag will cause the value being interpolated to be
+treated as a callable, Ren'Py will call that value with no arguments to
+get a new value to interpolate. For example::
+
+    init python:
+        def name():
+            if flag:
+                return "Alice"
+            else:
+                return "Bob"
+
+    default flag = False
+
+    g "My name is [name!f]." # Will display "My name is Bob."
+
+The ``!q`` flag ensures that text tags are properly quoted, so that
+displaying a string will not introduce unwanted formatting constructs::
 
     g "Don't pull a fast one on me, [playername!q]."
 
@@ -142,6 +158,7 @@ It should be noted that:
 
 The transformations are done in the following order:
 
+#. ``f`` (function evaluation)
 #. ``r``/``s`` (repr or str)
 #. ``t`` (translate)
 #. ``i`` (recursive interpolation)

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -104,21 +104,6 @@ Ren'Py's string interpolation is taken from the :pep:`3101` string
 formatting syntax. Ren'Py uses [ to introduce string formatting
 because { was taken by text tags.
 
-If the value being interpolated is callable, Ren'Py will call that
-value with no arguments to get a new value to interpolate. For example::
-
-    init python:
-        def name():
-            if flag:
-                return "Alice"
-            else:
-                return "Bob"
-
-    default flag = False
-
-    label start:
-        "My name is [name]." # Will display "My name is Bob."
-
 Along with the ``!s`` and ``!r`` conversion flags supported by Python, Ren'Py
 supports several more flags. The ``!q`` conversion flag ensures that
 text tags are properly quoted, so that displaying a string will not


### PR DESCRIPTION
Follow up/proof-of-concept to https://github.com/renpy/renpy/issues/5009 and 4d8d065c893d434abf75f9ec2bd5f6cd44a3ecb2.

Advantages over the original implementation as I see it:
- Makes it clear which interpolations will call functions, and which won't, when reading scripts.
- Is purely an additive feature, so no incompat with previous versions.
- Allows a game to use both modes, rather than having a binary config flag.
- Can surface exceptions in developer mode as there's no ambiguity over when a callable should be used/not used.

Other notes:
- `f` was selected as the flag due to its obvious link to "function" but could potentially be something else.