### PR TITLE
Add warnings and deprecated sections for image manipulators

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -1877,7 +1877,7 @@ class Tile(ImageBase):
         (:var:`config.screen_width`, :var:`config.screen_height`).
 
     .. deprecated:: 7.4.0
-        Use :func:`Tile(im, size=size, **properties) <Tile>`.
+        Use :func:`Tile(im, xysize=size, **properties) <Tile>`.
     """
 
     def __init__(self, im, size=None, **properties):

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -1012,8 +1012,9 @@ class FactorScale(ImageBase):
 
         image logo doubled = im.FactorScale("logo.png", 1.5)
 
-    The same effect can now be achieved with the :tpref:`zoom` or the
-    :tpref:`xzoom` and :tpref:`yzoom` transform properties.
+    .. deprecated:: 7.4.0
+        Use the :tpref:`zoom`, or the
+        :tpref:`xzoom` and :tpref:`yzoom` transform properties.
     """
 
     def __init__(self, im, width, height=None, bilinear=True, **properties):
@@ -1073,9 +1074,9 @@ class Flip(ImageBase):
 
         image eileen flip = im.Flip("eileen_happy.png", vertical=True)
 
-    The same effect can now be achieved by setting
-    :tpref:`xzoom` (for horizontal flip)
-    or :tpref:`yzoom` (for vertical flip) to a negative value.
+    .. deprecated:: 7.4.0
+        Set :tpref:`xzoom` (for horizontal flip)
+        or :tpref:`yzoom` (for vertical flip) to a negative value.
     """
 
     def __init__(self, im, horizontal=False, vertical=False, **properties):
@@ -1165,7 +1166,8 @@ class Crop(ImageBase):
 
         image logo crop = im.Crop("logo.png", (0, 0, 100, 307))
 
-    The same effect can now be achieved by setting the :tpref:`crop` transform property.
+    .. deprecated:: 7.4.0
+        Use the :tpref:`crop` transform property.
     """
 
     def __init__(self, im, x, y=None, w=None, h=None, **properties):
@@ -1365,7 +1367,8 @@ class Blur(ImageBase):
 
         image logo blurred = im.Blur("logo.png", 1.5)
 
-    The same effect can now be achieved with the :tpref:`blur` transform property.
+    .. deprecated:: 7.4.0
+        Use the :tpref:`blur` transform property.
     """
 
     def __init__(self, im, xrad, yrad=None, **properties):
@@ -1427,6 +1430,10 @@ class MatrixColor(ImageBase):
 
     The components of the transformed color are clamped to the
     range [0.0, 1.0].
+
+    .. deprecated:: 7.4.0
+        Use ``Transform(im, matrixcolor=matrix, **properties)``.
+        See :func:`Transform` and :tpref:`matrixcolor`.
     """
 
     def __init__(self, im, matrix, **properties):
@@ -1475,6 +1482,9 @@ class matrix(tuple):
     `matrix` is a 20 or 25 element list or tuple. If it is 20 elements
     long, it is padded with (0, 0, 0, 0, 1) to make a 5x5 matrix,
     suitable for multiplication.
+
+    .. deprecated:: 7.4.0
+        Use :class:`Matrix`.
     """
 
     def __new__(cls, *args):
@@ -1567,8 +1577,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an identity matrix, one that does not change color or
         alpha.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is IdentityMatrix().
+        .. deprecated:: 7.4.0
+            Use :func:`IdentityMatrix() <IdentityMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix(1, 0, 0, 0, 0,
@@ -1598,8 +1609,9 @@ im.matrix(%f, %f, %f, %f, %f.
             mostly sensitive to green, more of the green channel is
             kept then the other two channels.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is SaturationMatrix(value, desat).
+        .. deprecated:: 7.4.0
+            Use :func:`SaturationMatrix(value, desat) <SaturationMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         r, g, b = desat
@@ -1622,8 +1634,9 @@ im.matrix(%f, %f, %f, %f, %f.
         grayscale). This is equivalent to calling
         im.matrix.saturation(0).
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is SaturationMatrix(0).
+        .. deprecated:: 7.4.0
+            Use :func:`SaturationMatrix(0) <SaturationMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix.saturation(0.0)
@@ -1641,8 +1654,9 @@ im.matrix(%f, %f, %f, %f, %f.
         the value of the red channel is 100, the transformed color
         will have a red value of 50.)
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is TintMatrix(Color((r, g, b))).
+        .. deprecated:: 7.4.0
+            Use :func:`TintMatrix(Color((r, g, b))) <TintMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix(r, 0, 0, 0, 0,
@@ -1659,8 +1673,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that inverts the red, green, and blue
         channels of the image without changing the alpha channel.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is InvertMatrix(1.0).
+        .. deprecated:: 7.4.0
+            Use :func:`InvertMatrix(1.0) <InvertMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix(-1, 0, 0, 0, 1,
@@ -1681,8 +1696,9 @@ im.matrix(%f, %f, %f, %f, %f.
             a number between -1 and 1, with -1 the darkest possible
             image and 1 the brightest.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is BrightnessMatrix(b).
+        .. deprecated:: 7.4.0
+            Use :func:`BrightnessMatrix(b) <BrightnessMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix(1, 0, 0, 0, b,
@@ -1699,8 +1715,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that alters the opacity of an image. An
         `o` of 0.0 is fully transparent, while 1.0 is fully opaque.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is OpacityMatrix(o).
+        .. deprecated:: 7.4.0
+            Use :func:`OpacityMatrix(o) <OpacityMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix(1, 0, 0, 0, 0,
@@ -1718,8 +1735,9 @@ im.matrix(%f, %f, %f, %f, %f.
         be greater than 0.0, with values between 0.0 and 1.0 decreasing contrast, and
         values greater than 1.0 increasing contrast.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is ContrastMatrix(c).
+        .. deprecated:: 7.4.0
+            Use :func:`ContrastMatrix(c) <ContrastMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         return matrix.brightness(-.5) * matrix.tint(c, c, c) * matrix.brightness(.5)
@@ -1734,8 +1752,9 @@ im.matrix(%f, %f, %f, %f, %f.
         Returns an im.matrix that rotates the hue by `h` degrees, while
         preserving luminosity.
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is HueMatrix(h).
+        .. deprecated:: 7.4.0
+            Use :func:`HueMatrix(h) <HueMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         h = h * math.pi / 180
@@ -1769,8 +1788,9 @@ im.matrix(%f, %f, %f, %f, %f.
                 im.matrix.colorize("#f00", "#00f"))
 
 
-        A suitable equivalent for the :tpref:`matrixcolor` transform property
-        is ColorizeMatrix(black_color, white_color).
+        .. deprecated:: 7.4.0
+            Use :func:`ColorizeMatrix(black_color, white_color) <ColorizeMatrix>`
+            with the :tpref:`matrixcolor` transform property.
         """
 
         (r0, g0, b0, _a0) = renpy.easy.color(black_color) # type: ignore
