### PR TITLE
Skip unnecessary conditionals during interpolation

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -195,7 +195,10 @@ def parse(s):
                     state = LITERAL
                     lit = ''
 
-            elif c == '!' and brackets == 0 and parens == 0:
+            elif brackets:
+                pass
+
+            elif c == '!':
                 if s[pos+1:pos+2] == '=':
                     pos += 1
                 else:
@@ -203,7 +206,7 @@ def parse(s):
                     expr = s[cut:pos]
                     cut = pos + 1
 
-            elif c == ':' and brackets == 0 and parens == 0:
+            elif c == ':':
                 state = FORMAT
                 expr = s[cut:pos]
                 cut = pos + 1


### PR DESCRIPTION
Small optimisation for the fix in 10c02a4caf9a92e97b9c0bd108ab0084bdf1b79a.

We already bail early when inside parens (see code snip below), and taking the same approach with brackets allows us to short-circuit some unnecessary character checks.

https://github.com/renpy/renpy/blob/6a613314c5accfe231a3a063acc33f74aa9051b8/renpy/substitutions.py#L183-L184