### PR TITLE
Fix TranslateSay scrying

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2549,7 +2549,7 @@ class TranslateSay(Say):
             node = self.lookup()
 
             if (node is not None) and (node is not self):
-                next_node(self.lookup())
+                next_node(node)
                 return
 
         # Otherwise, say the text.
@@ -2562,22 +2562,21 @@ class TranslateSay(Say):
 
     def predict(self):
         node = self.lookup()
-        if node is None:
+
+        if node is None or node is self:
             return [ self.next ]
-        else:
-            return [ node ]
+
+        return [ node ]
 
     def scry(self):
         rv = Scry()
-
         node = self.lookup()
 
-        if node is None:
+        if node is None or node is self:
             rv._next = self.next
         else:
             rv._next = node
 
-        rv._next = self.lookup()
         return rv
 
 

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2569,13 +2569,13 @@ class TranslateSay(Say):
         return [ node ]
 
     def scry(self):
-        rv = Scry()
         node = self.lookup()
 
         if node is None or node is self:
-            rv._next = self.next
-        else:
-            rv._next = node
+            return Say.scry(self)
+
+        rv = Scry()
+        rv._next = self.next
 
         return rv
 


### PR DESCRIPTION
Addresses two issues:

- When `lookup` returned `self` both `predict` and `scry` could set up a loop returning references to `self` over and over.
  This PR adds an explicit check for `node is self` as was already being done in `execute`.
- When scrying, and no translation was active, the scry data would not contain `Say` specific information that is expected.
  This PR has `scry` defer to `Say.scry` when the result of `lookup()` is `None` or `self`.