### PR TITLE
Update existing Italian translations and add missing ones

### DIFF
--- a/launcher/game/tl/italian/common.rpy
+++ b/launcher/game/tl/italian/common.rpy
@@ -183,7 +183,7 @@ translate italian strings:
 
     # 00gui.rpy:232
     old "Are you sure you want to return to the main menu?\nThis will lose unsaved progress."
-    new "Confermi di voler tornare al menù principale?\nQuesto causerà la perdita di progressi non salvati."
+    new "Confermi di voler tornare al menu principale?\nQuesto causerà la perdita di progressi non salvati."
 
     # 00gui.rpy:233
     old "Are you sure you want to end the replay?"
@@ -203,7 +203,7 @@ translate italian strings:
 
     # 00keymap.rpy:250
     old "Saved screenshot as %s."
-    new "Screenshot salvato come %s."
+    new "Cattura di schermaa salvata come %s."
 
     # 00library.rpy:142
     old "Self-voicing disabled."
@@ -211,7 +211,7 @@ translate italian strings:
 
     # 00library.rpy:143
     old "Clipboard voicing enabled. "
-    new "Vocalizza Appunti abilitato. "
+    new "Vocalizzazione Appunti abilitata. "
 
     # 00library.rpy:144
     old "Self-voicing enabled. "
@@ -223,7 +223,7 @@ translate italian strings:
 
     # 00library.rpy:262
     old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
-    new "Questo programma contiene software libero rilasciato sotto una quantità di licenze, che includono la MIT License e la GNU Lesser General Public License. Una lista completa dei software, inclusi link al codice sorgente completo, si può trovare {a=https://www.renpy.org/l/license}qui{/a}."
+    new "Questo programma contiene software libero rilasciato sotto svariate licenze, che includono la MIT License e la GNU Lesser General Public License. Una lista completa dei software, inclusi link al codice sorgente completo, si può trovare {a=https://www.renpy.org/l/license}qui{/a}."
 
     # 00preferences.rpy:422
     old "Clipboard voicing enabled. Press 'shift+C' to disable."
@@ -231,7 +231,7 @@ translate italian strings:
 
     # 00preferences.rpy:424
     old "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
-    new "L'Assistente Vocale tenta di dire \"[renpy.display.tts.last]\". Premi 'alt+shift+V' per disabilitare."
+    new "L'Assistente Vocale direbbe \"[renpy.display.tts.last]\". Premi 'alt+shift+V' per disabilitare."
 
     # 00preferences.rpy:426
     old "Self-voicing enabled. Press 'v' to disable."
@@ -243,7 +243,7 @@ translate italian strings:
 
     # 00updater.rpy:367
     old "The Ren'Py Updater is not supported on mobile devices."
-    new "L'aggiornamento di Ren'Py non è supportato nei dispositivi mobili."
+    new "L'aggiornamento di Ren'Py non è supportato sui dispositivi mobili."
 
     # 00updater.rpy:486
     old "An error is being simulated."
@@ -333,16 +333,12 @@ translate italian strings:
     old "return"
     new "chiudi"
 
-
-translate italian strings:
-
     # renpy/common/00accessibility.rpy:32
     old "bar"
-    new "bar"
+    new "barra"
 
     # renpy/common/00accessibility.rpy:33
     old "selected"
-    # Automatic translation.
     new "selezionato"
 
     # renpy/common/00accessibility.rpy:34
@@ -351,42 +347,34 @@ translate italian strings:
 
     # renpy/common/00accessibility.rpy:35
     old "horizontal scroll"
-    # Automatic translation.
     new "scorrimento orizzontale"
 
     # renpy/common/00accessibility.rpy:36
     old "vertical scroll"
-    # Automatic translation.
     new "scorrimento verticale"
 
     # renpy/common/00accessibility.rpy:37
     old "activate"
-    # Automatic translation.
-    new "attivare"
+    new "attiva"
 
     # renpy/common/00accessibility.rpy:38
     old "deactivate"
-    # Automatic translation.
-    new "disattivare"
+    new "disattiva"
 
     # renpy/common/00accessibility.rpy:39
     old "increase"
-    # Automatic translation.
-    new "aumento"
+    new "aumenta"
 
     # renpy/common/00accessibility.rpy:40
     old "decrease"
-    # Automatic translation.
-    new "diminuzione"
+    new "diminuisci"
 
     # renpy/common/00accessibility.rpy:138
     old "Font Override"
-    # Automatic translation.
-    new "Sovrascrittura dei caratteri"
+    new "Forza Famiglia Caratteri"
 
     # renpy/common/00accessibility.rpy:142
     old "Default"
-    # Automatic translation.
     new "Predefinito"
 
     # renpy/common/00accessibility.rpy:146
@@ -399,8 +387,7 @@ translate italian strings:
 
     # renpy/common/00accessibility.rpy:156
     old "Text Size Scaling"
-    # Automatic translation.
-    new "Dimensione del testo in scala"
+    new "Scala Dimensioni del Testo"
 
     # renpy/common/00accessibility.rpy:162
     old "Reset"
@@ -408,22 +395,18 @@ translate italian strings:
 
     # renpy/common/00accessibility.rpy:168
     old "Line Spacing Scaling"
-    # Automatic translation.
-    new "Interlinea Scala"
+    new "Scala Interlinea"
 
     # renpy/common/00accessibility.rpy:180
     old "High Contrast Text"
-    # Automatic translation.
-    new "Testo ad alto contrasto"
+    new "Testo ad Alto Contrasto"
 
     # renpy/common/00accessibility.rpy:193
     old "Self-Voicing"
-    # Automatic translation.
-    new "Autocelebrazione"
+    new "Assistente Vocale"
 
     # renpy/common/00accessibility.rpy:197
     old "Off"
-    # Automatic translation.
     new "Spento"
 
     # renpy/common/00accessibility.rpy:201
@@ -432,7 +415,6 @@ translate italian strings:
 
     # renpy/common/00accessibility.rpy:205
     old "Clipboard"
-    # Automatic translation.
     new "Appunti"
 
     # renpy/common/00accessibility.rpy:209
@@ -441,73 +423,63 @@ translate italian strings:
 
     # renpy/common/00accessibility.rpy:223
     old "Self-Voicing Volume Drop"
-    # Automatic translation.
-    new "Caduta di volume autoavvertita"
+    new "Riduzione Volume dell'Assistente Vocale"
 
     # renpy/common/00accessibility.rpy:234
     old "The options on this menu are intended to improve accessibility. They may not work with all games, and some combinations of options may render the game unplayable. This is not an issue with the game or engine. For the best results when changing fonts, try to keep the text size the same as it originally was."
-    # Automatic translation.
-    new "Le opzioni di questo menu hanno lo scopo di migliorare l'accessibilità. Potrebbero non funzionare con tutti i giochi e alcune combinazioni di opzioni potrebbero rendere il gioco ingiocabile. Non si tratta di un problema del gioco o del motore. Per ottenere i migliori risultati quando si cambiano i caratteri, cercare di mantenere le dimensioni del testo uguali a quelle originarie."
+    new "Le opzioni di questo menu hanno lo scopo di migliorare l'accessibilità. Potrebbero non funzionare con tutti i giochi, e alcune combinazioni di opzioni potrebbero rendere il gioco ingiocabile. Non si tratta di un problema del gioco o del motore. Per ottenere i migliori risultati quando si cambiano i caratteri, cerca di mantenere le dimensioni del testo uguali a quelle originarie."
 
     # renpy/common/00action_file.rpy:378
     old "Save slot %s: [text]"
-    # Automatic translation.
-    new "Salva lo slot %s: [text]"
+    new "Salva nello slot %s: [text]"
 
     # renpy/common/00action_file.rpy:461
     old "Load slot %s: [text]"
-    # Automatic translation.
-    new "Caricare lo slot %s: [text]"
+    new "Carica slot %s: [text]"
 
     # renpy/common/00action_file.rpy:514
     old "Delete slot [text]"
-    # Automatic translation.
     new "Elimina slot [text]"
 
     # renpy/common/00action_file.rpy:593
     old "File page auto"
-    # Automatic translation.
-    new "Pagina di file automatica"
+    new "Pagina di file automatici"
 
     # renpy/common/00action_file.rpy:595
     old "File page quick"
-    # Automatic translation.
-    new "Pagina di file veloce"
+    new "Pagina di file rapidi"
 
     # renpy/common/00action_file.rpy:597
     old "File page [text]"
-    # Automatic translation.
     new "Pagina di file [text]"
 
     # renpy/common/00action_file.rpy:796
     old "Next file page."
-    # Automatic translation.
-    new "Pagina successiva."
+    new "Pagina di file successiva."
 
     # renpy/common/00action_file.rpy:868
     old "Previous file page."
-    # Automatic translation.
-    new "Pagina precedente."
+    new "Pagina di file precedente."
 
     # renpy/common/00action_file.rpy:944
     old "Quick save."
-    # Automatic translation.
     new "Salvataggio rapido."
 
     # renpy/common/00action_file.rpy:963
     old "Quick load."
-    # Automatic translation.
-    new "Carico rapido."
+    new "Caricamento rapido."
 
     # renpy/common/00action_other.rpy:381
     old "Language [text]"
-    # Automatic translation.
     new "Lingua [text]"
+
+    # 
+    old "Language"
+    new "Lingua"
 
     # renpy/common/00director.rpy:705
     old "The interactive director is not enabled here."
-    # Automatic translation.
-    new "Il direttore interattivo non è abilitato in questo caso."
+    new "L'interactive director non è abilitato qui."
 
     # renpy/common/00director.rpy:1504
     old "⬆"
@@ -519,13 +491,11 @@ translate italian strings:
 
     # renpy/common/00director.rpy:1574
     old "Done"
-    # Automatic translation.
     new "Fatto"
 
     # renpy/common/00director.rpy:1584
     old "(statement)"
-    # Automatic translation.
-    new "(dichiarazione)"
+    new "(istruzione)"
 
     # renpy/common/00director.rpy:1585
     old "(tag)"
@@ -533,46 +503,39 @@ translate italian strings:
 
     # renpy/common/00director.rpy:1586
     old "(attributes)"
-    # Automatic translation.
     new "(attributi)"
 
     # renpy/common/00director.rpy:1587
     old "(transform)"
-    new "(transform)"
+    new "(trasforma)"
 
     # renpy/common/00director.rpy:1612
     old "(transition)"
-    new "(transition)"
+    new "(transizioni)"
 
     # renpy/common/00director.rpy:1624
     old "(channel)"
-    # Automatic translation.
     new "(canale)"
 
     # renpy/common/00director.rpy:1625
     old "(filename)"
-    # Automatic translation.
-    new "(nome del file)"
+    new "(nome file)"
 
     # renpy/common/00director.rpy:1654
     old "Change"
-    # Automatic translation.
-    new "Cambiamento"
+    new "Cambia"
 
     # renpy/common/00director.rpy:1656
     old "Add"
-    # Automatic translation.
     new "Aggiungi"
 
     # renpy/common/00director.rpy:1662
     old "Remove"
-    # Automatic translation.
-    new "Rimuovere"
+    new "Rimuovi"
 
     # renpy/common/00director.rpy:1697
     old "Statement:"
-    # Automatic translation.
-    new "Dichiarazione:"
+    new "Istruzione:"
 
     # renpy/common/00director.rpy:1718
     old "Tag:"
@@ -580,63 +543,51 @@ translate italian strings:
 
     # renpy/common/00director.rpy:1734
     old "Attributes:"
-    # Automatic translation.
     new "Attributi:"
 
     # renpy/common/00director.rpy:1745
     old "Click to toggle attribute, right click to toggle negative attribute."
-    # Automatic translation.
-    new "Fare clic per attivare l'attributo, fare clic con il tasto destro per attivare l'attributo negativo."
+    new "Clicca per attivare/disattivare l'attributo, clicca con il tasto destro per attivare/disattivare l'attributo negativo."
 
     # renpy/common/00director.rpy:1757
     old "Transforms:"
-    # Automatic translation.
     new "Trasformazioni:"
 
     # renpy/common/00director.rpy:1768
     old "Click to set transform, right click to add to transform list."
-    # Automatic translation.
-    new "Fare clic per impostare la trasformazione, fare clic con il pulsante destro del mouse per aggiungere all'elenco delle trasformazioni."
+    new "Clicca per impostare la trasformazione, clicca con il tasto destro per aggiungere all'elenco delle trasformazioni."
 
     # renpy/common/00director.rpy:1780
     old "Behind:"
-    # Automatic translation.
     new "Dietro:"
 
     # renpy/common/00director.rpy:1789
     old "Click to set, right click to add to behind list."
-    # Automatic translation.
-    new "Fare clic per impostare, fare clic con il pulsante destro del mouse per aggiungere all'elenco retrostante."
+    new "Clicca per impostare, clicca con il tasto destro per aggiungere all'elenco di dietro."
 
     # renpy/common/00director.rpy:1801
     old "Transition:"
-    # Automatic translation.
     new "Transizione:"
 
     # renpy/common/00director.rpy:1819
     old "Channel:"
-    # Automatic translation.
     new "Canale:"
 
     # renpy/common/00director.rpy:1837
     old "Audio Filename:"
-    # Automatic translation.
     new "Nome del file audio:"
 
     # renpy/common/00gui.rpy:456
     old "This save was created on a different device. Maliciously constructed save files can harm your computer. Do you trust this save's creator and everyone who could have changed the file?"
-    # Automatic translation.
-    new "Questo salvataggio è stato creato su un dispositivo diverso. I file di salvataggio creati male possono danneggiare il computer. Vi fidate del creatore di questo salvataggio e di tutti coloro che potrebbero aver modificato il file?"
+    new "Questo salvataggio è stato creato su un dispositivo diverso. Un file di salvataggio creato in modo malevolo può danneggiare il tuo computer. Puoi fidarti di chi ha creato questo salvataggio e di tutti coloro che potrebbero aver modificato il file?"
 
     # renpy/common/00gui.rpy:457
     old "Do you trust the device the save was created on? You should only choose yes if you are the device's sole user."
-    # Automatic translation.
-    new "Vi fidate del dispositivo su cui è stato creato il salvataggio? Scegliere sì solo se si è l'unico utente del dispositivo."
+    new "Puoi fidarti del dispositivo su cui è stato creato il salvataggio? Dovresti scegliere sì solo se si è l'unico utente del dispositivo."
 
     # renpy/common/00keymap.rpy:322
     old "Failed to save screenshot as %s."
-    # Automatic translation.
-    new "Impossibile salvare l'immagine come %s."
+    new "Impossibile salvare la cattura di schermata come %s."
 
     # renpy/common/00preferences.rpy:271
     old "display"
@@ -644,27 +595,22 @@ translate italian strings:
 
     # renpy/common/00preferences.rpy:283
     old "transitions"
-    # Automatic translation.
     new "transizioni"
 
     # renpy/common/00preferences.rpy:292
     old "skip transitions"
-    # Automatic translation.
     new "saltare le transizioni"
 
     # renpy/common/00preferences.rpy:294
     old "video sprites"
-    # Automatic translation.
     new "sprite video"
 
     # renpy/common/00preferences.rpy:303
     old "show empty window"
-    # Automatic translation.
-    new "mostra la finestra vuota"
+    new "mostra finestra vuota"
 
     # renpy/common/00preferences.rpy:312
     old "text speed"
-    # Automatic translation.
     new "velocità del testo"
 
     # renpy/common/00preferences.rpy:320
@@ -677,97 +623,79 @@ translate italian strings:
 
     # renpy/common/00preferences.rpy:327
     old "skip"
-    # Automatic translation.
-    new "saltare"
+    new "salta"
 
     # renpy/common/00preferences.rpy:330
     old "skip unseen [text]"
-    # Automatic translation.
-    new "saltare non visto [text]"
+    new "salta [text] non visto"
 
     # renpy/common/00preferences.rpy:335
     old "skip unseen text"
-    # Automatic translation.
-    new "saltare il testo non visto"
+    new "salta il testo non visto"
 
     # renpy/common/00preferences.rpy:337
     old "begin skipping"
-    # Automatic translation.
-    new "iniziare a saltare"
+    new "inizia a saltare"
 
     # renpy/common/00preferences.rpy:341
     old "after choices"
-    # Automatic translation.
     new "dopo le scelte"
 
     # renpy/common/00preferences.rpy:348
     old "skip after choices"
-    # Automatic translation.
-    new "saltare dopo le scelte"
+    new "salta dopo le scelte"
 
     # renpy/common/00preferences.rpy:350
     old "auto-forward time"
-    # Automatic translation.
-    new "tempo di inoltro automatico"
+    new "ritmo di avanzamento automatico"
 
     # renpy/common/00preferences.rpy:364
     old "auto-forward"
-    # Automatic translation.
-    new "Inoltro automatico"
+    new "avanzamento automatico"
 
     # renpy/common/00preferences.rpy:371
     old "Auto forward"
-    # Automatic translation.
     new "Avanzamento automatico"
 
     # renpy/common/00preferences.rpy:374
     old "auto-forward after click"
-    # Automatic translation.
-    new "Inoltro automatico dopo il clic"
+    new "avanzamento automatico dopo il clic"
 
     # renpy/common/00preferences.rpy:383
     old "automatic move"
-    # Automatic translation.
     new "spostamento automatico"
 
     # renpy/common/00preferences.rpy:392
     old "wait for voice"
-    # Automatic translation.
-    new "attendere la voce"
+    new "dai tempo alla voce"
 
     # renpy/common/00preferences.rpy:401
     old "voice sustain"
-    # Automatic translation.
-    new "sostegno della voce"
+    new "mantenimento della voce"
 
     # renpy/common/00preferences.rpy:410
     old "self voicing"
