### PR TITLE
Allow to have the same model with 2 different default_fade

### DIFF
--- a/renpy/gl2/live2d.py
+++ b/renpy/gl2/live2d.py
@@ -521,12 +521,12 @@ class Live2D(renpy.display.displayable.Displayable):
     default_fade = 1.0
 
     def create_common(self):
-
-        rv = common_cache.get(self.filename, None)
+        key = (self.filename, self.default_fade)
+        rv = common_cache.get(key, None)
 
         if rv is None:
             rv = Live2DCommon(self.filename, self.default_fade)
-            common_cache[self.filename] = rv
+            common_cache[key] = rv
 
         self.common_cache = rv
 


### PR DESCRIPTION
On behalf of @auxiliaryout from Discord. His use case looked pretty legitimate.

Targeting fix branch as this should be completly backward compatiable.