### PR TITLE
Simplify renpy.transform.ALIASES and nuke dualangle_or_float_or_none

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -173,12 +173,6 @@ def position_or_none(x):
     return position.from_any(x)
 
 
-def dualangle_or_float_or_none(x):
-    if x is None:
-        return None
-    return DualAngle.from_any(x)
-
-
 def any_object(x):
     return x
 
@@ -1600,7 +1594,7 @@ class Interpolation(Statement):
         if anchorangles is not None:
             startangle, endangle = anchorangles[:2]
 
-            anchorangle = interpolate(complete, startangle, endangle, dualangle_or_float_or_none)
+            anchorangle = interpolate(complete, startangle, endangle, DualAngle.from_any)
             trans.state.anchorangle = anchorangle
 
         if anchorradii is not None:

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -27,12 +27,11 @@ from typing import Any
 # This file contains displayables that move, zoom, rotate, or otherwise
 # transform displayables. (As well as displayables that support them.)
 import math
-import types # @UnresolvedImport
 
 import renpy
 from renpy.display.layout import Container
 from renpy.display.accelerator import RenderTransform
-from renpy.atl import dualangle_or_float_or_none, position, DualAngle, position_or_none, any_object, bool_or_none, float_or_none, matrix, mesh
+from renpy.atl import position, DualAngle, position_or_none, any_object, bool_or_none, float_or_none, matrix, mesh
 from renpy.display.core import absolute
 
 class Camera(renpy.object.Object):
@@ -1270,28 +1269,28 @@ add_gl_property("gl_pixel_perfect")
 add_gl_property("gl_texture_scaling")
 add_gl_property("gl_texture_wrap")
 
-ALIASES = {
-    "alignaround" : (float, float),
-    "align" : (float, float),
-    "anchor" : (position_or_none, position_or_none),
-    "anchorangle" : dualangle_or_float_or_none,
-    "anchoraround" : (position_or_none, position_or_none),
-    "anchorradius" : position_or_none,
-    "angle" : float,
-    "around" : (position_or_none, position_or_none),
-    "offset" : (int, int),
-    "pos" : (position_or_none, position_or_none),
-    "radius" : position_or_none,
-    "size" : (int, int),
-    "xalign" : float,
-    "xcenter" : position_or_none,
-    "xycenter" : (position_or_none, position_or_none),
-    "xysize" : (position_or_none, position_or_none),
-    "yalign" : float,
-    "ycenter" : position_or_none,
-    }
+ALIASES = (
+    "alignaround", # (float, float),
+    "align", # (float, float),
+    "anchor", # (position_or_none, position_or_none),
+    "anchorangle", # dualangle_or_float_or_none,
+    "anchoraround", # (position_or_none, position_or_none),
+    "anchorradius", # position_or_none,
+    "angle", # float,
+    "around", # (position_or_none, position_or_none),
+    "offset", # (int, int),
+    "pos", # (position_or_none, position_or_none),
+    "radius", # position_or_none,
+    "size", # (int, int),
+    "xalign", # float,
+    "xcenter", # position_or_none,
+    "xycenter", # (position_or_none, position_or_none),
+    "xysize", # (position_or_none, position_or_none),
+    "yalign", # float,
+    "ycenter", # position_or_none,
+)
 
-renpy.atl.PROPERTIES.update(ALIASES)
+renpy.atl.PROPERTIES.update(dict.fromkeys(ALIASES))
 
 for name in ALIASES:
     setattr(Transform, name, Proxy(name))


### PR DESCRIPTION
DualAngle.from_any is already dualangle_or_float, and anchorangles (if not None) cannot be a tuple of None, it can only be a tuple of float (from older versions of renpy, maybe from user code passing it in but I doubt it) or a DualAngle

ALIASES's values were never read, because the only read values of PROPERTIES are those also present in diff2_properties or diff4_properties, both of which are only populated by add_property