### PR TITLE
Add lint toggles

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -259,7 +259,7 @@ label lint:
         interface.processing(_("Checking script for potential problems..."))
         lint_fn = project.current.temp_filename("lint.txt")
 
-        project.current.launch([ 'lint', lint_fn ], wait=True)
+        project.current.launch([ 'lint', lint_fn, *persistent.lint_options ], wait=True)
 
         e = renpy.editor.editor
         e.begin(True)

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -74,6 +74,14 @@ init python:
 
 
 default preference_tab = "general"
+define preference_tabs = {
+    "general" : _("General"),
+    "options" : _("Options"),
+    "theme" : _("Theme"),
+    "install" : _("Install Libraries"),
+    "actions" : _("Actions"),
+    "lint" : _("Lint Options"),
+    }
 
 screen preferences():
 
@@ -101,17 +109,12 @@ screen preferences():
 
                     has vbox
 
-                    # Projects directory selection.
                     add SEPARATOR2
 
                     add HALF_SPACER
 
-                    textbutton _("General") action SetVariable("preference_tab", "general") style "l_list"
-                    textbutton _("Options") action SetVariable("preference_tab", "options") style "l_list"
-                    textbutton _("Theme") action SetVariable("preference_tab", "theme") style "l_list"
-                    textbutton _("Install Libraries") action SetVariable("preference_tab", "install") style "l_list"
-                    textbutton _("Actions") action SetVariable("preference_tab", "actions") style "l_list"
-
+                    for i, l in preference_tabs.items():
+                        textbutton l action SetVariable("preference_tab", i) style "l_list"
 
                 if preference_tab == "general":
 
@@ -122,7 +125,6 @@ screen preferences():
 
                         has vbox
 
-                        # Projects directory selection.
                         add SEPARATOR2
 
 
@@ -242,7 +244,6 @@ screen preferences():
                             if ability.can_update:
                                 textbutton _("Daily check for update") style "l_checkbox" action [ToggleField(persistent, "daily_update_check"), SetField(persistent, "last_update_check", None)] selected persistent.daily_update_check
 
-
                 elif preference_tab == "theme":
 
                     frame:
@@ -252,7 +253,6 @@ screen preferences():
 
                         has vbox
 
-                        # Projects directory selection.
                         add SEPARATOR2
 
                         frame:
@@ -292,7 +292,6 @@ screen preferences():
 
                             use install_preferences
 
-
                 elif preference_tab == "actions":
 
                     frame:
@@ -315,6 +314,32 @@ screen preferences():
                             textbutton _("Open launcher project") style "l_nonbox" action [ project.Select("launcher"), Jump("front_page") ]
                             textbutton _("Reset window size") style "l_nonbox" action Preference("display", 1.0)
                             textbutton _("Clean temporary files") style "l_nonbox" action Jump("clean_tmp")
+
+                elif preference_tab == "lint":
+
+                    frame:
+                        style "l_indent"
+                        xmaximum TWOTHIRDS
+                        xfill True
+
+                        has vbox
+
+                        add SEPARATOR2
+
+                        frame:
+                            style "l_indent"
+                            has vbox
+
+                            text _("Lint toggles:")
+
+                            add HALF_SPACER
+
+                            textbutton _("Orphan translations") style "l_checkbox" action [NullAction()] # default True
+                            textbutton _("Parameters overriding builtin names") style "l_checkbox" action [NullAction()] # default False
+
+                            add SPACER
+
+                            textbutton _("Check Script (Lint)") action Jump("lint")
 
 
     textbutton _("Return") action Jump("front_page") style "l_left_button"

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -340,9 +340,9 @@ screen preferences():
                             textbutton _("Parameters overriding builtin names"):
                                 style "l_checkbox"
                                 action ToggleSetMembership(persistent.lint_options, "--builtins-parameters")
-                            # textbutton _("Word count and character count for speaking characters"):
-                            #     style "l_checkbox"
-                            #     action ToggleSetMembership(persistent.lint_options, "--words-char-count")
+                            textbutton _("Word count and character count for speaking characters"):
+                                style "l_checkbox"
+                                action ToggleSetMembership(persistent.lint_options, "--words-char-count")
 
                             add SPACER
 

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -337,9 +337,9 @@ screen preferences():
                             textbutton _("Orphan translations"):
                                 style "l_checkbox"
                                 action ToggleSetMembership(persistent.lint_options, "--orphan-tl")
-                            # textbutton _("Parameters overriding builtin names"):
-                            #     style "l_checkbox"
-                            #     action ToggleSetMembership(persistent.lint_options, "--builtins-parameters")
+                            textbutton _("Parameters overriding builtin names"):
+                                style "l_checkbox"
+                                action ToggleSetMembership(persistent.lint_options, "--builtins-parameters")
                             # textbutton _("Word count and character count for speaking characters"):
                             #     style "l_checkbox"
                             #     action ToggleSetMembership(persistent.lint_options, "--words-char-count")

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -19,14 +19,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+default persistent.show_edit_funcs = True
+default persistent.windows_console = False
+default persistent.lint_options = { # the ones which should be enabled by default
+    "--orphan-tl",
+}
+
 init python:
     from math import ceil
-
-    if persistent.show_edit_funcs is None:
-        persistent.show_edit_funcs = True
-
-    if persistent.windows_console is None:
-        persistent.windows_console = False
 
     def scan_translations(piglatin=True):
 
@@ -334,8 +334,15 @@ screen preferences():
 
                             add HALF_SPACER
 
