### PR TITLE
Update changelog.rst and template_projects.rst

### DIFF
--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -21,7 +21,7 @@ Vertical text handling under the harfbuzz text shaper has been fixed to
 properly place the text. Porting those changes to the freetype shaper
 is not possible, so the freetype shaper no longer supports vertical text.
 
-See :tpref:`vertical` for more information.
+See :propref:`vertical` for more information.
 
 Updater
 -------
@@ -46,10 +46,10 @@ Live2D.
 Fetch
 -----
 
-The :func:`renpy.fetch`` function now works during the image phase and
+The :func:`renpy.fetch` function now works during the image phase and
 during an interaction, as well as outside an interaction.
 
-The :func:`renpy.fetch`` function now takes a `params` argument, which
+The :func:`renpy.fetch` function now takes a `params` argument, which
 specifies parameters that will be added to the URL.
 
 Other Changes

--- a/sphinx/source/template_projects.rst
+++ b/sphinx/source/template_projects.rst
@@ -12,7 +12,7 @@ template project. If they do, the template project will be copied into
 the new project, and the following changes will be made:
 
 * The :var:`config.name`, :var:`config.save_directory`, and
-  :var:`config.build_name` variables will be set to the name of
+  :var:`build.name` variables will be set to the name of
   the new project.
 
 * The tl directory will be removed, and replaced with default translations


### PR DESCRIPTION
`changelog.rst`: Fix link to the vertical property and remove unncessary ` after renpy.fetch

`template_projects.rst`: config.build_name doesn't exist. Replaced it with build.name