### PR TITLE
doc: Clarify renpy.pause's parameters

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1542,7 +1542,7 @@ def imagemap(ground, selected, hotspots, unselected=None, overlays=False,
 def pause(delay=None, music=None, with_none=None, hard=False, predict=False, checkpoint=None, modal=None):
     """
     :doc: se_pause
-    :args: (delay=None, *, predict=False, modal=None, hard=False)
+    :args: (delay=None, *, predict=False, modal=True, hard=False)
 
     Causes Ren'Py to pause. Returns true if the user clicked to end the pause,
     or false if the pause timed out or was skipped.
@@ -1553,35 +1553,39 @@ def pause(delay=None, music=None, with_none=None, hard=False, predict=False, che
     The following should be given as keyword arguments:
 
     `predict`
-        If True, Ren'Py will only end the pause when all prediction, including
-        prediction scheduled with :func:`renpy.start_predict` and
-        :func:`renpy.start_predict_screen`, has been finished.
+        If True, when all prediction - including prediction scheduled with
+        :func:`renpy.start_predict` and :func:`renpy.start_predict_screen` - has
+        been finished, the pause will be ended.
 
         This also causes Ren'Py to prioritize prediction over display smoothness
         for the duration of the pause. Because of that, it's recommended to not
         display animations during prediction.
 
+        The pause will still end by other means - when the user clicks or skips,
+        or when the delay expires (if any).
+
     `modal`
-        If True or None, the pause will not end when a modal screen is being displayed.
+        If True, a timed pause will not end (it will hold) when a modal screen
+        is being displayed.
         If False, the pause will end while a modal screen is being displayed.
 
     `hard`
-        This must be given as a keyword argument. When True, Ren'Py may prevent
-        the user from clicking to interrupt the pause. If the player enables
-        skipping, the hard pause will be skipped. There may be other circumstances
-        where the hard pause ends early or prevents Ren'Py from operating properly,
-        these will not be treated as bugs.
+        When True, Ren'Py may prevent the user from clicking to interrupt the
+        pause. If the player enables skipping, the hard pause will be skipped.
+        There may be other circumstances where the hard pause ends early or
+        prevents Ren'Py from operating properly, these will not be treated as
+        bugs.
 
         In general, using hard pauses is rude. When the user clicks to advance
-        the game, it's an explicit request - the user wishes the game to advance.
-        To override that request is to assume you understand what the player
-        wants more than the player does.
-
-        Calling renpy.pause guarantees that whatever is on the screen will be
-        displayed for at least one frame, and hence has been shown to the
-        player.
+        the game, it's an explicit request - the user wishes the game to
+        advance. To override that request is to assume you understand what the
+        player wants more than the player does.
 
         tl;dr - Don't use renpy.pause with hard=True.
+
+    Calling renpy.pause guarantees that whatever is on the screen will be
+    displayed for at least one frame, and hence has been shown to the
+    player.
     """
 
     if renpy.config.skipping == "fast":

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1542,7 +1542,7 @@ def imagemap(ground, selected, hotspots, unselected=None, overlays=False,
 def pause(delay=None, music=None, with_none=None, hard=False, predict=False, checkpoint=None, modal=None):
     """
     :doc: se_pause
-    :args: (delay=None, *, hard=False, predict=False, modal=None)
+    :args: (delay=None, *, predict=False, modal=None, hard=False)
 
     Causes Ren'Py to pause. Returns true if the user clicked to end the pause,
     or false if the pause timed out or was skipped.
@@ -1551,6 +1551,19 @@ def pause(delay=None, music=None, with_none=None, hard=False, predict=False, che
         If given, the number of seconds Ren'Py should pause for.
 
     The following should be given as keyword arguments:
+
+    `predict`
+        If True, Ren'Py will only end the pause when all prediction, including
+        prediction scheduled with :func:`renpy.start_predict` and
+        :func:`renpy.start_predict_screen`, has been finished.
+
+        This also causes Ren'Py to prioritize prediction over display smoothness
+        for the duration of the pause. Because of that, it's recommended to not
+        display animations during prediction.
+
+    `modal`
+        If True or None, the pause will not end when a modal screen is being displayed.
+        If False, the pause will end while a modal screen is being displayed.
 
     `hard`
         This must be given as a keyword argument. When True, Ren'Py may prevent
@@ -1569,19 +1582,6 @@ def pause(delay=None, music=None, with_none=None, hard=False, predict=False, che
         player.
 
         tl;dr - Don't use renpy.pause with hard=True.
-
-    `predict`
-        If True, Ren'Py will end the pause when all prediction, including
-        prediction scheduled with :func:`renpy.start_predict` and
-        :func:`renpy.start_predict_screen`, has been finished.
-
-        This also causes Ren'Py to prioritize prediction over display smoothness
-        for the duration of the pause. Because of that, it's recommended to not
-        display animations during prediction.
-
-    `modal`
-        If True or None, the pause will not end when a modal screen is being displayed.
-        If False, the pause will end while a modal screen is being displayed.
     """
 
     if renpy.config.skipping == "fast":


### PR DESCRIPTION
It was unclear whether the pause ends when the time is expired AND the prediction is done, or if it ends when the time is expired OR the prediction is done.
From the issue the feature was proposed in, it's pretty clear that's an AND, and the passed time is a minimum rather than a maximum.
Now, what happens when the player clicks/skips, and what happens with timeless pauses ? I don't know, and I think it should be documented.

Also moves the hard parameter last, as it's not advised to use it.