### PR TITLE
Fix #5165

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -4510,8 +4510,8 @@ def get_sdl_dll():
     """
     :doc: sdl
 
-    :return: A ctypes.cdll object that refers to the library that contains
-    the instance of SDL2 that Ren'Py is using. If this can not be done, None is returned.
+    Returns a ctypes.cdll object that refers to the library that contains
+    the instance of SDL2 that Ren'Py is using. If this fails, None is returned.
     """
 
     global sdl_dll
@@ -4550,17 +4550,17 @@ def get_sdl_window_pointer():
     """
     :doc: sdl
 
-    :return: A pointer to the main window or None if the main window is not
-    displayed (or some other problem occurs).
-
     :rtype: ctypes.c_void_p | None
+
+    Returns a pointer to the main window, or None if the main window is not
+    displayed (or some other problem occurs).
     """
 
     try:
         window = pygame_sdl2.display.get_window()
 
         if window is None:
-            return
+            return None
 
         return window.get_sdl_window_pointer()
 

--- a/sphinx/source/other.rst
+++ b/sphinx/source/other.rst
@@ -129,7 +129,7 @@ with the specified value if provided.
 SDL
 ----
 
-The SDL2 dll can be accessed using `renpy.get_sdl_dll()`.
+The SDL2 dll can be accessed using :func:`renpy.get_sdl_dll`.
 This allows the use of SDL2 functions directly. However, using them often
 requires knowledge of the Python ctypes module.
 
@@ -138,20 +138,17 @@ with Ren'Py, including which features will or will not be compiled in. These
 functions may fail on platforms that can otherwise run Ren'Py. It's
 important to check for a None value before proceeding.
 
-In the following example, the position of the window will be taken from SDL2:
-
-::
+In the following example, the position of the window will be taken from SDL2::
 
     init python:
 
         import ctypes
 
         def get_window_position():
-            """Retrieve the position of the window from SDL2.
+            """Retrieves the position of the window from SDL2.
 
-            Returns:
-              The (x, y) of the upper left corner of the window, or
-              (0, 0) if it's not known.
+            Returns the (x, y) of the upper left corner of the window, or
+            (0, 0) if it's not known.
             """
 
             sdl = renpy.get_sdl_dll()


### PR DESCRIPTION
The :return: field did not support line breaks, and given that it's used nowhere else I found it better to just say it in english.
Also forgotten func role and minor grammar mistakes.