### PR TITLE
Move constant definitions into individual stores

### DIFF
--- a/renpy/common/000atl.rpy
+++ b/renpy/common/000atl.rpy
@@ -23,6 +23,8 @@
 # early, so Ren'Py knows about them when parsing other files.
 
 python early in _warper:
+    # Do not participate in saves.
+    _constant = True
 
     from renpy.atl import pause, instant
 

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -22,7 +22,8 @@
 # This file contains code that creates a few new statements.
 
 init -1200 python in audio:
-    pass
+    # Do not participate in saves.
+    _constant = True
 
 init -1200 python:
 

--- a/renpy/common/00achievement.rpy
+++ b/renpy/common/00achievement.rpy
@@ -21,6 +21,9 @@
 
 
 init -1500 python in achievement:
+    # Do not participate in saves.
+    _constant = True
+
     from store import persistent, renpy, config, Action
 
     # A list of backends that have been registered.

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -23,6 +23,8 @@
 # distributions.
 
 init -1500 python in build:
+    # Do not participate in saves.
+    _constant = True
 
     from store import config, store
 

--- a/renpy/common/00director.rpy
+++ b/renpy/common/00director.rpy
@@ -28,6 +28,9 @@ init offset = -1101
 default persistent._director_bottom = False
 
 init python in director:
+    # Do not participate in saves.
+    _constant = True
+
     from store import Action, config
     import store
 

--- a/renpy/common/00gamepad.rpy
+++ b/renpy/common/00gamepad.rpy
@@ -74,6 +74,9 @@ screen _gamepad_control(name, control, kind, mappings, back, i, total):
 
 
 init -1200 python in _gamepad:
+    # Do not participate in saves.
+    _constant = True
+
     from pygame_sdl2 import JOYHATMOTION, JOYAXISMOTION, JOYBUTTONDOWN
     import pygame_sdl2
     import os

--- a/renpy/common/00iap.rpy
+++ b/renpy/common/00iap.rpy
@@ -20,6 +20,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 init -1500 python in iap:
+    # Do not participate in saves.
+    _constant = True
 
     from store import persistent, Action
     import time

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -1,6 +1,8 @@
 ﻿init offset = -100
 
 python early in layeredimage:
+    # Do not participate in saves.
+    _constant = True
 
     from store import Transform, ConditionSwitch, Fixed, Null, config, Text, eval, At
     from collections import OrderedDict, defaultdict

--- a/renpy/common/00library.rpy
+++ b/renpy/common/00library.rpy
@@ -304,24 +304,6 @@ init -1700 python:
 
 
     ##########################################################################
-    # Constant stores.
-    #
-    # Set _constant on many default stores.
-
-    _errorhandling._constant = True
-    _gamepad._constant = True
-    _renpysteam._constant = True
-    _warper._constant = True
-    audio._constant = True
-    achievement._constant = True
-    build._constant = True
-    director._constant = True
-    iap._constant = True
-    layeredimage._constant = True
-    updater._constant = True
-
-
-    ##########################################################################
     # Misc.
 
     # Should we display tiles in places of transparency while in developer

--- a/renpy/common/00steam.rpy
+++ b/renpy/common/00steam.rpy
@@ -26,6 +26,8 @@ python early:
 
 
 init -1499 python in _renpysteam:
+    # Do not participate in saves.
+    _constant = True
 
     import collections
     import time

--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -21,6 +21,9 @@
 
 # This code applies an update.
 init -1500 python in updater:
+    # Do not participate in saves.
+    _constant = True
+
     from store import renpy, config, Action, DictEquality, persistent
     import store.build as build
 

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -673,6 +673,8 @@ screen _exception_actions(traceback_fn, tt, *args):
 
 
 python early in _errorhandling:
+    # Do not participate in saves.
+    _constant = True
 
     # These enable various error handling modes.
     rollback = True


### PR DESCRIPTION
No functional change, purely code organisation. Makes it more obvious when reading the file that defines a store whether that store is expected to be constant. Follows the pattern established in `00sync.rpy` and applies it where appropriate.