### PR TITLE
Better None pickling under py2

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1286,4 +1286,4 @@ copyreg.pickle(types.ModuleType, module_pickle)
 # Allow weakrefs to be pickled, with the reference being broken during
 # unpickling.
 
-copyreg.pickle(weakref.ReferenceType, lambda r : "None")
+copyreg.pickle(weakref.ReferenceType, lambda r : ({}.update, ()))

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1286,7 +1286,4 @@ copyreg.pickle(types.ModuleType, module_pickle)
 # Allow weakrefs to be pickled, with the reference being broken during
 # unpickling.
 
-def construct_None(*args):
-    return None
-
-copyreg.pickle(weakref.ReferenceType, lambda r : (construct_None, tuple()))
+copyreg.pickle(weakref.ReferenceType, lambda r : "None")

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1286,4 +1286,4 @@ copyreg.pickle(types.ModuleType, module_pickle)
 # Allow weakrefs to be pickled, with the reference being broken during
 # unpickling.
 
-copyreg.pickle(weakref.ReferenceType, lambda r : ({}.update, ()))
+copyreg.pickle(weakref.ReferenceType, lambda r : (print, ()))


### PR DESCRIPTION
Avoid taking a compatibility dependency to a function that useless