### PR TITLE
Prevent negative rollback counters

### DIFF
--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -901,7 +901,10 @@ class RollbackLog(renpy.object.Object):
             revlog.append(rb)
 
             if rb.hard_checkpoint:
-                self.rollback_limit -= 1
+                if self.rollback_limit:
+                    self.rollback_limit -= 1
+                elif self.rollback_block:
+                    self.rollback_block -= 1
 
             if rb.hard_checkpoint or (on_load and rb.checkpoint):
                 checkpoints -= 1


### PR DESCRIPTION
Fixes #5289.

As we pop from the end of the log we decrement the limit until it is exhausted, before continuing to decrement the block count as further entries are popped in an effort to find a place to end rollback.

Verified using the test case provided in the linked issue.