### PR TITLE
Treat string interpolations as Python expressions

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -303,6 +303,7 @@ init -1100 python:
             config.mixed_position = False
             config.drag_group_add_top = False
             config.transitions_use_child_placement = True
+            config.interpolate_exprs = False
 
     # The version of Ren'Py this script is intended for, or
     # None if it's intended for the current version.

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1411,6 +1411,9 @@ font_hinting = { None : "auto" }
 # at the cost of returning instances of the position type ?
 mixed_position = True
 
+# Should text interpolations be treated as Python expressions?
+interpolate_exprs = True
+
 # Should we execute costly tasks which are
 # avoidable when not generating the documentation ?
 generating_documentation = False

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -56,10 +56,22 @@ def interpolate(s, scope):
         elif not conv:
             raise ValueError('conversion specifier cannot be empty')
 
+        code = expr.strip()
+
+        if not code:
+            raise ValueError('expected expression')
+
+        if code[-1] == '=':
+            rv += expr
+            code = code[:-1]
+
+            if not conv and fmt is None:
+                conv = 'r'
+
         if renpy.config.interpolate_exprs:
-            value = renpy.python.py_eval(expr, {}, scope)
+            value = renpy.python.py_eval(code, {}, scope)
         else:
-            value, _ = formatter.get_field(expr, (), scope)
+            value, _ = formatter.get_field(code, (), scope)
 
         if conv:
             value = convert(value, conv, scope)

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -25,11 +25,10 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-
-
 import renpy
 import string
 import os
+
 
 update_translations = "RENPY_UPDATE_TRANSLATIONS" in os.environ
 formatter = string.Formatter()

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -37,18 +37,18 @@ formatter = string.Formatter()
 
 def interpolate(s, scope):
     """
-    A string formatter that uses Ren'Py's formatting rules. Ren'Py uses
-    square brackets to introduce formatting, and it supports a q conversion
-    that quotes the text being shown to the user.
+    Formats a string using Ren'Py's formatting rules. Ren'Py uses square
+    brackets to denote interpolation, but is otherwise similar to native
+    f-strings, with a few caveats and additional conversions available.
     """
 
     rv = ''
 
-    for lit, name, conv, fmt in parse(s):
+    for lit, expr, conv, fmt in parse(s):
         if lit:
             rv += lit
 
-        if name is None:
+        if expr is None:
             continue
 
         if conv is None:
@@ -56,7 +56,10 @@ def interpolate(s, scope):
         elif not conv:
             raise ValueError('conversion specifier cannot be empty')
 
-        value, _ = formatter.get_field(name, (), scope)
+        if renpy.config.interpolate_exprs:
+            value = renpy.python.py_eval(expr, {}, scope)
+        else:
+            value, _ = formatter.get_field(expr, (), scope)
 
         if conv:
             value = convert(value, conv, scope)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -88,6 +88,16 @@ enables bytecode hinting for MyFont.ttf.
 Text Interpolation Improvements
 -------------------------------
 
+Interpolations in strings are now treated as Python expressions, rather than
+simple fields. While not identical, this concept will feel familiar to those
+that have worked with Python f-strings. This allows for some logic to be
+incorporated directly::
+
+    default exp = 1000
+
+    label start:
+        e "I am level [exp // 225]!" # Will show "I am level 4!"
+
 When a variable is interpolated into a string, and the interpolation namespace
 exists, that namespace will be searched for the values to interpolate. For
 example, ::

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -63,6 +63,18 @@ add::
     style default:
         emoji_font None
 
+**Interpolation Changes** Interpolations in strings are now treated as Python
+expressions, this results in mostly equivelent behaviour when interpreting
+fields except when item getters are in use. For example::
+
+    # Previously
+    e "[player[money]]" #=> player['money']
+    # But now
+    e "[player[money]]" #=> player[money]
+
+To revert this behaviour, add the following to your game::
+
+    define config.interpolate_exprs = False
 
 **Polar Coordinate Changes** Ren'Py now enforces that the angles given to
 the :tpref:`angle` and :tpref:`anchorangle`

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -91,18 +91,17 @@ Ren'Py will search for variables in the following order:
 * Variables found in the global namespace.
 
 Ren'Py isn't limited to interpolating simple variables. It can also
-interpolate fields and components of tuples. So it's possible to have::
+interpolate any valid Python expression. So it's possible to have::
 
     g "My first name is [player.names[0]]."
 
 It's possible to apply formatting when displaying numbers. This
 will display a floating point number to two decimal places::
 
-    $ percent = 100.0 * points / max_points
-    g "I like you [percent:.2] percent!"
+    g "I like you [100.0 * points / max_points:.2] percent!"
 
