### PR TITLE
Correct config.fill_shrinks_frames to config.fill_shrinks_frame

### DIFF
--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -76,7 +76,7 @@ style properties could cause Frames, Windows, and Buttons to shrink in size. Now
 size is allowed. To revert this, add::
 
 
-    define config.fill_shrinks_frames = True
+    define config.fill_shrinks_frame = True
 
 
 .. _incompatible-8.2.1:


### PR DESCRIPTION
The Incompatible Changes page has the variable written as `config.fill_shrinks_frames`, but `config.fill_shrinks_frame` is the correct variable