-    # Automatic translation.
-    new "autocelebrazione"
+    new "assistente vocale"
 
     # renpy/common/00preferences.rpy:419
     old "self voicing volume drop"
-    # Automatic translation.
-    new "caduta di volume dell'autocelebrazione"
+    new "riduzione volume dell'assistente vocale"
 
     # renpy/common/00preferences.rpy:427
     old "clipboard voicing"
-    # Automatic translation.
-    new "Votazione degli appunti"
+    new "vocalizzazione degli appunti"
 
     # renpy/common/00preferences.rpy:436
     old "debug voicing"
-    new "debug voicing"
+    new "debug vocalizzazione"
 
     # renpy/common/00preferences.rpy:445
     old "emphasize audio"
-    # Automatic translation.
-    new "enfatizzare l'audio"
+    new "enfatizza audio"
 
     # renpy/common/00preferences.rpy:454
     old "rollback side"
-    # Automatic translation.
-    new "lato rollback"
+    new "lato riavvolgimento"
 
     # renpy/common/00preferences.rpy:464
     old "gl powersave"
@@ -775,8 +703,7 @@ translate italian strings:
 
     # renpy/common/00preferences.rpy:470
     old "gl framerate"
-    # Automatic translation.
-    new "framerate gl"
+    new "gl framerate"
 
     # renpy/common/00preferences.rpy:473
     old "gl tearing"
@@ -784,196 +711,157 @@ translate italian strings:
 
     # renpy/common/00preferences.rpy:476
     old "font transform"
-    # Automatic translation.
-    new "trasformazione dei caratteri"
+    new "trasformazioni dei caratteri"
 
     # renpy/common/00preferences.rpy:479
     old "font size"
-    # Automatic translation.
-    new "dimensione del carattere"
+    new "dimensione dei caratteri"
 
     # renpy/common/00preferences.rpy:487
     old "font line spacing"
-    # Automatic translation.
-    new "interlinea del carattere"
+    new "interlinea dei caratteri"
 
     # renpy/common/00preferences.rpy:495
     old "system cursor"
-    # Automatic translation.
     new "cursore di sistema"
 
     # renpy/common/00preferences.rpy:504
     old "renderer menu"
-    # Automatic translation.
     new "menu del renderer"
 
     # renpy/common/00preferences.rpy:507
     old "accessibility menu"
-    # Automatic translation.
-    new "menu accessibilità"
+    new "menu di accessibilità"
 
     # renpy/common/00preferences.rpy:510
     old "high contrast text"
-    # Automatic translation.
     new "testo ad alto contrasto"
 
     # renpy/common/00preferences.rpy:519
     old "audio when minimized"
-    # Automatic translation.
-    new "audio quando è ridotto a icona"
+    new "audio con finestra minimizzata"
 
     # renpy/common/00preferences.rpy:528
     old "audio when unfocused"
-    # Automatic translation.
-    new "audio quando non viene messo a fuoco"
+    new "audio con finestra non a fuoco"
 
     # renpy/common/00preferences.rpy:537
     old "web cache preload"
-    # Automatic translation.
     new "precaricamento della cache web"
 
     # renpy/common/00preferences.rpy:552
     old "voice after game menu"
-    # Automatic translation.
     new "voce dopo il menu di gioco"
 
     # renpy/common/00preferences.rpy:571
     old "main volume"
-    # Automatic translation.
     new "volume principale"
 
     # renpy/common/00preferences.rpy:572
     old "music volume"
-    # Automatic translation.
     new "volume della musica"
 
     # renpy/common/00preferences.rpy:573
     old "sound volume"
-    # Automatic translation.
-    new "volume del suono"
+    new "volume dei suoni"
 
     # renpy/common/00preferences.rpy:574
     old "voice volume"
-    # Automatic translation.
     new "volume della voce"
 
     # renpy/common/00preferences.rpy:575
     old "mute main"
-    # Automatic translation.
-    new "silenziamento principale"
+    new "silenzia il volume principale"
 
     # renpy/common/00preferences.rpy:576
     old "mute music"
-    # Automatic translation.
-    new "disattivare la musica"
+    new "silenzia la musica"
 
     # renpy/common/00preferences.rpy:577
     old "mute sound"
-    # Automatic translation.
-    new "Disattivare l'audio"
+    new "silenzia i suoni"
 
     # renpy/common/00preferences.rpy:578
     old "mute voice"
-    # Automatic translation.
-    new "voce muta"
+    new "silenzia voce"
 
     # renpy/common/00preferences.rpy:579
     old "mute all"
-    # Automatic translation.
-    new "disattivare tutti"
+    new "silenzia tutto"
 
     # renpy/common/00speechbubble.rpy:344
     old "Speech Bubble Editor"
-    # Automatic translation.
-    new "Editor di bolle vocali"
+    new "Editor di Bolle di Dialogo"
 
     # renpy/common/00speechbubble.rpy:349
     old "(hide)"
-    # Automatic translation.
-    new "(Nascondi)"
+    new "(nascondi)"
 
     # renpy/common/00sync.rpy:70
     old "Sync downloaded."
-    # Automatic translation.
-    new "Sincronizzazione scaricata."
+    new "Dati sincronizzati scaricati."
 
     # renpy/common/00sync.rpy:190
     old "Could not connect to the Ren'Py Sync server."
-    # Automatic translation.
     new "Impossibile connettersi al server Ren'Py Sync."
 
     # renpy/common/00sync.rpy:192
     old "The Ren'Py Sync server timed out."
-    # Automatic translation.
-    new "Il server Ren'Py Sync è scaduto."
+    new "Il server Ren'Py Sync non ha risposto in tempo."
 
     # renpy/common/00sync.rpy:194
     old "An unknown error occurred while connecting to the Ren'Py Sync server."
-    # Automatic translation.
     new "Si è verificato un errore sconosciuto durante la connessione al server Ren'Py Sync."
 
     # renpy/common/00sync.rpy:267
     old "The Ren'Py Sync server does not have a copy of this sync. The sync ID may be invalid, or it may have timed out."
-    # Automatic translation.
-    new "Il server Ren'Py Sync non dispone di una copia di questa sincronizzazione. L'ID della sincronizzazione potrebbe non essere valido o potrebbe essere scaduto."
+    new "Il server Ren'Py Sync non dispone di una copia di questi dati. L'ID di sincronizzazione potrebbe essere invalido o scaduto."
 
     # renpy/common/00sync.rpy:409
     old "Please enter the sync ID you generated.\nNever enter a sync ID you didn't create yourself."
-    # Automatic translation.
-    new "Inserire l'ID di sincronizzazione generato.\nNon inserite mai un ID di sincronizzazione che non avete creato voi stessi."
+    new "Inserire l'ID di sincronizzazione che hai generato.\nNon inserire mai un ID di sincronizzazione che non hai creato tu."
 
     # renpy/common/00sync.rpy:428
     old "The sync ID is not in the correct format."
-    # Automatic translation.
     new "L'ID di sincronizzazione non è nel formato corretto."
 
     # renpy/common/00sync.rpy:448
     old "The sync could not be decrypted."
-    # Automatic translation.
-    new "Non è stato possibile decifrare la sincronizzazione."
+    new "Non è stato possibile decifrare i dati sincronizzati."
 
     # renpy/common/00sync.rpy:471
     old "The sync belongs to a different game."
-    # Automatic translation.
-    new "La sincronizzazione appartiene a un gioco diverso."
+    new "I dati sincronizzati appartengono ad un gioco diverso."
 
     # renpy/common/00sync.rpy:476
     old "The sync contains a file with an invalid name."
-    # Automatic translation.
-    new "La sincronizzazione contiene un file con un nome non valido."
+    new "I dati sincronizzati contengono un file con un nome non valido."
 
     # renpy/common/00sync.rpy:529
     old "This will upload your saves to the {a=https://sync.renpy.org}Ren'Py Sync Server{/a}.\nDo you want to continue?"
-    # Automatic translation.
-    new "Questo caricherà i salvataggi sul server di sincronizzazione {a=https://sync.renpy.org}Ren'Py{/a}.\nVuoi continuare?"
+    new "I tuoi salvataggi saranno caricati sul {a=https://sync.renpy.org}Server di Sincronizzazione di Ren'Py{/a}.\nVuoi continuare?"
 
     # renpy/common/00sync.rpy:558
     old "Enter Sync ID"
-    # Automatic translation.
-    new "Immettere l'ID di sincronizzazione"
+    new "Immettere l'ID di Sincronizzazione"
 
     # renpy/common/00sync.rpy:569
     old "This will contact the {a=https://sync.renpy.org}Ren'Py Sync Server{/a}."
-    # Automatic translation.
-    new "Questo contatterà il server di sincronizzazione {a=https://sync.renpy.org}Ren'Py{/a}."
+    new "Verrà contattato il {a=https://sync.renpy.org}Server di Sincronizzazione di Ren'Py{/a}."
 
     # renpy/common/00sync.rpy:596
     old "Sync Success"
-    # Automatic translation.
-    new "Successo della sincronizzazione"
+    new "Sincronizzazione completata con Successo"
 
     # renpy/common/00sync.rpy:599
     old "The Sync ID is:"
-    # Automatic translation.
-    new "L'ID di sincronizzazione è:"
+    new "L'ID di Sincronizzazione è:"
 
     # renpy/common/00sync.rpy:605
     old "You can use this ID to download your save on another device.\nThis sync will expire in an hour.\nRen'Py Sync is supported by {a=https://www.renpy.org/sponsors.html}Ren'Py's Sponsors{/a}."
-    # Automatic translation.
-    new "È possibile utilizzare questo ID per scaricare il salvataggio su un altro dispositivo.\nQuesta sincronizzazione scadrà tra un'ora.\nRen'Py Sync è supportato da {a=https://www.renpy.org/sponsors.html}Gli sponsor di Ren'Py{/a}."
+    new "Puoi usare questo ID per scaricare il tuo salvataggio su un altro dispositivo.\nQuesta sincronizzazione scadrà tra un'ora.\nRen'Py Sync è supportato dagli {a=https://www.renpy.org/sponsors.html}Sponsor di Ren'Py{/a}."
 
     # renpy/common/00sync.rpy:631
     old "Sync Error"
-    # Automatic translation.
-    new "Errore di sincronizzazione"
+    new "Errore di Sincronizzazione"
 

--- a/launcher/game/tl/italian/developer.rpy
+++ b/launcher/game/tl/italian/developer.rpy
@@ -23,7 +23,7 @@ translate italian strings:
 
     # _developer/developer.rpym:51
     old "Image Location Picker"
-    new "Selettore Locazione Immagini"
+    new "Selettore Posizione Immagini"
 
     # _developer/developer.rpym:53
     old "Filename List"
@@ -79,7 +79,7 @@ translate italian strings:
 
     # _developer/inspector.rpym:38
     old "Displayable Inspector"
-    new "Ispettore dei Displayable"
+    new "Ispezionatore dei Displayable"
 
     # _developer/inspector.rpym:61
     old "Size"
@@ -99,7 +99,6 @@ translate italian strings:
 
     # _developer/inspector.rpym:139
     old "displayable:"
-    # Automatic translation.
     new "visualizzabile:"
 
     # _developer/inspector.rpym:145
@@ -116,7 +115,7 @@ translate italian strings:
 
     # 00console.rpy:182
     old "Press <esc> to exit console. Type help for help.\n"
-    new "Premi <esc> per uscire dalla console. Scrivi \"help\" per aiuto.\n"
+    new "Premi <esc> per uscire dalla console. Scrivi \"help\" per avere aiuto.\n"
 
     # 00console.rpy:186
     old "Ren'Py script enabled."
@@ -178,42 +177,32 @@ translate italian strings:
     old "jump <label>: jumps to label"
     new "jump <label>: salta alla label"
 
-
-translate italian strings:
-
     # renpy/common/_developer/developer.rpym:43
     old "Interactive Director (D)"
-    # Automatic translation.
-    new "Direttore interattivo (D)"
+    new "Interactive Director (D)"
 
     # renpy/common/_developer/developer.rpym:51
     old "Persistent Viewer"
-    # Automatic translation.
-    new "Visualizzatore persistente"
+    new "Visualizzatore dei dati Persistenti"
 
     # renpy/common/_developer/developer.rpym:59
     old "Show Image Load Log (F4)"
-    # Automatic translation.
-    new "Mostra registro caricamento immagini (F4)"
+    new "Mostra il Registro di Caricamento delle Immagini (F4)"
 
     # renpy/common/_developer/developer.rpym:62
     old "Hide Image Load Log (F4)"
-    # Automatic translation.
-    new "Nascondere il registro di caricamento dell'immagine (F4)"
+    new "Nascondi il Registro di Caricamento delle Immagini (F4)"
 
     # renpy/common/_developer/developer.rpym:65
     old "Image Attributes"
-    # Automatic translation.
-    new "Attributi dell'immagine"
+    new "Attributi dell'Immagine"
 
     # renpy/common/_developer/developer.rpym:70
     old "Speech Bubble Editor (Shift+B)"
-    # Automatic translation.
-    new "Editor di bolle vocali (Shift+B)"
+    new "Editor di Bolle di Dialogo (Shift+B)"
 
     # renpy/common/_developer/developer.rpym:97
     old "[name] [attributes] (hidden)"
-    # Automatic translation.
     new "[name] [attributes] (nascosto)"
 
     # renpy/common/_developer/developer.rpym:101
@@ -222,66 +211,53 @@ translate italian strings:
 
     # renpy/common/_developer/developer.rpym:162
     old "Hide deleted"
-    # Automatic translation.
-    new "Nascondi cancellato"
+    new "Nascondi cancellati"
 
     # renpy/common/_developer/developer.rpym:162
     old "Show deleted"
-    # Automatic translation.
-    new "Mostra cancellata"
+    new "Mostra cancellati"
 
     # renpy/common/_developer/developer.rpym:389
     old "Type to filter: "
-    # Automatic translation.
-    new "Tipo da filtrare: "
+    new "Tipi da filtrare: "
 
     # renpy/common/_developer/developer.rpym:507
     old "Textures: [tex_count] ([tex_size_mb:.1f] MB)"
-    # Automatic translation.
     new "Texture: [tex_count] ([tex_size_mb:.1f] MB)"
 
     # renpy/common/_developer/developer.rpym:511
     old "Image cache: [cache_pct:.1f]% ([cache_size_mb:.1f] MB)"
-    # Automatic translation.
     new "Cache immagini: [cache_pct:.1f]% ([cache_size_mb:.1f] MB)"
 
     # renpy/common/00console.rpy:789
     old "help: show this help\n help <expr>: show signature and documentation of <expr>"
-    # Automatic translation.
     new "help: mostra questo aiuto\n help <expr>: mostra la firma e la documentazione di <expr>"
 
     # renpy/common/00console.rpy:813
     old "Help may display undocumented functions. Please check that the function or\nclass you want to use is documented.\n\n"
-    # Automatic translation.
-    new "La guida potrebbe visualizzare funzioni non documentate. Verificate che la funzione o\nLa classe che si vuole utilizzare è documentata.\n\n"
+    new "La guida potrebbe visualizzare funzioni non documentate. Verifica che la funzione o\n classe che vuoi usare utilizzare sia documentata.\n\n"
 
     # renpy/common/00console.rpy:854
     old "stack: print the return stack"
-    # Automatic translation.
-    new "stack: stampare lo stack di ritorno"
+    new "stack: stampa a schermo lo stack di ritorno"
 
     # renpy/common/00console.rpy:908
     old "watch <expression>: watch a python expression\n watch short: makes the representation of traced expressions short (default)\n watch long: makes the representation of traced expressions as is"
-    # Automatic translation.
-    new "watch <expression>: guardare un'espressione python\n watch short: rende breve la rappresentazione delle espressioni tracciate (default)\n watch long: rende la rappresentazione delle espressioni tracciate come è"
+    new "watch <expression>: traccia un'espressione python\n watch short: rende breve la rappresentazione delle espressioni tracciate (default)\n watch long: rende la rappresentazione delle espressioni tracciate così come è"
 
     # renpy/common/00console.rpy:1028
     old "short: Shorten the representation of objects on the console (default)."
-    # Automatic translation.
     new "short: Accorcia la rappresentazione degli oggetti sulla console (impostazione predefinita)."
 
     # renpy/common/00console.rpy:1032
     old "long: Print the full representation of objects on the console."
-    # Automatic translation.
-    new "long: Stampa la rappresentazione completa degli oggetti sulla console."
+    new "long: Stampa sulla console la rappresentazione completa degli oggetti."
 
     # renpy/common/00console.rpy:1036
     old "escape: Enables escaping of unicode symbols in unicode strings."
-    # Automatic translation.
     new "escape: Abilita l'escape dei simboli unicode nelle stringhe unicode."
 
     # renpy/common/00console.rpy:1040
     old "unescape: Disables escaping of unicode symbols in unicode strings and print it as is (default)."
-    # Automatic translation.
-    new "unescape: Disabilita l'escape dei simboli unicode nelle stringhe unicode e le stampa così come sono (impostazione predefinita)."
+    new "unescape: Disabilita l'escape dei simboli unicode nelle stringhe unicode e le stampa a schermo così come sono (impostazione predefinita)."
 

--- a/launcher/game/tl/italian/error.rpy
+++ b/launcher/game/tl/italian/error.rpy
@@ -11,15 +11,15 @@ translate italian strings:
 
     # 00gltest.rpy:75
     old "Force Angle/DirectX Renderer"
-    new "Forza Renderer Angle/DirectX"
+    new "Forza Renderizzatore Angle/DirectX"
 
     # 00gltest.rpy:79
     old "Force OpenGL Renderer"
-    new "Forza Renderer OpenGL"
+    new "Forza Renderizzatore OpenGL"
 
     # 00gltest.rpy:83
     old "Force Software Renderer"
