### PR TITLE
Track hard checkpoints that have been blocked

### DIFF
--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -443,12 +443,11 @@ class RollbackLog(renpy.object.Object):
     (weakref to object, information needed to rollback that object)
     """
 
-    __version__ = 5
+    __version__ = 6
 
     nosave = [ 'old_store', 'mutated', 'identifier_cache' ]
     identifier_cache = None
     force_checkpoint = False
-    rollback_block = 0
 
     def __init__(self):
 
@@ -508,6 +507,11 @@ class RollbackLog(renpy.object.Object):
                         nrbl += 1
 
                 self.rollback_limit = nrbl
+
+        if version < 6:
+            hard = sum(e.hard_checkpoint for e in self.log)
+            self.rollback_block = max(0, hard - self.rollback_limit)
+            self.rollback_limit = hard - self.rollback_block
 
     def begin(self, force=False):
         """


### PR DESCRIPTION
This is necessary so they can be counted out as the log is truncated, keeping `rollback_limit` accurate. This results in correct reporting from `renpy.can_rollback()` in the scenario where `config.rollback_length` has been exceeded.

**[Original issue](https://github.com/renpy/renpy/issues/5014) (steps to repro on 8.1.3)**
Presents as `renpy.can_rollback` returning `True` despite rollback not being possible.

Repro:
- Start game
- Skip to 099 (careful not to overshoot)
- Rollback as much as possible (usually lands just below 010 but before 001).

Observations:
- `renpy.can_rollback` reports inaccurately
- Warnings in console
- Log runs out before rollback_limit hits 0

**New issue (following https://github.com/renpy/renpy/commit/2a62b88aeb83f538cce64b55ea9aad13b0d3fa4d)**
Presents as rollback becoming non-functional.

Repro:
- Start game
- Skip to 150 (ish)

Observation:
- Rollback is extremely limited or entirely non-functional
- Rollback_limit is close to 0 or even negative

---

<details><summary>Test code used for both repros.</summary>

```rpy
label main_menu:
    $ _confirm_quit = False
    return

define character.e = Character('Eileen', what_prefix='[cycle]')
default cycle = 0

label start:
    $ renpy.watch('renpy.game.log.rollback_limit')
    $ renpy.watch('len(renpy.game.log.log)')
    $ renpy.watch('renpy.can_rollback()')
    jump test

label test:
    $ renpy.block_rollback()
    e "01"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "02"
    e "03"
    e "04"
    e "05"
    e "06"
    e "07"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "08"
    e "09"
    e "10"
    e "11"
    e "12"
    e "13"
    e "14"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "15"
    e "16"
    e "17"
    e "18"
    e "19"
    e "20"
    e "21"
    e "22"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "23"
    e "24"
    e "25"
    e "26"
    e "27"
    e "28"
    e "29"
    e "30"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "31"
    e "32"
    e "33"
    e "34"
    e "35"
    e "36"
    e "37"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "38"
    e "39"
    e "40"
    e "41"
    e "42"
    e "43"
    e "44"
    e "45"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "46"
    e "47"
    e "48"
    e "49"
    e "50"
    e "51"
    e "52"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "53"
    e "54"
    e "55"
    e "56"
    e "57"
    e "58"
    e "59"
    e "60"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "61"
    e "62"
    e "63"
    e "64"
    e "65"
    e "66"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "67"
    e "68"
    e "69"
    e "70"
    e "71"
    e "72"
    e "73"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 0.1, modal=None)
    $ renpy.suspend_rollback(False)
    e "74"
    e "75"
    e "76"
    e "77"
    e "78"
    e "79"
    e "80"
    e "81"
    e "82"
    e "83"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "84"
    e "85"
    e "86"
    e "87"
    e "88"
    e "89"
    e "90"
    $ renpy.suspend_rollback(True)
    $renpy.pause(delay = 1.0, modal=None)
    $ renpy.suspend_rollback(False)
    e "91"
    e "92"
    e "93"
    e "94"
    e "95"
    e "96"
    e "97"
    e "98"
    e "99"
    $ cycle += 1
    jump test
```
</details>