### PR TITLE
Add package argument when building android from CLI

### DIFF
--- a/launcher/game/android.rpy
+++ b/launcher/game/android.rpy
@@ -198,7 +198,7 @@ init python:
         c.save(p.path)
 
 
-    def android_build(p=None, gui=True, bundle=False, install=False, launch=False, destination=None, opendir=False):
+    def android_build(p=None, gui=True, bundle=False, install=False, launch=False, destination=None, opendir=False, packages=None):
         """
         This actually builds the package.
         """
@@ -220,9 +220,12 @@ init python:
             reporter = distribute.TextReporter()
             rapt_interface = rapt.interface.Interface()
 
+        if not packages:
+            packages = ['android']
+
         distribute.Distributor(p,
             reporter=reporter,
-            packages=[ 'android' ],
+            packages=packages,
             build_update=False,
             noarchive=True,
             packagedest=dist,
@@ -711,6 +714,7 @@ init python:
         ap.add_argument("--install", action="store_true", help="Installs the app on a device.")
         ap.add_argument("--launch", action="store_true", help="Launches the app after build and install complete. Implies --install.")
         ap.add_argument("--destination", "--dest", default=None, action="store", help="The directory where the packaged files should be placed.")
+        ap.add_argument("--package", action="append", help="If given, a package to build. Defaults to building all packages.")
 
         args = ap.parse_args()
 
@@ -719,7 +723,12 @@ init python:
 
         p = project.Project(args.android_project)
 
-        android_build(p=p, gui=False, bundle=args.bundle, install=args.install, launch=args.launch, destination=args.destination)
+        if args.package:
+            packages = args.package
+        else:
+            packages = None
+
+        android_build(p=p, gui=False, bundle=args.bundle, install=args.install, launch=args.launch, destination=args.destination, packages=packages)
 
         return False
 


### PR DESCRIPTION
Allow to define a build.package for android.
`build.package("android_premium", "directory", "android all premium", "Android Core files and Premium", hidden=True, update=False, dlc=True)`

The package can be build from CLI:

`./renpy.sh launcher android_build the_question --package android_premium`