-    new "Forza Renderer Software"
+    new "Forza Renderizzatore Software"
 
     # 00gltest.rpy:93
     old "Enable"
@@ -31,7 +31,7 @@ translate italian strings:
 
     # 00gltest.rpy:141
     old "Performance Warning"
-    new "Avviso Prestazioni"
+    new "Avviso sulle Prestazioni"
 
     # 00gltest.rpy:146
     old "This computer is using software rendering."
@@ -39,7 +39,7 @@ translate italian strings:
 
     # 00gltest.rpy:148
     old "This computer is not using shaders."
-    new "Questo computer non fa uso degli shader."
+    new "Questo computer non sta usando gli shader."
 
     # 00gltest.rpy:150
     old "This computer is displaying graphics slowly."
@@ -135,7 +135,7 @@ translate italian strings:
 
     # _errorhandling.rpym:538
     old "Rollback"
-    new "Regredisci"
+    new "Riavvolgi"
 
     # _errorhandling.rpym:540
     old "Attempts a roll back to a prior time, allowing you to save or choose a different choice."
@@ -167,7 +167,7 @@ translate italian strings:
 
     # _errorhandling.rpym:606
     old "Open Parse Errors"
-    new "Apri errori di analisi"
+    new "Apri Errori di Analisi"
 
     # _errorhandling.rpym:608
     old "Opens the errors.txt file in a text editor."
@@ -177,51 +177,40 @@ translate italian strings:
     old "Copies the errors.txt file to the clipboard."
     new "Copia il file errors.txt negli appunti."
 
-
-translate italian strings:
-
     # renpy/common/00gltest.rpy:89
     old "Renderer"
-    new "Renderer"
+    new "Renderizzatore"
 
     # renpy/common/00gltest.rpy:100
     old "Force GL Renderer"
-    # Automatic translation.
-    new "Forza il renderizzatore GL"
+    new "Forza Renderizzatore GL"
 
     # renpy/common/00gltest.rpy:105
     old "Force ANGLE Renderer"
-    # Automatic translation.
-    new "Rendering angolare della forza"
+    new "Forza Renderizzatore ANGLE"
 
     # renpy/common/00gltest.rpy:110
     old "Force GLES Renderer"
-    # Automatic translation.
-    new "Forza il renderizzatore GLES"
+    new "Forza Renderizzatore GLES"
 
     # renpy/common/00gltest.rpy:116
     old "Force GL2 Renderer"
-    # Automatic translation.
-    new "Rendering Force GL2"
+    new "Forza Renderizzatore GL2"
 
     # renpy/common/00gltest.rpy:121
     old "Force ANGLE2 Renderer"
-    # Automatic translation.
-    new "Forza il renderizzatore ANGLE2"
+    new "Forza Renderizzatore ANGLE2"
 
     # renpy/common/00gltest.rpy:126
     old "Force GLES2 Renderer"
-    # Automatic translation.
-    new "Forza il renderizzatore GLES2"
+    new "Forza Renderizzatore GLES2"
 
     # renpy/common/00gltest.rpy:136
     old "Enable (No Blocklist)"
-    # Automatic translation.
-    new "Abilitazione (nessuna lista di blocco)"
+    new "Abilita (nessuna lista di blocco)"
 
     # renpy/common/00gltest.rpy:159
     old "Powersave"
-    # Automatic translation.
     new "Risparmio energetico"
 
     # renpy/common/00gltest.rpy:173
@@ -230,7 +219,6 @@ translate italian strings:
 
     # renpy/common/00gltest.rpy:177
     old "Screen"
-    # Automatic translation.
     new "Schermo"
 
     # renpy/common/00gltest.rpy:181
@@ -247,58 +235,47 @@ translate italian strings:
 
     # renpy/common/00gltest.rpy:249
     old "This game requires use of GL2 that can't be initialised."
-    # Automatic translation.
-    new "Questo gioco richiede l'uso di GL2 che non può essere inizializzato."
+    new "Questo gioco richiede l'uso di GL2, che non può essere inizializzato."
 
     # renpy/common/00gltest.rpy:259
     old "The {a=edit:1:log.txt}log.txt{/a} file may contain information to help you determine what is wrong with your computer."
-    # Automatic translation.
-    new "Il file {a=edit:1:log.txt}log.txt{/a} può contenere informazioni che aiutano a determinare il problema del computer."
+    new "Il file {a=edit:1:log.txt}log.txt{/a} può contenere informazioni che possono aiutarti a determinare il problema del tuo computer."
 
     # renpy/common/00gltest.rpy:264
     old "More details on how to fix this can be found in the {a=[url]}documentation{/a}."
-    # Automatic translation.
-    new "Maggiori dettagli su come risolvere questo problema sono disponibili nella documentazione di {a=[url]}{/a} ."
+    new "Maggiori dettagli su come risolvere questo problema sono disponibili nella documentazione di {a=[url]}{/a}."
 
     # renpy/common/00gltest.rpy:281
     old "Change render options"
-    # Automatic translation.
-    new "Modifica delle opzioni di rendering"
+    new "Modifica le opzioni di rendering"
 
     # renpy/common/00gamepad.rpy:58
     old "Press or move the '[control!s]' [kind]."
-    # Automatic translation.
-    new "Premere o spostare il pulsante '[control!s]'[kind]."
+    new "Premi o sposta l'input '[control!s]'[kind]."
 
     # renpy/common/_errorhandling.rpym:555
     old "Open"
-    # Automatic translation.
-    new "Aperto"
+    new "Apri"
 
     # renpy/common/_errorhandling.rpym:559
     old "Copy BBCode"
-    # Automatic translation.
-    new "Copiare il codice BBC"
+    new "Copia BBCode"
 
     # renpy/common/_errorhandling.rpym:561
     old "Copies the traceback.txt file to the clipboard as BBcode for forums like https://lemmasoft.renai.us/."
-    # Automatic translation.
     new "Copia il file traceback.txt negli appunti come BBcode per forum come https://lemmasoft.renai.us/."
 
     # renpy/common/_errorhandling.rpym:563
     old "Copy Markdown"
-    # Automatic translation.
-    new "Copiare Markdown"
+    new "Copia Markdown"
 
     # renpy/common/_errorhandling.rpym:565
     old "Copies the traceback.txt file to the clipboard as Markdown for Discord."
-    # Automatic translation.
     new "Copia il file traceback.txt negli appunti come Markdown per Discord."
 
     # renpy/common/_errorhandling.rpym:626
     old "Ignores the exception, allowing you to continue."
-    # Automatic translation.
-    new "Ignora l'eccezione, consentendo di continuare."
+    new "Ignora l'eccezione, permettendo di continuare l'esecuzione."
 
     # renpy/common/_errorhandling.rpym:637
     old "Console"
@@ -306,6 +283,5 @@ translate italian strings:
 
     # renpy/common/_errorhandling.rpym:639
     old "Opens a console to allow debugging the problem."
-    # Automatic translation.
     new "Apre una console per consentire il debug del problema."
 

--- a/launcher/game/tl/italian/gui.rpy
+++ b/launcher/game/tl/italian/gui.rpy
@@ -203,23 +203,23 @@ translate italian strings:
 
     # gui.rpy:220
     old "## File Slot Buttons"
-    new "## Pulsanti Slot"
+    new "## Pulsanti Slot File"
 
     # gui.rpy:222
     old "## A file slot button is a special kind of button. It contains a thumbnail image, and text describing the contents of the save slot. A save slot uses image files in gui/button, like the other kinds of buttons."
-    new "## Un pulsante Slot è un tipo di pulsante speciale. Contiene un'immagine miniatura, e testo che riporta i contenuti dello slot. Uno Slot Save usa immagini presenti in gui/button, come tutti gli altri tipi di pulsante."
+    new "## Un pulsante slot è un tipo di pulsante speciale. Contiene un'immagine miniatura, e testo che riporta i contenuti dello slot. Uno slot di salvataggio usa immagini presenti in gui/button, come tutti gli altri tipi di pulsante."
 
     # gui.rpy:226
     old "## The save slot button."
-    new "## Il pulsante slot."
+    new "## Il pulsante slot salvataggio."
 
     # gui.rpy:234
     old "## The width and height of thumbnails used by the save slots."
-    new "## Larghezza e altezza delle miniature usate dallo slot."
+    new "## Larghezza e altezza delle miniature usate dallo slot di salvataggio."
 
     # gui.rpy:238
     old "## The number of columns and rows in the grid of save slots."
-    new "## Numero di colonne e righe della griglia degli slot."
+    new "## Numero di colonne e righe della griglia degli slot di salvataggio."
 
     # gui.rpy:243
     old "## Positioning and Spacing"
@@ -327,8 +327,7 @@ translate italian strings:
 
     # gui.rpy:331
     old "## History"
-    # Automatic translation.
-    new "## Storia"
+    new "## Cronologia"
 
     # gui.rpy:333
     old "## The history screen displays dialogue that the player has already dismissed."
@@ -380,7 +379,7 @@ translate italian strings:
 
     # gui.rpy:403
     old "## This increases the size of the quick buttons to make them easier to touch on tablets and phones."
-    new "## Questo aumenta la dimensione dei Pulsanti Rapidi per renderli più facili da toccare su tablet e telefoni."
+    new "## Questo aumenta la dimensione dei pulsanti rapidi per renderli più facili da toccare su tablet e telefoni."
 
     # gui.rpy:409
     old "## This changes the size and spacing of various GUI elements to ensure they are easily visible on phones."
@@ -408,7 +407,7 @@ translate italian strings:
 
     # gui.rpy:456
     old "## Quick buttons."
-    new "## Pulsanti Rapidi."
+    new "## Pulsanti rapidi."
 
     # gui.rpy:17
     old "## GUI Configuration Variables"
@@ -434,41 +433,31 @@ translate italian strings:
     old "## Mobile devices"
     new "## Dispositivi mobili"
 
-
-translate italian strings:
-
     # gui/game/gui.rpy:5
     old "## The init offset statement causes the initialization statements in this file to run before init statements in any other file."
-    # Automatic translation.
-    new "## L'istruzione init offset fa sì che le istruzioni di inizializzazione in questo file vengano eseguite prima delle istruzioni di init in qualsiasi altro file."
+    new "## L'istruzione init offset fa sì che le istruzioni di inizializzazione in questo file vengano eseguite prima di quelle di inizializzazione in qualsiasi altro file."
 
     # gui/game/gui.rpy:14
     old "## Enable checks for invalid or unstable properties in screens or transforms"
-    # Automatic translation.
-    new "## Abilita i controlli per le proprietà non valide o instabili nelle schermate o nelle trasformazioni"
+    new "## Abilita i controlli per proprietà non valide o instabili nelle schermate o nelle trasformazioni"
 
     # gui/game/gui.rpy:278
     old "## The position of the main menu text."
-    # Automatic translation.
     new "## La posizione del testo del menu principale."
 
     # gui/game/gui.rpy:287
     old "## Generic frames."
-    # Automatic translation.
     new "## Cornici generiche."
 
     # gui/game/gui.rpy:307
     old "## The default GUI only uses sliders and vertical scrollbars. All of the other bars are only used in creator-written screens."
-    # Automatic translation.
-    new "## L'interfaccia grafica predefinita utilizza solo i cursori e le barre di scorrimento verticali. Tutte le altre barre sono utilizzate solo nelle schermate scritte dal creatore."
+    new "## L'interfaccia grafica predefinita usa solo cursori e barre di scorrimento verticali. Tutte le altre barre sono utilizzate solo in schermate scritte dai creatori di giochi."
 
     # gui/game/gui.rpy:368
     old "## The maximum number of NVL-mode entries Ren'Py will display. When more entries than this are to be show, the oldest entry will be removed."
-    # Automatic translation.
-    new "## Il numero massimo di voci in modalità NVL che Ren'Py visualizzerà. Se devono essere visualizzate più voci di questa, la voce più vecchia verrà rimossa."
+    new "## Il numero massimo di voci in modalità NVL che Ren'Py visualizzerà. Se ne devono essere visualizzate di più, la voce più vecchia verrà rimossa."
 
     # gui/game/gui.rpy:446
     old "## Change the size and spacing of various things."
-    # Automatic translation.
-    new "## Cambia la dimensione e la spaziatura di vari elementi."
+    new "## Cambia dimensione e spaziatura di vari elementi."
 

--- a/launcher/game/tl/italian/launcher.rpy
+++ b/launcher/game/tl/italian/launcher.rpy
@@ -1,4 +1,5 @@
 ﻿translate italian strings:
+
     # game/new_project.rpy:77
     old "{#language name and font}"
     new "Italiano"
@@ -37,19 +38,19 @@
 
     # android.rpy:31
     old "An x86 Java Development Kit is required to build Android packages on Windows. The JDK is different from the JRE, so it's possible you have Java without having the JDK.\n\nPlease {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}download and install the JDK{/a}, then restart the Ren'Py launcher."
-    new "La versione a 32-bit del Java Development Kit é necessaria per compilare pacchetti Android su Windows. Il JDK é diverso dal JRE ed é quindi possibile che tu abbia installato Java senza però aver installato il JDK.\n\nSi prega di {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}scaricare ed installare il JDK{/a} e, successivamente, riavviare il launcher di Ren'Py."
+    new "La versione a 32-bit del Java Development Kit è necessaria per compilare pacchetti Android su Windows. Il JDK è diverso dal JRE ed è quindi possibile che tu abbia installato Java senza però aver installato il JDK.\n\nSi prega di {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}scaricare ed installare il JDK{/a} e, successivamente, riavviare il launcher di Ren'Py."
 
     # android.rpy:32
     old "RAPT has been installed, but you'll need to install the Android SDK before you can build Android packages. Choose Install SDK to do this."
-    new "RAPT é stato installato ma devi ancora installare l'Android SDK prima di poter compilare pacchetti per Android; scegli \"Installa SDK\" per farlo."
+    new "RAPT è stato installato ma devi ancora installare l'Android SDK prima di poter compilare pacchetti per Android; scegli \"Installa SDK\" per farlo."
 
     # android.rpy:33
     old "RAPT has been installed, but a key hasn't been configured. Please create a new key, or restore android.keystore."
-    new "RAPT é stato installato, ma la chiave non é stata configurata. Si prega di creare una chiave o di ripristinare android.keystore."
+    new "RAPT è stato installato, ma la chiave non è stata configurata. Si prega di creare una chiave o di ripristinare android.keystore."
 
     # android.rpy:34
     old "The current project has not been configured. Use \"Configure\" to configure it before building."
-    new "Il progetto corrente non é stato configurato. Usa \"Configura\" per configurarlo prima della compilazione."
+    new "Il progetto corrente non è stato configurato. Usa \"Configura\" per configurarlo prima della compilazione."
 
     # android.rpy:35
     old "Choose \"Build\" to build the current project, or attach an Android device and choose \"Build & Install\" to build and install it on the device."
@@ -57,15 +58,15 @@
 
     # android.rpy:37
     old "Attempts to emulate an Android phone.\n\nTouch input is emulated through the mouse, but only when the button is held down. Escape is mapped to the menu button, and PageUp is mapped to the back button."
-    new "Tenta di emulare un dispositivo Android.\n\nL'input tattile viene emulato attraverso il mouse, ma soltanto quando viene eseguito un click. Esc é assegnato al pulsante \"menu\" e PaginaSu é assegnato al pulsante \"indietro\"."
+    new "Tenta di emulare un dispositivo Android.\n\nL'input tattile viene emulato attraverso il mouse, ma soltanto quando viene eseguito un click. Esc è assegnato al pulsante \"menu\" e PaginaSu è assegnato al pulsante \"indietro\"."
 
     # android.rpy:38
     old "Attempts to emulate an Android tablet.\n\nTouch input is emulated through the mouse, but only when the button is held down. Escape is mapped to the menu button, and PageUp is mapped to the back button."
-    new "Tenta di emulare un tablet Android.\n\nL'input tattile viene emulato attraverso il mouse, ma solo quando viene eseguito un click. Esc é assegnato al pulsante \"menu\" e PaginaSu é assegnato al pulsante \"indietro\"."
+    new "Tenta di emulare un tablet Android.\n\nL'input tattile viene emulato attraverso il mouse, ma solo quando viene eseguito un click. Esc è assegnato al pulsante \"menu\" e PaginaSu è assegnato al pulsante \"indietro\"."
 
     # android.rpy:39
     old "Attempts to emulate a televison-based Android console, like the OUYA or Fire TV.\n\nController input is mapped to the arrow keys, Enter is mapped to the select button, Escape is mapped to the menu button, and PageUp is mapped to the back button."
-    new "Prova ed emulare una console connessa al televisore come OUYA o Fire TV.\n\nL'input del controller é assegnato alle freccie direzionali, Invio é assegnato al tasto \"select\", \"Esc\" é assegnato al tasto \"menu\" e PageUp é assegnato al tasto \"back\". "
+    new "Prova ed emulare una console connessa al televisore come OUYA o Fire TV.\n\nL'input del controller è assegnato alle freccie direzionali, Invio è assegnato al tasto \"select\", \"Esc\" è assegnato al tasto \"menu\" e PageUp è assegnato al tasto \"back\". "
 
     # android.rpy:41
     old "Downloads and installs the Android SDK and supporting packages. Optionally, generates the keys required to sign the package."
@@ -105,7 +106,7 @@
 
     # android.rpy:240
     old "Copying Android files to distributions directory."
-    new "Copia dei file Android nelle directory di distribuzione."
+    new "Copia dei file Android nella cartella delle distribuzioni."
 
     # android.rpy:304
     old "Android: [project.current.name!q]"
@@ -121,8 +122,7 @@
 
     # android.rpy:337
     old "Tablet"
