### PR TITLE
Centralise safety features for persistent data

### DIFF
--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -32,7 +32,7 @@ import weakref
 
 import renpy
 
-from renpy.compat.pickle import dump, persistent_dumps, loads
+from renpy.compat.pickle import dump, dumps, loads
 
 # The class that's used to hold the persistent data.
 
@@ -223,8 +223,6 @@ def load(filename):
     return persistent
 
 
-safe_types = None # type: set[type] | None
-
 def init():
     """
     Loads the persistent data from disk.
@@ -233,12 +231,8 @@ def init():
     disk, so that we can configure the savelocation system.
     """
 
-    global safe_types
-    safe_types = set()
-    for sd in renpy.python.store_dicts.values():
-        for v in sd.values():
-            if isinstance(v, type):
-                safe_types.add(v)
+    if renpy.config.early_developer and not PY2:
+        init_debug_pickler()
 
     filename = os.path.join(renpy.config.savedir, "persistent.new") # type: ignore
     persistent = load(filename)
@@ -255,6 +249,34 @@ def init():
         backup[k] = safe_deepcopy(v)
 
     return persistent
+
+
+def init_debug_pickler():
+    import io, pickle
+
+    safe_types = set()
+
+    for d in renpy.python.store_dicts.values():
+        for v in d.values():
+            if isinstance(v, type):
+                safe_types.add(v)
+
+    class DebugPickler(pickle.Pickler):
+        def reducer_override(self, obj):
+            t = obj if isinstance(obj, type) else type(obj)
+
+            if t not in safe_types and t.__module__.startswith("store"):
+                cls = (t.__module__ + '.' + t.__qualname__)[6:]
+                raise TypeError("{} is not safe for use in persistent.".format(cls))
+
+            return NotImplemented # lets normal reducing take place
+
+    global dumps
+
+    def dumps(o):
+        b = io.BytesIO()
+        DebugPickler(b, renpy.compat.pickle.PROTOCOL).dump(o)
+        return b.getvalue()
 
 
 # A map from field name to merge function.
@@ -422,7 +444,7 @@ def save():
         return
 
     try:
-        data = persistent_dumps(renpy.game.persistent)
+        data = dumps(renpy.game.persistent)
         compressed = zlib.compress(data, 3)
         compressed += renpy.savetoken.sign_data(data).encode("utf-8")
         renpy.loadsave.location.save_persistent(compressed)


### PR DESCRIPTION
Follow up to #4545 to group all the associated logic in one place and reduce impact outside of developer mode.

Notes: Uses `__qualname__` but this is a py3-only code path, so it's okay to use.