### PR TITLE
Gamepad event fix

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -283,9 +283,13 @@ def map_event(ev, keysym):
     """
 
     if ev.type == renpy.display.core.EVENTNAME:
-        if (keysym in ev.eventnames) and not ev.up:
-            return True
-
+        if isinstance(keysym, list):
+            for k in keysym:
+                if (k in ev.eventnames) and not ev.up:
+                    return True
+        else:
+            if (keysym in ev.eventnames) and not ev.up:
+                return True
         return False
 
     if isinstance(keysym, list):

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -32,32 +32,54 @@ pad_bindings = {
     "pad_lefttrigger_pos" : [ "rollback", ],
     "pad_back_press" : [ "rollback", ],
 
+    "repeat_pad_leftshoulder_press" : [ "rollback", ],
+    "repeat_pad_lefttrigger_pos" : [ "rollback", ],
+    "repeat_pad_back_press" : [ "rollback", ],
+
     "pad_guide_press" : [ "game_menu", ],
     "pad_start_press" : [ "game_menu", ],
 
     "pad_y_press" : [ "hide_windows", ],
+    "pad_x_press" : [ "button_alternate" ],
 
     "pad_rightshoulder_press" : [ "rollforward", ],
+    "repeat_pad_rightshoulder_press" : [ "rollforward", ],
 
-    "pad_righttrigger_press" : [ "dismiss", "button_select" ],
-    "pad_a_press" : [ "dismiss", "button_select" ],
-    "pad_b_press" : [ "button_alternate" ],
+    "pad_righttrigger_pos" : [ "dismiss", "button_select", "bar_activate", "bar_deactivate" ],
+    "pad_a_press" : [ "dismiss", "button_select", "bar_activate", "bar_deactivate"],
+    "pad_b_press" : [ "game_menu" ],
 
-    "pad_dleft_press" : [ "focus_left", "bar_left" ],
-    "pad_leftx_neg" : [ "focus_left", "bar_left" ],
-    "pad_rightx_neg" : [ "focus_left", "bar_left" ],
+    "pad_dpleft_press" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
+    "pad_leftx_neg" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
+    "pad_rightx_neg" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
 
-    "pad_dpright_press" : [ "focus_right", "bar_right" ],
-    "pad_leftx_pos" : [ "focus_right", "bar_right" ],
-    "pad_rightx_pos" : [ "focus_right", "bar_right" ],
+    "pad_dpright_press" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
+    "pad_leftx_pos" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
+    "pad_rightx_pos" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
 
-    "pad_dpup_press" : [ "focus_up", "bar_up" ],
-    "pad_lefty_neg" : [ "focus_up", "bar_up" ],
-    "pad_righty_neg" : [ "focus_up", "bar_up" ],
+    "pad_dpup_press" : [ "focus_up", "bar_up", "viewport_uparrow" ],
+    "pad_lefty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
+    "pad_righty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
 
-    "pad_dpdown_press" : [ "focus_down", "bar_down" ],
-    "pad_lefty_pos" : [ "focus_down", "bar_down" ],
-    "pad_righty_pos" : [ "focus_down", "bar_down" ],
+    "pad_dpdown_press" : [ "focus_down", "bar_down", "viewport_downarrow" ],
+    "pad_lefty_pos" : [ "focus_down", "bar_down", "viewport_downarrow" ],
+    "pad_righty_pos" : [ "focus_down", "bar_down", "viewport_downarrow" ],
+
+    "repeat_pad_dpleft_press" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
+    "repeat_pad_leftx_neg" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
+    "repeat_pad_rightx_neg" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
+
+    "repeat_pad_dpright_press" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
+    "repeat_pad_leftx_pos" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
+    "repeat_pad_rightx_pos" : [ "focus_right", "bar_right", "viewport_rightarrow" ],
+
+    "repeat_pad_dpup_press" : [ "focus_up", "bar_up", "viewport_uparrow" ],
+    "repeat_pad_lefty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
+    "repeat_pad_righty_neg" : [ "focus_up", "bar_up", "viewport_uparrow" ],
+
+    "repeat_pad_dpdown_press" : [ "focus_down", "bar_down", "viewport_downarrow" ],
+    "repeat_pad_lefty_pos" : [ "focus_down", "bar_down", "viewport_downarrow" ],
+    "repeat_pad_righty_pos" : [ "focus_down", "bar_down", "viewport_downarrow" ],
 }
 
 all_preferences = [ ]

--- a/sphinx/source/keymap.rst
+++ b/sphinx/source/keymap.rst
@@ -226,13 +226,14 @@ gamepad bindings is given below::
         "pad_start_press" : [ "game_menu", ],
 
         "pad_y_press" : [ "hide_windows", ],
+        "pad_x_press" : [ "button_alternate" ],
 
         "pad_rightshoulder_press" : [ "rollforward", ],
         "repeat_pad_rightshoulder_press" : [ "rollforward", ],
 
         "pad_righttrigger_pos" : [ "dismiss", "button_select", "bar_activate", "bar_deactivate" ],
         "pad_a_press" : [ "dismiss", "button_select", "bar_activate", "bar_deactivate"],
-        "pad_b_press" : [ "button_alternate" ],
+        "pad_b_press" : [ "game_menu" ],
 
         "pad_dpleft_press" : [ "focus_left", "bar_left", "viewport_leftarrow" ],
         "pad_leftx_neg" : [ "focus_left", "bar_left", "viewport_leftarrow" ],


### PR DESCRIPTION
Adds a fix for the `map_event` function so it can handle a list of gamepad bindings as well as a singular binding. Also updates the documentation to reflect the default pad_bindings as of 8.2 (notably the update to button_alternate).