-    # Automatic translation.
-    new "Tavoletta"
+    new "Tablet"
 
     # android.rpy:341
     old "Television"
@@ -206,11 +206,10 @@
 
     # choose_theme.rpy:303
     old "Could not change the theme. Perhaps options.rpy was changed too much."
-    new "Non é stato possibile cambiare il tema. Forse options.rpy é stato modificato troppo radicalmente."
+    new "Non è stato possibile cambiare il tema. Forse options.rpy è stato modificato troppo radicalmente."
 
     # choose_theme.rpy:370
     old "Planetarium"
-    # Automatic translation.
     new "Planetario"
 
     # choose_theme.rpy:425
@@ -255,7 +254,7 @@
 
     # distribute.rpy:569
     old "All packages have been built.\n\nDue to the presence of permission information, unpacking and repacking the Linux and Macintosh distributions on Windows is not supported."
-    new "Tutti i pacchetti sono stati compilati.\n\nData la presenza di limitazioni sui permessi, estrarre e ri-archiviare le distribuzioni Linux e Macintosh su Windows non é supportato."
+    new "Tutti i pacchetti sono stati compilati.\n\nData la presenza di limitazioni sui permessi, estrarre e ri-archiviare le distribuzioni Linux e Macintosh su Windows non è supportato."
 
     # distribute.rpy:752
     old "Archiving files..."
@@ -395,7 +394,7 @@
 
     # editor.rpy:359
     old "An exception occured while launching the text editor:\n[exception!q]"
-    new "Si é verificata un'eccezione durante il lancio dell'editor:\n[exception!q]"
+    new "Si è verificata un'eccezione durante il lancio dell'editor:\n[exception!q]"
 
     # editor.rpy:457
     old "Select Editor"
@@ -403,7 +402,7 @@
 
     # editor.rpy:472
     old "A text editor is the program you'll use to edit Ren'Py script files. Here, you can select the editor Ren'Py will use. If not already present, the editor will be automatically downloaded and installed."
-    new "L'editor di testo é il programma che viene usato per modificare i file di script di Ren'Py. Qui puoi selezionare l'editor da usare con Ren'Py. Se assente nel sistema, l'editor verrà automaticamente scaricato ed installato."
+    new "L'editor di testo è il programma che viene usato per modificare i file di script di Ren'Py. Qui puoi selezionare l'editor da usare con Ren'Py. Se assente nel sistema, l'editor verrà automaticamente scaricato ed installato."
 
     # editor.rpy:494
     old "Cancel"
@@ -439,8 +438,7 @@
 
     # front_page.rpy:166
     old "The Question"
-    # Automatic translation.
-    new "La domanda"
+    new "La Domanda"
 
     # front_page.rpy:182
     old "Active Project"
@@ -484,7 +482,7 @@
 
     # front_page.rpy:237
     old "Change/Update GUI"
-    new "Cambia/Aggiorna GUI"
+    new "Cambia/Aggiorna Interfaccia Grafica"
 
     # front_page.rpy:239
     old "Change Theme"
@@ -612,7 +610,7 @@
 
     # interface.rpy:356
     old "While [what!qt], an error occured:"
-    new "Durante [what!qt], si é verificato un errore:"
+    new "Durante [what!qt], si è verificato un errore:"
 
     # interface.rpy:356
     old "[exception!q]"
@@ -644,7 +642,7 @@
 
     # ios.rpy:28
     old "To build iOS packages, please download renios, unzip it, and place it into the Ren'Py directory. Then restart the Ren'Py launcher."
-    new "Per compilare pacchetti iOS scarica renios, scompattalo, e ponilo nella directory di Ren'py. Quindi riavvia il Ren'Py launcher."
+    new "Per compilare pacchetti iOS scarica renios, scompattalo, e ponilo nella cartella di Ren'Py. Quindi riavvia il Ren'Py launcher."
 
     # ios.rpy:29
     old "The directory in where Xcode projects will be placed has not been selected. Choose 'Select Directory' to select it."
@@ -652,7 +650,7 @@
 
     # ios.rpy:30
     old "There is no Xcode project corresponding to the current Ren'Py project. Choose 'Create Xcode Project' to create one."
-    new "Non esiste un progetto Xcode che corrisponda al progetto Ren'py corrente. Scegli 'Crea Progetto Xcode' per crearne uno."
+    new "Non esiste un progetto Xcode che corrisponda al progetto Ren'Py corrente. Scegli 'Crea Progetto Xcode' per crearne uno."
 
     # ios.rpy:31
     old "An Xcode project exists. Choose 'Update Xcode Project' to update it with the latest game files, or use Xcode to build and install it."
@@ -832,7 +830,7 @@
 
     # new_project.rpy:38
     old "New GUI Interface"
-    new "Nuova Interfaccia GUI"
+    new "Nuova Interfaccia Grafica"
 
     # new_project.rpy:48
     old "Both interfaces have been translated to your language."
@@ -840,7 +838,7 @@
 
     # new_project.rpy:50
     old "Only the new GUI has been translated to your language."
-    new "Solo la nuova GUI è stata tradotta nella tua lingua."
+    new "Solo la nuova interfaccia grafica è stata tradotta nella tua lingua."
 
     # new_project.rpy:52
     old "Only the legacy theme interface has been translated to your language."
@@ -856,11 +854,11 @@
 
     # new_project.rpy:69
     old "Which interface would you like to use? The new GUI has a modern look, supports wide screens and mobile devices, and is easier to customize. Legacy themes might be necessary to work with older example code.\n\n[language_support!t]\n\nIf in doubt, choose the new GUI, then click Continue on the bottom-right."
-    new "Quale interfaccia vorresti usare? La nuova GUI ha un aspetto moderno, supporta il wide screen e i dispositivi mobili, ed è più facile da personalizzare. I vecchi temi possono essere necessari per operare con con esempi datati.\n\n[language_support!t]\n\nNel dubbio, scegli la nuova GUI, quindi clicca Continua in basso a destra."
+    new "Quale interfaccia vorresti usare? La nuova interfaccia grafica ha un aspetto moderno, supporta il wide screen e i dispositivi mobili, ed è più facile da personalizzare. I vecchi temi possono essere necessari per operare con con esempi datati.\n\n[language_support!t]\n\nNel dubbio, scegli la nuova interfaccia, quindi clicca Continua in basso a destra."
 
     # new_project.rpy:69
     old "Legacy Theme Interface"
-    new "Interfaccia Vecchio Tema"
+    new "Interfaccia Temi Vecchia"
 
     # new_project.rpy:90
     old "Choose Project Template"
@@ -940,7 +938,11 @@
 
     # preferences.rpy:199
     old "Open launcher project"
-    new "Apri progetto del Launcher"
+    new "Apri progetto del launcher"
+
+    # preferences.rpy:338
+    old "Open projects.txt"
+    new "Apri projects.txt"
 
     # preferences.rpy:213
     old "Language:"
@@ -1108,8 +1110,7 @@
 
     # updater.rpy:91
     old "Release"
-    # Automatic translation.
-    new "Rilascio"
+    new "Release"
 
     # updater.rpy:97
     old "{b}Recommended.{/b} The version of Ren'Py that should be used in all newly-released games."
@@ -1125,7 +1126,6 @@
 
     # updater.rpy:114
     old "Experimental"
-    # Automatic translation.
     new "Sperimentale"
 
     # updater.rpy:120
@@ -1134,8 +1134,7 @@
 
     # updater.rpy:126
     old "Nightly"
-    # Automatic translation.
-    new "Notturno"
+    new "Nightly"
 
     # updater.rpy:132
     old "The bleeding edge of Ren'Py development. This may have the latest features, or might not run at all."
@@ -1205,77 +1204,61 @@
     old "PROJECTS:"
     new "PROGETTI:"
 
-translate italian strings:
-
     # game/add_file.rpy:37
     old "The file name may not be empty."
-    # Automatic translation.
     new "Il nome del file non può essere vuoto."
 
     # game/android.rpy:37
     old "A 64-bit/x64 Java [JDK_REQUIREMENT] Development Kit is required to build Android packages on Windows. The JDK is different from the JRE, so it's possible you have Java without having the JDK.\n\nPlease {a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}download and install the JDK{/a}, then restart the Ren'Py launcher."
-    # Automatic translation.
-    new "Per creare pacchetti Android su Windows è necessario un kit di sviluppo Java [JDK_REQUIREMENT] a 64 bit/x64. Il JDK è diverso dal JRE, quindi è possibile avere Java senza avere il JDK.\n\n{a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}scaricare e installare il JDK{/a}, quindi riavviare il lanciatore Ren'Py."
+    new "Per creare pacchetti Android su Windows è necessario un Java Development Kit [JDK_REQUIREMENT] a 64 bit/x64. Il JDK è diverso dal JRE, quindi è possibile che tu abbia Java senza avere il JDK.\n\n{a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}Scarica ed installa il JDK{/a}, quindi riavvia il launcher Ren'Py."
 
     # game/android.rpy:39
     old "RAPT has been installed, but a key hasn't been configured. Please generate new keys, or copy android.keystore and bundle.keystore to the base directory."
-    # Automatic translation.
-    new "RAPT è stato installato, ma non è stata configurata una chiave. Generare nuove chiavi o copiare android.keystore e bundle.keystore nella directory di base."
+    new "RAPT è stato installato, ma non è stata configurata una chiave. Genera delle nuove chiavi, o copia dei file android.keystore e bundle.keystore esistenti nella cartella di base."
 
     # game/android.rpy:41
     old "Please select if you want a Play Bundle (for Google Play), or a Universal APK (for sideloading and other app stores)."
-    # Automatic translation.
-    new "Selezionare se si desidera un Play Bundle (per Google Play) o un APK universale (per il sideloading e altri app store)."
+    new "Seleziona se vuoi un Play Bundle (per Google Play) o un APK universale (per il sideloading ed altri app store)."
 
     # game/android.rpy:46
     old "Attempts to emulate a televison-based Android console.\n\nController input is mapped to the arrow keys, Enter is mapped to the select button, Escape is mapped to the menu button, and PageUp is mapped to the back button."
-    # Automatic translation.
-    new "Tenta di emulare una console Android basata su televisore.\n\nL'input del controller è mappato ai tasti freccia, Invio è mappato al pulsante di selezione, Escape è mappato al pulsante del menu e PageUp è mappato al pulsante indietro."
+    new "Tenta di emulare una console Android per televisori.\n\nL'input del controller è mappato ai tasti freccia, Invio al pulsante di selezione, Esc al pulsante del menu, e PageUp al pulsante indietro."
 
     # game/android.rpy:48
     old "Downloads and installs the Android SDK and supporting packages."
-    # Automatic translation.
     new "Scarica e installa l'SDK di Android e i pacchetti di supporto."
 
     # game/android.rpy:49
     old "Generates the keys required to sign the package."
-    # Automatic translation.
     new "Genera le chiavi necessarie per firmare il pacchetto."
 
     # game/android.rpy:56
     old "Lists the connected devices."
-    # Automatic translation.
     new "Elenca i dispositivi collegati."
 
     # game/android.rpy:57
     old "Pairs with a device over Wi-Fi, on Android 11+."
-    # Automatic translation.
-    new "Si abbina a un dispositivo tramite Wi-Fi, su Android 11+."
+    new "Si abbina ad un dispositivo tramite Wi-Fi, su Android 11+."
 
     # game/android.rpy:58
     old "Connects to a device over Wi-Fi, on Android 11+."
-    # Automatic translation.
-    new "Si collega a un dispositivo tramite Wi-Fi, su Android 11+."
+    new "Si collega ad un dispositivo tramite Wi-Fi, su Android 11+."
 
     # game/android.rpy:59
     old "Disconnects a device connected over Wi-Fi."
-    # Automatic translation.
     new "Disconnette un dispositivo connesso tramite Wi-Fi."
 
     # game/android.rpy:61
     old "Removes Android temporary files."
-    # Automatic translation.
     new "Rimuove i file temporanei di Android."
 
     # game/android.rpy:63
     old "Builds an Android App Bundle (ABB), intended to be uploaded to Google Play. This can include up to 2GB of data."
-    # Automatic translation.
-    new "Costruisce un bundle di applicazioni Android (ABB), destinato a essere caricato su Google Play. Può includere fino a 2 GB di dati."
+    new "Compila un Bundle Applicazione Android (ABB), destinato ad essere caricato su Google Play. Può includere fino a 2 GB di dati."
 
     # game/android.rpy:64
     old "Builds a Universal APK package, intended for sideloading and stores other than Google Play. This can include up to 2GB of data."
-    # Automatic translation.
-    new "Crea un pacchetto APK universale, destinato al caricamento laterale e a negozi diversi da Google Play. Può includere fino a 2 GB di dati."
+    new "Crea un pacchetto APK universale, destinato al sideloading e a negozi diversi da Google Play. Può includere fino a 2 GB di dati."
 
     # game/android.rpy:327
     old "Android: [project.current.display_name!q]"
@@ -1283,13 +1266,11 @@ translate italian strings:
 
     # game/android.rpy:383
     old "Install SDK"
-    # Automatic translation.
-    new "Installare l'SDK"
+    new "Installazione dell'SDK"
 
     # game/android.rpy:387
     old "Generate Keys"
-    # Automatic translation.
-    new "Generare le chiavi"
+    new "Generazione delle Chiavi"
 
     # game/android.rpy:397
     old "Play Bundle"
@@ -1297,222 +1278,179 @@ translate italian strings:
 
     # game/android.rpy:402
     old "Universal APK"
-    new "Universal APK"
+    new "APK Universale"
 
     # game/android.rpy:452
     old "List Devices"
-    # Automatic translation.
-    new "Elenco dispositivi"
+    new "Elenco Dispositivi"
 
     # game/android.rpy:456
     old "Wi-Fi Debugging Pair"
-    # Automatic translation.
-    new "Coppia di debug Wi-Fi"
+    new "Abbinamento Debug Wi-Fi"
 
     # game/android.rpy:460
     old "Wi-Fi Debugging Connect"
-    # Automatic translation.
-    new "Debug Wi-Fi Connetti"
+    new "Connessione Debug Wi-Fi"
 
     # game/android.rpy:464
     old "Wi-Fi Debugging Disconnect"
-    # Automatic translation.
-    new "Disconnessione del debug Wi-Fi"
+    new "Disconnessione Debug Wi-Fi"
 
     # game/android.rpy:468
     old "Clean"
-    # Automatic translation.
-    new "Pulito"
+    new "Pulisci"
 
     # game/android.rpy:573
     old "Wi-Fi Pairing Code"
-    # Automatic translation.
-    new "Codice di accoppiamento Wi-Fi"
+    new "Codice di Abbinamento Wi-Fi"
 
     # game/android.rpy:573
     old "If supported, this can be found in 'Developer options', 'Wireless debugging', 'Pair device with pairing code'."
-    # Automatic translation.
-    new "Se supportato, si trova in \"Opzioni sviluppatore\", \"Debug wireless\", \"Accoppiamento del dispositivo con codice di accoppiamento\"."
+    new "Se supportato, si trova in \"Opzioni sviluppatore\", \"Debug wireless\", \"Abbinamento del dispositivo con codice\"."
 
     # game/android.rpy:580
     old "Pairing Host & Port"
-    # Automatic translation.
-    new "Accoppiamento di host e porta"
+    new "Abbinamento di Host e Porta"
 
     # game/android.rpy:596
     old "IP Address & Port"
-    # Automatic translation.
-    new "Indirizzo IP e porta"
+    new "Indirizzo IP e Porta"
 
     # game/android.rpy:596
     old "If supported, this can be found in 'Developer options', 'Wireless debugging'."
-    # Automatic translation.
-    new "Se supportato, si trova in \"Opzioni sviluppatore\", \"Debug wireless\"."
+    new "Se supportato, si trova in 'Opzioni sviluppatore', 'Debug wireless'."
 
     # game/android.rpy:612
     old "This can be found in 'List Devices'."
-    # Automatic translation.
-    new "Si trova in \"Elenco dispositivi\"."
+    new "Si trova in 'Elenco dispositivi'."
 
     # game/android.rpy:632
     old "Cleaning up Android project."
-    # Automatic translation.
     new "Pulizia del progetto Android."
 
     # game/androidstrings.rpy:7
     old "{} is not a directory."
-    # Automatic translation.
-    new "{} non è una directory."
+    new "{} non è una cartella."
 
     # game/androidstrings.rpy:8
     old "{} does not contain a Ren'Py game."
-    # Automatic translation.
-    new "{} non contiene un gioco di Ren'Py."
+    new "{} non contiene un gioco Ren'Py."
 
     # game/androidstrings.rpy:10
     old "Run configure before attempting to build the app."
-    # Automatic translation.
-    new "Eseguire configure prima di tentare di costruire l'applicazione."
+    new "Esegui configura prima di tentare la compilazione della app."
 
     # game/androidstrings.rpy:11
     old "Updating project."
-    # Automatic translation.
     new "Aggiornamento del progetto."
 
     # game/androidstrings.rpy:12
     old "Creating assets directory."
-    # Automatic translation.
-    new "Creazione della directory delle risorse."
+    new "Creazione della cartella delle risorse."
 
     # game/androidstrings.rpy:13
     old "Packaging internal data."
-    # Automatic translation.
-    new "Dati interni dell'imballaggio."
+    new "Pacchettizzazione dei dati interni."
 
     # game/androidstrings.rpy:14
     old "I'm using Gradle to build the package."
-    # Automatic translation.
     new "Sto usando Gradle per creare il pacchetto."
 
     # game/androidstrings.rpy:15
     old "The build seems to have failed."
-    # Automatic translation.
-    new "La compilazione sembra essere fallita."
+    new "La compilazione sembra aver fallito."
 
     # game/androidstrings.rpy:16
     old "I'm installing the bundle."