-Ren'Py's string interpolation is taken from the :pep:`3101` string
-formatting syntax. Ren'Py uses [ to introduce string formatting
+Ren'Py's string formatting is taken from the :pep:`3101` string
+formatting syntax. Ren'Py uses [ to introduce string interpolation
 because { was taken by text tags.
 
 Along with the ``!s`` and ``!r`` conversion flags supported by Python, Ren'Py


### PR DESCRIPTION
Supercedes #5023 based on feedback. Going commit-by-commit and hiding whitespace changes is recommended.

---

This allows Python expressions to be used with text interpolation, i.e. `"I have [apples * 4] apple slices."`. This comes with a compatibility variable `config.interpolate_exprs` to revert to the old behaviour.

A single parser is compatible with, and used for, both old and new modes of operation. Code in `common` is expected to use interpolations able to be interpreted correctly in both mode of operation. Aside from not being able to use expressions, the main potential "gotcha" is the difference in how item access is interpreted (i.e. `foo[bar]`). This is documented on the incompatible changes page, along with how to retain the current mode of operation.

A side effect of the single parser is that `expr!conversion:format` is now valid (this is what Python uses) in addition to Ren'Py's existing `expr:format!conversion` format. Both formats will work with both modes. Additionally the trailing `=` syntax used for debugging (see f-string documentation) is also able to be used with the old mode of operation.

Performance wise, the new parser clocks in ~35% slower over a range of test strings of varying complexity. This sounds worse than it is in the real world however, as each parse is still in the order of low single digit (and often sub 1) microseconds (on 12 year-old hardware), and parsing only takes place if Ren'Py has already determined that a string contains a `[` character. The overall impact is expected to be negligible in typical and even more extreme cases.

---

**Notes**

This change moves us away from the `string.Formatter` implementation provided by the Python stdlib in favour of a collection of functions that provide the same function. The reasons for this are two-fold. First, in order to correctly provide the trailing `=` syntax for debug expressions, more context was needed than the encapsulated functions of `string.Formatter` were able to provide, this change eliminates that issue. The second reason is that not only were we not taking advantage of the main reason to use `string.Formatter` (its native C string parser), it was also doing things we never care about such as tracking which fields from the provided scope are used. We do retain use of its `get_field` function for our old mode of operation and continue to benefit accordingly from it's native C field parser (a separate beast to its string parser, mentioned above) to retrieve nested values.

While this feature is very similar to native f-string functionality, it's not identical. The identified and deemed acceptable gaps are:
- Nested format interpolation, i.e. `{value:{width}.{precision}}`
- `*` unpacking, i.e `{*playlist,}`

Finally, on an implementation level, the `is` operator is intentionally, though unusually, used when checking the state of the parse despite being an integer. The reason for this is speed, and it is safe to do so because the states are defined only once per call and assigned to state directly (rather than from a literal) ensuring that for the duration of each `parse` call they will remain comparable.

---

**Testing**

Testing was done against the following strings to ensure they parsed sanely. Interpolations that are already remained valid and parsed the same. Some interpolations (such as with `format:conversion` flipped) are now valid and are usable with both old and new modes. Some more complex interpolations that were misinterpreted by the old parser now parse in such a way as to be usable with the new mode, and explode no worse than previously in the old mode.

The same set of strings were used for benchmarking, with the exception of "quoted brackets" which cannot be parsed with the old parser at all.

<details><summary>Test data</summary>

```rpy
define hello = 'hi'
define world = 'everybody'
define foo = 2
define bar = 8
define qux = 13
define wat = 'a'
define b = 2
define i = 1
define fn = lambda x: x / 2
define boop = b'BOOP'
define lol = b'abc'

default a = 1

label start:
    'hello world'                                               # none
    'hello [world]'                                             # single
    '[hello] [world]'                                           # double
    '[foo:01] [bar!r] [qux:10!r] [wat!r:12]'                    # suffixes
    '["two" if True else "three"]'                              # quotes
    '["""two" if True else "three"""]'                          # triple-quotes
    "['''two[''' if True else 'three(']"                        # quoted brackets
    "[a != b!r]"                                                # != in expr
    '[hello[i]]'                                                # getitem
    '["!sr"]'                                                   # quoted !
    '[a!r:!>10] [[[a:!>10!r]'                                   # complex format
    '[(lambda x: x*2)(3)]'                                      # lambda in parens
    """f(oo[b'''"y']''' + b''']'"'"''' + boop + b'']"""         # extreme
    '''fo)o[b"""'y']""" + b"""]"'"'""" + boop + (lol[1:2])]'''  # extreme plus specials
    '''hello [[ world, [[[hello[0]]'''                          # literal [
    $ a = [1, 1, 4]
    '''hello [[ w[[or[[[[[[ld, [fn(a[b])] l[[o[['''             # literal [ extreme
    'hello [({"a": "b"})!q]'                                    # : in parens
    '[hello=]'                                                  # trailing =
    '#[ hello = ]'                                              # = whitespace
    '[hello=:]'                                                 # = empty format
    '[hello=!u]'                                                # = conversion
    '["\\n".join("abc")]'                                       # escape
    '["a \\" character"]'                                       # quote escape
    '[""""escaped\\""""]'                                       # quote escape in triple
    '["no escape\\\\"]'                                         # escape escape
    return

    'Strings from here on are expected to parse sanely, but fail either validation or evaluation.'

    '[foo:01] [bar!r] [qux:01!r] [wat!r:01]'                    # invalid format for type
    '[!sr] ["!sr"]'                                             # empty expression
    '[sr!]'                                                     # empty conversion
    '[sr!#]'                                                    # invalid conversion
    """f(oo, [b'''"y']'''e''']'"'"''' boop''] lol"""            # invalid syntax
    '''fo)o, [b"""'y']"""e"""]"'"'""" boop""(lol[)] lol'''      # invalid syntax plus specials
    '''hello [[ w[[or[[[[[[ld, [hello(a[b])] l[[o[['''          # type error during execution
    'hello [({"a": "b"})]'                                      # interpolates unescaped brace
    return
```
</details>