### PR TITLE
Ensure that all checkpoints are tracked

### DIFF
--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -737,6 +737,8 @@ class RollbackLog(renpy.object.Object):
         if hard and (not self.current.hard_checkpoint):
             if self.rollback_limit < renpy.config.hard_rollback_limit:
                 self.rollback_limit += 1
+            else:
+                self.rollback_block += 1
 
             if hard == "not_greedy":
                 self.current.not_greedy = True


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/5311 in which the problem description can be found along with a test case.

Once the `hard_rollback_limit` is exceeded, hard checkpoints are added to the number of blocked checkpoints, ensuring that when totalled limit and block counts total the number of hard checkpoints currently in the log.

Now that the entire log is counted, it makes it safe to count hard checkpoints out of the log, first from the blocked count, and then from the limit count, never dropping below zero.