-    # Automatic translation.
     new "Sto installando il pacchetto."
 
     # game/androidstrings.rpy:17
     old "Installing the bundle appears to have failed."
-    # Automatic translation.
-    new "L'installazione del bundle sembra essere fallita."
+    new "L'installazione del pacchetto sembra aver fallita."
 
     # game/androidstrings.rpy:18
     old "Launching app."
-    # Automatic translation.
     new "Avvio dell'applicazione."
 
     # game/androidstrings.rpy:19
     old "Launching the app appears to have failed."
-    # Automatic translation.
-    new "L'avvio dell'applicazione sembra non essere riuscito."
+    new "L'avvio dell'applicazione sembra aver fallito."
 
     # game/androidstrings.rpy:20
     old "The build seems to have succeeded."
-    # Automatic translation.
-    new "La costruzione sembra essere riuscita."
+    new "La compilazione sembra essere riuscita."
 
     # game/androidstrings.rpy:21
     old "What is the full name of your application? This name will appear in the list of installed applications."
-    # Automatic translation.
-    new "Qual è il nome completo dell'applicazione? Questo nome apparirà nell'elenco delle applicazioni installate."
+    new "Qual è il nome completo per la tua applicazione? Questo nome apparirà nell'elenco delle applicazioni installate."
 
     # game/androidstrings.rpy:22
     old "What is the short name of your application? This name will be used in the launcher, and for application shortcuts."
-    # Automatic translation.
-    new "Qual è il nome breve della vostra applicazione? Questo nome verrà utilizzato nel launcher e per i collegamenti all'applicazione."
+    new "Qual è il nome breve per la tua applicazione? Questo nome verrà utilizzato nel launcher e per le scorciatoie all'applicazione."
 
     # game/androidstrings.rpy:23
     old "What is the name of the package?\n\nThis is usually of the form com.domain.program or com.domain.email.program. It may only contain ASCII letters and dots. It must contain at least one dot."
-    # Automatic translation.
-    new "Qual è il nome del pacchetto?\n\nDi solito ha la forma com.domain.program o com.domain.email.program. Può contenere solo lettere ASCII e punti. Deve contenere almeno un punto."
+    new "Qual è il nome del pacchetto?\n\nDi solito ha la forma com.dominio.programma o com.dominio.email.programma. Può contenere solo lettere ASCII e punti. Deve contenere almeno un punto."
 
     # game/androidstrings.rpy:24
     old "The package name may not be empty."
-    # Automatic translation.
     new "Il nome del pacchetto non può essere vuoto."
 
     # game/androidstrings.rpy:25
     old "The package name may not contain spaces."
-    # Automatic translation.
     new "Il nome del pacchetto non può contenere spazi."
 
     # game/androidstrings.rpy:26
     old "The package name must contain at least one dot."
-    # Automatic translation.
     new "Il nome del pacchetto deve contenere almeno un punto."
 
     # game/androidstrings.rpy:27
     old "The package name may not contain two dots in a row, or begin or end with a dot."
-    # Automatic translation.
     new "Il nome del pacchetto non può contenere due punti di seguito, né iniziare o terminare con un punto."
 
     # game/androidstrings.rpy:28
     old "Each part of the package name must start with a letter, and contain only letters, numbers, and underscores."
-    # Automatic translation.
     new "Ogni parte del nome del pacchetto deve iniziare con una lettera e contenere solo lettere, numeri e trattini bassi."
 
     # game/androidstrings.rpy:29
     old "{} is a Java keyword, and can't be used as part of a package name."
-    # Automatic translation.
     new "{} è una parola chiave di Java e non può essere usata come parte del nome di un pacchetto."
 
     # game/androidstrings.rpy:30
     old "What is the application's version?\n\nThis should be the human-readable version that you would present to a person. It must contain only numbers and dots."
-    # Automatic translation.
-    new "Qual è la versione dell'applicazione?\n\nQuesta deve essere la versione leggibile che presentereste a una persona. Deve contenere solo numeri e punti."
+    new "Qual è la versione dell'applicazione?\n\nDeve essere la versione leggibile che presenteresti anche ad una persona. Deve contenere solo numeri e punti."
 
     # game/androidstrings.rpy:31
     old "The version number must contain only numbers and dots."
-    # Automatic translation.
     new "Il numero di versione deve contenere solo numeri e punti."
 
     # game/androidstrings.rpy:32
     old "How much RAM (in GB) do you want to allocate to Gradle?\nThis must be a positive integer number."
-    # Automatic translation.
-    new "Quanta RAM (in GB) si vuole allocare a Gradle?\nDeve essere un numero intero positivo."
+    new "Quanta RAM (in GB) vuoi allocare a Gradle?\nDeve essere un numero intero positivo."
 
     # game/androidstrings.rpy:33
     old "The RAM size must contain only numbers and be positive."
-    # Automatic translation.
     new "La dimensione della RAM deve contenere solo numeri ed essere positiva."
 
     # game/androidstrings.rpy:34
     old "How would you like your application to be displayed?"
-    # Automatic translation.
-    new "Come desiderate che venga visualizzata la vostra candidatura?"
+    new "Come desideri che venga visualizzata l'applicazione?"
 
     # game/androidstrings.rpy:35
     old "In landscape orientation."
-    # Automatic translation.
     new "In orientamento orizzontale."
 
     # game/androidstrings.rpy:36
     old "In portrait orientation."
-    # Automatic translation.
     new "In orientamento verticale."
 
     # game/androidstrings.rpy:37
     old "In the user's preferred orientation."
-    # Automatic translation.
     new "Nell'orientamento preferito dall'utente."
 
     # game/androidstrings.rpy:38
     old "Which app store would you like to support in-app purchasing through?"
-    # Automatic translation.
-    new "Attraverso quale app store vorreste supportare gli acquisti in-app?"
+    new "Attraverso quale app store vuoi supportare gli acquisti in-app?"
 
     # game/androidstrings.rpy:39
     old "Google Play."
@@ -1524,188 +1462,151 @@ translate italian strings:
 
     # game/androidstrings.rpy:41
     old "Both, in one app."
-    # Automatic translation.
-    new "Entrambi, in un'unica applicazione."
+    new "Entrambi in un'unica applicazione."
 
     # game/androidstrings.rpy:42
     old "Neither."
-    # Automatic translation.
     new "Né l'uno né l'altro."
 
     # game/androidstrings.rpy:43
     old "Do you want to automatically update the Java source code?"
-    # Automatic translation.
-    new "Si desidera aggiornare automaticamente il codice sorgente Java?"
+    new "Vuoi aggiornare automaticamente il codice sorgente Java?"
 
     # game/androidstrings.rpy:44
     old "Yes. This is the best choice for most projects."
-    # Automatic translation.
-    new "Sì, è la scelta migliore per la maggior parte dei progetti."
+    new "Sì. Questa è la scelta migliore per la maggior parte dei progetti."
 
     # game/androidstrings.rpy:45
     old "No. This may require manual updates when Ren'Py or the project configuration changes."
-    # Automatic translation.
-    new "No. Potrebbe essere necessario un aggiornamento manuale quando Ren'Py o la configurazione del progetto cambiano."
+    new "No. Potrebbe essere necessario un aggiornamento manuale quando cambiano Ren'Py o la configurazione del progetto."
 
     # game/androidstrings.rpy:46
     old "Unknown configuration variable: {}"
-    # Automatic translation.
     new "Variabile di configurazione sconosciuta: {}"
 
     # game/androidstrings.rpy:47
     old "I'm compiling a short test program, to see if you have a working JDK on your system."
-    # Automatic translation.
-    new "Sto compilando un breve programma di prova, per vedere se avete un JDK funzionante sul vostro sistema."
+    new "Sto compilando un piccolo programma di prova, per vedere se hai un JDK funzionante sul sistema."
 
     # game/androidstrings.rpy:48
     old "I was unable to use javac to compile a test file. If you haven't installed the Java Development Kit yet, please download it from:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nThe JDK is different from the JRE, so it's possible you have Java without having the JDK. Please make sure you installed the 'JavaSoft (Oracle) registry keys'.\n\nWithout a working JDK, I can't continue."
-    # Automatic translation.
-    new "Non sono riuscito a utilizzare javac per compilare un file di prova. Se non avete ancora installato il Java Development Kit, scaricatelo da:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nIl JDK è diverso dal JRE, quindi è possibile che abbiate Java senza avere il JDK. Assicurarsi di aver installato le \"chiavi di registro JavaSoft (Oracle)\".\n\nSenza un JDK funzionante, non posso continuare."
+    new "Non ho potuto usare javac per compilare un file di prova. Se non hai ancora installato il Java Development Kit, scaricalo da:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nIl JDK è diverso dal JRE, quindi è possibile che tu abbia Java senza avere il JDK. Assicurati di aver installato le 'chiavi di registro JavaSoft (Oracle)'.\n\nSenza un JDK funzionante, non posso continuare."
 
     # game/androidstrings.rpy:49
     old "The version of Java on your computer does not appear to be JDK 8, which is the only version supported by the Android SDK. If you need to install JDK 8, you can download it from:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nYou can also set the JAVA_HOME environment variable to use a different version of Java."
-    # Automatic translation.
-    new "La versione di Java presente sul computer non sembra essere JDK 8, che è l'unica versione supportata dall'SDK di Android. Se è necessario installare JDK 8, è possibile scaricarlo da:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nÈ anche possibile impostare la variabile d'ambiente JAVA_HOME per utilizzare una versione diversa di Java."
+    new "La versione di Java presente sul computer non sembra essere JDK 8, che è l'unica versione supportata dall'SDK di Android. Se devi installare JDK 8, puoi scaricarlo da:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nPuoi anche impostare la variabile d'ambiente JAVA_HOME per utilizzare una versione diversa di Java."
 
     # game/androidstrings.rpy:50
     old "The JDK is present and working. Good!"
-    # Automatic translation.
     new "Il JDK è presente e funzionante. Bene!"
 
     # game/androidstrings.rpy:51
     old "The Android SDK has already been unpacked."
-    # Automatic translation.
     new "L'SDK Android è già stato scompattato."
 
     # game/androidstrings.rpy:52
     old "Do you accept the Android SDK Terms and Conditions?"
-    # Automatic translation.
-    new "Accettate i termini e le condizioni dell'SDK Android?"
+    new "Accetti i Termini e le Condizioni dell'SDK di Android?"
 
     # game/androidstrings.rpy:53
     old "I'm downloading the Android SDK. This might take a while."
-    # Automatic translation.
     new "Sto scaricando l'SDK di Android. Potrebbe volerci un po'."
 
     # game/androidstrings.rpy:54
     old "I'm extracting the Android SDK."
-    # Automatic translation.
-    new "Sto estraendo l'SDK Android."
+    new "Sto estraendo l'SDK di Android."
 
     # game/androidstrings.rpy:55
     old "I've finished unpacking the Android SDK."
-    # Automatic translation.
     new "Ho finito di scompattare l'SDK di Android."
 
     # game/androidstrings.rpy:56
     old "I'm about to download and install the required Android packages. This might take a while."
-    # Automatic translation.
-    new "Sto per scaricare e installare i pacchetti Android necessari. Potrebbe volerci un po'."
+    new "Sto per scaricare ed installare i pacchetti Android necessari. Potrebbe volerci un po'."
 
     # game/androidstrings.rpy:57
     old "I was unable to accept the Android licenses."
-    # Automatic translation.
-    new "Non ho potuto accettare le licenze Android."
+    new "Non ho potuto accettare le licenze di Android."
 
     # game/androidstrings.rpy:59
     old "I was unable to install the required Android packages."
-    # Automatic translation.
-    new "Non sono riuscito a installare i pacchetti Android richiesti."
+    new "Non ho potuto  installare i pacchetti Android necessari."
 
     # game/androidstrings.rpy:60
     old "I've finished installing the required Android packages."
-    # Automatic translation.
     new "Ho finito di installare i pacchetti Android necessari."
 
     # game/androidstrings.rpy:61
     old "It looks like you're ready to start packaging games."
-    # Automatic translation.
-    new "Sembra che siate pronti per iniziare a confezionare giochi."
+    new "Sembra che sia tutto pronto per iniziare a confezionare giochi."
 
     # game/androidstrings.rpy:62
     old "Please enter your name or the name of your organization."
-    # Automatic translation.
-    new "Inserite il vostro nome o il nome della vostra organizzazione."
+    new "Inserisci il tuo nome o quello della tua organizzazione."
 
     # game/androidstrings.rpy:63
     old "I found an android.keystore file in the rapt directory. Do you want to use this file?"
-    # Automatic translation.
-    new "Ho trovato un file android.keystore nella directory rapt. Si vuole usare questo file?"
+    new "Ho trovato un file android.keystore nella cartella rapt. Vuoi usare questo?"
 
     # game/androidstrings.rpy:64
     old "I can create an application signing key for you. This key is required to create Universal APK for sideloading and stores other than Google Play.\n\nDo you want to create a key?"
-    # Automatic translation.
-    new "Posso creare una chiave di firma dell'applicazione per voi. Questa chiave è necessaria per creare APK universali per il caricamento laterale e per gli store diversi da Google Play.\n\nVolete creare una chiave?"
+    new "Posso creare una chiave di firma dell'applicazione per te. Questa chiave è necessaria per creare APK universali per il sideloading e per gli store diversi da Google Play.\n\nVuoi creare una chiave?"
 
     # game/androidstrings.rpy:65
     old "I will create the key in the android.keystore file.\n\nYou need to back this file up. If you lose it, you will not be able to upgrade your application.\n\nYou also need to keep the key safe. If evil people get this file, they could make fake versions of your application, and potentially steal your users' data.\n\nWill you make a backup of android.keystore, and keep it in a safe place?"
-    # Automatic translation.
-    new "Creerò la chiave nel file android.keystore.\n\nÈ necessario eseguire un backup di questo file. Se lo si perde, non sarà possibile aggiornare l'applicazione.\n\nÈ inoltre necessario tenere la chiave al sicuro. Se persone malintenzionate ottengono questo file, potrebbero creare versioni false della vostra applicazione e potenzialmente rubare i dati dei vostri utenti.\n\nFarete un backup di android.keystore e lo terrete in un posto sicuro?"
+    new "Creerò la chiave nel file android.keystore.\n\nDovrai eseguire un backup di questo file. Se lo si perde, non sarà possibile aggiornare l'applicazione.\n\nÈ inoltre necessario tenere la chiave al sicuro. Se persone malintenzionate ottengono questo file, potrebbero creare versioni false della tua applicazione e potenzialmente rubare i dati dei tuoi utenti.\n\nFarai un backup di android.keystore e lo conserverai al sicuro?"
 
     # game/androidstrings.rpy:66
     old "\n\nSaying 'No' will prevent key creation."
-    # Automatic translation.
-    new "\n\nDicendo \"No\" si impedisce la creazione della chiave."
+    new "\n\nDicendo 'No' si impedisce la creazione della chiave."
 
     # game/androidstrings.rpy:67
     old "Could not create android.keystore. Is keytool in your path?"
-    # Automatic translation.
-    new "Impossibile creare android.keystore. Keytool è nel vostro percorso?"
+    new "Impossibile creare android.keystore. Il programma keytool è presente nel path di sistema?"
 
     # game/androidstrings.rpy:68
     old "I've finished creating android.keystore. Please back it up, and keep it in a safe place."
-    # Automatic translation.
-    new "Ho finito di creare android.keystore. Eseguire il backup e conservarlo in un luogo sicuro."
+    new "Ho creato il file android.keystore. Eseguine il backup, e conservalo al sicuro."
 
     # game/androidstrings.rpy:69
     old "I found a bundle.keystore file in the rapt directory. Do you want to use this file?"
-    # Automatic translation.
-    new "Ho trovato un file bundle.keystore nella directory rapt. Si vuole usare questo file?"
+    new "Ho trovato un file bundle.keystore nella cartella rapt. Vuoi usarlo?"
 
     # game/androidstrings.rpy:70
     old "I can create a bundle signing key for you. This key is required to build an Android App Bundle (AAB) for upload to Google Play.\n\nDo you want to create a key?"
-    # Automatic translation.
-    new "Posso creare una chiave di firma del bundle per voi. Questa chiave è necessaria per creare un bundle di applicazioni Android (AAB) da caricare su Google Play.\n\nVolete creare una chiave?"
+    new "Posso creare una chiave di firma del bundle per te. Questa è necessaria per creare un Bundle di Applicazioni Android (AAB) da caricare su Google Play.\n\nVuoi creare una chiave?"
 
     # game/androidstrings.rpy:71
     old "I will create the key in the bundle.keystore file.\n\nYou need to back this file up. If you lose it, you will not be able to upgrade your application.\n\nYou also need to keep the key safe. If evil people get this file, they could make fake versions of your application, and potentially steal your users' data.\n\nWill you make a backup of bundle.keystore, and keep it in a safe place?"
-    # Automatic translation.
-    new "Creerò la chiave nel file bundle.keystore.\n\nÈ necessario eseguire un backup di questo file. Se lo si perde, non sarà possibile aggiornare l'applicazione.\n\nÈ inoltre necessario tenere la chiave al sicuro. Se persone malintenzionate ottengono questo file, potrebbero creare versioni false della vostra applicazione e potenzialmente rubare i dati dei vostri utenti.\n\nSi può fare un backup di bundle.keystore e conservarlo in un luogo sicuro?"
+    new "Creerò la chiave nel file bundle.keystore.\n\nDovrai eseguire un backup di questo file. Se lo si perde, non sarà possibile aggiornare l'applicazione.\n\nÈ inoltre necessario tenere la chiave al sicuro. Se persone malintenzionate ottengono questo file, potrebbero creare versioni false della tua applicazione e potenzialmente rubare i dati dei tuoi utenti.\n\nFarai un backup di bundle.keystore e lo conserverai al sicuro?"
 
     # game/androidstrings.rpy:73
     old "Could not create bundle.keystore. Is keytool in your path?"
