### PR TITLE
Add lint check for font aliases in font_name_map

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -716,6 +716,8 @@ def check_style(name, s):
                         check_file(name, f, directory="fonts")
                 elif v is None and k.endswith("emoji_font"):
                     pass
+                elif v in renpy.config.font_name_map.keys():
+                    check_file(name, renpy.config.font_name_map[v], directory="fonts")
                 else:
                     check_file(name, v, directory="fonts")
 


### PR DESCRIPTION
Prevent Lint from erroneously reporting a font file is not loadable when the font name is an alias in `config.font_name_map` for a file that *is* loadable.

Before:
```
Ren'Py 8.3.0.24061402+nightly lint report, generated at: Sat Jun 15 16:50:22 2024

Style style.default uses file 'Varela Round', which is not loadable.

Style style.say_label uses file 'Varela Round', which is not loadable.

Style style.button_text uses file 'Varela Round', which is not loadable.

Style style.gui_text uses file 'Varela Round', which is not loadable.

Style style.choice_button_text uses file 'Varela Round', which is not loadable.
```

After:
```
Ren'Py 8.3.0.24061402+nightly lint report, generated at: Sat Jun 15 16:48:53 2024

```

Where:
```renpy
define config.font_name_map = {
    "Varela Round": "VarelaRound-Regular.ttf"
}
define gui.text_font = "Varela Round"
```

The PR that originally added font aliases was #3730.