### PR TITLE
Hotfix last part of 5162

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -119,10 +119,7 @@ def relative(n, base, limit):
     while a float is interpreted as a fraction of the limit).
     """
 
-    if isinstance(n, (int, absolute)):
-        return n
-    else:
-        return min(int(n * base), limit)
+    return min(int(absolute.compute_raw(n, base)), limit)
 
 cdef class RenderTransform:
     """


### PR DESCRIPTION
About the change at the top of `cartesian_to_polar_anchor` : I don't know what to do. `xanchor` and `yanchor` are of the position type as specified at the bottom of the file, so clearly there needs to be a call to `scale` to set them up on a common metric.
And despite how the bottom of the file specifies it, wrongly describing `xanchoraround` and `yanchoraround` as type `float`, they are documented as type `position`, so, what the hell ? Everything needs to be scaled apparently : `xanchor` and `yanchor`, as I said, but `xanchoraround` and `yanchoraround` as well ; and it seems `anchorradius` too since it's documented as taking a position but since we apparently convert it on-the-fly I don't know what to think of it !
@renpytom halp