### PR TITLE
Allow mousewheel to paginate save/load screen

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -662,6 +662,7 @@ screen file_slots(title):
                     spacing gui.page_spacing
 
                     textbutton _("<") action FilePagePrevious()
+                    key "save_page_prev" action FilePagePrevious()
 
                     if config.has_autosave:
                         textbutton _("{#auto_page}A") action FilePage("auto")
@@ -674,6 +675,7 @@ screen file_slots(title):
                         textbutton "[page]" action FilePage(page)
 
                     textbutton _(">") action FilePageNext()
+                    key "save_page_next" action FilePageNext()
 
                 if config.has_sync:
                     if CurrentScreenName() == "save":

--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -129,6 +129,10 @@ init -1600 python:
         # Delete a save.
         save_delete = [ 'K_DELETE', 'KP_DELETE' ],
 
+        # Save/load screen pagination.
+        save_page_prev = ['mousedown_4'],
+        save_page_next = ['mousedown_5'],
+
         # Draggable.
         drag_activate = [ 'mousedown_1' ],
         drag_deactivate = [ 'mouseup_1' ],

--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -695,6 +695,7 @@ screen file_slots(title):
                 spacing gui.page_spacing
 
                 textbutton _("<") action FilePagePrevious()
+                key "save_page_prev" action FilePagePrevious()
 
                 if config.has_autosave:
                     textbutton _("{#auto_page}A") action FilePage("auto")
@@ -707,6 +708,7 @@ screen file_slots(title):
                     textbutton "[page]" action FilePage(page)
 
                 textbutton _(">") action FilePageNext()
+                key "save_page_next" action FilePageNext()
 
 
 style page_label is gui_label

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -663,6 +663,7 @@ screen file_slots(title):
                 spacing gui.page_spacing
 
                 textbutton _("<") action FilePagePrevious()
+                key "save_page_prev" action FilePagePrevious()
 
                 if config.has_autosave:
                     textbutton _("{#auto_page}A") action FilePage("auto")
@@ -675,6 +676,7 @@ screen file_slots(title):
                     textbutton "[page]" action FilePage(page)
 
                 textbutton _(">") action FilePageNext()
+                key "save_page_next" action FilePageNext()
 
 
 style page_label is gui_label


### PR DESCRIPTION
Allow use of mousewheel to navigate between pages in the default save/load screen.

Not sure if there is a deliberate reason for omitting it, but as a player it has always bothered me that I couldn't scroll through my savegames using the mousewheel.