### PR TITLE
Fix 'max_height' is not defined error in create_mesh()

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1615,6 +1615,8 @@ class Layout(object):
         # The y coordinate of the top line.
         top = 0
 
+        _, max_height = self.size
+
         for line in lines:
 
             # Line bottom is the y coordinate of the bottom line.


### PR DESCRIPTION
Missing definition in the very last commit https://github.com/renpy/renpy/commit/fe1023fe74e5a0b1fd26ceed7d662aaabf39b881 that makes games crash