### PR TITLE
Restore intended behaviour for c in conversion

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -214,7 +214,7 @@ class Formatter(string.Formatter):
             value = value.lower()
 
         if "c" in conversion:
-            value = value.capitalize()
+            value = value[:1].capitalize() + value[1:]
 
         return value
 


### PR DESCRIPTION
The change to `str.capitalize` over `str.upper` was to cover the case of digraphs such as "ǌ" (see pydoc ref). However the remainder of the string should remain untouched per our docs, with full `str.capitalize` parity being achieved by combining the `l` and `c` conversions.

Use of capitalize does swap one quirk with another: Previously "Ǌ", "ǋ", and "ǌ" would all become "Ǌ"; now they will all become "ǋ". The potential down casing of the constituent J of the upper case form ends up being a better trade off than the up casing of the J from the two latter forms, especially within the context of the c conversion.

ref: https://docs.python.org/3/library/stdtypes.html#str.capitalize

Follow up to https://github.com/renpy/renpy/pull/3534 and 8396e98a4303f5b966fdc86289b56fd39af94e32.