### PR TITLE
fix: `TranslateSay.predict`

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2549,7 +2549,7 @@ class TranslateSay(Say):
     def predict(self):
         node = self.lookup()
         if node is None:
-            return self.next
+            return [ self.next ]
         else:
             return [ node ]
 


### PR DESCRIPTION
Based on `The Question` & `Tutorial`.
`self.next` field always contains sub type of `ast.Node`