### PR TITLE
lint: Allow emoji_font to be None

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -709,6 +709,8 @@ def check_style(name, s):
                 if isinstance(v, renpy.text.font.FontGroup):
                     for f in set(v.map.values()):
                         check_file(name, f, directory="fonts")
+                elif v is None and k.endswith("emoji_font"):
+                    pass
                 else:
                     check_file(name, v, directory="fonts")
 


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/5272.