-    # Automatic translation.
-    new "Impossibile creare bundle.keystore. Keytool è nel percorso?"
+    new "Impossibile creare bundle.keystore. Il programma keytool è nel path di sistema?"
 
     # game/androidstrings.rpy:74
     old "I've opened the directory containing android.keystore and bundle.keystore. Please back them up, and keep them in a safe place."
-    # Automatic translation.
-    new "Ho aperto la directory contenente android.keystore e bundle.keystore. Eseguire il backup e conservarli in un luogo sicuro."
+    new "Ho aperto la cartella contenente android.keystore e bundle.keystore. Eseguine il backup e conservali al sicuro."
 
     # game/choose_directory.rpy:67
     old "Select Projects Directory"
-    # Automatic translation.
-    new "Selezionare la directory dei progetti"
+    new "Selezionare la cartella dei progetti"
 
     # game/choose_theme.rpy:508
     old "changing the theme"
-    # Automatic translation.
-    new "cambiare il tema"
+    new "cambio del tema"
 
     # game/distribute.rpy:1745
     old "Copying files..."
-    # Automatic translation.
     new "Copia dei file..."
 
     # game/distribute_gui.rpy:157
     old "Build Distributions: [project.current.display_name!q]"
-    # Automatic translation.
-    new "Costruire le distribuzioni: [project.current.display_name!q]"
+    new "Compila Distribuzioni: [project.current.display_name!q]"
 
     # game/distribute_gui.rpy:195
     old "Update old-game"
-    # Automatic translation.
-    new "Aggiornamento del vecchio gioco"
+    new "Aggiornamento old-game"
 
     # game/distribute_gui.rpy:231
     old "(DLC)"
@@ -1713,23 +1614,19 @@ translate italian strings:
 
     # game/dmgcheck.rpy:50
     old "Ren'Py is running from a read only folder. Some functionality will not work."
-    # Automatic translation.
-    new "Ren'Py viene eseguito da una cartella di sola lettura. Alcune funzionalità non funzioneranno."
+    new "Ren'Py sta girando da una cartella di sola lettura. Alcune funzionalità non saranno disponibili."
 
     # game/dmgcheck.rpy:50
     old "This is probably because Ren'Py is running directly from a Macintosh drive image. To fix this, quit this launcher, copy the entire %s folder somewhere else on your computer, and run Ren'Py again."
-    # Automatic translation.
-    new "Questo probabilmente è dovuto al fatto che Ren'Py viene eseguito direttamente da un'immagine dell'unità Macintosh. Per risolvere il problema, chiudere il programma di avvio, copiare l'intera cartella %s in un altro punto del computer ed eseguire nuovamente Ren'Py."
+    new "Ciò è probabilmente perché Ren'Py è stato eseguito direttamente da un'immagine di unità Macintosh. Per risolvere il problema, chiudi questo launcher, copia l'intera cartella %s in un altro punto del computer, ed eseguire nuovamente Ren'Py."
 
     # game/editor.rpy:152
     old "A modern editor with many extensions including advanced Ren'Py integration."
-    # Automatic translation.
-    new "Un editor moderno con molte estensioni, compresa l'integrazione avanzata con Ren'Py."
+    new "Un editor moderno con molte estensioni, compresa un'integrazione avanzata con Ren'Py."
 
     # game/editor.rpy:153
     old "A modern editor with many extensions including advanced Ren'Py integration.\n{a=jump:reinstall_vscode}Upgrade Visual Studio Code to the latest version.{/a}"
-    # Automatic translation.
-    new "Un editor moderno con molte estensioni, compresa l'integrazione avanzata con Ren'Py.\n{a=jump:reinstall_vscode}Aggiornare Visual Studio Code alla versione più recente.{/a}"
+    new "Un editor moderno con molte estensioni, compresa un'integrazione avanzata con Ren'Py.\n{a=jump:reinstall_vscode}Aggiornare Visual Studio Code alla versione più recente.{/a}"
 
     # game/editor.rpy:169
     old "Visual Studio Code"
@@ -1737,12 +1634,10 @@ translate italian strings:
 
     # game/editor.rpy:169
     old "Up to 110 MB download required."
-    # Automatic translation.
     new "È richiesto un download fino a 110 MB."
 
     # game/editor.rpy:182
     old "A modern and approachable text editor."
-    # Automatic translation.
     new "Un editor di testo moderno e accessibile."
 
     # game/editor.rpy:196
@@ -1751,7 +1646,6 @@ translate italian strings:
 
     # game/editor.rpy:196
     old "Up to 150 MB download required."
-    # Automatic translation.
     new "È richiesto un download fino a 150 MB."
 
     # game/editor.rpy:211
@@ -1760,27 +1654,22 @@ translate italian strings:
 
     # game/editor.rpy:220
     old "Visual Studio Code (System)"
-    # Automatic translation.
-    new "Codice di Visual Studio (sistema)"
+    new "Visual Studio Code (Sistema)"
 
     # game/editor.rpy:220
     old "Uses a copy of Visual Studio Code that you have installed outside of Ren'Py. It's recommended you install the language-renpy extension to add support for Ren'Py files."
-    # Automatic translation.
     new "Utilizza una copia di Visual Studio Code installata al di fuori di Ren'Py. Si consiglia di installare l'estensione language-renpy per aggiungere il supporto ai file di Ren'Py."
 
     # game/editor.rpy:226
     old "System Editor"
-    # Automatic translation.
-    new "Editor di sistema"
+    new "Editor di Sistema"
 
     # game/editor.rpy:245
     old "None"
-    # Automatic translation.
     new "Nessuno"
 
     # game/editor.rpy:352
     old "Edit [text]."
-    # Automatic translation.
     new "Modifica [text]."
 
     # game/front_page.rpy:165
@@ -1789,12 +1678,10 @@ translate italian strings:
 
     # game/front_page.rpy:182
     old "Open project"
-    # Automatic translation.
-    new "Progetto aperto"
+    new "Apri progetto"
 
     # game/front_page.rpy:188
     old "Actions"
-    # Automatic translation.
     new "Azioni"
 
     # game/front_page.rpy:219
@@ -1807,123 +1694,99 @@ translate italian strings:
 
     # game/gui7.rpy:302
     old "{size=-4}\n\nThis will not overwrite gui/main_menu.png, gui/game_menu.png, and gui/window_icon.png, but will create files that do not exist.{/size}"
-    # Automatic translation.
-    new "{size=-4}\n\nQuesto non sovrascriverà gui/main_menu.png, gui/game_menu.png e gui/window_icon.png, ma creerà file che non esistono.{/size}"
+    new "{size=-4}\n\nNon saranno sovrascritti i file gui/main_menu.png, gui/game_menu.png e gui/window_icon.png, ma saranno creati i file che non esistono.{/size}"
 
     # game/gui7.rpy:333
     old "Custom. The GUI is optimized for a 16:9 aspect ratio."
-    # Automatic translation.
     new "Personalizzato. L'interfaccia grafica è ottimizzata per un rapporto d'aspetto 16:9."
 
     # game/gui7.rpy:350
     old "WIDTH"
-    # Automatic translation.
     new "LARGHEZZA"
 
     # game/gui7.rpy:350
     old "Please enter the width of your game, in pixels."
-    # Automatic translation.
-    new "Inserire la larghezza del gioco, in pixel."
+    new "Inserisci la larghezza del gioco, in pixel."
 
     # game/gui7.rpy:360
     old "The width must be a number."
-    # Automatic translation.
     new "La larghezza deve essere un numero."
 
     # game/gui7.rpy:366
     old "HEIGHT"
-    # Automatic translation.
     new "ALTEZZA"
 
     # game/gui7.rpy:366
     old "Please enter the height of your game, in pixels."
-    # Automatic translation.
-    new "Inserire l'altezza del gioco, in pixel."
+    new "Inserisci l'altezza del gioco, in pixel."
 
     # game/gui7.rpy:376
     old "The height must be a number."
-    # Automatic translation.
     new "L'altezza deve essere un numero."
 
     # game/gui7.rpy:424
     old "creating a new project"
-    # Automatic translation.
-    new "creare un nuovo progetto"
+    new "creazione di un nuovo progetto"
 
     # game/gui7.rpy:428
     old "activating the new project"
-    # Automatic translation.
-    new "attivare il nuovo progetto"
+    new "attivazione del nuovo progetto"
 
     # game/install.rpy:33
     old "Could not install [name!t], as a file matching [zipglob] was not found in the Ren'Py SDK directory."
-    # Automatic translation.
-    new "Impossibile installare [name!t], poiché non è stato trovato un file corrispondente a [zipglob] nella directory dell'SDK di Ren'Py."
+    new "Impossibile installare [name!t], poiché non è stato trovato un file corrispondente a [zipglob] nella cartella dell'SDK di Ren'Py."
 
     # game/install.rpy:79
     old "Successfully installed [name!t]."
-    # Automatic translation.
-    new "Installato con successo [name!t]."
+    new "[name!t] installato con successo."
 
     # game/install.rpy:111
     old "This screen allows you to install libraries that can't be distributed with Ren'Py. Some of these libraries may require you to agree to a third-party license before being used or distributed."
-    # Automatic translation.
-    new "Questa schermata consente di installare le librerie che non possono essere distribuite con Ren'Py. Alcune di queste librerie possono richiedere l'accettazione di una licenza di terze parti prima di essere utilizzate o distribuite."
+    new "Questa schermata ti permette di installare le librerie che non possono essere distribuite con Ren'Py. Alcune di queste possono richiedere l'accettazione di una licenza di terze parti prima di essere utilizzate o distribuite."
 
     # game/install.rpy:117
     old "Install Steam Support"
-    # Automatic translation.
-    new "Installare il supporto Steam"
+    new "Installa il Supporto a Steam"
 
     # game/install.rpy:126
     old "Before installing Steam support, please make sure you are a {a=https://partner.steamgames.com/}Steam partner{/a}."
-    # Automatic translation.
-    new "Prima di installare il supporto Steam, assicuratevi di essere un partner di Steam {a=https://partner.steamgames.com/}{/a} ."
+    new "Prima di installare il supporto a Steam, assicurati di essere un partner di Steam {a=https://partner.steamgames.com/}{/a}."
 
     # game/install.rpy:138
     old "Steam support has already been installed."
-    # Automatic translation.
-    new "Il supporto per Steam è già stato installato."
+    new "Il supporto a Steam è già stato installato."
 
     # game/install.rpy:142
     old "Install Live2D Cubism SDK for Native"
-    # Automatic translation.
-    new "Installare l'SDK di Live2D Cubism per Native"
+    new "Installa l'SDK Live2D Cubism for Native"
 
     # game/install.rpy:156
     old "Install Libraries"
-    # Automatic translation.
-    new "Installare le librerie"
+    new "Installa Librerie"
 
     # game/install.rpy:182
     old "The {a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} adds support for displaying Live2D models. Place CubismSdkForNative-4-{i}version{/i}.zip in the Ren'Py SDK directory, and then click Install. Distributing a game with Live2D requires you to accept a license from Live2D, Inc."
-    # Automatic translation.
-    new "{a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} aggiunge il supporto per la visualizzazione di modelli Live2D. Inserire CubismSdkForNative-4-{i}versione{/i}.zip nella directory Ren'Py SDK, quindi fare clic su Install. La distribuzione di un gioco con Live2D richiede l'accettazione di una licenza da parte di Live2D, Inc."
+    new "Il {a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} aggiunge il supporto per la visualizzazione di modelli Live2D. Posiziona CubismSdkForNative-4-{i}version{/i}.zip nella cartella dell'SDK di Ren'Py, quindi clicca Installa. La distribuzione di un gioco con Live2D richiede l'accettazione di una licenza da parte di Live2D, Inc."
 
     # game/install.rpy:186
     old "Live2D in Ren'Py doesn't support the Web, Android x86_64 (including emulators and Chrome OS), and must be added to iOS projects manually. Live2D must be reinstalled after upgrading Ren'Py or installing Android support."
-    # Automatic translation.
-    new "Live2D in Ren'Py non supporta il Web, Android x86_64 (compresi gli emulatori e Chrome OS) e deve essere aggiunto manualmente ai progetti iOS. Live2D deve essere reinstallato dopo l'aggiornamento di Ren'Py o l'installazione del supporto Android."
+    new "Live2D in Ren'Py non supporta il Web, Android x86_64 (compresi gli emulatori e Chrome OS), e deve essere aggiunto manualmente ai progetti iOS. Live2D deve essere reinstallato dopo l'aggiornamento di Ren'Py o l'installazione del supporto Android."
 
     # game/install.rpy:191
     old "Open Ren'Py SDK Directory"
-    # Automatic translation.
-    new "Aprire la directory dell'SDK di Ren'Py"
+    new "Aprire la Cartella dell'SDK di Ren'Py"
 
     # game/installer.rpy:10
     old "Downloading [extension.download_file]."
-    # Automatic translation.
-    new "Download di [extension.download_file]."
+    new "Scaricamento di [extension.download_file]."
 
     # game/installer.rpy:11
     old "Could not download [extension.download_file] from [extension.download_url]:\n{b}[extension.download_error]"
-    # Automatic translation.
     new "Impossibile scaricare [extension.download_file] da [extension.download_url]:\n{b}[extension.download_error]"
 
     # game/installer.rpy:12
     old "The downloaded file [extension.download_file] from [extension.download_url] is not correct."
-    # Automatic translation.
-    new "Il file scaricato [extension.download_file] da [extension.download_url] non è corretto."
+    new "Il file [extension.download_file] scaricato da [extension.download_url] non è corretto."
 
     # game/interface.rpy:124
     old "[interface.version]"
@@ -1931,13 +1794,11 @@ translate italian strings:
 
     # game/interface.rpy:141
     old "Ren'Py Sponsor Information"
-    # Automatic translation.
-    new "Informazioni sullo sponsor di Ren'Py"
+    new "Informazioni sugli Sponsor di Ren'Py"
 
     # game/interface.rpy:385
     old "opening the log file"
-    # Automatic translation.
-    new "apertura del file di log"
+    new "apertura del file di registro"
 
     # game/ios.rpy:269
     old "iOS: [project.current.display_name!q]"
@@ -1945,133 +1806,151 @@ translate italian strings:
 
     # game/ios.rpy:379
     old "There are known issues with the iOS simulator on Apple Silicon. Please test on x86_64 or iOS devices."
-    # Automatic translation.
-    new "Ci sono problemi noti con il simulatore iOS su Apple Silicon. Eseguire il test su dispositivi x86_64 o iOS."
+    new "Ci sono noti problemi con il simulatore iOS su Apple Silicon. Dovresti testare su x86_64 o dispositivi iOS."
 
     # game/itch.rpy:45
     old "Downloading the itch.io butler."
-    # Automatic translation.
-    new "Scaricare il maggiordomo di itch.io."
+    new "Scaricamento dell'itch.io butler."
 
     # game/navigation.rpy:168
     old "Navigate: [project.current.display_name!q]"
-    # Automatic translation.
-    new "Navigare: [project.current.display_name!q]"
+    new "Navigazione: [project.current.display_name!q]"
 
     # game/new_project.rpy:81
     old "You will be creating an [new_project_language]{#this substitution may be localized} language project. Change the launcher language in preferences to create a project in another language."
-    # Automatic translation.
-    new "Verrà creato un progetto in lingua [new_project_language]{#this substitution may be localized}. Cambiate la lingua di lancio nelle preferenze per creare un progetto in un'altra lingua."
+    new "Verrà creato un progetto in [new_project_language]{#this substitution may be localized}. Cambia la lingua di lancio in preferenze per creare un progetto in un'altra lingua."
 
     # game/preferences.rpy:106
     old "General"
-    # Automatic translation.
     new "Generale"
 
     # game/preferences.rpy:107
     old "Options"
-    # Automatic translation.
     new "Opzioni"
+
+    # game/preferences.rpy:258
+    old "Prefer the web documentation"
+    new "Preferire la documentazione web"
 
     # game/preferences.rpy:224
     old "Sponsor message"
-    # Automatic translation.
     new "Messaggio dello sponsor"
+
+    # game/preferences.rpy:262
+    old "Restore window position"
+    new "Ripristina posizione della finestra"
 
     # game/preferences.rpy:227
     old "Daily check for update"
-    # Automatic translation.
-    new "Controllo giornaliero dell'aggiornamento"
+    new "Controllo giornaliero degli aggiornamenti"
+
+    # game/preferences.rpy:266
+    old "Prefer RPU updates"
+    new "Preferire aggiornamenti RPU"
 
     # game/preferences.rpy:246
     old "Launcher Theme:"
-    # Automatic translation.
-    new "Tema del launcher:"
+    new "Tema del Launcher:"
 
     # game/preferences.rpy:250
     old "Default theme"
-    # Automatic translation.
     new "Tema predefinito"
 
     # game/preferences.rpy:251
     old "Dark theme"
-    # Automatic translation.
     new "Tema scuro"
 
     # game/preferences.rpy:252
     old "Custom theme"
-    # Automatic translation.
     new "Tema personalizzato"
 
     # game/preferences.rpy:256
     old "Information about creating a custom theme can be found {a=[skins_url]}in the Ren'Py Documentation{/a}."
-    # Automatic translation.
     new "Le informazioni sulla creazione di un tema personalizzato sono disponibili all'indirizzo {a=[skins_url]}nella documentazione di Ren'Py{/a}."
 
     # game/preferences.rpy:273
     old "Install Libraries:"
