### PR TITLE
New detection for iPad

### DIFF
--- a/renpy/main.py
+++ b/renpy/main.py
@@ -252,8 +252,9 @@ def choose_variants():
         renpy.config.variants.insert(0, 'web') # type: ignore
 
         # mobile
-        userAgent = emscripten.run_script_string(r'''navigator.userAgent''')
-        mobile = re.search('Mobile|Android|iPad|iPhone', userAgent)
+        mobile = emscripten.run_script_int(
+            r'''/Mobile|Android|iPad|iPhone/.test(navigator.userAgent)
+            || (navigator.userAgent.indexOf("Mac") != -1 && navigator.maxTouchPoints > 1)''')
         if mobile:
             renpy.config.variants.insert(0, 'mobile') # type: ignore
         # Reserve android/ios for when the OS API is exposed


### PR DESCRIPTION
Since iOS 13, Safari uses the desktop mode by default on iPad which removes the "iPad" string from the User-Agent header. The new detection looks for an Apple product with touch enabled (there is no MacOS product with touch screens AFAIK).

Fix https://github.com/renpy/renpy/issues/5022