### PR TITLE
Factorize and improve some Barvalue subclasses

### DIFF
--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -113,33 +113,6 @@ init -1500 python:
                 self.start_time = None
 
     class __GenericValue(BarValue, FieldEquality):
-        """
-        :doc: value
-        {args}
-
-        {desc}
-
-        {params}
-        `range`
-            The range to adjust over.
-        `max_is_zero`
-            If True, then when the {target} is zero, the value of the bar will
-            be `range`, and all other values will be shifted down by 1.
-            This works both ways - when the bar is set to the maximum, the
-            {target} is set to 0.
-
-            This is used internally, for some preferences.
-        `style`
-            The styles of the created bar.
-        `offset`
-            An offset to add to the value.
-        `step`
-            The amount to change the bar by. If None, defaults to 1/10th of
-            the bar.
-        `action`
-            If not None, an action to call when the {target} is changed.
-        """
-
         # pickle defaults
         offset = 0
         action = None
@@ -201,19 +174,19 @@ init -1500 python:
 
     @renpy.pure
     class DictValue(__GenericValue):
-        docdic = dict(
-            desc="""
-            A bar value that allows the user to adjust the value of a key in a
-            dict, or of an element in list.
-            """,
-            params="""
-            `dict`
-                The dict, or the list.
-            `key`
-                The key, or the index when using a list.
-            """,
-            target="value of the key",
-        )
+        """
+        :doc: value
+        {args}
+
+        A bar value that allows the user to adjust the value of a key in
+        a dict, or of an element in list.
+
+        `dict`
+            The dict, or the list.
+        `key`
+            The key, or the index when using a list.
+        {params}
+        """
 
         kind = "key or index"
 
@@ -238,16 +211,19 @@ init -1500 python:
 
     @renpy.pure
     class FieldValue(__GenericValue):
-        docdic = dict(
-            desc="A bar value that allows the user to adjust the value of a field on an object.",
-            params="""
-            `object`
-                The object.
-            `field`
-                The field name, a string.
-            """,
-            target="field",
-        )
+        """
+        :doc: value
+        {args}
+
+        A bar value that allows the user to adjust the value of a field
+        on an object.
+
+        `object`
+            The object.
+        `field`
+            The field name, a string.
+        {params}
+        """
 
         kind = "field"
 
@@ -269,17 +245,19 @@ init -1500 python:
 
     @renpy.pure
     class VariableValue(FieldValue):
-        docdic = dict(
-            desc="A bar value that allows the user to adjust the value of a variable in the default store.",
-            params="""
-            `variable`
-                The `variable` parameter must be a string, and can be a simple
-                name like "strength", or one with dots separating the variable
-                from fields, like "hero.strength" or
-                "persistent.show_cutscenes".
-            """,
-            target="variable",
-        )
+        """
+        :doc: value
+        {args}
+
+        A bar value that allows the user to adjust the value of a variable in
+        the default store.
+
+        `variable`
+            The `variable` parameter must be a string, and can be a simple
+            name like "strength", or one with dots separating the variable
+            from fields, like "hero.strength" or "persistent.show_cutscenes".
+        {params}
+        """
 
         kind = "variable"
 
@@ -288,21 +266,23 @@ init -1500 python:
 
     @renpy.pure
     class ScreenVariableValue(__GenericValue):
