### PR TITLE
Avoid trying to snap when not snapping

### DIFF
--- a/renpy/display/dragdrop.py
+++ b/renpy/display/dragdrop.py
@@ -672,6 +672,7 @@ class Drag(renpy.display.displayable.Displayable, renpy.revertable.RevertableObj
             # Record when the snap started
             self.snap_start = at
             redraw(self, 0)
+            self.snapping = True
         elif self.target_at <= at or self.target_at <= self.at:
             # Snap complete
             self.x = self.target_x
@@ -681,7 +682,7 @@ class Drag(renpy.display.displayable.Displayable, renpy.revertable.RevertableObj
             if self.snapping:
                 run(self.snapped, self, self.target_x, self.target_y, True)
             self.snapping = False
-        else:
+        elif self.snapping:
             # Snap in progress
             done = (at - self.snap_start) / (self.target_at - self.snap_start)
             if self.snap_warper is not None:


### PR DESCRIPTION
Seeks to address a rare issue where a drag will be treated as mid snap animation, despite snap never having been called. I'm not sure this is the best solution, but it does appear to be _a_ solution, as I've not managed to recreate it with this change made locally.

I've been unable to come up with an easily reproducible test case for this, but have seen it multiple times during development.

My best guess is that it's to do with the drag widget being replaced and having it's x/y values updated at the same time, such that the time values trick it into thinking it's mid snap, despite `snap` never having been called.