### PR TITLE
Differentiate between adv and nvl menus for window auto hide

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1883,15 +1883,17 @@ class Menu(Node):
 
         next_node(self.next)
 
-        if self.has_caption or renpy.config.choice_empty_window:
-            statement_name("menu-with-caption")
-        else:
-            statement_name("menu")
-
         if self.arguments is not None:
             args, kwargs = self.arguments.evaluate()
         else:
             args = kwargs = None
+
+        if self.has_caption or renpy.config.choice_empty_window:
+            statement_name("menu-with-caption")
+        elif kwargs is not None and kwargs.get('nvl') is True:
+            statement_name("menu-nvl")
+        else:
+            statement_name("menu")
 
         choices = [ ]
         narration = [ ]

--- a/renpy/common/000window.rpy
+++ b/renpy/common/000window.rpy
@@ -107,6 +107,9 @@ init -1200 python:
         if not store._window_auto:
             return
 
+        if statement == 'menu' and menu == nvl_menu:
+            statement = 'menu-nvl'
+
         if statement in config.window_auto_hide:
             _window_hide(auto=True)
 


### PR DESCRIPTION
Use "menu-nvl" instead of "menu" for `config.window_auto_hide` when showing a nvl menu, as this kind of menus don't need to hide the dialogue window by default (contrary to adv menu).

Fix #5089.