-        docdic = dict(
-            desc="""
-            A bar value that adjusts the value of a variable in a screen.
+        """
+        :doc: value
+        {args}
 
-            In a ``use``\ d screen, this targets a variable in the context of
-            the screen containing the ``use``\ d one(s). To target variables
-            within a ``use``\ d screen, and only in that case, use
-            :func:`LocalVariableValue` instead.
-            """,
-            params="""
-            `variable`
-                A string giving the name of the variable to adjust.
-            """,
-            target="variable",
-        )
+        A bar value that adjusts the value of a variable in a screen.
+
+        In a ``use``\ d screen, this targets a variable in the context of
+        the screen containing the ``use``\ d one(s). To target variables
+        within a ``use``\ d screen, and only in that case, use
+        :func:`LocalVariableValue` instead.
+
+        `variable`
+            A string giving the name of the variable to adjust.
+        {params}
+        """
+
+        kind = "screen variable"
 
         identity_fields = ()
         equality_fields = __GenericValue.equality_fields + ('variable',)
@@ -329,25 +309,25 @@ init -1500 python:
 
     # unpure
     class LocalVariableValue(DictValue):
-        docdic = dict(
-            desc="""
-            A bar value that adjusts the value of a variable in a
-            ``use``\ d screen.
+        """
+        :doc: value
+        {args}
 
-            To target a variable in a top-level screen, prefer using
-            :func:`ScreenVariableValue`.
+        A bar value that adjusts the value of a variable in a ``use``\ d
+        screen.
 
-            For more information, see :ref:`sl-use`.
+        To target a variable in a top-level screen, prefer using
+        :func:`ScreenVariableValue`.
 
-            This must be created in the context that the variable is set in -
-            it can't be passed in from somewhere else.
-            """,
-            params="""
-            `variable`
-                A string giving the name of the variable to adjust.
-            """,
-            target="variable",
-        )
+        For more information, see :ref:`sl-use`.
+
+        This must be created in the context that the variable is set in
+        - it can't be passed in from somewhere else.
+
+        `variable`
+            A string giving the name of the variable to adjust.
+        {params}
+        """
 
         kind = "local variable"
 
@@ -355,30 +335,46 @@ init -1500 python:
             super(LocalVariableValue, self).__init__(sys._getframe(1).f_locals, variable, *args, **kwargs)
 
 init -1500 python hide:
-    if config.generating_documentation:
-        import inspect
-        import itertools
+    if not config.generating_documentation:
+        return
 
-        docbase = inspect.cleandoc(__GenericValue.__doc__)
-        __GenericValue.__doc__ = None # del is illegal for __doc__
+    import inspect
+    import itertools
 
-        for value in (DictValue, FieldValue, VariableValue, ScreenVariableValue, LocalVariableValue):
-            docdic = value.docdic
-            del value.docdic
+    suffix = inspect.cleandoc("""
+    `range`
+        The range to adjust over.
+    `max_is_zero`
+        If True, then when the {kind}'s value is zero, the value of the
+        bar will be `range`, and all other values will be shifted down
+        by 1. This works both ways - when the bar is set to the maximum,
+        the value of the {kind} is set to 0.
 
-            params = []
-            for param in itertools.islice(inspect.signature(value.__init__).parameters.values(), 1, None):
-                if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
-                    params.append(param)
+        This is used internally, for some preferences.
+    `style`
+        The styles of the created bar.
+    `offset`
+        An offset to add to the value.
+    `step`
+        The amount to change the bar by. If None, defaults to 1/10th of
+        the bar.
+    `action`
+        If not None, an action to call when the {kind}'s value is changed.
+    """)
 
-            params.extend(itertools.islice(inspect.signature(__GenericValue.__init__).parameters.values(), 1, None))
+    for value in (DictValue, FieldValue, VariableValue, ScreenVariableValue, LocalVariableValue):
+        docstr = inspect.cleandoc(value.__doc__)
 
-            docdic["args"] = ":args: " + str(inspect.Signature(parameters=params))
+        params = []
+        for param in itertools.islice(inspect.signature(value.__init__).parameters.values(), 1, None):
+            if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+                params.append(param)
 
-            docdic["desc"] = inspect.cleandoc(docdic["desc"])
-            docdic["params"] = inspect.cleandoc(docdic["params"])
+        params.extend(itertools.islice(inspect.signature(__GenericValue.__init__).parameters.values(), 1, None))
 
-            value.__doc__ = docbase.format(**docdic)
+        value.__doc__ = docstr.format(**{
+            'args': ":args: " + str(inspect.Signature(parameters=params)),
+            'params': suffix.format(**{'kind': value.kind})})
 
 init -1500 python:
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -252,12 +252,12 @@ init -1500 python:
             super().__init__(*args, **kwargs)
 
         def get_value(self):
-            value = _get_field(self.object, self.field, "field")
+            value = _get_field(self.object, self.field, self.kind)
 
             return value
 
         def set_value(self, value):
-            _set_field(self.object, self.field, value, "field")
+            _set_field(self.object, self.field, value, self.kind)
 
     @renpy.pure
     class VariableValue(FieldValue):
@@ -273,7 +273,7 @@ init -1500 python:
             target="variable",
         )
 
-        kind="variable"
+        kind = "variable"
 
         def __init__(self, variable, *args, **kwargs):
             super().__init__(store, variable, *args, **kwargs)

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -314,8 +314,10 @@ init -1500 python:
         def get_value(self):
             cs = renpy.current_screen()
 
-            if (cs is None) or (self.variable not in cs.scope):
-                raise Exception("{} is not defined in the {} screen.".format(self.variable, cs.screen_name))
+            if cs is None:
+                raise Exception("No current screen.")
+            if self.variable not in cs.scope:
+                raise Exception("The {!r} variable is not defined in the {} screen.".format(self.variable, cs.screen_name))
 
             value = cs.scope[self.variable]
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -223,7 +223,7 @@ init -1500 python:
         def __init__(self, dict, key, *args, **kwargs):
             self.dict = dict
             self.key = key
-            super().__init__(*args, **kwargs)
+            super(DictValue, self).__init__(*args, **kwargs)
 
         def get_value(self):
             value = self.dict[self.key]
@@ -257,7 +257,7 @@ init -1500 python:
         def __init__(self, object, field, *args, **kwargs):
             self.object = object
             self.field = field
-            super().__init__(*args, **kwargs)
+            super(FieldValue, self).__init__(*args, **kwargs)
 
         def get_value(self):
             value = _get_field(self.object, self.field, self.kind)
@@ -284,7 +284,7 @@ init -1500 python:
         kind = "variable"
 
         def __init__(self, variable, *args, **kwargs):
-            super().__init__(store, variable, *args, **kwargs)
+            super(VariableValue, self).__init__(store, variable, *args, **kwargs)
 
     @renpy.pure
     class ScreenVariableValue(__GenericValue):
@@ -309,7 +309,7 @@ init -1500 python:
 
         def __init__(self, variable, *args, **kwargs):
             self.variable = variable
-            super().__init__(*args, **kwargs)
+            super(ScreenVariableValue, self).__init__(*args, **kwargs)
 
         def get_value(self):
             cs = renpy.current_screen()
@@ -350,21 +350,19 @@ init -1500 python:
         kind = "local variable"
 
         def __init__(self, variable, *args, **kwargs):
-            super().__init__(sys._getframe(1).f_locals, variable, *args, **kwargs)
+            super(LocalVariableValue, self).__init__(sys._getframe(1).f_locals, variable, *args, **kwargs)
 
 init -1500 python hide:
-    import inspect
+    if not PY2:
+        import inspect
 
-    docbase = inspect.cleandoc(__GenericValue.__doc__)
-    __GenericValue.__doc__ = None # del is illegal for __doc__
+        docbase = inspect.cleandoc(__GenericValue.__doc__)
+        __GenericValue.__doc__ = None # del is illegal for __doc__
 
-    for value in (DictValue, FieldValue, VariableValue, ScreenVariableValue, LocalVariableValue):
-        docdic = value.docdic
-        del value.docdic
+        for value in (DictValue, FieldValue, VariableValue, ScreenVariableValue, LocalVariableValue):
+            docdic = value.docdic
+            del value.docdic
 
-        if PY2:
-            docdic["args"] = ""
-        else:
             params = []
             for k, param in enumerate(inspect.signature(value.__init__).parameters.values()):
                 if k and (param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)):
