### PR TITLE
Adjustments to display_menu layer selection

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1307,9 +1307,7 @@ def display_menu(items,
 
             item_actions.append(me)
 
-        if "_layer" in scope:
-            layer = scope.pop("_layer")
-        elif type == "nvl":
+        if type == "nvl":
             layer = renpy.config.nvl_choice_layer
         else:
             layer = renpy.config.choice_layer

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1187,6 +1187,7 @@ def display_menu(items,
                  screen="choice",
                  type="menu", # @ReservedAssignment
                  predict_only=False,
+                 layer=None,
                  **kwargs):
     """
     :doc: se_menu
@@ -1217,6 +1218,7 @@ def display_menu(items,
     menu_args, menu_kwargs = get_menu_args()
     screen = menu_kwargs.pop("screen", screen)
     with_none = menu_kwargs.pop("_with_none", with_none)
+    layer = menu_kwargs.pop("_layer", layer)
     mode = menu_kwargs.pop("_mode", type)
 
     if interact:
@@ -1307,10 +1309,11 @@ def display_menu(items,
 
             item_actions.append(me)
 
-        if type == "nvl":
-            layer = renpy.config.nvl_choice_layer
-        else:
-            layer = renpy.config.choice_layer
+        if not layer:
+            if type == "nvl":
+                layer = renpy.config.nvl_choice_layer
+            else:
+                layer = renpy.config.choice_layer
 
         show_screen(
             screen,


### PR DESCRIPTION
Follow up to #4848.

I'd **strongly suggest considering only taking the first of these commits** unless we think there's a real demand for the functionality of the latter.

If we do want the second, the rationale here is that it would better mirror the expectation already established by `with_none` in this function which already parallels similar arguments in functions such as `show_screen`, and avoids accidentally pulling from scope now or in future which seems like it would only ever lead to confusion and never be truly intentional.