### PR TITLE
Allow use italic/bold italic instance for variable font by default

### DIFF
--- a/renpy/text/hbfont.pyx
+++ b/renpy/text/hbfont.pyx
@@ -521,9 +521,14 @@ cdef class HBFont:
                 if "bold" in face.variations.instance:
                     bold = 0.0
                     instance = "bold"
+                elif "bold italic" in face.variations.instance:
+                    bold = 0.0
+                    instance = "bold italic"
             else:
                 if "regular" in face.variations.instance:
                     instance = "regular"
+                elif "italic" in face.variations.instance:
+                    instance = "italic"
 
         if bold:
             antialias = True


### PR DESCRIPTION
Variable fonts are usually divided into regular fonts and italic fonts, and italic fonts do not contain `bold` instance but `bold italic` instance usually.

Currently, renpy only uses `bold` instance for bold text, that causes when setting `config.font_replacement_map["sample-vf-font.ttf", True, True] = ("sample-vf-font-italic.ttf", True, False)` and use bold italic text, it will not use `bold italic` instance for "sample-vf-font-italic.ttf", but manually setting bold for it instead.

```shell
$ renpy.variable_font_info('NotoSans-full-vf.ttf')
Maximum texture size: 4096x4096
  Named Instance: 'extralight'
  Named Instance: 'light'
  Named Instance: 'regular'
  Named Instance: 'medium'
  Named Instance: 'semibold'
  Named Instance: 'bold'
  Named Instance: 'extrabold'
  Named Instance: 'black'
  Axis: 'weight' (minimum=100.0, default=400.0, maximum=900.0)
  Axis: 'width' (minimum=62.5, default=100.0, maximum=100.0)

$ renpy.variable_font_info('NotoSans-Italic-full-vf.ttf')
  Named Instance: 'extralight italic'
  Named Instance: 'light italic'
  Named Instance: 'italic'
  Named Instance: 'medium italic'
  Named Instance: 'semibold italic'
  Named Instance: 'bold italic'
  Named Instance: 'extrabold italic'
  Named Instance: 'black italic'
  Axis: 'weight' (minimum=100.0, default=400.0, maximum=900.0)
  Axis: 'width' (minimum=62.5, default=100.0, maximum=100.0)
```

<details><summary>Before (manually bold)</summary>
<p>

![image](https://github.com/renpy/renpy/assets/36539925/c890a90a-d2d1-42db-808c-f432c3c36aec)

</p>
</details> 

<details><summary>After (use "bold italic" instance correctly)</summary>
<p>

![image](https://github.com/renpy/renpy/assets/36539925/0a6c402c-6ca8-4aec-8310-c4ea55757807)

</p>
</details> 