@@ -374,10 +372,10 @@ init -1500 python hide:
 
             docdic["args"] = ":args: " + str(inspect.Signature(parameters=params))
 
-        docdic["desc"] = inspect.cleandoc(docdic["desc"])
-        docdic["params"] = inspect.cleandoc(docdic["params"])
+            docdic["desc"] = inspect.cleandoc(docdic["desc"])
+            docdic["params"] = inspect.cleandoc(docdic["params"])
 
-        value.__doc__ = docbase.format(**docdic)
+            value.__doc__ = docbase.format(**docdic)
 
 init -1500 python:
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -355,7 +355,7 @@ init -1500 python:
             super(LocalVariableValue, self).__init__(sys._getframe(1).f_locals, variable, *args, **kwargs)
 
 init -1500 python hide:
-    if not PY2:
+    if config.generating_documentation:
         import inspect
 
         docbase = inspect.cleandoc(__GenericValue.__doc__)

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -371,7 +371,7 @@ init -1500 python hide:
                 if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
                     params.append(param)
 
-            params.extend(itertools.islice(inspect.signature(__GenericValue.__init__).parameters.values()), 1, None)
+            params.extend(itertools.islice(inspect.signature(__GenericValue.__init__).parameters.values(), 1, None))
 
             docdic["args"] = ":args: " + str(inspect.Signature(parameters=params))
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -209,7 +209,7 @@ init -1500 python:
             `key`
                 The key.
             """,
-            target="value of a key",
+            target="value of the key",
         )
 
         identity_fields = ('dict',)

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -357,6 +357,7 @@ init -1500 python:
 init -1500 python hide:
     if config.generating_documentation:
         import inspect
+        import itertools
 
         docbase = inspect.cleandoc(__GenericValue.__doc__)
         __GenericValue.__doc__ = None # del is illegal for __doc__
@@ -366,11 +367,11 @@ init -1500 python hide:
             del value.docdic
 
             params = []
-            for k, param in enumerate(inspect.signature(value.__init__).parameters.values()):
-                if k and (param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)):
+            for param in itertools.islice(inspect.signature(value.__init__).parameters.values(), 1, None):
+                if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
                     params.append(param)
 
-            params.extend(tuple(inspect.signature(__GenericValue.__init__).parameters.values())[1:])
+            params.extend(itertools.islice(inspect.signature(__GenericValue.__init__).parameters.values()), 1, None)
 
             docdic["args"] = ":args: " + str(inspect.Signature(parameters=params))
 

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -1,4 +1,4 @@
-# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
+﻿# Copyright 2004-2023 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -215,6 +215,8 @@ init -1500 python:
             target="value of the key",
         )
 
+        kind = "key or index"
+
         identity_fields = ('dict',)
         equality_fields = __GenericValue.equality_fields + ('key',)
 
@@ -229,7 +231,10 @@ init -1500 python:
             return value
 
         def set_value(self, value):
-            self.dict[self.key] = value
+            try:
+                self.dict[self.key] = value
+            except LookupError as e:
+                raise Exception("The {!r} {} does not exist".format(self.key, self.kind)) # from e # PY3 only
 
     @renpy.pure
     class FieldValue(__GenericValue):
@@ -342,6 +347,8 @@ init -1500 python:
             target="variable",
         )
 
+        kind = "local variable"
+
         def __init__(self, variable, *args, **kwargs):
             super().__init__(sys._getframe(1).f_locals, variable, *args, **kwargs)
 
@@ -349,7 +356,7 @@ init -1500 python hide:
     import inspect
 
     docbase = inspect.cleandoc(__GenericValue.__doc__)
-    __GenericValue.__doc__ = None
+    __GenericValue.__doc__ = None # del is illegal for __doc__
 
     for value in (DictValue, FieldValue, VariableValue, ScreenVariableValue, LocalVariableValue):
         docdic = value.docdic

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -202,12 +202,15 @@ init -1500 python:
     @renpy.pure
     class DictValue(__GenericValue):
         docdic = dict(
-            desc="A bar value that allows the user to adjust the value of a key in a dict.",
+            desc="""
+            A bar value that allows the user to adjust the value of a key in a
+            dict, or of an element in list.
+            """,
             params="""
             `dict`
-                The dict.
+                The dict, or the list.
             `key`
-                The key.
+                The key, or the index when using a list.
             """,
             target="value of the key",
         )


### PR DESCRIPTION
- factorize the most common BarValue subclasses, using the same recipe (but in a much simpler way) as in #4473, which considerably shortens the code and avoids code duplication
- fix the `kind` parameter of `FieldValue` and `VariableValue` - it was saved but never passed to \_get_field and \_set_field
- fix some subclasses doc entries that weren't appropriately worded, some which set variables mentioned "fields"
- implement LocalVariableValue, supersede and fix #5055, and allow it to have adequately-worded exceptions

The doc has been tested.