### PR TITLE
Update 

### DIFF
--- a/sphinx/source/atl.rst
+++ b/sphinx/source/atl.rst
@@ -33,7 +33,7 @@ The transform statement  must be run at init time. If it is found outside an
 ``init`` block, then it is automatically placed inside an ``init`` block with a
 priority of 0. The transform may have a list of parameters, which must be
 supplied when it is called. Default values for the right-most parameters can
-be given by adding "=" and the value (e.g. "transform a (b, c=0):").
+be given by adding ``=`` and the value (e.g. ``transform a (b, c=0):``).
 
 `qualname` must be a set of dot-separated Python identifiers. The transform created
 by the ATL block is bound to this name, within the given
@@ -102,13 +102,13 @@ Each logical line in an ATL block must contain one or more ATL statements.
 
 There are two kinds of ATL statements: simple and complex. Simple statements
 do not take an ATL block. A single logical line may contain one or more ATL
-statements, separated by commas. A complex statement contains a block, must
-be on its own line. The first line of a complex statement always ends with a
+statements, separated by commas. A complex statement always contains a block, and
+must be on its own line. The first line of a complex statement always ends with a
 colon ``:``.
 
 By default, statements in a block are executed in the order in which they
 appear, starting with the first statement in the block. Execution terminates
-when the end of the block is reached. Time statements change this, as
+when the end of the block is reached. Th ``time`` statements change this, as
 described in the appropriate section below.
 
 Execution of a block terminates when all statements in the block have
@@ -633,11 +633,11 @@ Warpers
 =======
 
 A warper is a function that can change the amount of time an interpolation
-statement considers to have elapsed. The following warpers are defined by
-default. They are defined as functions from t to t', where t and t' are
-floating point numbers, with t ranging from 0.0 to 1.0 over the given
-amount of time. (If the statement has 0 duration, then t is 1.0 when it runs.)
-t' should start at 0.0 and end at 1.0, but can be greater or less.
+statement considers to have elapsed. They are defined as functions from t to t',
+where t and t' are floating point numbers, with t ranging from 0.0 to 1.0 over
+the given amount of time. (If the statement has 0 duration, then t is 1.0 when
+it runs.) t' should start at 0.0 and end at 1.0, but can be greater or less.
+The following warpers are defined by default.
 
 ``pause``
     Pause, then jump to the new value. If ``t == 1.0``, ``t' = 1.0``. Otherwise,
@@ -690,7 +690,7 @@ interpreted as a fraction of the size of the containing area (for
 :propref:`pos`) or of the displayable (for :propref:`anchor`).
 
 Note that not all properties are independent. For example, :propref:`xalign` and :propref:`xpos`
-both update some of the same underlying data. In a parallel statement, not more than
+both update some of the same underlying data. In a ``parallel`` statement, not more than
 one block should adjust properties sharing the same data. The angle and radius properties set
 both horizontal and vertical positions.
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -21,7 +21,7 @@ Vertical text handling under the harfbuzz text shaper has been fixed to
 properly place the text. Porting those changes to the freetype shaper
 is not possible, so the freetype shaper no longer supports vertical text.
 
-See :tpref:`vertical` for more information.
+See :propref:`vertical` for more information.
 
 Updater
 -------
@@ -46,10 +46,10 @@ Live2D.
 Fetch
 -----
 
-The :func:`renpy.fetch`` function now works during the image phase and
+The :func:`renpy.fetch` function now works during the image phase and
 during an interaction, as well as outside an interaction.
 
-The :func:`renpy.fetch`` function now takes a `params` argument, which
+The :func:`renpy.fetch` function now takes a `params` argument, which
 specifies parameters that will be added to the URL.
 
 Other Changes

--- a/sphinx/source/template_projects.rst
+++ b/sphinx/source/template_projects.rst
@@ -12,7 +12,7 @@ template project. If they do, the template project will be copied into
 the new project, and the following changes will be made:
 
 * The :var:`config.name`, :var:`config.save_directory`, and
-  :var:`config.build_name` variables will be set to the name of
+  :var:`build.name` variables will be set to the name of
   the new project.
 
 * The tl directory will be removed, and replaced with default translations

--- a/sphinx/source/transitions.rst
+++ b/sphinx/source/transitions.rst
@@ -237,7 +237,7 @@ and hide statements. This transition can be enabled by setting the
 
 The transition will occur after one or more ``scene``, ``show``, or ``hide`` statements,
 provided the statement are not followed by a  with statement, or a transition
-caused by :ref:`dialogue window management`, like the various ``window`` statements.
+caused by :ref:`dialogue-window-management`, like the various ``window`` statements.
 It's also disabled when in a menu context.
 
 For example::


### PR DESCRIPTION
* Fix a broken ref to dialogue-window-management in transistions.rst
* Fix some language and formatting issues in atl.rst.

Also, this line is missing some information: `Otherwise, the event propagates to any containing event handler.` Is it supposed to be `any block containing`