-    # Automatic translation.
-    new "Installare le librerie:"
+    new "Installa Librerie:"
 
     # game/preferences.rpy:300
     old "Reset window size"
-    # Automatic translation.
-    new "Azzeramento delle dimensioni della finestra"
+    new "Ripristina le dimensioni della finestra"
 
     # game/preferences.rpy:301
     old "Clean temporary files"
-    # Automatic translation.
-    new "Pulire i file temporanei"
+    new "Pulisci i file temporanei"
 
     # game/preferences.rpy:308
     old "Cleaning temporary files..."
-    # Automatic translation.
     new "Pulizia dei file temporanei..."
 
     # game/preferences.rpy:338
     old "{#in language font}Welcome! Please choose a language"
-    # Automatic translation.
-    new "{#in language font}Benvenuti! Scegliere una lingua"
+    new "{#in language font}Salve! Per favore scegli una lingua"
 
     # game/preferences.rpy:373
     old "{#in language font}Start using Ren'Py in [lang_name]"
-    # Automatic translation.
-    new "{#in language font}Iniziare a usare Ren'Py in [lang_name]"
+    new "{#in language font}Inizia ad usare Ren'Py in [lang_name]"
+
+    # game/preferences.rpy:234
+    old "Game Options:"
+    new "Opzioni di Gioco"
+
+    # game/preferences.rpy:241
+    old "Skip splashscreen"
+    new "Salta schermata di caricamento"
+
+    # game/preferences.rpy:364
+    old "Lint toggles:"
+    new "Opzioni lint:"
+
+    # game/preferences.rpy:368
+    old "Check for orphan/obsolete translations"
+    new "Controlla la presenza di traduzioni orfane/obsolete"
+
+    # game/preferences.rpy:371
+    old "Check parameters shadowing reserved names"
+    new "Controlla la presenza di parametri che oscurano nomi riservati"
+
+    # game/preferences.rpy:374
+    old "Print block, word, and character counts by speaking character."
+    new "Riporta il numero di blocchi, parole, e caratteri per personaggio parlante"
+
+    # game/preferences.rpy:377
+    old "Unclosed text tags"
+    new "Frammenti di testo non chiusi"
+
+    # game/preferences.rpy:380
+    old "Show all unreachable blocks and orphaned translations."
+    new "Mostra tutti i blocchi irraggiungibili e le traduzioni orfane"
 
     # game/project.rpy:46
     old "Lint checks your game for potential mistakes, and gives you statistics."
-    # Automatic translation.
-    new "Lint controlla il gioco alla ricerca di potenziali errori e fornisce statistiche."
+    new "Lint controlla la presenza nel gioco di potenziali errori e fornisce statistiche."
 
     # game/project.rpy:283
     old "This may be because the project is not writeable."
-    # Automatic translation.
-    new "Questo può essere dovuto al fatto che il progetto non è scrivibile."
+    new "Ciò può essere dovuto al fatto che il progetto non è scrivibile."
 
     # game/translations.rpy:91
     old "Translations: [project.current.display_name!q]"
-    # Automatic translation.
     new "Traduzioni: [project.current.display_name!q]"
 
     # game/translations.rpy:342
     old "Extract Dialogue: [project.current.display_name!q]"
-    # Automatic translation.
-    new "Estratto Dialogo: [project.current.display_name!q]"
+    new "Estrazione Dialogo: [project.current.display_name!q]"
 
     # game/translations.rpy:391
     old "Language (or None for the default language):"
-    # Automatic translation.
-    new "Lingua (o Nessuna per la lingua predefinita):"
+    new "Lingua (o None per la lingua predefinita):"
 
     # game/updater.rpy:64
     old "Release (Ren'Py 8, Python 3)"
-    # Automatic translation.
-    new "Rilascio (Ren'Py 8, Python 3)"
+    new "Release (Ren'Py 8, Python 3)"
 
     # game/updater.rpy:65
     old "Release (Ren'Py 7, Python 2)"
-    # Automatic translation.
-    new "Rilascio (Ren'Py 7, Python 2)"
+    new "Release (Ren'Py 7, Python 2)"
 
     # game/updater.rpy:69
     old "Prerelease (Ren'Py 8, Python 3)"
@@ -2083,33 +1962,27 @@ translate italian strings:
 
     # game/updater.rpy:77
     old "Nightly (Ren'Py 8, Python 3)"
-    # Automatic translation.
-    new "Notturno (Ren'Py 8, Python 3)"
+    new "Nightly (Ren'Py 8, Python 3)"
 
     # game/updater.rpy:78
     old "Nightly (Ren'Py 7, Python 2)"
-    # Automatic translation.
-    new "Notturno (Ren'Py 7, Python 2)"
+    new "Nightly (Ren'Py 7, Python 2)"
 
     # game/updater.rpy:108
     old "The update channel controls the version of Ren'Py the updater will download."
-    # Automatic translation.
     new "Il canale di aggiornamento controlla la versione di Ren'Py che il programma di aggiornamento scaricherà."
 
     # game/updater.rpy:116
     old "• {a=https://www.renpy.org/doc/html/changelog.html}View change log{/a}"
-    # Automatic translation.
-    new "- {a=https://www.renpy.org/doc/html/changelog.html}Visualizza il registro delle modifiche{/a}"
+    new "• {a=https://www.renpy.org/doc/html/changelog.html}Visualizza il registro delle modifiche{/a}"
 
     # game/updater.rpy:118
     old "• {a=https://www.renpy.org/dev-doc/html/changelog.html}View change log{/a}"
-    # Automatic translation.
-    new "- {a=https://www.renpy.org/dev-doc/html/changelog.html}Visualizza il registro delle modifiche{/a}"
+    new "• {a=https://www.renpy.org/dev-doc/html/changelog.html}Visualizza il registro delle modifiche{/a}"
 
     # game/updater.rpy:124
     old "• This version is installed and up-to-date."
-    # Automatic translation.
-    new "- Questa versione è installata e aggiornata."
+    new "• Questa versione è installata e aggiornata."
 
     # game/updater.rpy:136
     old "%B %d, %Y"
@@ -2117,23 +1990,19 @@ translate italian strings:
 
     # game/updater.rpy:215
     old "Fetching the list of update channels"
-    # Automatic translation.
-    new "Recuperare l'elenco dei canali di aggiornamento"
+    new "Recupero dell'elenco dei canali di aggiornamento"
 
     # game/updater.rpy:220
     old "downloading the list of update channels"
-    # Automatic translation.
-    new "scaricare l'elenco dei canali di aggiornamento"
+    new "scaricamento dell'elenco dei canali di aggiornamento"
 
     # game/web.rpy:428
     old "Preparing progressive download"
-    # Automatic translation.
     new "Preparazione del download progressivo"
 
     # game/web.rpy:485
     old "Creating package..."
-    # Automatic translation.
-    new "Creazione di pacchetti..."
+    new "Creazione pacchetto..."
 
     # game/web.rpy:505
     old "Web: [project.current.display_name!q]"
@@ -2141,38 +2010,29 @@ translate italian strings:
 
     # game/web.rpy:535
     old "Build Web Application"
-    # Automatic translation.
-    new "Creare un'applicazione web"
+    new "Compila un'Applicazione Web"
 
     # game/web.rpy:536
     old "Build and Open in Browser"
-    # Automatic translation.
-    new "Costruire e aprire nel browser"
+    new "Compila e Apri nel Browser"
 
     # game/web.rpy:537
     old "Open in Browser"
-    # Automatic translation.
-    new "Aprire nel browser"
+    new "Apri nel Browser"
 
     # game/web.rpy:538
     old "Open build directory"
-    # Automatic translation.
-    new "Aprire la directory di compilazione"
+    new "Apri la cartella di compilazione"
 
     # game/web.rpy:560
     old "Images and music can be downloaded while playing. A 'progressive_download.txt' file will be created so you can configure this behavior."
-    # Automatic translation.
-    new "Le immagini e la musica possono essere scaricate durante la riproduzione. Verrà creato un file \"progressive_download.txt\" per configurare questo comportamento."
+    new "Le immagini e la musica possono essere scaricate mentre si gioca. Verrà creato un file \"progressive_download.txt\" per configurare questo comportamento."
 
     # game/web.rpy:568
     old "Before packaging web apps, you'll need to download RenPyWeb, Ren'Py's web support. Would you like to download RenPyWeb now?"
-    # Automatic translation.
-    new "Prima di confezionare le applicazioni web, è necessario scaricare RenPyWeb, il supporto web di Ren'Py. Volete scaricare RenPyWeb ora?"
-
-
-translate italian strings:
+    new "Prima di pacchettizzare le applicazioni web, è necessario scaricare RenPyWeb, il supporto web di Ren'Py. Vuoi scaricare RenPyWeb ora?"
 
     # game/updater.rpy:79
     old "A nightly build of fixes to the release version of Ren'Py."
-    # Automatic translation.
-    new "Una build notturna di correzioni alla versione di rilascio di Ren'Py."
+    new "Una build nightly con correzioni alla versione di rilascio di Ren'Py."
+

--- a/launcher/game/tl/italian/options.rpy
+++ b/launcher/game/tl/italian/options.rpy
@@ -23,7 +23,6 @@ translate italian strings:
 
     # options.rpy:17
     old "Ren'Py 7 Default GUI"
-    # Automatic translation.
     new "GUI predefinita di Ren'Py 7"
 
     # options.rpy:20
@@ -198,26 +197,19 @@ translate italian strings:
     old "## Icon"
     new "## Icona"
 
-
-translate italian strings:
-
     # gui/game/options.rpy:31
     old "## Text that is placed on the game's about screen. Place the text between the triple-quotes, and leave a blank line between paragraphs."
-    # Automatic translation.
-    new "## Testo che viene inserito nella schermata del gioco. Posizionare il testo tra le virgolette triple e lasciare una riga vuota tra i paragrafi."
+    new "## Testo che viene inserito nella schermata informazioni del gioco. Inserisci il testo tra triple virgolette e lascia una riga vuota tra i paragrafi."
 
     # gui/game/options.rpy:47
     old "## These three variables control, among other things, which mixers are shown to the player by default. Setting one of these to False will hide the appropriate mixer."
-    # Automatic translation.
-    new "## Queste tre variabili controllano, tra le altre cose, quali mixer vengono mostrati al giocatore per impostazione predefinita. Impostando una di queste variabili a False, si nasconde il mixer appropriato."
+    new "## Queste tre variabili controllano, tra le altre cose, quali mixer vengono mostrati al giocatore per impostazione predefinita. Impostando una di queste a False, si nasconde il mixer appropriato."
 
     # gui/game/options.rpy:82
     old "## Between screens of the game menu."
-    # Automatic translation.
     new "## Tra le schermate del menu di gioco."
 
     # gui/game/options.rpy:203
     old "## A Google Play license key is required to perform in-app purchases. It can be found in the Google Play developer console, under \"Monetize\" > \"Monetization Setup\" > \"Licensing\"."
-    # Automatic translation.
     new "## Per eseguire gli acquisti in-app è necessaria una chiave di licenza Google Play. Si trova nella console per sviluppatori di Google Play, in \"Monetizzazione\" > \"Impostazione monetizzazione\" > \"Licenze\"."
 

--- a/launcher/game/tl/italian/screens.rpy
+++ b/launcher/game/tl/italian/screens.rpy
@@ -1,5 +1,4 @@
-﻿
-translate italian strings:
+﻿translate italian strings:
 
     # screens.rpy:9
     old "## Styles"
@@ -7,20 +6,19 @@ translate italian strings:
 
     # screens.rpy:87
     old "## In-game screens"
-    new "## Schermi interni al gioco"
+    new "## Schermate interne al gioco"
 
     # screens.rpy:91
     old "## Say screen"
-    # Automatic translation.
-    new "## Dire schermo"
+    new "## Schermata dei dialoghi"
 
     # screens.rpy:93
     old "## The say screen is used to display dialogue to the player. It takes two parameters, who and what, which are the name of the speaking character and the text to be displayed, respectively. (The who parameter can be None if no name is given.)"
-    new "## Il say screen è usato per mostrare dialoghi al giocatore. Richiede due parametri, who e what, che sono il nome del personaggio che parla e il testo da mostrare. (Il parametro who può essere None se non si intende fornire un nome)"
+    new "## La schermata dei dialoghi (say) è usata per mostrare dialoghi al giocatore. Richiede due parametri, who e what, che sono il nome del personaggio che parla e il testo da mostrare. (Il parametro who può essere None se non si intende fornire un nome)"
 
     # screens.rpy:98
     old "## This screen must create a text displayable with id \"what\", as Ren'Py uses this to manage text display. It can also create displayables with id \"who\" and id \"window\" to apply style properties."
-    new "## Questo schermo crea un displayable di testo con id \"what\", che Ren'py usa per gestire la visualizzazione del testo. Può creare anche displayable con id \"who\" e id \"window\" per applicarvi proprietà di stile."
+    new "## Questa schermata crea un displayable di testo con id \"what\", che Ren'Py usa per gestire la visualizzazione del testo. Può creare anche displayable con id \"who\" e id \"window\" per applicarvi proprietà di stile."
 
     # screens.rpy:102
     old "## https://www.renpy.org/doc/html/screen_special.html#say"
@@ -28,16 +26,15 @@ translate italian strings:
 
     # screens.rpy:169
     old "## Input screen"
-    # Automatic translation.
-    new "## Schermata di ingresso"
+    new "## Schermata di inserimento"
 
     # screens.rpy:171
     old "## This screen is used to display renpy.input. The prompt parameter is used to pass a text prompt in."
-    new "## Questo schermo si usa per mostrare renpy.input. Il parametro prompt è usato per fornire un prompt testuale."
+    new "## Questa schermata si usa per mostrare renpy.input. Il parametro prompt è usato per fornire un prompt testuale."
 
     # screens.rpy:174
     old "## This screen must create an input displayable with id \"input\" to accept the various input parameters."
-    new "## Questo schermo deve creare un input displayable con id \"input\" per accettare i vari parametri dell'input."
+    new "## Questa schermata deve creare un displayable input con id \"input\" per accettare i vari parametri dell'input."
 
     # screens.rpy:177
     old "## http://www.renpy.org/doc/html/screen_special.html#input"
@@ -45,12 +42,11 @@ translate italian strings:
 
     # screens.rpy:205
     old "## Choice screen"
-    # Automatic translation.
     new "## Schermata di scelta"
 
     # screens.rpy:207
     old "## This screen is used to display the in-game choices presented by the menu statement. The one parameter, items, is a list of objects, each with caption and action fields."
-    new "## Questo screen è usato per mostrare le scelte nel gioco, offerte dal comando 'menu'. Il solo parametro, 'items', è una lista di oggetti, ciascuna coi campi 'caption' e 'action'."
+    new "## Questa schermata è usata per mostrare le scelte nel gioco, offerte dal comando 'menu'. Il solo parametro, 'items', è una lista di oggetti, ciascuna coi campi 'caption' e 'action'."
 
     # screens.rpy:211
     old "## http://www.renpy.org/doc/html/screen_special.html#choice"
@@ -62,12 +58,11 @@ translate italian strings:
 
     # screens.rpy:244
     old "## Quick Menu screen"
-    # Automatic translation.
-    new "## Schermata del menu rapido"
+    new "## Schermata del Menu Rapido"
 
     # screens.rpy:246
     old "## The quick menu is displayed in-game to provide easy access to the out-of-game menus."
-    new "## Il Quick Menu è mostrato durante il gioco per fornire accesso rapido ai menu esterni."
+    new "## Il menu rapido è mostrato durante il gioco per fornire accesso facile ai menu esterni."
 
     # screens.rpy:261
     old "Back"
@@ -91,11 +86,11 @@ translate italian strings:
 
     # screens.rpy:266
     old "Q.Save"
-    new "Salva V."
+    new "Salva R."
 
     # screens.rpy:267
     old "Q.Load"
-    new "Carica V."
+    new "Carica R."
 
     # screens.rpy:268
     old "Prefs"
@@ -107,12 +102,11 @@ translate italian strings:
 
     # screens.rpy:291
     old "## Navigation screen"
-    # Automatic translation.
     new "## Schermata di navigazione"
 
     # screens.rpy:293
     old "## This screen is included in the main and game menus, and provides navigation to other menus, and to start the game."
-    new "## Questo screen è incluso nel main menu e nel game menu, e consente di navigare verso altri menu o di  iniziare il gioco."
+    new "## Questa schermata è inclusa nei menu principale e di gioco, e consente di navigare verso altri menu o di iniziare il gioco."
 
     # screens.rpy:308
     old "Start"
@@ -140,7 +134,7 @@ translate italian strings:
 
     # screens.rpy:332
     old "## Help isn't necessary or relevant to mobile devices."
-    new "## L'Aiuto non è necessario nei dispositivi mobili."
+    new "## L'Aiuto non è necessario o rilevante sui dispositivi mobili."
 
     # screens.rpy:333
     old "Help"
@@ -148,7 +142,7 @@ translate italian strings:
 
     # screens.rpy:335
     old "## The quit button is banned on iOS and unnecessary on Android."
-    new "## Il pulsante Esci è vietato in iOS e inutile su Android."
+    new "## Il pulsante esci è vietato su iOS e inutile su Android."
 
     # screens.rpy:336
     old "Quit"
@@ -156,12 +150,11 @@ translate italian strings:
 
     # screens.rpy:350
     old "## Main Menu screen"
-    # Automatic translation.
     new "## Schermata del menu principale"
 
     # screens.rpy:352
     old "## Used to display the main menu when Ren'Py starts."
-    new "## Usato per mostrare il main menu quando si avvia Ren'Py."
+    new "## Usato per mostrare il menu principale quando si avvia Ren'Py."
 
     # screens.rpy:354
     old "## http://www.renpy.org/doc/html/screen_special.html#main-menu"
