### PR TITLE
Fix permission requesting on Android platform

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -4531,7 +4531,7 @@ def get_sdl_dll():
 
         lib = os.path.dirname(sys.executable) + "/"
 
-        DLLS = [ None, lib + "librenpython.dll", lib + "librenpython.dylib", lib + "librenpython.so", "SDL2.dll", "libSDL2.dylib", "libSDL2-2.0.so.0" ]
+        DLLS = [ None, lib + "librenpython.dll", lib + "librenpython.dylib", lib + "librenpython.so", "librenpython.so", "SDL2.dll", "libSDL2.dylib", "libSDL2-2.0.so.0" ]
 
         import ctypes
 


### PR DESCRIPTION
On android platform renpy.request_permission produce an exception: 
`AttributeError: 'NoneType' object has no attribute 'SDL_AndroidRequestPermission'`

See: #5510

It happens because `renpy.exports.get_sdl_dll()` function return None on android platform. Function tries to find a native `librenpython.so` in `os.path.dirname(sys.executable) + "/"`, but this path on Android is point to `/data/user/0/{package.name}/files`, which does not contain this file. 

So I added just `librenpython.so` in libs list, just like in the old versions where there is no this problem and function started to return what it had to.