### PR TITLE
Treat interpolation as Python expressions

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -299,6 +299,7 @@ init -1100 python:
             config.simple_box_reverse = True
             build.itch_channels = list(build.itch_channels.items())
             style.default.shaper = "freetype"
+            config.interpolate_exprs = False
 
     # The version of Ren'Py this script is intended for, or
     # None if it's intended for the current version.

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1401,6 +1401,12 @@ simple_box_reverse = False
 # A map from font name to the hinting for the font.
 font_hinting = { None : "auto" }
 
+# A map of exact-match text interpolation aliases.
+interpolate_aliases = { }
+
+# Should text interpolations be treated as Python expressions?
+interpolate_exprs = True
+
 del os
 del collections
 

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -130,7 +130,7 @@ class Formatter(string.Formatter):
                     if brackets:
                         brackets -= 1
                     else:
-                        yield lit, s[cut:pos], fmt or '', conv
+                        yield lit, s[cut:pos], '', None
                         cut = pos + 1
                         state = LITERAL
                         lit = ''
@@ -146,7 +146,6 @@ class Formatter(string.Formatter):
                     state = FORMAT
                     expr = s[cut:pos]
                     cut = pos + 1
-                    fmt = ''
 
             elif state is CONVERSION:
                 if c == ']':
@@ -161,7 +160,6 @@ class Formatter(string.Formatter):
                     state = FORMAT
                     conv = s[cut:pos]
                     cut = pos + 1
-                    fmt = ''
 
                 elif c not in FLAGS:
                     if fmt is None:

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -200,7 +200,7 @@ def interpolate(s, scope):
         if lit:
             rv += lit
 
-        if not expr:
+        if expr is None:
             continue
 
         if conv is None:


### PR DESCRIPTION
This allows Python expressions to be used with text interpolation, i.e. `"I have [apples * 4] apple slices."`. This comes with a compatibility variable `config.interpolate_exprs` to revert to toggle the old interpolation behaviour.

A single parser is compatible with and used for both modes of operation. This allows common code maintained as part of Ren'Py to explicitly opt-in to this new functionality (using the undocumented `f` conversion flag), irrespective of a game's default, avoiding the need for the code to determine the origin of interpolations.

A side effect of this is that `expr!conversion:format` is now valid (this is what Python uses) in addition to Ren'Py's existing `expr:format!conversion` format. Both formats will work with both modes.

Performance wise, the new parser clocks in ~35% slower over a range of test strings of varying complexity. This sounds worse than it is in the real world however, as each parse is still in the order of low single digit microseconds (on 12 year-old hardware), and parsing only takes place if Ren'Py has already determined that it contains a `[` character. The overall impact is expected to be negligible in typical and even more extreme cases.

---

A secondary feature is to use `config.interpolate_aliases` to allow convenient aliases to be defined for use in scripts. For example:

```rpy
define config.interpolate_aliases["money"] = "player.metrics.money"
e "I have [money] dollars."     # => matches and would be treated as "I have [player.metrics.money] dollars."
e "I have [money * 2] dollars." # => would not match and would be treated normally
```

---

**Notes**

~~If performance ever rises to the point of contention, the lowest hanging fruit would be to separate from the `string.Formatter` class entirely (save for legacy-mode field interpretation), as it does a lot of work (in Python, rather than C) which we don't really benefit from. However at the time of writing, performance does not appear problematic enough to warrant this.~~
This ended up being done as it simplified not only the string building (because Python's formatter has various tangential concerns that we do not), but also adding support for f-string style trailing `=` functionality where `[abc=]` is treated as shorthand for `abc=[abc!r]`.

While very similar to native f-string functionality, it's not identical. When writing the code for this it was more pragmatic to, having already extracted the expression, eval it as is before running it through the usual formatting pipeline. While it would be possible to wrap it in f-string syntax prior to evaluation, it would require additional overhead to determine a safe string delimiter, and also introduce f-string limitations that the current approach does not hit (such as the inability to use `}` characters) which didn't seem beneficial.

The `is` operator is intentionally, though unusually, used when checking the state of the parse despite being an integer for speed. It is safe because the states are assigned only once per call and also assigned to state directly (rather than from a literal) ensuring that within each call to parse they will be the same objects in memory.

---

**Testing**

Testing was done against the following strings to ensure they parsed sanely. Interpolations that are already remained valid and parsed the same. Some interpolations (such as with `format:conversion` flipped) are now valid and are usable with both old and new modes. Some more complex interpolations that were misinterpreted by the old parser now parse in such as way to be usable with the new mode, and explode no worse than previously in the old mode.

The same set of strings were used for benchmarking, with the exception of "quoted brackets" which cannot be parsed with the old parser at all.

<details><summary>Test data</summary>

```rpy
define hello = 'hi'
define world = 'everybody'
define foo = 2
define bar = 8
define qux = 13
define wat = 'a'
define b = 2
define i = 1
define fn = lambda x: x / 2
define boop = b'BOOP'
define lol = b'abc'

default a = 1

label start:
    'hello world'                                               # none
    'hello [world]'                                             # single
    '[hello] [world]'                                           # double
    '[foo:01] [bar!r] [qux:10!r] [wat!r:12]'                    # suffixes
    '["two" if True else "three"]'                              # quotes
    '["""two" if True else "three"""]'                          # triple-quotes
    "['''two[''' if True else 'three(']"                        # quoted brackets
    "[a != b!r]"                                                # != in expr
    '[hello[i]]'                                                # getitem
    '["!sr"]'                                                   # quoted !
    '[a!r:!>10] [[[a:!>10!r]'                                   # complex format
    '[(lambda x: x*2)(3)]'                                      # lambda in parens
    """f(oo[b'''"y']''' + b''']'"'"''' + boop + b'']"""         # extreme
    '''fo)o[b"""'y']""" + b"""]"'"'""" + boop + (lol[1:2])]'''  # extreme plus specials
    '''hello [[ world, [[[hello[0]]'''                          # literal [
    $ a = [1, 1, 4]
    '''hello [[ w[[or[[[[[[ld, [fn(a[b])] l[[o[['''             # literal [ extreme
    'hello [({"a": "b"})!q]'                                    # : in parens
    '[hello=]'                                                  # trailing =
    '#[ hello = ]'                                              # = whitespace
    '[hello=:]'                                                 # = empty format
    '[hello=!u]'                                                # = conversion
    return

    'Strings from here on are expected to parse sanely, but raise for other reasons.'

    '[foo:01] [bar!r] [qux:01!r] [wat!r:01]'                    # invalid format for type
    '[!sr] ["!sr"]'                                             # empty expression
    """f(oo, [b'''"y']'''e''']'"'"''' boop''] lol"""            # invalid syntax
    '''fo)o, [b"""'y']"""e"""]"'"'""" boop""(lol[)] lol'''      # invalid syntax plus specials
    '''hello [[ w[[or[[[[[[ld, [hello(a[b])] l[[o[['''          # type error during execution
    'hello [({"a": "b"})]'                                      # interpolates unescaped brace
    return

```
</details>

---

- [ ] Document new functionality.
- [ ] Add to changelog and incompatible changes page.