### PR TITLE
Filter events propagated through containers

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -304,7 +304,7 @@ init -1100 python:
             config.drag_group_add_top = False
             config.transitions_use_child_placement = True
             config.interpolate_exprs = False
-            config.containers_pass_transform_events = False
+            config.containers_pass_transform_events.clear()
             config.say_replace_event = False
             config.screens_never_cancel_hide = False
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1436,8 +1436,8 @@ defer_tl_scripts = False
 # Should transitions take placement from child displayables?
 transitions_use_child_placement = True
 
-# Should containers pass transform events to their children?
-containers_pass_transform_events = True
+# Which transform events should containers pass to their children?
+containers_pass_transform_events = {'hover', 'idle', 'insensitive'}
 
 # Should the say screens be given the replace event for the second and
 # later pauses?

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -138,7 +138,7 @@ class Container(renpy.display.displayable.Displayable):
 
         super(Container, self).set_transform_event(event)
 
-        if renpy.config.containers_pass_transform_events:
+        if event in renpy.config.containers_pass_transform_events:
 
             for i in self.children:
                 i.set_transform_event(event)

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -181,7 +181,7 @@ events.
 
 To disable this, add to your game::
 
-    define config.containers_pass_transform_events = True
+    define config.containers_pass_transform_events = ()
 
 **Say Screens Are Supplied the Replace Event.** Say screens are now supplied
 the "replace" (rather than "show") transform event for the second and subsequent pauses.


### PR DESCRIPTION
Possible solution to #5268. Inspired by comment on the original issue and included below.

---

> It might make sense to change that going forwards, just for hover and idle, but this is going to be an 8.2 thing.

_Originally posted by @renpytom in https://github.com/renpy/renpy/issues/4578#issuecomment-1528933364_