### PR TITLE
Rework the language basics page

### DIFF
--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -864,7 +864,7 @@ class Lexer(object):
 
     def string(self):
         """
-        Lexes a string, and returns the string to the user, or None if
+        Lexes a non-triple-quoted string, and returns the string to the user, or None if
         no string could be found. This also takes care of expanding
         escapes and collapsing whitespace.
 
@@ -926,6 +926,9 @@ class Lexer(object):
         This is about the same as the double-quoted strings, except that
         runs of whitespace with multiple newlines are turned into a single
         newline.
+
+        Except in the case of a raw string where this returns a simple string,
+        this returns a list of strings.
         """
 
         s = self.match(r'r?"""([^\\"]|\\.|"(?!""))*"""')

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -1,5 +1,3 @@
-.. _building-distributions:
-
 Building Distributions
 ======================
 
@@ -27,22 +25,22 @@ Macintosh
     as a single file. The updater does not work with this package.
 
 Windows
-     A zip file targeting Windows x86_64.
+    A zip file targeting Windows x86_64.
 
 Windows, Mac, and Linux for Markets
-     A distribution that contains the information required to run on
-     software markets like itch.io and Steam. This isn't meant to be
-     run directly (and probably won't work on the Mac), but should be
-     fed to the app store upload process.
+    A distribution that contains the information required to run on
+    software markets like itch.io and Steam. This isn't meant to be
+    run directly (and probably won't work on the Mac), but should be
+    fed to the app store upload process.
 
 .. warning::
 
-  The zip and tar.bz2 files that Ren'Py produces contain permissions
-  information that must be present for Ren'Py to run on Linux and
-  Macintosh.
+    The zip and tar.bz2 files that Ren'Py produces contain permissions
+    information that must be present for Ren'Py to run on Linux and
+    Macintosh.
 
-  Unpacking and re-packing a zip file on Windows and then running it
-  on Linux or Macintosh is not supported.
+    Unpacking and re-packing a zip file on Windows and then running it
+    on Linux or Macintosh is not supported.
 
 Basic Configuration
 -------------------
@@ -63,31 +61,31 @@ use.
 
 .. var:: build.directory_name = "..."
 
-   This is used to create the names of directories in the archive
-   files. For example, if this is set to "mygame-1.0", the Linux
-   version of the project will unpack to "mygame-1.0-linux".
+    This is used to create the names of directories in the archive
+    files. For example, if this is set to "mygame-1.0", the Linux
+    version of the project will unpack to "mygame-1.0-linux".
 
-   This is also used to determine the name of the directory in
-   which the package files are placed. For example, if you set
-   build.directory_name to mygame-1.0, the archive files will
-   be placed in mygame-1.0-dists in the directory above the base
-   directory.
+    This is also used to determine the name of the directory in
+    which the package files are placed. For example, if you set
+    build.directory_name to mygame-1.0, the archive files will
+    be placed in mygame-1.0-dists in the directory above the base
+    directory.
 
-   This variable should not contain special characters like spaces,
-   colons, and semicolons. If not set, it defaults to :var:`build.name`
-   a dash, and :var:`config.version`.
+    This variable should not contain special characters like spaces,
+    colons, and semicolons. If not set, it defaults to :var:`build.name`
+    a dash, and :var:`config.version`.
 
 .. var:: build.executable_name = "..."
 
-   This variable controls the name of the executables that the user
-   clicks on to start the game.
+    This variable controls the name of the executables that the user
+    clicks on to start the game.
 
-   This variable should not contain special characters like spaces,
-   colons, and semicolons. If not set, it defaults to :var:`build.name`.
+    This variable should not contain special characters like spaces,
+    colons, and semicolons. If not set, it defaults to :var:`build.name`.
 
-   For example, if this is set to "mygame", the user will be able
-   to run mygame.exe on Windows, mygame.app on Macintosh, and
-   mygame.sh on Linux.
+    For example, if this is set to "mygame", the user will be able
+    to run mygame.exe on Windows, mygame.app on Macintosh, and
+    mygame.sh on Linux.
 
 .. _special-files:
 
@@ -173,15 +171,15 @@ must match at least one character.
 
 For example::
 
-     # Include README.txt
-     build.classify("README.txt", "all")
+    # Include README.txt
+    build.classify("README.txt", "all")
 
-     # But exclude all other txt files.
-     build.classify("**.txt", None)
+    # But exclude all other txt files.
+    build.classify("**.txt", None)
 
-     # Add png and jpg files in the game directory into an archive.
-     build.classify("game/**.png", "archive")
-     build.classify("game/**.jpg", "archive")
+    # Add png and jpg files in the game directory into an archive.
+    build.classify("game/**.png", "archive")
+    build.classify("game/**.jpg", "archive")
 
 Documentation
 -------------

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -1,5 +1,3 @@
-.. _labels-control-flow:
-
 Labels & Control Flow
 =====================
 

--- a/sphinx/source/language_basics.rst
+++ b/sphinx/source/language_basics.rst
@@ -10,10 +10,10 @@ elements that make up statements.
 Files
 =====
 
-The script of a Ren'Py game is made up of all the files found under
-the :file:`game/` directory ending with the .rpy extension. Ren'Py will
-consider each of these files (in the Unicode order of their paths),
-and will use the contents of the files as the script.
+The script of a Ren'Py game is made up of all the files found under the
+:file:`game/` directory ending with the :file:`.rpy` extension. Ren'Py will
+consider each of these files (in the Unicode order of their paths), and will
+use the contents of the files as the script.
 
 Generally, there's no difference between a script written in one big file and a
 script broken into multiple files. Control can be transferred within the script
@@ -140,15 +140,15 @@ using other delimiters.
 
 ::
 
-   "This statement, and the if statement that follows, is part of a block."
+    "This statement, and the if statement that follows, are part of a block."
 
-   if True:
+    if True:
 
-       "But this statement is part of a new block."
+        "But this statement is part of a new block."
 
-       "This is also part of that new block."
+        "This is also part of that new block."
 
-   "This is part of the first block, again."
+    "This is part of the first block, again."
 
 
 .. _elements-of-statements:
@@ -217,7 +217,7 @@ Ren'Py statements are made of a few basic parts.
 
     .. note::
 
-        This concerns strings found *directly* in Ren'Py script, such as in
+        This applies to strings found *directly* in Ren'Py script, such as in
         :ref:`say-statement` or :doc:`menus`. Strings found inside
         :ref:`python statements <python-statement>`, or in expressions (see
         below), follow ordinary Python rules.

--- a/sphinx/source/language_basics.rst
+++ b/sphinx/source/language_basics.rst
@@ -3,7 +3,7 @@ Language Basics
 ===============
 
 Before we can describe the Ren'Py language, we must first describe the
-structure of a Ren'Py script. This includes how a files are broken into
+structure of a Ren'Py script. This includes how files are broken into
 blocks made up of lines, and how those lines are broken into the
 elements that make up statements.
 
@@ -11,73 +11,60 @@ Files
 =====
 
 The script of a Ren'Py game is made up of all the files found under
-the game directory ending with the .rpy extension. Ren'Py will
+the :file:`game/` directory ending with the .rpy extension. Ren'Py will
 consider each of these files (in the Unicode order of their paths),
 and will use the contents of the files as the script.
 
-Generally, there's no difference between a script broken into multiple
-files, and a script that consists of one big file. Control can be
-transferred between files by jumping to or calling a label in another
-file.  This makes the division of a script up into files a matter of
-personal style – some game-makers prefer to have small files (like one
-per event, or one per day), while others prefer to have one big
-script.
+Generally, there's no difference between a script written in one big file and a
+script broken into multiple files. Control can be transferred within the script
+(including between files) by jumping to or calling a :doc:`label <label>` in
+another file. This makes the division of a script up into files a matter of
+personal style : some game creators prefer to have small files (like one
+per event, or one per day), while others prefer to have one big script.
 
-To speed up loading time, Ren'Py will compile the .rpy files into
-.rpyc files when it starts up. When a .rpy file is changed, the .rpyc
-file will be updated when Ren'Py starts up. However, if a .rpyc file
-exists without a corresponding .rpy file, the .rpyc file will be
-used. This can lead to problems if a .rpy file is deleted without
-deleting the .rpyc file.
+To speed up loading time, Ren'Py will compile the :file:`.rpy` files into
+:file:`.rpyc` files when it starts up. When a :file:`.rpy` file is changed, the
+:file:`.rpyc` file will be updated when Ren'Py starts up. However, if a
+:file:`.rpyc` file exists without a corresponding :file:`.rpy` file, the
+:file:`.rpyc` file will be used. This can lead to problems if a :file:`.rpy`
+file is deleted, or renamed, or moved, without deleting the :file:`.rpyc`
+file : the script it contains will still get executed.
 
-Filenames must being with a letter or number, and may not begin with
+Filenames must begin with a letter or number, but may not begin with
 "00", as Ren'Py uses such files for its own purposes.
 
 Base Directory
 --------------
 
 The base directory is the directory that contains all files that are
-distributed with the game. (It may also contain some files that are not
-distributed with the game.) Things like README files should be placed in the
-base directory, from where they will be distributed.
+distributed with the game (even though not all the files in the base directory
+are usually distributed). See also : :doc:`build`. Things like README files
+should be placed in the base directory.
 
-The base directory is created underneath the Ren'Py directory, and has the name
-of your game. For example, if your Ren'Py directory is named renpy-6.11.2, and
-your game is named "HelloWorld", your base directory will be
-renpy-6.11.2/HelloWorld.
+The base directory is created within the "Projects Directory", which can be set
+in the Launcher, when you create a new game. For example, if your Projects
+Directory is named :file:`renpygames`, and your game is named "HelloWorld", your
+base directory will be :file:`renpygames/HelloWorld`.
 
 Game Directory
 --------------
 
-The game directory is almost always a directory named "game" underneath the
-base directory. For example, if your base directory is renpy-6.11.2/HelloWorld,
-your game directory will be renpy-6.11.2/HelloWorld/game.
-
-However, Ren'Py searches directories in the following order:
-
-* The name of the executable, without the suffix. For example,
-  if the executable is named moonlight.exe, it will look for
-  a directory named moonlight under the base directory.
-* The name of the executable, without the suffix, and with
-  a prefix ending with _ removed. For example, if the executable
-  is moonlight_en.exe, Ren'Py will look for a directory named en.
-* The directories "game", "data", and "launcher", in that order.
-
-The launcher will only properly recognize the "game" and "data" directories,
-however.
+The game directory is a directory named "game" inside the base directory. For
+example, if your base directory is :file:`renpygames/HelloWorld`, your game
+directory will be :file:`renpygames/HelloWorld/game`.
 
 The game directory contains all the files used by the game. It, including all
-subdirectories, is scanned for .rpy and .rpyc files, and those are combined to
-form the game script. It is scanned for .rpa archive files, and those are
-automatically used by the game. Finally, when the game gives a path to a file
-to load, it is loaded relative to the game directory. (But note that
-config.searchpath can change this.)
+subdirectories, is scanned for :file:`.rpy` and :file:`.rpyc` files, and those
+are combined to form the game script. It is scanned for :file:`.rpa` archive
+files, and those are automatically used by the game. Finally, when Ren'Py takes
+or considers a path to a file, the path is (with very few exceptions) relative
+to the game directory (but note that :var:`config.searchpath` can change this).
 
 Comments
 ========
 
 A Ren'Py script file may contain comments. A comment begins with a
-hash mark ('#'), and ends at the end of the line containing the
+hash mark (``#``), and ends at the end of the line containing the
 comment. As an exception, a comment may not be part of a string.
 
 ::
@@ -98,19 +85,19 @@ A script file is broken up into :dfn:`logical lines`. A logical line
 always begins at the start of a line in the file. A logical line ends
 at the end of a line, unless:
 
-* The last character on the line is a backslash ('\\').
+* The last character on the line is a backslash (``\``).
 
-* The line contains an open parenthesis character ('(', '{', or '['),
-  that hasn't been matched by the cooresponding close parenthesis
-  character (')', '}', or ']', respectively).
+* The line contains an open parenthesis character (``(``, ``{``, or ``[``),
+  that hasn't been matched by the cooresponding closing parenthesis
+  character (\ ``)``, ``}``, or ``]``, respectively).
 
-* The end of the line occurs during a string.
+* The end of the line occurs during a string - *any* string, even with single
+  quotes, as opposed to Python rules.
 
 Once a logical line ends, the next logical line begins at the start of
 the next line.
 
-Most statements in the Ren'Py language consist of a single logical
-line, while some statements consist of multiple lines.
+Most statements in the Ren'Py language consist of a single logical line.
 
 ::
 
@@ -122,7 +109,7 @@ line, while some statements consist of multiple lines.
    $ a = [ "Because of parenthesis, this line also",
            "spans more than one line." ]
 
-Empty logical lines are ignored.
+Empty lines are ignored and do not count as logical lines.
 
 
 Indentation and Blocks
@@ -143,13 +130,13 @@ dividing a file into blocks are:
 
 * All logical lines inside a block must have the same indentation.
 
-* A block ends when a logical line is encountered with less
+* A block ends when a non-empty logical line is encountered with less
   indentation than the lines in the block.
 
-Indentation is very important to Ren'Py, and cause syntax or logical
-errors when it's incorrect. At the same time, the use of indentation
-to convey block structure provides us a way of indicating that
-structure without overwhelming the script text.
+Indentation is very important in Ren'Py, as it is in Python, and it can cause
+syntax or logical errors when it's incorrect. At the same time, the use of
+indentation to express the block structure is far simpler than other languages
+using other delimiters.
 
 ::
 
@@ -173,7 +160,7 @@ Ren'Py statements are made of a few basic parts.
 
 :dfn:`Keyword`
     A keyword is a word that must literally appear in the script of the game.
-    Keywords are used to introduce statements and properties.
+    Keywords are typically used to introduce statements and properties.
 
 :dfn:`Name`
     A name begins with a letter or underscore, which is followed by
@@ -201,20 +188,39 @@ Ren'Py statements are made of a few basic parts.
     ``beach``, ``night``, and ``happy``.
 
 :dfn:`String`
-    A string begins with a quote character (one of ", ', or \`),
-    contains some sequence of characters, and ends with the same quote
-    character.
+    A string begins with a quote character (one of ", ', or \`), contains some
+    sequence of characters, and ends with the same quote character.
 
     The backslash character (\\) is used to escape quotes, special
     characters such as % (written as \\%), [ (written as \\[), and
     { (written as \\{). It's also used to include newlines, using the \\n
     sequence.
 
-    Inside a Ren'Py string, consecutive whitespace is compressed into
-    a single whitespace character, unless a space is preceded by a
-    backslash. ::
+    Inside a Ren'Py string, consecutive sequences of whitespace and line
+    breaks are compressed into a single whitespace character, unless a space is
+    preceded by a backslash. ::
 
         'Strings can\'t contain their delimiter, unless you escape it.'
+
+        "There will be a space between the two following
+         words."
+
+        "There will be a line break between\nthese."
+
+        "And there will be three spaces between\ \ \ these."
+
+    The ``r`` prefix is supported, and follow more or less the same rules as in
+    Python. Other prefixes, like ``u``, ``b`` or ``f``, are not supported.
+    Triple-quoted strings are generally not accepted in places where a normal
+    string is expected, and when they are, they usually yield a different
+    result - see :ref:`monologue-mode` for an example.
+
+    .. note::
+
+        This concerns strings found *directly* in Ren'Py script, such as in
+        :ref:`say-statement` or :doc:`menus`. Strings found inside
+        :ref:`python statements <python-statement>`, or in expressions (see
+        below), follow ordinary Python rules.
 
 :dfn:`Simple Expression`
     A simple expression is a Python expression, used to include Python
@@ -235,30 +241,26 @@ Ren'Py statements are made of a few basic parts.
     are all simple expressions. But ``3 + 4`` is not, as the
     expression ends at the end of a string.
 
-:dfn:`At List`
-    An at list is a list of simple expressions, separated by commas.
-
 :dfn:`Python Expression`
-    A Python expression is an arbitrary Python expression, that may
-    not include a colon. These are used to express the conditions in
-    the if and while statements.
+    A Python expression is an arbitrary Python expression, that may not include
+    a colon. These are used to express the conditions in the
+    :ref:`if <if-statement>` and :ref:`while <while-statement>` statements.
 
 
 Common Statement Syntax
 =======================
 
-Most Ren'Py statements share a common syntax. With the exception of
-the say statement, they begin with a keyword that introduces the
-statement. This keyword is followed by a parameter, if the statement
-takes one.
+Most Ren'Py statements share a common syntax. With the exception of the
+:ref:`say-statement`, they begin with a keyword that introduces the statement.
+This keyword is followed by a parameter, if the statement takes one.
 
 The parameter is then followed by one or more properties. Properties
 may be supplied in any order, provided each property is only supplied
 once. A property starts off with a keyword. For most properties, the
 property name is followed by one of the syntax elements given above.
 
-If the statement takes a block, the line ends with a colon
-(:). Otherwise, the line just ends.
+If the statement takes a block, the line ends with a colon (:). Otherwise, the
+line just ends.
 
 
 .. _python-basics:
@@ -268,11 +270,10 @@ Python Expression Syntax
 
 .. note::
 
-  It may not be necessary to read this section thoroughly right
-  now. Instead, skip ahead, and if you find yourself unable to figure
-  out an example, or want to figure out how things actually work, you
-  can go back and review this.
-
+    It may not be necessary to read this section thoroughly right
+    now. Instead, skip ahead, and if you find yourself unable to figure
+    out an example, or want to figure out how things actually work, you
+    can go back and review this.
 
 Many portions of Ren'Py take Python expressions. For example, defining
 a new Character involves a call to the :func:`Character` function. While
@@ -293,7 +294,7 @@ Here's a synopsis of Python expressions.
     Python strings begin with " or ', and end with the same
     character. \\ is used to escape the end character, and to
     introduce special characters like newlines (\\n). Unlike Ren'Py
-    strings, Python strings can't span lines.
+    strings, Python strings can't span several lines, or be delimited with \`.
 
 :dfn:`True, False, None`
     There are three special values. ``True`` is a true value, ``False`` is
@@ -320,32 +321,29 @@ Here's a synopsis of Python expressions.
     may vary. A list begins with a ``[``, contains a comma-separated
     list of expressions, and ends with ``]``. For example::
 
-        [ ]
-        [ 1 ]
-        [ 1, 2 ]
-        [ 1, 2, 3 ]
+        []
+        [1]
+        [1, 2]
+        [1, 2, 3]
 
 :dfn:`Variable`
-    Python expressions can use variables, that store values defined
-    using the ``define`` statement or Python statements. A variable begins
-    with a letter or underscore, and then has zero or more letters,
-    numbers, or underscores. For example::
+    Python expressions can use variables, that store values defined using the
+    :ref:`define-statement` or the :ref:`default-statement`. A variable name
+    follows the rules of a :dfn:`name` as explained in
+    :ref:`elements-of-statements`. For example::
 
-       name
-       love_love_points
-       trebuchet2_range
-
-    Variables beginning with _ are reserved for Ren'Py's use, and
-    shouldn't be used by creators.
+        playername
+        love_love_points
+        trebuchet2_range
 
 :dfn:`Field Access`
-    Python modules and objects have fields, which can be accessed
-    with by following an expression (usually a variable) with a
-    dot and the field name. For example::
+    Python modules and objects have fields, which can be accessed by following
+    an expression (usually a variable) with a dot and the field name.
+    For example::
 
        config.screen_width
 
-    Consists of a variable (config) followed by a field access
+    consists of a variable (config) followed by a field access
     (screen_width).
 
 :dfn:`Call`
@@ -354,18 +352,18 @@ Here's a synopsis of Python expressions.
     left-parenthesis, a comma-separated list of arguments, and a
     right-parenthesis. The argument list begins with the position
     arguments, which are Python expressions. These are followed by
-    keyword arguments, which consist of the argument name, and equals
-    sign, and an expression. In the example example::
+    keyword arguments, which consist of the argument name, an equals
+    sign, and an expression. In this example::
 
         Character("Eileen", type=adv, color="#0f0")
 
-    we call the Character function. It's given one positional
+    we call the :func:`Character` function. It's given one positional
     argument, the string "Eileen". It's given two keyword argument:
     ``type`` with the value of the ``adv`` variable, and ``color``
-    with a string value of "#0f0".
+    with a string value of ``"#0f0"``.
 
-    Constructors are a type of function which returns a new object,
-    and are called the same way.
+    Other objects than functions can be called, and are widely known as
+    :dfn:`callables`.
 
 When reading this documentation, you might see a function signature
 like:
@@ -384,16 +382,21 @@ This function:
 * Has one keyword argument, position, which has a default value
   of (0, 0).
 
-Since the functions ends with \*\*properties, it means that it can
+Since the functions ends with ``**properties``, it means that it can
 take :doc:`style properties <style_properties>` as additional keyword
-arguments. Other special entries are \*args, which means that it takes
-an arbitrary number of positional parameters, and \*\*kwargs, which means
-that the keyword arguments are described in the documentation.
+arguments. Other special entries are ``*args``, which means that it takes
+an arbitrary number of positional parameters, and ``**kwargs``, which means
+that it takes a wide range of keyword parameters which are usually explained
+in the function's documentation.
 
-Python is a lot more powerful than we have space for in this manual.
-To learn Python in more detail, we recommend starting with the Python
-tutorial, which is available from
-`python.org <https://docs.python.org/tutorial/index.html>`__.
-While we don't think a deep knowledge of Python is necessary to work
-with Ren'Py, the basics of Python statements and expressions is
-often helpful.
+When you see a ``/`` symbol on its own in a function signature, it means that
+the parameters before it are positional-only, and should not be passed by
+keyword. When you see a ``*`` symbol on its own, conversely, it means that the
+parameters *after* it are keyword-only, which means that they should only be
+passed using the ``name=value`` syntax.
+
+Python is a lot more powerful than we have space for in this manual. To learn
+Python in more detail, we recommend starting with the Python tutorial, which is
+available from `python.org <https://docs.python.org/tutorial/index.html>`__.
+While a deep knowledge of Python is not necessary to work with Ren'Py, knowing
+the basics of Python statements and expressions is often helpful.


### PR DESCRIPTION
A lot of rewordings and using roles to put the text in shape.
Remove a troublesome explanation about the game directory, which doesn't seem to have any practical use and is in any case far too advanced for this page.
More details about how strings are parsed, and the differences with python syntax.
Remove the "at list" entry which is far too specific for general syntax.
Add more details about meaningful signature syntax.