@@ -169,20 +162,19 @@ translate italian strings:
 
     # screens.rpy:369
     old "## The use statement includes another screen inside this one. The actual contents of the main menu are in the navigation screen."
-    new "## Il comando 'use' include un'altro schermo all'interno di questo. I reali contenuti del main menu sono nel navigation screen."
+    new "## Il comando 'use' include un'altra schermata all'interno della corrente. I contenuti effettivi del menu principale sono nella schermata di navigazione."
 
     # screens.rpy:413
     old "## Game Menu screen"
-    # Automatic translation.
-    new "## Schermata del menu di gioco"
+    new "## Schermata del Menu di Gioco"
 
     # screens.rpy:415
     old "## This lays out the basic common structure of a game menu screen. It's called with the screen title, and displays the background, title, and navigation."
-    new "## Costruisce la struttura comune di tutti gli screen game menu. Viene avviato nella schermata del titolo, e mostra lo sfondo, il titolo e la navigazione."
+    new "## Costituisce la struttura comune di qualunque schermata del menu di gioco. Viene avviato nella schermata del titolo, e mostra lo sfondo, il titolo e la navigazione."
 
     # screens.rpy:418
     old "## The scroll parameter can be None, or one of \"viewport\" or \"vpgrid\". This screen is intended to be used with one or more children, which are transcluded (placed) inside it."
-    new "## Il parametro 'scroll' può essere None, oppure uno fra \"viewport\" o \"vpgrid\". Questo screen è creato per essere usato con uno o più figli, che sono trasclusi (piazzati) dentro di esso."
+    new "## Il parametro 'scroll' può essere None, oppure uno fra \"viewport\" o \"vpgrid\". Questa schermata è progettata per essere usata con uno o più figli, che sono trasclusi (piazzati) dentro di esso."
 
     # screens.rpy:476
     old "Return"
@@ -190,20 +182,19 @@ translate italian strings:
 
     # screens.rpy:539
     old "## About screen"
-    # Automatic translation.
-    new "## Informazioni sullo schermo"
+    new "## Schermata delle informazioni"
 
     # screens.rpy:541
     old "## This screen gives credit and copyright information about the game and Ren'Py."
-    new "## Questo screen fornisce i crediti e le informazioni di copyright sul gioco e su Ren'Py."
+    new "## Questa schermata visualizza i crediti e le informazioni di copyright sul gioco e su Ren'Py."
 
     # screens.rpy:544
     old "## There's nothing special about this screen, and hence it also serves as an example of how to make a custom screen."
-    new "## Non c'è niente di speciale in questo screen, pertanto può servire come esempio su come si crea uno screen personalizzato."
+    new "## Non c'è niente di speciale in questa schermata, pertanto può servire come esempio su come si crea una schermata personalizzata."
 
     # screens.rpy:551
     old "## This use statement includes the game_menu screen inside this one. The vbox child is then included inside the viewport inside the game_menu screen."
-    new "## Questo comando 'use' include lo screen game_menu dentro questo screen. Il figlio di vbox è quindi incluso nel viewport all'interno dello screen game_menu. \n## ===PER NEOFITI===: in pratica viene prima chiamato il game menu che stabilisce spaziature, sfondo, titoli e una viewport. Questo screen chiama e mostra il navigation screen a sinistra, che a sua volta determina quale screen (opzioni, slot, aiuto...) mostrare nella viewport a destra."
+    new "## Questo comando 'use' include la schermata game_menu all'interno della corrente. Il figlio di vbox è quindi incluso nel viewport all'interno dello screen game_menu. \n## ===PER NEOFITI===: in pratica viene prima chiamato il game menu che stabilisce spaziature, sfondo, titoli e una viewport. Questo screen chiama e mostra il navigation screen a sinistra, che a sua volta determina quale screen (opzioni, slot, aiuto...) mostrare nella viewport a destra."
 
     # screens.rpy:561
     old "Version [config.version!t]\n"
@@ -223,8 +214,7 @@ translate italian strings:
 
     # screens.rpy:582
     old "## Load and Save screens"
-    # Automatic translation.
-    new "## Schermate di caricamento e salvataggio"
+    new "## Schermate di Caricamento e Salvataggio"
 
     # screens.rpy:584
     old "## These screens are responsible for letting the player save the game and load it again. Since they share nearly everything in common, both are implemented in terms of a third screen, file_slots."
@@ -284,7 +274,6 @@ translate italian strings:
 
     # screens.rpy:711
     old "## Preferences screen"
-    # Automatic translation.
     new "## Schermata delle preferenze"
 
     # screens.rpy:713
@@ -341,19 +330,19 @@ translate italian strings:
 
     # screens.rpy:767
     old "Text Speed"
-    new "Velocità Testo"
+    new "Velocità del Testo"
 
     # screens.rpy:771
     old "Auto-Forward Time"
-    new "Avanzamento automatico"
+    new "Ritmo di Avanzamento Automatico"
 
     # screens.rpy:778
     old "Music Volume"
-    new "Volume Musica"
+    new "Volume della Musica"
 
     # screens.rpy:785
     old "Sound Volume"
-    new "Volume Suoni"
+    new "Volume dei Suoni"
 
     # screens.rpy:791
     old "Test"
@@ -361,16 +350,15 @@ translate italian strings:
 
     # screens.rpy:795
     old "Voice Volume"
-    new "Volume Voce"
+    new "Volume della Voce"
 
     # screens.rpy:806
     old "Mute All"
-    new "Silenzio"
+    new "Silenzia Tutto"
 
     # screens.rpy:882
     old "## History screen"
-    # Automatic translation.
-    new "## Schermata della storia"
+    new "## Schermata della cronologia"
 
     # screens.rpy:884
     old "## This is a screen that displays the dialogue history to the player. While there isn't anything special about this screen, it does have to access the dialogue history stored in _history_list."
@@ -398,7 +386,6 @@ translate italian strings:
 
     # screens.rpy:965
     old "## Help screen"
-    # Automatic translation.
     new "## Schermata di aiuto"
 
     # screens.rpy:967
@@ -423,7 +410,7 @@ translate italian strings:
 
     # screens.rpy:1004
     old "Advances dialogue and activates the interface."
-    new "Avanza nei dialoghi e conferma scelta."
+    new "Avanza nei dialoghi e conferma opzioni."
 
     # screens.rpy:1007
     old "Space"
@@ -467,8 +454,7 @@ translate italian strings:
 
     # screens.rpy:1027
     old "Page Up"
-    # Automatic translation.
-    new "Pagina su"
+    new "Pagina Su"
 
     # screens.rpy:1028
     old "Rolls back to earlier dialogue."
@@ -476,8 +462,7 @@ translate italian strings:
 
     # screens.rpy:1031
     old "Page Down"
-    # Automatic translation.
-    new "Pagina giù"
+    new "Pagina Giù"
 
     # screens.rpy:1032
     old "Rolls forward to later dialogue."
@@ -485,7 +470,7 @@ translate italian strings:
 
     # screens.rpy:1036
     old "Hides the user interface."
-    new "Nascondi l'interfaccia."
+    new "Nascondi l'interfaccia utente."
 
     # screens.rpy:1040
     old "Takes a screenshot."
@@ -513,7 +498,7 @@ translate italian strings:
 
     # screens.rpy:1066
     old "Mouse Wheel Down"
-    new "Rotella Giu"
+    new "Rotella Giù"
 
     # screens.rpy:1073
     old "Right Trigger\nA/Bottom Button"
@@ -529,7 +514,7 @@ translate italian strings:
 
     # screens.rpy:1081
     old "Right Shoulder"
-    new "Laterale Destro"
+    new "Dorsale Destro"
 
     # screens.rpy:1082
     old "Roll forward to later dialogue."
@@ -537,13 +522,11 @@ translate italian strings:
 
     # screens.rpy:1085
     old "D-Pad, Sticks"
-    # Automatic translation.
-    new "D-Pad, bastoni"
+    new "Croce direzionale, Joystick"
 
     # screens.rpy:1089
     old "Start, Guide"
-    # Automatic translation.
-    new "Avvio, Guida"
+    new "Start, Guida"
 
     # screens.rpy:1090
     old "Access the game menu."
@@ -551,7 +534,7 @@ translate italian strings:
 
     # screens.rpy:1093
     old "Y/Top Button"
-    new "Y/Pulsante superiore"
+    new "Pulsante Y/Superiore"
 
     # screens.rpy:1096
     old "Calibrate"
@@ -559,16 +542,15 @@ translate italian strings:
 
     # screens.rpy:1124
     old "## Additional screens"
-    new "## Screen addizionali"
+    new "## Schermate addizionali"
 
     # screens.rpy:1128
     old "## Confirm screen"
-    # Automatic translation.
-    new "## Conferma la schermata"
+    new "## Schermata di conferma"
 
     # screens.rpy:1130
     old "## The confirm screen is called when Ren'Py wants to ask the player a yes or no question."
-    new "## Lo screen confirm è usato quando Ren'Py vuole porre una domanda 'sì o no?' al giocatore."
+    new "## La schermata di conferma (confirm) è usata quando Ren'Py vuole porre una domanda 'sì o no?' al giocatore."
 
     # screens.rpy:1133
     old "## http://www.renpy.org/doc/html/screen_special.html#confirm"
@@ -592,12 +574,11 @@ translate italian strings:
 
     # screens.rpy:1191
     old "## Skip indicator screen"
-    # Automatic translation.
     new "## Schermata dell'indicatore di salto"
 
     # screens.rpy:1193
     old "## The skip_indicator screen is displayed to indicate that skipping is in progress."
-    new "## Lo screen skip_indicator è impiegato per indicare che è in corso la modalità salto."
+    new "## La schermata skip_indicator è visualizzata per indicare che è in corso la modalità salto."
 
     # screens.rpy:1196
     old "## https://www.renpy.org/doc/html/screen_special.html#skip-indicator"
@@ -613,12 +594,11 @@ translate italian strings:
 
     # screens.rpy:1247
     old "## Notify screen"
-    # Automatic translation.
     new "## Schermata di notifica"
 
     # screens.rpy:1249
     old "## The notify screen is used to show the player a message. (For example, when the game is quicksaved or a screenshot has been taken.)"
-    new "## Lo screen notify è usato per mostrare una notifica al giocatore (per esempio, quando si salva rapidamente o si cattura una schermata)."
+    new "## La schermata di notifica (notify) è usata per mostrare una notifica al giocatore (per esempio, quando si salva rapidamente o si cattura una schermata)."
 
     # screens.rpy:1252
     old "## https://www.renpy.org/doc/html/screen_special.html#notify-screen"
@@ -626,12 +606,11 @@ translate italian strings:
 
     # screens.rpy:1286
     old "## NVL screen"
-    # Automatic translation.
-    new "## Schermo NVL"
+    new "## Schermata NVL"
 
     # screens.rpy:1288
     old "## This screen is used for NVL-mode dialogue and menus."
-    new "## Questo screen è usato per dialoghi e menu in modalità NVL."
+    new "## Questa schermata è usata per dialoghi e menu in modalità NVL."
 
     # screens.rpy:1290
     old "## http://www.renpy.org/doc/html/screen_special.html#nvl"
@@ -651,7 +630,7 @@ translate italian strings:
 
     # screens.rpy:1406
     old "## Mobile Variants"
-    new "## Varianti Mobilità"
+    new "## Varianti Mobili"
 
     # screens.rpy:1413
     old "## Since a mouse may not be present, we replace the quick menu with a version that uses fewer and bigger buttons that are easier to touch."
@@ -695,14 +674,11 @@ translate italian strings:
 
     # screens.rpy:1079
     old "Left Trigger\nLeft Shoulder"
-    new "Grilletto Sinistro\nLaterale Sinistro"
-
-translate italian strings:
+    new "Grilletto Sinistro\nDorsale Sinistro"
 
     # gui/game/screens.rpy:120
     old "## Make the namebox available for styling through the Character object."
-    # Automatic translation.
-    new "## Rendere la casella dei nomi disponibile per lo styling attraverso l'oggetto Character."
+    new "## Rendi la casella dei nomi disponibile per lo styling attraverso l'oggetto Character."
 
     # gui/game/screens.rpy:173
     old "## https://www.renpy.org/doc/html/screen_special.html#input"
@@ -714,8 +690,7 @@ translate italian strings:
 
     # gui/game/screens.rpy:329
     old "## The quit button is banned on iOS and unnecessary on Android and Web."
-    # Automatic translation.
-    new "## Il pulsante di abbandono è vietato su iOS e non è necessario su Android e sul Web."
+    new "## Il pulsante esci è vietato su iOS e inutile su Android e sul Web."
 
     # gui/game/screens.rpy:348
     old "## https://www.renpy.org/doc/html/screen_special.html#main-menu"
@@ -723,23 +698,19 @@ translate italian strings:
 
     # gui/game/screens.rpy:676
     old "Upload Sync"
-    # Automatic translation.
-    new "Sincronizzazione del caricamento"
+    new "Carica dati per la Sincronizzazione"
 
     # gui/game/screens.rpy:680
     old "Download Sync"
-    # Automatic translation.
-    new "Scarica Sync"
+    new "Scarica dati Sincronizzati"
 
     # gui/game/screens.rpy:921
     old "## This determines what tags are allowed to be displayed on the history screen."
-    # Automatic translation.
     new "## Determina quali tag possono essere visualizzati nella schermata della cronologia."
 
     # gui/game/screens.rpy:1049
     old "Opens the accessibility menu."
-    # Automatic translation.
-    new "Apre il menu di accessibilità."
+    new "Apri il menu di accessibilità."
 
     # gui/game/screens.rpy:1139
     old "## https://www.renpy.org/doc/html/screen_special.html#confirm"
@@ -747,8 +718,7 @@ translate italian strings:
 
     # gui/game/screens.rpy:1248
     old "## We have to use a font that has the BLACK RIGHT-POINTING SMALL TRIANGLE glyph in it."
-    # Automatic translation.
-    new "## Dobbiamo usare un carattere che contenga il glifo NERO TRIANGOLO PICCOLO IN PUNTA DESTRA."
+    new "## Bisogna usare un carattere che contenga il glifo BLACK RIGHT-POINTING SMALL TRIANGLE."
 
     # gui/game/screens.rpy:1296
     old "## https://www.renpy.org/doc/html/screen_special.html#nvl"
@@ -756,13 +726,11 @@ translate italian strings:
 
     # gui/game/screens.rpy:1410
     old "## Bubble screen"
-    # Automatic translation.
-    new "## Schermo a bolle"
+    new "## Schermata a bolle"
 
     # gui/game/screens.rpy:1412
     old "## The bubble screen is used to display dialogue to the player when using speech bubbles. The bubble screen takes the same parameters as the say screen, must create a displayable with the id of \"what\", and can create displayables with the \"namebox\", \"who\", and \"window\" ids."
-    # Automatic translation.
-    new "## La schermata bubble è usata per visualizzare il dialogo al giocatore quando si usano le bolle vocali. Lo schermo a bolle prende gli stessi parametri dello schermo say, deve creare un visualizzabile con l'id \"what\" e può creare visualizzabili con gli id \"namebox\", \"who\" e \"window\"."
+    new "## La schermata a bolle (bubble) è usata per visualizzare il dialogo al giocatore quando si usano le bolle di dialogo. La schermata a bolle prende gli stessi parametri della schermata say, deve creare un visualizzabile con l'id \"what\" e può creare visualizzabili con gli id \"namebox\", \"who\" e \"window\"."
 
     # gui/game/screens.rpy:1417
     old "## https://www.renpy.org/doc/html/bubble.html#bubble-screen"

--- a/launcher/game/tl/italian/script.rpym
+++ b/launcher/game/tl/italian/script.rpym
@@ -13,7 +13,6 @@ label start:
     # aggiungere un file (chiamato "bg room.png" oppure "bg room.jpg")
     # alla directory 'images' per cambiarla.
 
-
     scene bg room
 
     # Mostra lo sprite di un personaggio.
@@ -26,11 +25,11 @@ label start:
 
     "Funziona davvero!"
 
-    e "Hai creato un nuovo gioco Ren'py."
+    e "Hai creato un nuovo gioco Ren'Py."
 
     e "Quando aggiungerai una storia, immagini e musica, potrai distribuirlo nel mondo!"
 
-    # Questo finisce il gioco.
+    # Questo termina il gioco.
 
     return
 


### PR DESCRIPTION
Hello again everyone, this time I decided I would contribute something to Ren'Py!
My initial idea was to work on translating both of the example novels included with the SDK, since I was surprised to see that they aren't available in my native language, Italian. However, after starting to work on them, I noticed how many strings from the engine were not properly translated: a few were missing here and there, some had a few inconsistencies or slightly bad word forms, and quite a big chunk were of really low quality due to being machine-translated. So, here I got to work:

* [x] Updating and improving the Italian translation for the engine template and launcher
    * [x] Checking and revising all translations marked as automatic (then unmarking them)
    * [x] Slightly revising the existing manual translations (correcting inconsistent capitalization and unnatural word forms)
    * [x] Creating translations for entirely missing strings
* ~[ ] Translating example and tutorial novels to Italian~ (will be moved to distinct PRs)
    ~* [ ] The Question~
    ~* [ ] Tutorial (this will probably take a while, but I think it's a good chance to study Ren'Py better)~

You might have noticed that I've sent this as a draft PR. What I've already checked on the list is effectively completed, but I thought of making a single pull request for everything since that's probably easier to manage. If that's okay with you, I will first complete everything on the to-do list, and then mark this request as completed, so that you can then merge; otherwise, I will split what is still missing at time of writing into separate PRs. If you have any comments about my contribution, or if you think there are things to fix in it, please let me know as soon as you see fit!