### PR TITLE
fix warp_to_line behavior

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -2062,7 +2062,7 @@ def warp_to_line(warp_spec):
     """
 
     renpy.warp.warp_spec = warp_spec
-    renpy.warp.warp()
+    full_restart()
 
 
 def screenshot(filename):


### PR DESCRIPTION
warp_to_line() now has the problem Ren'Py doesn't return to main_menu when the game ends after warp by warp_to_line().
This fixes it.