### PR TITLE
Add root folder for Web archives

### DIFF
--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -482,8 +482,9 @@ init python:
                 zip_targets.append(os.path.join(dn, file))
 
         with zipfile.ZipFile(destination + ".zip", 'w') as zf:
+            parent_path = os.path.dirname(os.path.abspath(destination))
             for i, target in enumerate(zip_targets):
-                zf.write(target, os.path.relpath(target, destination))
+                zf.write(target, os.path.relpath(target, parent_path))
                 reporter.progress(_("Creating package..."), i + 1, len(zip_targets))
 
         # Start the web server.


### PR DESCRIPTION
The current ZIP archive structure looks like that:
* game/
* game.zip
* index.html
* ...

This PR changes it that way:
* MyGame-1.0-web/
  * game/
  * game.zip
  * index.html
  * ...

The ZIP archive for other platforms always contains a single root folder where the game files are put, so this PR makes the format more consistent for Web. This also prevents the need to create a new folder manually where to extract the ZIP content on the Web server.