### PR TITLE
Lint check_conflicting_properties

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -1102,6 +1102,9 @@ def lint():
     check_unreachables(all_stmts)
     check_orphan_translations(none_language_ids, translated_ids)
 
+    if not renpy.config.check_conflicting_properties:
+        print("It is advised to set config.check_conflicting_properties to True.")
+
     for f in renpy.config.lint_hooks:
         f()
 


### PR DESCRIPTION
Old projects _should_ put that config to True, and new projects which for some reason would empty the default gui screen and start anew should even more.
In the report, I placed it above the statistics and not with the config.developer check because it's more serious than both : there are valid reasons to put a boolean expression as config.developer and not rely on the "auto" behavior, but the only reason we didn't set that config to True by default is because it would trigger on vanilla projects generated from the beginning of renpy 7 I believe, which is a huge lot (maybe a majority).

Now, a problem is that this config is not listed in the config doc page, so a decision should be made on whether we document it, but I'm against because if you should never set it to False, we shouldn't place that in the official documentation.
Or instead we could put a longer lint message explaining what kind of bugs it prevents and how to fix them - and if that's too long on your report, too bad for you : activate the config and fix the mistakes.