### PR TITLE
Prevent creation of a "store" substore

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -206,6 +206,9 @@ def create_store(name):
     Creates the store with `name`.
     """
 
+    if name == "store.store":
+        raise NameError('Cannot create a substore named "store".')
+
     parent, _, var = name.rpartition('.')
 
     if parent:


### PR DESCRIPTION
Prevents this at the highest level.
Blocking it at the define/default level would be not as good because a lot of things create stores : python blocks, define, default, and now transforms.