### PR TITLE
Tweak get_sdl_dll() documentation

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -4510,13 +4510,9 @@ def get_sdl_dll():
     """
     :doc: sdl
 
-    This returns a ctypes.cdll object that refers to the library that contains
-    the instance of SDL2 that Ren'Py is using.
-
-    If this can not be done, None is returned.
+    :return: A ctypes.cdll object that refers to the library that contains
+    the instance of SDL2 that Ren'Py is using. If this can not be done, None is returned.
     """
-
-
 
     global sdl_dll
 
@@ -4554,8 +4550,10 @@ def get_sdl_window_pointer():
     """
     :doc: sdl
 
-    Returns a pointer (of type ctypes.c_void_p) to the main window, or None
-    if the main window is not displayed, or some other problem occurs.
+    :return: A pointer to the main window or None if the main window is not
+    displayed (or some other problem occurs).
+
+    :rtype: ctypes.c_void_p | None
     """
 
     try:

--- a/sphinx/source/other.rst
+++ b/sphinx/source/other.rst
@@ -129,13 +129,16 @@ with the specified value if provided.
 SDL
 ----
 
-These functions let you use the Python ctypes module to call functions in
-the SDL dll. There are no guarantees as to the version of SDL2 that's included
-with Ren'Py, including which features will or will not be compiled in. These
-functions may fail on platforms that can otherwise run Ren'Py, and so it's
-important to check for None before proceeding.
+The SDL2 dll can be accessed using `renpy.get_sdl_dll()`.
+This allows the use of SDL2 functions directly. However, using them often
+requires knowledge of the Python ctypes module.
 
-.. include:: inc/sdl
+There are no guarantees as to the version of SDL2 that's included
+with Ren'Py, including which features will or will not be compiled in. These
+functions may fail on platforms that can otherwise run Ren'Py. It's
+important to check for a None value before proceeding.
+
+In the following example, the position of the window will be taken from SDL2:
 
 ::
 
@@ -144,10 +147,11 @@ important to check for None before proceeding.
         import ctypes
 
         def get_window_position():
-            """
-            Retrieves the position of the window from SDL2.  Returns
-            the (x, y) of the upper left corner of the window, or
-            (0, 0) if it's not known.
+            """Retrieve the position of the window from SDL2.
+
+            Returns:
+              The (x, y) of the upper left corner of the window, or
+              (0, 0) if it's not known.
             """
 
             sdl = renpy.get_sdl_dll()
@@ -160,15 +164,15 @@ important to check for None before proceeding.
             if win is None:
                 return (0, 0)
 
-            SDL_GetWindowPosition = sdl.SDL_GetWindowPosition
-
             x = ctypes.c_int()
             y = ctypes.c_int()
 
-            SDL_GetWindowPosition(win, ctypes.byref(x), ctypes.byref(y))
+            result = sdl.SDL_GetWindowPosition(win, ctypes.byref(x), ctypes.byref(y))
+
+            return result
 
 
-
+.. include:: inc/sdl
 
 Miscellaneous
 -------------


### PR DESCRIPTION
In this PR:

- `:return:` is used in `get_sdl_dll()` and `get_sdl_window_pointer()` docstrings to let sphinx decide the formatting of the return description.

- In the SDL section of the documentation, the example is placed before the function documentation. 

- The example function is modified to return the value that's pulled from SDL.