@@ -1797,8 +1817,9 @@ def Grayscale(im, desat=(0.2126, 0.7152, 0.0722), **properties):
     An image manipulator that creates a desaturated version of the image
     manipulator `im`.
 
-    The same effect can now be achieved by supplying SaturationMatrix(0)
-    to the :tpref:`matrixcolor` transform property.
+    .. deprecated:: 7.4.0
+        Set the :tpref:`matrixcolor` transform property to
+        :func:`SaturationMatrix(0) <SaturationMatrix>`.
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat), **properties)
@@ -1812,8 +1833,9 @@ def Sepia(im, tint=(1.0, .94, .76), desat=(0.2126, 0.7152, 0.0722), **properties
     An image manipulator that creates a sepia-toned version of the image
     manipulator `im`.
 
-    The same effect can now be achieved by supplying SepiaMatrix()
-    to the :tpref:`matrixcolor` transform property.
+    .. deprecated:: 7.4.0
+        Set the :tpref:`matrixcolor` transform property to
+        :func:`SepiaMatrix() <SepiaMatrix>`
     """
 
     return MatrixColor(im, matrix.saturation(0.0, desat) * matrix.tint(tint[0], tint[1], tint[2]), **properties)
@@ -1854,8 +1876,8 @@ class Tile(ImageBase):
         If not None, a (width, height) tuple. If None, this defaults to
         (:var:`config.screen_width`, :var:`config.screen_height`).
 
-    The same effect can now be achieved using the :func:`Tile`
-    displayable, with ``Tile(im, size=size)``.
+    .. deprecated:: 7.4.0
+        Use :func:`Tile(im, size=size, **properties) <Tile>`.
     """
 
     def __init__(self, im, size=None, **properties):

--- a/sphinx/source/im.rst
+++ b/sphinx/source/im.rst
@@ -1,7 +1,5 @@
 :orphan:
 
-.. _image-manipulator:
-
 Image Manipulators
 ==================
 
@@ -14,16 +12,25 @@ An image manipulator can be used any place a displayable can, but not
 vice-versa. An :func:`Image` is a kind of image manipulator, so an
 Image can be used whenever an image manipulator is required.
 
-With the few exceptions listed below, the use of image manipulators is
-historic. A number of image manipulators that had been documented in the
-past should no longer be used, as they suffer from inherent problems.
-In any case except for `im.Data`, the :func:`Transform` displayable provides
-similar functionality in a more general manner, while fixing the problems.
+.. warning::
+
+    The use of image manipulators is
+    historic. A number of image manipulators that had been documented in the
+    past should no longer be used, as they suffer from inherent problems,
+    and in general (except for :func:`im.Data`), the :func:`Transform`
+    displayable provides similar functionality while fixing the problems.
 
 .. include:: inc/im_im
 
 im.MatrixColor
 --------------
+
+.. warning::
+
+    The im.MatrixColor image manipulator has been replaced by Transforms
+    and ATL transforms that specify the matrixcolor property. Each `im.matrix`
+    generator has been given a new `Matrix` equivalent, which can be found
+    in the :doc:`matrixcolor documentation <matrixcolor>`.
 
 The im.MatrixColor image manipulator is an image manipulator that uses
 a matrix to control how the colors of an image are transformed. The
@@ -40,11 +47,6 @@ first desaturates the image, and then tints it blue. When the
 intermediate image is not needed, multiplying matrices is far
 more efficient, in both time and image cache space, than using
 two im.MatrixColors.
-
-The im.MatrixColor image manipulator has been replaced by Transforms
-and ATL transforms that specify the matrixcolor property. Each `im.matrix`
-generator has been given a new `Matrix` equivalent, which can be found
-in the :doc:`matrixcolor documentation <matrixcolor>`.
 
 .. warning::
 


### PR DESCRIPTION
7.4.0 was (apparently) the first release to include 06004f1b575984d996120370bd37d9d084af3da5 and 76e03b3c36a025f5df05d851a0cf2a12cec45766 which led image manipulators towards the path of deprecation.
![image](https://github.com/renpy/renpy/assets/44340603/af26f679-7ca1-47e3-ba1b-72cfacd02693)
![image](https://github.com/renpy/renpy/assets/44340603/659ea1f3-dde3-4bdb-8990-4036209bfc7f)
