### PR TITLE
Be more lenient with '@' in image names

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -690,7 +690,7 @@ class Image(ImageBase):
 
         if "@" in filename:
             base = filename.rpartition(".")[0]
-            extras = base.partition("@")[2].split(",")
+            extras = base.rpartition("@")[2].partition("/")[0].split(",")
 
             for i in extras:
                 try:


### PR DESCRIPTION
Currently, the '@' character in image names must be placed at the end, followed by a float value. It will raise an exception otherwise.

I'd like to be able to do the following:
- Name a directory `xyz@2` and have all the images inside it be oversampled
- ~~Name an asset or directory of assets after the handle of an artist who created them without throwing an error~~

Notes:
- The most specific specifier should win, so `assets@2/image@2.5.png` should have an oversample of 2.5.
- ~~I realize naming an asset after an artist's handle is a niche request, so I understand if you'd rather not have this to prevent confusion.~~

***

Examples of old behavior, which work the same / are unchanged:
```
images/assets/image.png -> no oversampling
images/assets/image@2.png -> oversampling of 2, and so on
images/assets/image@3,2.png -> 3 (I'm not sure what the purpose of allowing commas is)
```

Examples of new behavior, which previously threw exceptions:
```
images/assets@2/image.png -> 2
images/assets@2/image@2.5.png -> 2.5
images/assets@2/image@3,2.png -> 3
```