### PR TITLE
Allow any iterable to build a color, not just a tuple

### DIFF
--- a/renpy/color.py
+++ b/renpy/color.py
@@ -163,18 +163,15 @@ class Color(tuple):
             if isinstance(c, Color):
                 return c
 
-            try:
-                c = tuple(c)
-            except Exception:
-                pass
-            else:
-                lenc = len(c)
+            c = tuple(c)
 
-                if lenc == 4:
-                    return tuple.__new__(cls, c)
+            lenc = len(c)
 
-                if lenc == 3:
-                    return tuple.__new__(cls, c + (int(255 * alpha),))
+            if lenc == 4:
+                return tuple.__new__(cls, c)
+
+            if lenc == 3:
+                return tuple.__new__(cls, c + (int(255 * alpha),))
 
         if hsv is not None:
             rgb = colorsys.hsv_to_rgb(*hsv)

--- a/renpy/color.py
+++ b/renpy/color.py
@@ -129,36 +129,28 @@ class Color(tuple):
         if color is not None:
             c = color
 
-            if isinstance(c, tuple):
-                if isinstance(c, Color):
-                    return c
-
-                if len(c) == 4:
-                    return tuple.__new__(cls, c)
-
-                if len(c) == 3:
-                    return tuple.__new__(cls, c + (int(255 * alpha),))
-
             if isinstance(c, basestring):
                 if c[0] == '#':
                     c = c[1:]
 
-                if len(c) == 6:
-                    r = int(c[0]+c[1], 16)
-                    g = int(c[2]+c[3], 16)
-                    b = int(c[4]+c[5], 16)
+                lenc = len(c)
+
+                if lenc == 6:
+                    r = int(c[:2], 16)
+                    g = int(c[2:4], 16)
+                    b = int(c[4:], 16)
                     a = int(alpha * 255)
-                elif len(c) == 8:
-                    r = int(c[0]+c[1], 16)
-                    g = int(c[2]+c[3], 16)
-                    b = int(c[4]+c[5], 16)
-                    a = int(c[6]+c[7], 16)
-                elif len(c) == 3:
+                elif lenc == 8:
+                    r = int(c[:2], 16)
+                    g = int(c[2:4], 16)
+                    b = int(c[4:6], 16)
+                    a = int(c[6:], 16)
+                elif lenc == 3:
                     r = int(c[0], 16) * 0x11
                     g = int(c[1], 16) * 0x11
                     b = int(c[2], 16) * 0x11
                     a = int(alpha * 255)
-                elif len(c) == 4:
+                elif lenc == 4:
                     r = int(c[0], 16) * 0x11
                     g = int(c[1], 16) * 0x11
                     b = int(c[2], 16) * 0x11
@@ -167,6 +159,22 @@ class Color(tuple):
                     raise Exception("Color string {!r} must be 3, 4, 6, or 8 hex digits long.".format(c))
 
                 return tuple.__new__(cls, (r, g, b, a)) # type: ignore
+
+            if isinstance(c, Color):
+                return c
+
+            try:
+                c = tuple(c)
+            except Exception:
+                pass
+            else:
+                lenc = len(c)
+
+                if lenc == 4:
+                    return tuple.__new__(cls, c)
+
+                if lenc == 3:
+                    return tuple.__new__(cls, c + (int(255 * alpha),))
 
         if hsv is not None:
             rgb = colorsys.hsv_to_rgb(*hsv)


### PR DESCRIPTION
The complete version raises an exception when it didn't use to, when passing an invalid `color` parameter with another valid parameter (for example `Color(3, rgb=(1, 1., .3))`), which I think doesn't make sense to allow.
The first commit can be taken alone to avoid that new error and stay strictly compatible.