### PR TITLE
textshader: convert static int to float

### DIFF
--- a/renpy/common/00textshader_ren.py
+++ b/renpy/common/00textshader_ren.py
@@ -219,7 +219,7 @@ renpy.register_textshader(
 
     vertex_30="""
     vec2 l__jitter = u__jitter * u_text_to_drawable;
-    gl_Position.xy += l__jitter * u_random.xy - l__jitter / 2;
+    gl_Position.xy += l__jitter * u_random.xy - l__jitter / 2.0;
     """,
 
     u__jitter=(3.0, 3.0),
@@ -273,7 +273,7 @@ renpy.register_textshader(
     """,
 
     vertex_40="""
-    gl_Position.y += cos(2 * 3.14159265359 * (a_text_index / u__wavelength + u_time * u__frequency)) * u__amplitude * u_text_to_drawable;
+    gl_Position.y += cos(2.0 * 3.14159265359 * (a_text_index / u__wavelength + u_time * u__frequency)) * u__amplitude * u_text_to_drawable;
     """,
 
     u__amplitude=5.0,


### PR DESCRIPTION
```py
renpy.gl2.gl2shader.ShaderError: ERROR: 0:15: '/' : wrong operand types - no operation '/' exists that takes a left-hand operand of type 'highp 2-component vector of float' and a right operand of type 'const int' (or there is no acceptable conversion)

renpy.gl2.gl2shader.ShaderError: ERROR: 0:17: '*' : wrong operand types - no operation '*' exists that takes a left-hand operand of type 'const int' and a right operand of type 'const float' (or there is no acceptable conversion)
ERROR: 0:17: '*' : wrong operand types - no operation '*' exists that takes a left-hand operand of type 'const int' and a right operand of type 'highp float' (or there is no acceptable conversion)
ERROR: 0:17: 'cos' : no matching overloaded function found
```