### PR TITLE
Fix incorrect parameter for unclosed text tags

### DIFF
--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -345,7 +345,7 @@ screen preferences():
                                 action ToggleSetMembership(persistent.lint_options, "--words-char-count")
                             textbutton _("Unclosed text tags"):
                                 style "l_checkbox"
-                                action ToggleSetMembership(persistent.lint_options, "--unclosed-text-tags")
+                                action ToggleSetMembership(persistent.lint_options, "--check-unclosed-tags")
 
                             add SPACER
 


### PR DESCRIPTION
Fix incorrect parameter for unclosed text tags in preferences.rpy.
```
usage: renpy.py [--savedir DIRECTORY] [--trace LEVEL] [--version] [--compile] [--keep-orphan-rpyc]
                [--errors-in-editor] [--safe-mode] [--json-dump FILE] [--json-dump-private]
                [--json-dump-common] [-h] [--error-code] [--orphan-tl] [--builtins-parameters]
                [--words-char-count] [--check-unclosed-tags]
                [basedir] [command] [filename]
renpy.py: error: unrecognized arguments: --unclosed-text-tags
```