### PR TITLE
Retain correct types during spline interpolation

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -264,17 +264,17 @@ def interpolate(t, a, b, typ):
 # Interpolate the value of a spline. This code is based on Aenakume's code,
 # from 00splines.rpy.
 
-def interpolate_spline(t, spline):
+def interpolate_spline(t, spline, typ):
 
     if isinstance(spline[-1], tuple):
-        return tuple(interpolate_spline(t, i) for i in zip(*spline))
+        return tuple(interpolate_spline(t, i, ty) for i, ty in zip(zip(*spline), typ))
 
     if spline[0] is None:
         return spline[-1]
 
-    mixed_position = renpy.config.mixed_position
-    if mixed_position:
+    if renpy.config.mixed_position and typ in (position_or_none, position):
         spline = [position_or_none(i) for i in spline]
+
     lenspline = len(spline)
 
     if lenspline == 2:
@@ -322,10 +322,7 @@ def interpolate_spline(t, spline):
 
         rv = get_catmull_rom_value(t, *spline[sector - 1:sector + 3])
 
-    if mixed_position:
-        return rv
-    # legacy
-    elif rv is None:
+    if rv is None:
         return None
     else:
         return type(spline[-1])(rv)
@@ -1606,7 +1603,7 @@ class Interpolation(Statement):
 
         # Handle any splines we might have.
         for name, values in splines:
-            value = interpolate_spline(complete, values)
+            value = interpolate_spline(complete, values, PROPERTIES[name])
             setattr(trans.state, name, value)
 
         if (st >= self.duration) and (not force_frame):

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -173,6 +173,12 @@ def position_or_none(x):
     return position.from_any(x)
 
 
+def dualangle_or_float_or_none(x):
+    if x is None:
+        return None
+    return DualAngle.from_any(x)
+
+
 def any_object(x):
     return x
 
@@ -1589,7 +1595,7 @@ class Interpolation(Statement):
         if anchorangles is not None:
             startangle, endangle = anchorangles[:2]
 
-            anchorangle = interpolate(complete, startangle, endangle, DualAngle.from_any)
+            anchorangle = interpolate(complete, startangle, endangle, dualangle_or_float_or_none)
             trans.state.anchorangle = anchorangle
 
         if anchorradii is not None:

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -31,7 +31,7 @@ import math
 import renpy
 from renpy.display.layout import Container
 from renpy.display.accelerator import RenderTransform
-from renpy.atl import position, DualAngle, position_or_none, any_object, bool_or_none, float_or_none, matrix, mesh
+from renpy.atl import dualangle_or_float_or_none, position, DualAngle, position_or_none, any_object, bool_or_none, float_or_none, matrix, mesh
 from renpy.display.core import absolute
 
 class Camera(renpy.object.Object):
@@ -1265,28 +1265,28 @@ add_gl_property("gl_pixel_perfect")
 add_gl_property("gl_texture_scaling")
 add_gl_property("gl_texture_wrap")
 
-ALIASES = (
-    "alignaround", # (float, float),
-    "align", # (float, float),
-    "anchor", # (position_or_none, position_or_none),
-    "anchorangle", # dualangle_or_float_or_none,
-    "anchoraround", # (position_or_none, position_or_none),
-    "anchorradius", # position_or_none,
-    "angle", # float,
-    "around", # (position_or_none, position_or_none),
-    "offset", # (int, int),
-    "pos", # (position_or_none, position_or_none),
-    "radius", # position_or_none,
-    "size", # (int, int),
-    "xalign", # float,
-    "xcenter", # position_or_none,
-    "xycenter", # (position_or_none, position_or_none),
-    "xysize", # (position_or_none, position_or_none),
-    "yalign", # float,
-    "ycenter", # position_or_none,
-)
+ALIASES = {
+    "alignaround" : (float, float),
+    "align" : (float, float),
+    "anchor" : (position_or_none, position_or_none),
+    "anchorangle" : dualangle_or_float_or_none,
+    "anchoraround" : (position_or_none, position_or_none),
+    "anchorradius" : position_or_none,
+    "angle" : float,
+    "around" : (position_or_none, position_or_none),
+    "offset" : (int, int),
+    "pos" : (position_or_none, position_or_none),
+    "radius" : position_or_none,
+    "size" : (int, int),
+    "xalign" : float,
+    "xcenter" : position_or_none,
+    "xycenter" : (position_or_none, position_or_none),
+    "xysize" : (position_or_none, position_or_none),
+    "yalign" : float,
+    "ycenter" : position_or_none,
+    }
 
-renpy.atl.PROPERTIES.update(dict.fromkeys(ALIASES))
+renpy.atl.PROPERTIES.update(ALIASES)
 
 for name in ALIASES:
     setattr(Transform, name, Proxy(name))

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -1267,7 +1267,7 @@ add_gl_property("gl_texture_wrap")
 
 ALIASES = {
     "alignaround" : (float, float),
-    "align" : (float, float),
+    "align" : (position_or_none, position_or_none), # document as (float, float)
     "anchor" : (position_or_none, position_or_none),
     "anchorangle" : dualangle_or_float_or_none,
     "anchoraround" : (position_or_none, position_or_none),
@@ -1278,11 +1278,11 @@ ALIASES = {
     "pos" : (position_or_none, position_or_none),
     "radius" : position_or_none,
     "size" : (int, int),
-    "xalign" : float,
+    "xalign" : position_or_none, # document as float,
     "xcenter" : position_or_none,
     "xycenter" : (position_or_none, position_or_none),
     "xysize" : (position_or_none, position_or_none),
-    "yalign" : float,
+    "yalign" : position_or_none, # document as float
     "ycenter" : position_or_none,
     }
 


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/5274.

- Brings back transform `ALIASES` type-mapping since they're needed for interpolation.
- Looks up and passes the type to interpolate_splines.
- Only attempts to convert to `position` when the config flag is true, and the passed type is position.

Tested with:
```rpy
transform example:
    align (0, 0) offset (0, 0)
    linear 2.0 offset (50, 100) knot (0, 33) knot (50, 66)
    align (0, 0) offset (0, 0)
    linear 2.0 align (.5, 1.) knot (0, .33) knot (.5, .66)
    align (0, 0) offset (0, 0)
    linear 2.0 pos (50, 100) knot (0.2, 33) knot (500, 66)
```