-                            textbutton _("Orphan translations") style "l_checkbox" action [NullAction()] # default True
-                            textbutton _("Parameters overriding builtin names") style "l_checkbox" action [NullAction()] # default False
+                            textbutton _("Orphan translations"):
+                                style "l_checkbox"
+                                action ToggleSetMembership(persistent.lint_options, "--orphan-tl")
+                            # textbutton _("Parameters overriding builtin names"):
+                            #     style "l_checkbox"
+                            #     action ToggleSetMembership(persistent.lint_options, "--builtins-parameters")
+                            # textbutton _("Word count and character count for speaking characters"):
+                            #     style "l_checkbox"
+                            #     action ToggleSetMembership(persistent.lint_options, "--words-char-count")
 
                             add SPACER
 

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -860,7 +860,7 @@ def report_character_stats(charastats):
             count = charastats[char]
             rv.append(
                 " * " + char
-                + " has " + humanize(count.blocks) + " blocks of dialogue, "
+                + " has " + humanize(count.blocks) + (" block " if count.blocks == 1 else " blocks ") + "of dialogue, "
                 + "containing " + humanize(count.words) + " words and "
                 + humanize(count.characters) + " characters."
             )
@@ -871,14 +871,14 @@ def report_character_stats(charastats):
         for char, count in charastats.items():
             nblocks_to_char[count.blocks].append(char)
 
-        for count, chars in sorted(nblocks_to_char.items(), reverse=True):
+        for nblocks, chars in sorted(nblocks_to_char.items(), reverse=True):
             chars.sort()
 
             start = humanize_listing(chars, singular_suffix=" has ", plural_suffix=" have ")
 
             rv.append(
-                " * " + start + humanize(count) +
-                (" block " if count == 1 else " blocks ") + "of dialogue" +
+                " * " + start + humanize(nblocks) +
+                (" block " if nblocks == 1 else " blocks ") + "of dialogue" +
                 (" each." if len(chars) > 1 else ".")
                 )
 

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -732,7 +732,8 @@ def check_parameters(kind, node_name, parameter_info):
 
 def check_label(node):
 
-    check_parameters("label", node.name, node.parameters)
+    if args.builtins_parameters:
+        check_parameters("label", node.name, node.parameters)
 
     def add_arg(n):
         if n is None:
@@ -758,7 +759,8 @@ def check_screen(node):
         report("The screen %s has not been given a parameter list.", node.screen.name)
         add("This can be fixed by writing 'screen %s():' instead.", node.screen.name)
 
-    check_parameters("screen", node.screen.name, node.screen.parameters)
+    if args.builtins_parameters:
+        check_parameters("screen", node.screen.name, node.screen.parameters)
 
 
 def check_styles():
@@ -776,7 +778,8 @@ def check_init(node):
 
 
 def check_transform(node):
-    check_parameters("ATL transform", node.varname, node.parameters)
+    if args.builtins_parameters:
+        check_parameters("ATL transform", node.varname, node.parameters)
 
 
 def humanize(n):
@@ -1017,9 +1020,10 @@ def lint():
     ap.add_argument("filename", nargs='?', action="store", help="The file to write to.")
     ap.add_argument("--error-code", action="store_true", help="If given, the error code is 0 if the game has no lint errros, 1 if lint errors are found.")
     ap.add_argument("--orphan-tl", action="store_true", help="If given, orphan translations are reported.")
-    # ap.add_argument("--builtins-parameters", action="store_true", help="If given, renpy or python builtin names in renpy statement parameters are reported.")
+    ap.add_argument("--builtins-parameters", action="store_true", help="If given, renpy or python builtin names in renpy statement parameters are reported.")
     # ap.add_argument("--words-char-count", action="store_true", help="If given, the number of words and characters for each character is reported.")
 
+    global args
     args = ap.parse_args()
 
     if args.filename:

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -970,6 +970,9 @@ def lint():
     ap = renpy.arguments.ArgumentParser(description="Checks the script for errors and prints script statistics.", require_command=False)
     ap.add_argument("filename", nargs='?', action="store", help="The file to write to.")
     ap.add_argument("--error-code", action="store_true", help="If given, the error code is 0 if the game has no lint errros, 1 if lint errors are found.")
+    ap.add_argument("--orphan-tl", action="store_true", help="If given, orphan translations are reported.")
+    # ap.add_argument("--builtins-parameters", action="store_true", help="If given, renpy or python builtin names in renpy statement parameters are reported.")
+    # ap.add_argument("--words-char-count", action="store_true", help="If given, the number of words and characters for each character is reported.")
 
     args = ap.parse_args()
 
@@ -1073,7 +1076,7 @@ def lint():
         elif isinstance(node, renpy.ast.Label):
             check_label(node)
 
-        elif isinstance(node, renpy.ast.Translate):
+        elif isinstance(node, renpy.ast.Translate) and args.orphan_tl:
             language = node.language
             if language is None:
                 none_language_ids.add(node.identifier)
@@ -1103,7 +1106,8 @@ def lint():
     check_styles()
     check_filename_encodings()
     check_unreachables(all_stmts)
-    check_orphan_translations(none_language_ids, translated_ids)
+    if args.orphan_tl:
+        check_orphan_translations(none_language_ids, translated_ids)
 
     for f in renpy.config.lint_hooks:
         f()


### PR DESCRIPTION
This adds the option to toggle certain Lint checks, so as to have some useful features implemented, but not bloating the report (or the report time) by default.
I guess the choice of which check is optional and which is enabled by default is up to some debate.
It should be noted that I include no mechanism to deprecate some of these options and remove them from people's persistent - but it's relatively easy to do it in an init python.

Also, #5001 is there, but only for the None language (which seems to fulfill the provided use-case).
And #3878 is here too, disabled by default.