### PR TITLE
Update German Translation Files

### DIFF
--- a/launcher/game/tl/german/common.rpy
+++ b/launcher/game/tl/german/common.rpy
@@ -163,43 +163,43 @@ translate german strings:
 
     # 00gui.rpy:227
     old "Are you sure?"
-    new "Sind Sie sicher?"
+    new "Bist Du sicher?"
 
     # 00gui.rpy:228
     old "Are you sure you want to delete this save?"
-    new "Sind Sie sicher, dass Sie diese Datei löschen möchten?"
+    new "Bist Du sicher, dass Du diese Datei löschen möchtest?"
 
     # 00gui.rpy:229
     old "Are you sure you want to overwrite your save?"
-    new "Sind Sie sicher, dass Sie diese Datei überschreiben möchten?"
+    new "Bist Du sicher, dass Du diese Datei überschreiben möchtest?"
 
     # 00gui.rpy:230
     old "Loading will lose unsaved progress.\nAre you sure you want to do this?"
-    new "Beim Laden geht ungespeicherter Fortschritt verloren.\nSind Sie sicher, dass Sie das tun möchten?"
+    new "Beim Laden geht ungespeicherter Fortschritt verloren.\nBist Du sicher, dass Du das tun möchtest?"
 
     # 00gui.rpy:231
     old "Are you sure you want to quit?"
-    new "Sind Sie sicher, dass Sie beenden möchten?"
+    new "Bist Du sicher, dass Du das Spiel beenden möchtest?"
 
     # 00gui.rpy:232
     old "Are you sure you want to return to the main menu?\nThis will lose unsaved progress."
-    new "Sind Sie sicher, dass Sie zurück zum Hauptmenü möchten?\nUngespeicherter Fortschritt geht dabei verloren."
+    new "Bist Du sicher, dass Du zurück zum Hauptmenü möchtest?\nUngespeicherter Fortschritt geht dabei verloren."
 
     # 00gui.rpy:233
     old "Are you sure you want to end the replay?"
-    new "Sind Sie sicher, dass sie die Szenen-Wiederholung beenden möchten?"
+    new "Bist Du sicher, dass Du die Szenen-Wiederholung beenden möchtest?"
 
     # 00gui.rpy:234
     old "Are you sure you want to begin skipping?"
-    new "Sind Sie sicher, dass Sie Text überspringen möchten?"
+    new "Bist Du sicher, dass Du vorspulen möchtest?"
 
     # 00gui.rpy:235
     old "Are you sure you want to skip to the next choice?"
-    new "Sind Sie sicher, dass Sie zur nächsten Auswahl springen möchten?"
+    new "Bist Du sicher, dass Du zur nächsten Entscheidung springen möchtest?"
 
     # 00gui.rpy:236
     old "Are you sure you want to skip unseen dialogue to the next choice?"
-    new "Sind Sie sicher, dass sie ungesehenen Dialog bis zur nächsten Entscheidung überspringen möchten?"
+    new "Bist Du sicher, dass Du ungesehenen Dialog bis zur nächsten Entscheidung überspringen möchtest?"
 
     # 00keymap.rpy:250
     old "Saved screenshot as %s."
@@ -220,7 +220,7 @@ translate german strings:
 
     # 00library.rpy:179
     old "Skip Mode"
-    new "Skip-Modus"
+    new "Vorspul-Modus"
 
     # 00library.rpy:262
     old "This program contains free software under a number of licenses, including the MIT License and GNU Lesser General Public License. A complete list of software, including links to full source code, can be found {a=https://www.renpy.org/l/license}here{/a}."
@@ -229,19 +229,19 @@ translate german strings:
     # 00preferences.rpy:422
     old "Clipboard voicing enabled. Press 'shift+C' to disable."
     # Automatic translation.
-    new "Zwischenablage-Voicing aktiviert. Drücken Sie 'Umschalt+C' zum Deaktivieren."
+    new "Zwischenablage-Voicing aktiviert. Drücke 'Shift+C' zum Deaktivieren."
 
     # 00preferences.rpy:424
     old "Self-voicing would say \"[renpy.display.tts.last]\". Press 'alt+shift+V' to disable."
-    new "Sprachausgabe würde \"[renpy.display.tts.last]\" sagen. Zum deaktivieren 'alt+shift+V' drücken."
+    new "Sprachausgabe würde \"[renpy.display.tts.last]\" sagen. Drücke 'Alt+Shift+V' zum Deaktivieren."
 
     # 00preferences.rpy:426
     old "Self-voicing enabled. Press 'v' to disable."
-    new "Sprachausgabe aktiviert. Zum deaktivieren 'v' drücken."
+    new "Sprachausgabe aktiviert. Drücke 'V' zum Deaktivieren."
 
     # 00iap.rpy:217
     old "Contacting App Store\nPlease Wait..."
-    new "Kontaktiert App Store\nBitte warten..."
+    new "Kontaktiere App Store\nBitte warten..."
 
     # 00updater.rpy:367
     old "The Ren'Py Updater is not supported on mobile devices."
@@ -249,7 +249,7 @@ translate german strings:
 
     # 00updater.rpy:486
     old "An error is being simulated."
-    new "Ein Error wird simuliert."
+    new "Ein Fehler wird simuliert."
 
     # 00updater.rpy:662
     old "Either this project does not support updating, or the update status file was deleted."
@@ -278,7 +278,7 @@ translate german strings:
     # 00updater.rpy:1049
     old "While unpacking {}, unknown type {}."
     # Automatic translation.
-    new "Beim Auspacken {}, unbekannter Typ {}."
+    new "Beim Entpacken {}, unbekannter Typ {}."
 
     # 00updater.rpy:1393
     old "Updater"
@@ -290,7 +290,7 @@ translate german strings:
 
     # 00updater.rpy:1406
     old "[u.version] is available. Do you want to install it?"
-    new "[u.version] ist verfügbar. Möchten Sie sie installieren?"
+    new "[u.version] ist verfügbar. Möchtest Du es installieren?"
 
     # 00updater.rpy:1408
     old "Preparing to download the updates."
@@ -351,13 +351,11 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:34
     old "viewport"
-    # Automatic translation.
-    new "Ansichtsfenster"
+    new "Viewport"
 
     # renpy/common/00accessibility.rpy:35
     old "horizontal scroll"
-    # Automatic translation.
-    new "Horizontales Blättern"
+    new "horizontaler Bildlauf"
 
     # renpy/common/00accessibility.rpy:36
     old "vertical scroll"
@@ -366,8 +364,7 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:37
     old "activate"
-    # Automatic translation.
-    new "aktivieren."
+    new "aktivieren"
 
     # renpy/common/00accessibility.rpy:38
     old "deactivate"
@@ -376,8 +373,7 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:39
     old "increase"
-    # Automatic translation.
-    new "erhöhen."
+    new "erhöhen"
 
     # renpy/common/00accessibility.rpy:40
     old "decrease"
@@ -419,13 +415,11 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:180
     old "High Contrast Text"
-    # Automatic translation.
-    new "Hochkontrastiger Text"
+    new "Kontrastreicher Text"
 
     # renpy/common/00accessibility.rpy:193
     old "Self-Voicing"
-    # Automatic translation.
-    new "Selbstanzeige"
+    new "Sprachausgabe"
 
     # renpy/common/00accessibility.rpy:197
     old "Off"
@@ -434,8 +428,7 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:201
     old "Text-to-speech"
-    # Automatic translation.
-    new "Text-in-Sprache"
+    new "Text-zu-Sprache"
 
     # renpy/common/00accessibility.rpy:205
     old "Clipboard"
@@ -449,53 +442,43 @@ translate german strings:
 
     # renpy/common/00accessibility.rpy:223
     old "Self-Voicing Volume Drop"
-    # Automatic translation.
-    new "Selbstlautstärkeabfall"
+    new "Lautstärkeabfall Sprachausgabe"
 
     # renpy/common/00accessibility.rpy:234
     old "The options on this menu are intended to improve accessibility. They may not work with all games, and some combinations of options may render the game unplayable. This is not an issue with the game or engine. For the best results when changing fonts, try to keep the text size the same as it originally was."
-    # Automatic translation.
-    new "Die Optionen in diesem Menü dienen der Verbesserung der Zugänglichkeit. Sie funktionieren möglicherweise nicht mit allen Spielen, und einige Kombinationen von Optionen können das Spiel unspielbar machen. Dies ist kein Problem mit dem Spiel oder der Engine. Die besten Ergebnisse beim Ändern von Schriftarten erzielen Sie, wenn Sie die ursprüngliche Textgröße beibehalten."
+    new "Die Optionen in diesem Menü dienen der Verbesserung der Zugänglichkeit. Sie funktionieren möglicherweise nicht mit allen Spielen, und einige Kombinationen von Optionen können das Spiel unspielbar machen. Dies ist kein Problem mit dem Spiel oder der Engine. Die besten Ergebnisse beim Ändern von Schriftarten erzielst Du, wenn Du die ursprüngliche Textgröße beibehältst."
 
     # renpy/common/00action_file.rpy:378
     old "Save slot %s: [text]"
-    # Automatic translation.
-    new "Steckplatz %s speichern: [text]"
+    new "Speicherplatz %s speichern: [text]"
 
     # renpy/common/00action_file.rpy:461
     old "Load slot %s: [text]"
-    # Automatic translation.
-    new "Steckplatz %s laden: [text]"
+    new "Speicherplatz %s laden: [text]"
 
     # renpy/common/00action_file.rpy:514
     old "Delete slot [text]"
-    # Automatic translation.
-    new "Steckplatz löschen [text]"
+    new "Speicherplatz löschen [text]"
 
     # renpy/common/00action_file.rpy:593
     old "File page auto"
-    # Automatic translation.
-    new "Datei Seite auto"
+    new "Spielstände: Seite auto-speichern"
 
     # renpy/common/00action_file.rpy:595
     old "File page quick"
-    # Automatic translation.
-    new "Datei Seite schnell"
+    new "Spielstände: Seite schnell-speichern"
 
     # renpy/common/00action_file.rpy:597
     old "File page [text]"
-    # Automatic translation.
-    new "Datei-Seite [text]"
+    new "Spielstände: Seite [text]"
 
     # renpy/common/00action_file.rpy:796
     old "Next file page."
-    # Automatic translation.
-    new "Nächste Dateiseite."
+    new "Nächste Seite."
 
     # renpy/common/00action_file.rpy:868
     old "Previous file page."
-    # Automatic translation.
-    new "Vorherige Dateiseite."
+    new "Vorherige Seite."
 
     # renpy/common/00action_file.rpy:944
     old "Quick save."
@@ -527,35 +510,30 @@ translate german strings:
 
     # renpy/common/00director.rpy:1574
     old "Done"
-    # Automatic translation.
-    new "Erledigt"
+    new "Fertig"
 
     # renpy/common/00director.rpy:1584
     old "(statement)"
-    # Automatic translation.
-    new "(Erklärung)"
+    new "(Statement)"
 
     # renpy/common/00director.rpy:1585
     old "(tag)"
-    # Automatic translation.
     new "(Tag)"
 
     # renpy/common/00director.rpy:1586
     old "(attributes)"
-    # Automatic translation.
     new "(Attribute)"
 
     # renpy/common/00director.rpy:1587
     old "(transform)"
-    new "(transform)"
+    new "(Transform)"
 
     # renpy/common/00director.rpy:1612
     old "(transition)"
-    new "(transition)"
+    new "(Transition)"
 
     # renpy/common/00director.rpy:1624
     old "(channel)"
-    # Automatic translation.
     new "(Kanal)"
 
     # renpy/common/00director.rpy:1625
@@ -565,23 +543,19 @@ translate german strings:
 
     # renpy/common/00director.rpy:1654
     old "Change"
-    # Automatic translation.
-    new "Ändern Sie"
+    new "Ändern"
 
     # renpy/common/00director.rpy:1656
     old "Add"
-    # Automatic translation.
-    new "hinzufügen"
+    new "Hinzufügen"
 
     # renpy/common/00director.rpy:1662
     old "Remove"
-    # Automatic translation.
-    new "entfernen"
+    new "Entfernen"
 
     # renpy/common/00director.rpy:1697
     old "Statement:"
-    # Automatic translation.
-    new "Erklärung:"
+    new "Statement:"
 
     # renpy/common/00director.rpy:1718
     old "Tag:"
@@ -594,18 +568,15 @@ translate german strings:
 
     # renpy/common/00director.rpy:1745
     old "Click to toggle attribute, right click to toggle negative attribute."
-    # Automatic translation.
-    new "Klicken Sie auf das Attribut, um es einzuschalten, klicken Sie mit der rechten Maustaste, um das negative Attribut einzuschalten."
+    new "Klicke auf das Attribut, um es umzuschalten; klicke mit der rechten Maustaste, um das negative Attribut umzuschalten."
 
     # renpy/common/00director.rpy:1757
     old "Transforms:"
-    # Automatic translation.
-    new "Verwandeln:"
+    new "Transforms:"
 
     # renpy/common/00director.rpy:1768
     old "Click to set transform, right click to add to transform list."
-    # Automatic translation.
-    new "Klicken Sie, um die Transformation festzulegen, und klicken Sie mit der rechten Maustaste, um sie zur Transformationsliste hinzuzufügen."
+    new "Klicke, um das Transform festzulegen; klicke mit der rechten Maustaste, um es zur Liste hinzuzufügen."
 
     # renpy/common/00director.rpy:1780
     old "Behind:"
@@ -619,8 +590,7 @@ translate german strings:
 
     # renpy/common/00director.rpy:1801
     old "Transition:"
-    # Automatic translation.
-    new "Überleitung:"
+    new "Transition:"
 
     # renpy/common/00director.rpy:1819
     old "Channel:"
@@ -634,13 +604,12 @@ translate german strings:
 
     # renpy/common/00gui.rpy:456
     old "This save was created on a different device. Maliciously constructed save files can harm your computer. Do you trust this save's creator and everyone who could have changed the file?"
-    # Automatic translation.
-    new "Dieser Spielstand wurde auf einem anderen Gerät erstellt. Böswillig erstellte Speicherdateien können Ihrem Computer schaden. Vertrauen Sie dem Ersteller dieses Spielstands und allen, die die Datei geändert haben könnten?"
+    new "Dieser Spielstand wurde auf einem anderen Gerät erstellt. Böswillig erstellte Speicherstände können Deinem Computer schaden. Vertraust Du dem Ersteller dieses Spielstands und allen, die die Datei geändert haben könnten?"
 
     # renpy/common/00gui.rpy:457
     old "Do you trust the device the save was created on? You should only choose yes if you are the device's sole user."
     # Automatic translation.
-    new "Vertrauen Sie dem Gerät, auf dem die Sicherung erstellt wurde? Sie sollten nur dann Ja wählen, wenn Sie der einzige Benutzer des Geräts sind."
+    new "Vertraust Du dem Gerät, auf dem die Sicherung erstellt wurde? Du solltest nur dann Ja wählen, wenn Du der einzige Benutzer des Geräts bist."
 
     # renpy/common/00keymap.rpy:322
     old "Failed to save screenshot as %s."
@@ -654,12 +623,10 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:283
     old "transitions"
-    # Automatic translation.
     new "Übergänge"
 
     # renpy/common/00preferences.rpy:292
     old "skip transitions"
-    # Automatic translation.
     new "Übergänge überspringen"
 
     # renpy/common/00preferences.rpy:294
@@ -700,32 +667,29 @@ translate german strings:
     # renpy/common/00preferences.rpy:335
     old "skip unseen text"
     # Automatic translation.
-    new "ungesehenen Text übergehen"
+    new "ungesehenen Text überspringen"
 
     # renpy/common/00preferences.rpy:337
     old "begin skipping"
-    # Automatic translation.
-    new "mit dem Springen beginnen"
+    new "mit dem Vorspulen beginnen"
 
     # renpy/common/00preferences.rpy:341
     old "after choices"
-    # Automatic translation.
-    new "nach der Wahl"
+    new "nach Entscheidungen"
 
     # renpy/common/00preferences.rpy:348
     old "skip after choices"
-    # Automatic translation.
-    new "nach Auswahlen überspringen"
+    new "Vorspulen nach Entscheidungen"
 
     # renpy/common/00preferences.rpy:350
     old "auto-forward time"
     # Automatic translation.
-    new "automatische Vorlaufzeit"
+    new "Zeit des automatischen Blätterns"
 
     # renpy/common/00preferences.rpy:364
     old "auto-forward"
     # Automatic translation.
-    new "automatisches Weiterleiten"
+    new "automatisches Blättern"
 
     # renpy/common/00preferences.rpy:371
     old "Auto forward"
@@ -754,23 +718,19 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:410
     old "self voicing"
-    # Automatic translation.
-    new "selbststimmend"
+    new "Sprachausgabe"
 
     # renpy/common/00preferences.rpy:419
     old "self voicing volume drop"
-    # Automatic translation.
-    new "Selbststimmende Lautstärkeabnahme"
+    new "Lautstärkeabnahme der Sprachausgabe"
 
     # renpy/common/00preferences.rpy:427
     old "clipboard voicing"
-    # Automatic translation.
-    new "Clipboard-Intonation"
+    new "Sprachausgabe zur Zwischenablage"
 
     # renpy/common/00preferences.rpy:436
     old "debug voicing"
-    # Automatic translation.
-    new "Intonation debuggen"
+    new "Sprachausgabe debuggen"
 
     # renpy/common/00preferences.rpy:445
     old "emphasize audio"
@@ -789,7 +749,7 @@ translate german strings:
     # renpy/common/00preferences.rpy:470
     old "gl framerate"
     # Automatic translation.
-    new "Gl-Framerate"
+    new "gl-Framerate"
 
     # renpy/common/00preferences.rpy:473
     old "gl tearing"
@@ -797,8 +757,7 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:476
     old "font transform"
-    # Automatic translation.
-    new "Schriftart umwandeln"
+    new "Schriftart Transform"
 
     # renpy/common/00preferences.rpy:479
     old "font size"
@@ -822,13 +781,11 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:507
     old "accessibility menu"
-    # Automatic translation.
-    new "Menü Barrierefreiheit"
+    new "Barrierefreiheit-Menü"
 
     # renpy/common/00preferences.rpy:510
     old "high contrast text"
-    # Automatic translation.
-    new "Text mit hohem Kontrast"
+    new "kontrastreicher Text"
 
     # renpy/common/00preferences.rpy:519
     old "audio when minimized"
@@ -837,8 +794,7 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:528
     old "audio when unfocused"
-    # Automatic translation.
-    new "Audio bei Unschärfe"
+    new "Audio wenn im Hintergrund"
 
     # renpy/common/00preferences.rpy:537
     old "web cache preload"
@@ -852,28 +808,23 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:571
     old "main volume"
-    # Automatic translation.
-    new "Hauptvolumen"
+    new "Master-Lautstärke"
 
     # renpy/common/00preferences.rpy:572
     old "music volume"
-    # Automatic translation.
-    new "Musiklautstärke"
+    new "Musik-Lautstärke"
 
     # renpy/common/00preferences.rpy:573
     old "sound volume"
-    # Automatic translation.
-    new "Lautstärke"
+    new "Ton-Lautstärke"
 
     # renpy/common/00preferences.rpy:574
     old "voice volume"
-    # Automatic translation.
-    new "Sprachlautstärke"
+    new "Stimmen-Lautstärke"
 
     # renpy/common/00preferences.rpy:575
     old "mute main"
-    # Automatic translation.
-    new "Hauptstummschaltung"
+    new "Master stummschalten"
 
     # renpy/common/00preferences.rpy:576
     old "mute music"
@@ -887,13 +838,11 @@ translate german strings:
 
     # renpy/common/00preferences.rpy:578
     old "mute voice"
-    # Automatic translation.
-    new "stumme Stimme"
+    new "Stimme stummschalten"
 
     # renpy/common/00preferences.rpy:579
     old "mute all"
-    # Automatic translation.
-    new "alle stumm schalten"
+    new "alles stummschalten"
 
     # renpy/common/00speechbubble.rpy:344
     old "Speech Bubble Editor"
@@ -933,7 +882,7 @@ translate german strings:
     # renpy/common/00sync.rpy:409
     old "Please enter the sync ID you generated.\nNever enter a sync ID you didn't create yourself."
     # Automatic translation.
-    new "Bitte geben Sie die von Ihnen erstellte Sync-ID ein.\nGeben Sie niemals eine Sync-ID ein, die Sie nicht selbst erstellt haben."
+    new "Bitte gib die von Dir erstellte Sync-ID ein.\nGie niemals eine Sync-ID ein, die Du nicht selbst erstellt hast."
 
     # renpy/common/00sync.rpy:428
     old "The sync ID is not in the correct format."
@@ -958,7 +907,7 @@ translate german strings:
     # renpy/common/00sync.rpy:529
     old "This will upload your saves to the {a=https://sync.renpy.org}Ren'Py Sync Server{/a}.\nDo you want to continue?"
     # Automatic translation.
-    new "Dadurch werden Ihre Spielstände auf den {a=https://sync.renpy.org}Ren'Py Sync Server{/a} hochgeladen.\nMöchten Sie fortfahren?"
+    new "Dadurch werden Deine Spielstände auf den {a=https://sync.renpy.org}Ren'Py Sync Server{/a} hochgeladen.\nMöchtest Du fortfahren?"
 
     # renpy/common/00sync.rpy:558
     old "Enter Sync ID"
@@ -983,7 +932,7 @@ translate german strings:
     # renpy/common/00sync.rpy:605
     old "You can use this ID to download your save on another device.\nThis sync will expire in an hour.\nRen'Py Sync is supported by {a=https://www.renpy.org/sponsors.html}Ren'Py's Sponsors{/a}."
     # Automatic translation.
-    new "Sie können diese ID verwenden, um Ihren Spielstand auf ein anderes Gerät herunterzuladen.\nDiese Synchronisierung läuft in einer Stunde ab.\nRen'Py Sync wird unterstützt von {a=https://www.renpy.org/sponsors.html}Ren'Py's Sponsors{/a}."
+    new "Du kannst diese ID verwenden, um Deinen Spielstand auf ein anderes Gerät herunterzuladen.\nDiese Synchronisierung läuft in einer Stunde ab.\nRen'Py Sync wird unterstützt von {a=https://www.renpy.org/sponsors.html}Ren'Py's Sponsors{/a}."
 
     # renpy/common/00sync.rpy:631
     old "Sync Error"

--- a/launcher/game/tl/german/developer.rpy
+++ b/launcher/game/tl/german/developer.rpy
@@ -119,15 +119,15 @@ translate german strings:
 
     # 00console.rpy:182
     old "Press <esc> to exit console. Type help for help.\n"
-    new "Drücken Sie <esc>, um die Konsole zu schließen. Geben Sie „help“ ein, um die Hilfe anzuzeigen.\n"
+    new "Drücke <esc>, um die Konsole zu schließen. Gib „help“ ein, um die Hilfe anzuzeigen.\n"
 
     # 00console.rpy:186
     old "Ren'Py script enabled."
-    new "Ren’Py Skript aktiviert."
+    new "Ren'Py Skript aktiviert."
 
     # 00console.rpy:188
     old "Ren'Py script disabled."
-    new "Ren’Py Skript deaktiviert."
+    new "Ren'Py Skript deaktiviert."
 
     # 00console.rpy:398
     old "help: show this help"
@@ -143,7 +143,7 @@ translate german strings:
 
     # 00console.rpy:415
     old " <python expression or statement>: run the expression or statement"
-    new " <python expression or statement>: startet den Ausdruck oder die Anweisung"
+    new " <python Ausdruck oder Anweisung>: startet den Ausdruck oder die Anweisung"
 
     # 00console.rpy:423
     old "clear: clear the console history"
@@ -186,23 +186,19 @@ translate german strings:
 
     # renpy/common/_developer/developer.rpym:43
     old "Interactive Director (D)"
-    # Automatic translation.
-    new "Interaktiver Direktor (D)"
+    new "Interaktiver Regisseur (D)"
 
     # renpy/common/_developer/developer.rpym:51
     old "Persistent Viewer"
-    # Automatic translation.
-    new "Dauerhafter Betrachter"
+    new "Übersicht persistenter Variablen"
 
     # renpy/common/_developer/developer.rpym:59
     old "Show Image Load Log (F4)"
-    # Automatic translation.
-    new "Bildladeprotokoll anzeigen (F4)"
+    new "Ladeprotokoll aller Bilder anzeigen (F4)"
 
     # renpy/common/_developer/developer.rpym:62
     old "Hide Image Load Log (F4)"
-    # Automatic translation.
-    new "Bildladeprotokoll ausblenden (F4)"
+    new "Ladeprotokoll aller Bilder ausblenden (F4)"
 
     # renpy/common/_developer/developer.rpym:65
     old "Image Attributes"
@@ -211,32 +207,28 @@ translate german strings:
 
     # renpy/common/_developer/developer.rpym:70
     old "Speech Bubble Editor (Shift+B)"
-    # Automatic translation.
-    new "Sprechblasen-Editor (Umschalt+B)"
+    new "Sprechblasen-Editor (Shift+B)"
 
     # renpy/common/_developer/developer.rpym:97
     old "[name] [attributes] (hidden)"
-    # Automatic translation.
-    new "[name] [attributes] (versteckt)"
+    new "[Name] [Attribute] (versteckt)"
 
     # renpy/common/_developer/developer.rpym:101
     old "[name] [attributes]"
-    new "[name] [attributes]"
+    new "[Name] [Attribute]"
 
     # renpy/common/_developer/developer.rpym:162
     old "Hide deleted"
-    # Automatic translation.
-    new "Ausblenden gelöscht"
+    new "Gelöschtes verbergen"
 
     # renpy/common/_developer/developer.rpym:162
     old "Show deleted"
-    # Automatic translation.
-    new "Anzeigen gelöscht"
+    new "Gelöschtes anzeigen"
 
     # renpy/common/_developer/developer.rpym:389
     old "Type to filter: "
     # Automatic translation.
-    new "Typ zum Filtern: "
+    new "Filtertyp: "
 
     # renpy/common/_developer/developer.rpym:507
     old "Textures: [tex_count] ([tex_size_mb:.1f] MB)"
@@ -255,23 +247,20 @@ translate german strings:
 
     # renpy/common/00console.rpy:813
     old "Help may display undocumented functions. Please check that the function or\nclass you want to use is documented.\n\n"
-    # Automatic translation.
-    new "Die Hilfe kann undokumentierte Funktionen anzeigen. Bitte prüfen Sie, ob die Funktion oder\nKlasse, die Sie verwenden möchten, dokumentiert ist.\n\n"
+    new "Die Hilfe kann undokumentierte Funktionen anzeigen. Bitte prüfe, ob die Funktion\noder Klasse, die Du verwenden möchtest, dokumentiert ist.\n\n"
 
     # renpy/common/00console.rpy:854
     old "stack: print the return stack"
-    # Automatic translation.
-    new "stack: den Rückgabestapel drucken"
+    new "stack: den Stack anzeigen"
 
     # renpy/common/00console.rpy:908
     old "watch <expression>: watch a python expression\n watch short: makes the representation of traced expressions short (default)\n watch long: makes the representation of traced expressions as is"
-    # Automatic translation.
-    new "watch <expression>: einen Python-Ausdruck beobachten\n watch short: macht die Darstellung der nachverfolgten Ausdrücke kurz (Standard)\n watch long: macht die Darstellung von verfolgten Ausdrücken wie folgt"
+    new "watch <expression>: einen Python-Ausdruck beobachten\n watch short: macht die Darstellung der nachverfolgten Ausdrücke kurz (Voreinstellung)\n watch long: macht die Darstellung von verfolgten Ausdrücken wie sie sind"
 
     # renpy/common/00console.rpy:1028
     old "short: Shorten the representation of objects on the console (default)."
     # Automatic translation.
-    new "short: Verkürzt die Darstellung von Objekten auf der Konsole (Standard)."
+    new "short: Verkürzt die Darstellung von Objekten auf der Konsole (Voreinstellung)."
 
     # renpy/common/00console.rpy:1032
     old "long: Print the full representation of objects on the console."
@@ -280,11 +269,9 @@ translate german strings:
 
     # renpy/common/00console.rpy:1036
     old "escape: Enables escaping of unicode symbols in unicode strings."
-    # Automatic translation.
-    new "escape: Ermöglicht das Escaping von Unicode-Symbolen in Unicode-Strings."
+    new "escape: Aktiviert das Escaping von Unicode-Symbolen in Unicode-Strings."
 
     # renpy/common/00console.rpy:1040
     old "unescape: Disables escaping of unicode symbols in unicode strings and print it as is (default)."
-    # Automatic translation.
     new "unescape: Deaktiviert das Escaping von Unicode-Symbolen in Unicode-Zeichenfolgen und druckt sie so, wie sie sind (Voreinstellung)."
 

--- a/launcher/game/tl/german/error.rpy
+++ b/launcher/game/tl/german/error.rpy
@@ -23,8 +23,7 @@ translate german strings:
 
     # 00gltest.rpy:93
     old "Enable"
-    # Automatic translation.
-    new "Aktivieren Sie"
+    new "Aktivieren"
 
     # 00gltest.rpy:109
     old "Changes will take effect the next time this program is run."
@@ -40,7 +39,7 @@ translate german strings:
 
     # 00gltest.rpy:148
     old "This computer is not using shaders."
-    new "Dieser Computer verwendet keine Shaders."
+    new "Dieser Computer verwendet keine Shader."
 
     # 00gltest.rpy:150
     old "This computer is displaying graphics slowly."
@@ -107,8 +106,7 @@ translate german strings:
 
     # 00gamepad.rpy:58
     old "Press or move the [control!s] [kind]."
-    # Automatic translation.
-    new "Drücken Sie oder bewegen Sie die [control!s] [kind] ."
+    new "Drücke oder bewege [control!s] [kind] ."
 
     # 00gamepad.rpy:66
     old "Skip (A)"
@@ -117,8 +115,7 @@ translate german strings:
 
     # 00gamepad.rpy:69
     old "Back (B)"
-    # Automatic translation.
-    new "Rücken (B)"
+    new "Zurück (B)"
 
     # _errorhandling.rpym:495
     old "Open Traceback"
@@ -144,11 +141,11 @@ translate german strings:
 
     # _errorhandling.rpym:538
     old "Rollback"
-    new "Zurückscrollen"
+    new "Zurückspulen"
 
     # _errorhandling.rpym:540
     old "Attempts a roll back to a prior time, allowing you to save or choose a different choice."
-    new "Versucht zu einem früheren Zeitpunkt zu gehen und ermöglicht es zu speichern oder eine andere Auswahl zu treffen."
+    new "Versucht zu einem früheren Zeitpunkt zu spulen, damit Du erneut speichern oder eine andere Entscheidung treffen kannst."
 
     # _errorhandling.rpym:543
     old "Ignore"
@@ -156,7 +153,7 @@ translate german strings:
 
     # _errorhandling.rpym:545
     old "Ignores the exception, allowing you to continue. This often leads to additional errors."
-    new "Ignoriert den Fehler und ermöglicht es, fortzusetzen. Dies führt oft zu weiteren Fehlern."
+    new "Ignoriert den Fehler und ermöglicht es, fortzufahren. Dies führt oft zu weiteren Fehlern."
 
     # _errorhandling.rpym:548
     old "Reload"
@@ -176,7 +173,7 @@ translate german strings:
 
     # _errorhandling.rpym:606
     old "Open Parse Errors"
-    new "Parse Errors öffnen"
+    new "Syntaxfehler öffnen"
 
     # _errorhandling.rpym:608
     old "Opens the errors.txt file in a text editor."
@@ -229,7 +226,7 @@ translate german strings:
 
     # renpy/common/00gltest.rpy:159
     old "Powersave"
-    new "Powersave"
+    new "Energiesparen"
 
     # renpy/common/00gltest.rpy:173
     old "Framerate"
@@ -259,13 +256,11 @@ translate german strings:
 
     # renpy/common/00gltest.rpy:259
     old "The {a=edit:1:log.txt}log.txt{/a} file may contain information to help you determine what is wrong with your computer."
-    # Automatic translation.
-    new "Die Datei {a=edit:1:log.txt}log.txt{/a} kann Informationen enthalten, die Ihnen helfen, das Problem mit Ihrem Computer zu lösen."
+    new "Die Datei {a=edit:1:log.txt}log.txt{/a} kann Informationen enthalten, die Dir helfen, das Problem mit Deinem Computer zu lösen."
 
     # renpy/common/00gltest.rpy:264
     old "More details on how to fix this can be found in the {a=[url]}documentation{/a}."
-    # Automatic translation.
-    new "Weitere Einzelheiten zur Behebung dieses Problems finden Sie in der Dokumentation {a=[url]}{/a} ."
+    new "Weitere Einzelheiten zur Behebung dieses Problems findest Du in der Dokumentation {a=[url]}{/a} ."
 
     # renpy/common/00gltest.rpy:281
     old "Change render options"
@@ -274,13 +269,11 @@ translate german strings:
 
     # renpy/common/00gamepad.rpy:58
     old "Press or move the '[control!s]' [kind]."
-    # Automatic translation.
-    new "Drücken Sie oder bewegen Sie die Taste '[control!s]' [kind]."
+    new "Drücke oder bewege die Taste '[control!s]' [kind]."
 
     # renpy/common/_errorhandling.rpym:555
     old "Open"
-    # Automatic translation.
-    new "Öffnen Sie"
+    new "Öffnen"
 
     # renpy/common/_errorhandling.rpym:559
     old "Copy BBCode"
@@ -304,8 +297,7 @@ translate german strings:
 
     # renpy/common/_errorhandling.rpym:626
     old "Ignores the exception, allowing you to continue."
-    # Automatic translation.
-    new "Ignoriert die Ausnahme, so dass Sie fortfahren können."
+    new "Ignoriert den Fehler, so dass Du fortfahren kannst."
 
     # renpy/common/_errorhandling.rpym:637
     old "Console"

--- a/launcher/game/tl/german/launcher.rpy
+++ b/launcher/game/tl/german/launcher.rpy
@@ -17,7 +17,7 @@
 
     # add_file.rpy:28
     old "Enter the name of the script file to create."
-    new "Geben Sie den Namen der zu erstellenden Script-Datei ein."
+    new "Gib den Namen der zu erstellenden Script-Datei ein."
 
     # add_file.rpy:31
     old "The filename must have the .rpy extension."
@@ -29,31 +29,31 @@
 
     # add_file.rpy:42
     old "# Ren'Py automatically loads all script files ending with .rpy. To use this\n# file, define a label and jump to it from another file.\n"
-    new "# Ren’Py lädt automatisch alle Skript-Dateien, die auf .rpy enden. Um diese\n# Datei zu verwenden, setzen sie ein Label und springen sie aus einer anderen Datei dorthin.\n"
+    new "# Ren'Py lädt automatisch alle Skript-Dateien, die auf .rpy enden. Um diese\n# Datei zu verwenden, setze ein Label und springe aus einer anderen Datei dorthin.\n"
 
     # android.rpy:30
     old "To build Android packages, please download RAPT, unzip it, and place it into the Ren'Py directory. Then restart the Ren'Py launcher."
-    new "Um eine Android-Datei zu erstellen, laden Sie bitte RAPT herunter, entpacken Sie es und platzieren Sie es im Ren’Py Verzeichnis. Starten Sie dann bitte Ren’Py neu."
+    new "Um eine Android-Datei zu erstellen, lade bitte RAPT herunter, entpacke es und platziere es im Ren'Py Verzeichnis. Starte dann bitte Ren'Py neu."
 
     # android.rpy:31
     old "An x86 Java Development Kit is required to build Android packages on Windows. The JDK is different from the JRE, so it's possible you have Java without having the JDK.\n\nPlease {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}download and install the JDK{/a}, then restart the Ren'Py launcher."
-    new "Ein x86 Java-Development-Kit wird benötigt, um Android-Packages auf Windows zu erstellen. Das JDK unterscheidet sich vom JRE, daher ist es möglich, dass Sie Java ohne das JDK installiert haben.\n\nBitte {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}laden Sie das JDK herunter und installieren Sie es{/a}, dann starten Sie den Ren’Py-Launcher neu."
+    new "Ein x86 Java-Development-Kit wird benötigt, um Android-Packages auf Windows zu erstellen. Das JDK unterscheidet sich vom JRE, daher ist es möglich, dass Du Java ohne das JDK installiert hast.\n\nBitte {a=http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html}lade das JDK herunter und installiere es{/a}, dann starte den Ren'Py-Launcher neu."
 
     # android.rpy:32
     old "RAPT has been installed, but you'll need to install the Android SDK before you can build Android packages. Choose Install SDK to do this."
-    new "RAPT wurde installiert, aber Sie müssen das Android-SDK installieren, bevor Sie Android-Dateien erstellen können. Wählen Sie „SDK Installieren“, um dies zu tun."
+    new "RAPT wurde installiert, aber Du musst das Android-SDK installieren, bevor Du Android-Dateien erstellen kannst. Wähle „SDK Installieren“, um dies zu tun."
 
     # android.rpy:33
     old "RAPT has been installed, but a key hasn't been configured. Please create a new key, or restore android.keystore."
-    new "RAPT wurde installiert, aber ein Key wurde nicht eingestellt. Bitte erstellen Sie einen neuen Key oder stellen Sie android.keystore wieder her."
+    new "RAPT wurde installiert, aber ein Key wurde nicht eingestellt. Bitte erstelle einen neuen Key oder stelle android.keystore wieder her."
 
     # android.rpy:34
     old "The current project has not been configured. Use \"Configure\" to configure it before building."
-    new "Das aktuelle Projekt wurde nicht eingestellt. Verwenden Sie „Einstellen“, um es vor der Erstellung anzupassen."
+    new "Das aktuelle Projekt wurde nicht konfiguriert. Verwende „Konfigurieren“, um es vor der Erstellung anzupassen."
 
     # android.rpy:35
     old "Choose \"Build\" to build the current project, or attach an Android device and choose \"Build & Install\" to build and install it on the device."
-    new "Wählen Sie „Erstellen“, um das aktuelle Projekt zu erstellen oder schließen Sie ein Android-Gerät an und wählen Sie „Erstellen und installieren“, um es zu erstellen und auf dem Gerät zu installieren."
+    new "Wähle „Erstellen“, um das aktuelle Projekt zu erstellen oder schließe ein Android-Gerät an und wähle „Erstellen und Installieren“, um es zu erstellen und auf dem Gerät zu installieren."
 
     # android.rpy:37
     old "Attempts to emulate an Android phone.\n\nTouch input is emulated through the mouse, but only when the button is held down. Escape is mapped to the menu button, and PageUp is mapped to the back button."
@@ -77,7 +77,7 @@
 
     # android.rpy:43
     old "Opens the file containing the Google Play keys in the editor.\n\nThis is only needed if the application is using an expansion APK. Read the documentation for more details."
-    new "Öffnet die Datei mit den Google-Play-Keys im Editor.\n\nDies ist nur nötig, wenn die Anwendung ein Expansion-APK verwendet. Lesen Sie die Dokumentation für weitere Details."
+    new "Öffnet die Datei mit den Google-Play-Keys im Editor.\n\nDies ist nur nötig, wenn die Anwendung ein Expansion-APK verwendet. Lies die Dokumentation für weitere Details."
 
     # android.rpy:44
     old "Builds the Android package."
@@ -85,12 +85,12 @@
 
     # android.rpy:45
     old "Builds the Android package, and installs it on an Android device connected to your computer."
-    new "Erstellt die Android-Datei und installiert es auf ein Android-Gerät, das mit Ihrem Computer verbunden ist."
+    new "Erstellt die Android-Datei und installiert sie auf ein Android-Gerät, das mit Deinem Computer verbunden ist."
 
     # android.rpy:46
     old "Builds the Android package, installs it on an Android device connected to your computer, then launches the app on your device."
     # Automatic translation.
-    new "Erstellt das Android-Paket, installiert es auf einem Android-Gerät, das mit Ihrem Computer verbunden ist, und startet dann die App auf Ihrem Gerät."
+    new "Erstellt das Android-Paket, installiert es auf einem Android-Gerät, das mit Deinem Computer verbunden ist, und startet dann die App auf Deinem Gerät."
 
     # android.rpy:48
     old "Connects to an Android device running ADB in TCP/IP mode."
@@ -124,13 +124,11 @@
 
     # android.rpy:337
     old "Tablet"
-    # Automatic translation.
-    new "Tablette"
+    new "Tablet"
 
     # android.rpy:341
     old "Television"
-    # Automatic translation.
-    new "Fernsehen"
+    new "Fernseher"
 
     # android.rpy:353
     old "Build:"
@@ -142,7 +140,7 @@
 
     # android.rpy:365
     old "Configure"
-    new "Einstellen"
+    new "Konfigurieren"
 
     # android.rpy:369
     old "Build Package"
@@ -150,7 +148,7 @@
 
     # android.rpy:373
     old "Build & Install"
-    new "Erstellen und installieren"
+    new "Erstellen und Installieren"
 
     # android.rpy:377
     old "Build, Install & Launch"
@@ -175,7 +173,7 @@
 
     # android.rpy:437
     old "Before packaging Android apps, you'll need to download RAPT, the Ren'Py Android Packaging Tool. Would you like to download RAPT now?"
-    new "Bevor Sie Android-Apps erstellen können, müssen Sie RAPT herunterladen, das Ren’Py-Android-Packaging-Tool. Möchten Sie RAPT jetzt herunterladen?"
+    new "Bevor Du Android-Apps erstellen kannst, musst Du RAPT herunterladen, das Ren'Py-Android-Packaging-Tool. Möchtest Du RAPT jetzt herunterladen?"
 
     # android.rpy:496
     old "Remote ADB Address"
@@ -183,7 +181,7 @@
 
     # android.rpy:496
     old "Please enter the IP address and port number to connect to, in the form \"192.168.1.143:5555\". Consult your device's documentation to determine if it supports remote ADB, and if so, the address and port to use."
-    new "Bitte geben Sie die IP-Adresse und die Port-Nummer zum Verbinden ein, Beispiel: „192.168.1.143:5555“. Schauen Sie im Handbuch ihres Geräts nach, um festzustellen, ob es Remote-ADB unterstützt, und wenn ja, schauen Sie die Adresse und den Port nach."
+    new "Bitte gib die IP-Adresse und die Port-Nummer zum Verbinden ein, Beispiel: „192.168.1.143:5555“. Schau im Handbuch Deines Geräts nach, um zu prüfen, ob es Remote-ADB unterstützt, und wenn ja, welche Adresse und Port zu verwenden sind."
 
     # android.rpy:508
     old "Invalid remote ADB address"
@@ -208,12 +206,11 @@
 
     # choose_directory.rpy:73
     old "Ren'Py was unable to run python with tkinter to choose the directory. Please install the python-tk or tkinter package."
-    # Automatic translation.
-    new "Ren'Py war nicht in der Lage, python mit tkinter auszuführen, um das Verzeichnis auszuwählen. Bitte installieren Sie das Paket python-tk oder tkinter."
+    new "Ren'Py war nicht in der Lage, Python mit tkinter auszuführen, um das Verzeichnis auszuwählen. Bitte installiere das Paket python-tk oder tkinter."
 
     # choose_theme.rpy:303
     old "Could not change the theme. Perhaps options.rpy was changed too much."
-    new "Konnte Theme nicht ändern. Vielleicht wurde options.rpy zu stark verändert."
+    new "Konnte das Design nicht ändern. Vielleicht wurde options.rpy zu stark verändert."
 
     # choose_theme.rpy:370
     old "Planetarium"
@@ -251,15 +248,15 @@
 
     # distribute.rpy:459
     old "Building distributions failed:\n\nThe build.directory_name variable may not include the space, colon, or semicolon characters."
-    new "Erstellen von Veröffentlichungen gescheiter:\n\nDie build.directory_name Variable darf keine Leerzeichen, Doppelpunkte oder Semikolons enthalten."
+    new "Erstellen von Veröffentlichungen gescheitert:\n\nDie build.directory_name Variable darf keine Leerzeichen, Doppelpunkte oder Semikolons enthalten."
 
     # distribute.rpy:504
     old "No packages are selected, so there's nothing to do."
-    new "Keine Packages wurden ausgewählt."
+    new "Es wurden keine Packages ausgewählt."
 
     # distribute.rpy:516
     old "Scanning Ren'Py files..."
-    new "Ren’Py-Dateien werden geprüft..."
+    new "Ren'Py-Dateien werden geprüft..."
 
     # distribute.rpy:569
     old "All packages have been built.\n\nDue to the presence of permission information, unpacking and repacking the Linux and Macintosh distributions on Windows is not supported."
@@ -323,8 +320,7 @@
 
     # distribute_gui.rpy:194
     old "Add from clauses to calls, once"
-    # Automatic translation.
-    new "Von-Klauseln zu Aufrufen hinzufügen, sobald"
+    new "An \"call\" Befehle \"from\" anfügen (einmalig)"
 
     # distribute_gui.rpy:195
     old "Refresh"
@@ -349,12 +345,11 @@
 
     # distribute_gui.rpy:241
     old "Add from clauses to calls"
-    # Automatic translation.
-    new "Von-Klauseln zu Aufrufen hinzufügen"
+    new "An \"call\" Befehle \"from\" anfügen"
 
     # distribute_gui.rpy:242
     old "Force Recompile"
-    new "Neu kompilieren"
+    new "Neukompilierung erzwingen"
 
     # distribute_gui.rpy:246
     old "Build"
@@ -362,16 +357,15 @@
 
     # distribute_gui.rpy:250
     old "Adding from clauses to call statements that do not have them."
-    # Automatic translation.
-    new "Hinzufügen von \"from\"-Klauseln zu Aufrufanweisungen, die diese nicht enthalten."
+    new "Anfügen von \"from\"-Klauseln an \"call\" Befehle, die diese nicht enthalten."
 
     # distribute_gui.rpy:271
     old "Errors were detected when running the project. Please ensure the project runs without errors before building distributions."
-    new "Fehler wurden beim Starten des Projekts gefunden. Bitte stellen Sie sicher, dass das Projekt ohne Fehler läuft, bevor Sie Veröffentlichungen erstellen."
+    new "Beim Starten des Projekts wurden Fehler gefunden. Bitte stell sicher, dass das Projekt ohne Fehler läuft, bevor Du Veröffentlichungen erstellst."
 
     # distribute_gui.rpy:288
     old "Your project does not contain build information. Would you like to add build information to the end of options.rpy?"
-    new "Ihr Projekt enthält keine Erstellinformationen. Würden Sie gerne Erstellinformationen am Ende der options.rpy-Datei einfügen?"
+    new "Dein Projekt enthält keine Einstellungsinformationen für die Erstellung. Sollen sie am Ende der options.rpy-Datei eingefügt werden?"
 
     # editor.rpy:150
     old "{b}Recommended.{/b} A beta editor with an easy to use interface and features that aid in development, such as spell-checking. Editra currently lacks the IME support required for Chinese, Japanese, and Korean text input."
@@ -383,7 +377,7 @@
 
     # editor.rpy:167
     old "This may have occured because wxPython is not installed on this system."
-    new "Dies ist vermutlich passiert, weil wxPython nicht auf Ihrem System installiert ist."
+    new "Dies ist vermutlich passiert, weil wxPython nicht auf Deinem System installiert ist."
 
     # editor.rpy:169
     old "Up to 22 MB download required."
@@ -399,15 +393,15 @@
 
     # editor.rpy:182
     old "This may have occured because Java is not installed on this system."
-    new "Dies ist vermutlich passiert, weil Java nicht auf Ihrem System installiert ist."
+    new "Dies ist vermutlich passiert, weil Java nicht auf Deinem System installiert ist."
 
     # editor.rpy:191
     old "Invokes the editor your operating system has associated with .rpy files."
-    new "Startet den Editor, den dein Betriebssystem mit .rpy-Dateien assoziiert."
+    new "Startet den Editor, den Dein Betriebssystem mit .rpy-Dateien assoziiert."
 
     # editor.rpy:207
     old "Prevents Ren'Py from opening a text editor."
-    new "Verhindert, dass Ren’Py einen Texteditor öffnet."
+    new "Verhindert, dass Ren'Py einen Texteditor öffnet."
 
     # editor.rpy:359
     old "An exception occured while launching the text editor:\n[exception!q]"
@@ -419,7 +413,7 @@
 
     # editor.rpy:472
     old "A text editor is the program you'll use to edit Ren'Py script files. Here, you can select the editor Ren'Py will use. If not already present, the editor will be automatically downloaded and installed."
-    new "Ein Texeditor ist ein Programm, das verwendet wird, um Ren’Py Skript-Dateien zu bearbeiten. Hier können Sie den Editor auswählen, den Ren’Py verwenden soll. Wenn dieser noch nicht installiert ist, wird er automatisch heruntergeladen und installiert."
+    new "Ein Texeditor ist ein Programm, das verwendet wird, um Ren'Py Skript-Dateien zu bearbeiten. Hier kannst Du den Editor auswählen, den Ren'Py verwenden soll. Wenn dieser noch nicht installiert ist, wird er automatisch heruntergeladen und installiert."
 
     # editor.rpy:494
     old "Cancel"
@@ -428,7 +422,7 @@
     # front_page.rpy:35
     old "Open [text] directory."
     # Automatic translation.
-    new "Öffnen Sie das Verzeichnis [text]."
+    new "Öffne das Verzeichnis [text]."
 
     # front_page.rpy:91
     old "PROJECTS:"
@@ -452,8 +446,7 @@
 
     # front_page.rpy:149
     old "Select project [text]."
-    # Automatic translation.
-    new "Wählen Sie das Projekt [text]."
+    new "Wähle das Projekt [text]."
 
     # front_page.rpy:165
     old "Tutorial"
@@ -474,11 +467,11 @@
 
     # front_page.rpy:195
     old "game"
-    new "Spielverzeichnis"
+    new "game"
 
     # front_page.rpy:196
     old "base"
-    new "Hauptverzeichnis"
+    new "base"
 
     # front_page.rpy:197
     old "images"
@@ -494,7 +487,7 @@
 
     # front_page.rpy:214
     old "All script files"
-    new "Alle Dateien"
+    new "Alle Skript Dateien"
 
     # front_page.rpy:221
     old "Actions"
@@ -522,7 +515,7 @@
 
     # front_page.rpy:251
     old "Build Distributions"
-    new "Applikation erstellen"
+    new "Veröffentlichungen erstellen"
 
     # front_page.rpy:253
     old "Android"
@@ -546,7 +539,7 @@
 
     # front_page.rpy:287
     old "Deleting persistent data..."
-    new "Lösche Persistent-Dateien..."
+    new "Lösche persistente Daten..."
 
     # front_page.rpy:295
     old "Recompiling all rpy files into rpyc files..."
@@ -559,22 +552,19 @@
 
     # gui7.rpy:250
     old "Please click on the color scheme you wish to use, then click Continue. These colors can be changed and customized later."
-    new "Bitte wählen Sie das Farbschema, dass Sie benutzen möchten und klicken Sie dann auf \"Weiter\". Diese Farben können später wieder geändert werden."
+    new "Bitte wähle das Farbschema, dass Du benutzen möchtest und klicke dann auf \"Weiter\". Diese Farben können später wieder geändert werden."
 
     # gui7.rpy:294
     old "{b}Warning{/b}\nContinuing will overwrite customized bar, button, save slot, scrollbar, and slider images.\n\nWhat would you like to do?"
-    # Automatic translation.
-    new "{b}Warnung{/b}\nWenn Sie fortfahren, werden benutzerdefinierte Balken-, Schaltflächen-, Speicherplatz-, Bildlaufleisten- und Schiebereglerbilder überschrieben.\n\nWas würden Sie gerne tun?"
+    new "{b}Warnung{/b}\nWenn Du fortfährst, werden benutzerdefinierte Balken-, Schaltflächen-, Speicherplatz-, Bildlaufleisten- und Schiebereglerbilder überschrieben.\n\nWas würdest Du gerne tun?"
 
     # gui7.rpy:294
     old "Choose new colors, then regenerate image files."
-    # Automatic translation.
-    new "Wählen Sie neue Farben, und generieren Sie die Bilddateien neu."
+    new "Wähle neue Farben, und generiere die Bilddateien neu."
 
     # gui7.rpy:294
     old "Regenerate the image files using the colors in gui.rpy."
-    # Automatic translation.
-    new "Die Bilddateien werden unter Verwendung der Farben in gui.rpy neu generiert."
+    new "Die Bilddateien unter Verwendung der Farben in gui.rpy neu generieren."
 
     # gui7.rpy:314
     old "PROJECT NAME"
@@ -582,7 +572,7 @@
 
     # gui7.rpy:314
     old "Please enter the name of your project:"
-    new "Bitte geben Sie den Namen Ihres Projekts ein:"
+    new "Bitte gib den Namen Deines Projekts ein:"
 
     # gui7.rpy:322
     old "The project name may not be empty."
@@ -590,11 +580,11 @@
 
     # gui7.rpy:327
     old "[project_name!q] already exists. Please choose a different project name."
-    new "[project_name!q] existiert bereits. Bitte wählen Sie einen anderen Projektnamen."
+    new "[project_name!q] existiert bereits. Bitte wähle einen anderen Projektnamen."
 
     # gui7.rpy:330
     old "[project_dir!q] already exists. Please choose a different project name."
-    new "[project_dir!q] existiert bereits. Bitte wählen Sie einen anderen Projektnamen."
+    new "[project_dir!q] existiert bereits. Bitte wähle einen anderen Projektnamen."
 
     # gui7.rpy:341
     old "What resolution should the project use? Although Ren'Py can scale the window up and down, this is the initial size of the window, the size at which assets should be drawn, and the size at which the assets will be at their sharpest.\n\nThe default of [default_size[0]]x[default_size[1]] is a reasonable compromise."
@@ -602,11 +592,11 @@
 
     # gui7.rpy:389
     old "Creating the new project..."
-    new "Erstellt neues Projekt..."
+    new "Erstelle neues Projekt..."
 
     # gui7.rpy:391
     old "Updating the project..."
-    new "Aktualisiert das Projekt..."
+    new "Aktualisiere das Projekt..."
 
     # interface.rpy:107
     old "Documentation"
@@ -614,11 +604,11 @@
 
     # interface.rpy:108
     old "Ren'Py Website"
-    new "Ren’Py Webseite"
+    new "Ren'Py Website"
 
     # interface.rpy:109
     old "Ren'Py Games List"
-    new "Ren’Py Spieleliste"
+    new "Ren'Py Spieleliste"
 
     # interface.rpy:117
     old "update"
@@ -674,23 +664,19 @@
 
     # ios.rpy:28
     old "To build iOS packages, please download renios, unzip it, and place it into the Ren'Py directory. Then restart the Ren'Py launcher."
-    # Automatic translation.
-    new "Um iOS-Pakete zu erstellen, laden Sie bitte renios herunter, entpacken Sie es und legen Sie es in das Ren'Py-Verzeichnis. Dann starten Sie den Ren'Py Launcher neu."
+    new "Um iOS-Pakete zu erstellen, lade bitte renios herunter, entpacke es und lege es in das Ren'Py-Verzeichnis. Dann starte den Ren'Py Launcher neu."
 
     # ios.rpy:29
     old "The directory in where Xcode projects will be placed has not been selected. Choose 'Select Directory' to select it."
-    # Automatic translation.
-    new "Das Verzeichnis, in dem Xcode-Projekte gespeichert werden sollen, wurde nicht ausgewählt. Wählen Sie \"Verzeichnis auswählen\", um es auszuwählen."
+    new "Das Verzeichnis, in dem Xcode-Projekte gespeichert werden sollen, wurde nicht ausgewählt. Wähle \"Verzeichnis auswählen\", um es auszuwählen."
 
     # ios.rpy:30
     old "There is no Xcode project corresponding to the current Ren'Py project. Choose 'Create Xcode Project' to create one."
-    # Automatic translation.
-    new "Es gibt kein Xcode-Projekt, das dem aktuellen Ren'Py-Projekt entspricht. Wählen Sie \"Xcode-Projekt erstellen\", um eines zu erstellen."
+    new "Es gibt kein Xcode-Projekt, das dem aktuellen Ren'Py-Projekt entspricht. Wähle \"Xcode-Projekt erstellen\", um eines zu erstellen."
 
     # ios.rpy:31
     old "An Xcode project exists. Choose 'Update Xcode Project' to update it with the latest game files, or use Xcode to build and install it."
-    # Automatic translation.
-    new "Ein Xcode-Projekt ist vorhanden. Wählen Sie \"Xcode-Projekt aktualisieren\", um es mit den neuesten Spieldateien zu aktualisieren, oder verwenden Sie Xcode, um es zu erstellen und zu installieren."
+    new "Ein Xcode-Projekt ist vorhanden. Wähle \"Xcode-Projekt aktualisieren\", um es mit den neuesten Spieldateien zu aktualisieren, oder verwende Xcode, um es zu erstellen und zu installieren."
 
     # ios.rpy:33
     old "Attempts to emulate an iPhone.\n\nTouch input is emulated through the mouse, but only when the button is held down."
@@ -730,7 +716,7 @@
     # ios.rpy:126
     old "The Xcode project already exists. Would you like to rename the old project, and replace it with a new one?"
     # Automatic translation.
-    new "Das Xcode-Projekt existiert bereits. Möchten Sie das alte Projekt umbenennen und es durch ein neues ersetzen?"
+    new "Das Xcode-Projekt existiert bereits. Möchtest Du das alte Projekt umbenennen und es durch ein neues ersetzen?"
 
     # ios.rpy:211
     old "iOS: [project.current.name!q]"
@@ -746,8 +732,7 @@
 
     # ios.rpy:264
     old "Select Xcode Projects Directory"
-    # Automatic translation.
-    new "Wählen Sie das Xcode-Projektverzeichnis"
+    new "Auswahl des Xcode-Projektverzeichnisses"
 
     # ios.rpy:268
     old "Create Xcode Project"
@@ -771,8 +756,7 @@
 
     # ios.rpy:345
     old "Before packaging iOS apps, you'll need to download renios, Ren'Py's iOS support. Would you like to download renios now?"
-    # Automatic translation.
-    new "Bevor Sie iOS-Apps paketieren können, müssen Sie renios herunterladen, die iOS-Unterstützung von Ren'Py. Möchten Sie renios jetzt herunterladen?"
+    new "Bevor iOS-Apps erstellt werden können, musst Du renios herunterladen, die iOS-Unterstützung von Ren'Py. Möchtest Du das jetzt tun?"
 
     # ios.rpy:354
     old "XCODE PROJECTS DIRECTORY"
@@ -782,22 +766,19 @@
     # ios.rpy:354
     old "Please choose the Xcode Projects Directory using the directory chooser.\n{b}The directory chooser may have opened behind this window.{/b}"
     # Automatic translation.
-    new "Bitte wählen Sie das Xcode-Projektverzeichnis über die Verzeichnisauswahl.\n{b}Möglicherweise hat sich das Verzeichnisauswahlfenster hinter diesem Fenster geöffnet.{/b}"
+    new "Bitte wähle das Xcode-Projektverzeichnis über die Verzeichnisauswahl.\n{b}Möglicherweise hat sich das Verzeichnisauswahlfenster hinter diesem Fenster geöffnet.{/b}"
 
     # ios.rpy:359
     old "Ren'Py has set the Xcode Projects Directory to:"
-    # Automatic translation.
-    new "Ren'Py hat das Xcode-Projektverzeichnis auf gesetzt:"
+    new "Ren'Py hat das Xcode-Projektverzeichnis wie folgt gesetzt:"
 
     # itch.rpy:60
     old "The built distributions could not be found. Please choose 'Build' and try again."
-    # Automatic translation.
-    new "Die erstellten Distributionen konnten nicht gefunden werden. Bitte wählen Sie 'Bauen' und versuchen Sie es erneut."
+    new "Die erstellten Veröffentlichungen konnten nicht gefunden werden. Bitte wähle 'Erstellen' und versuche es erneut."
 
     # itch.rpy:91
     old "No uploadable files were found. Please choose 'Build' and try again."
-    # Automatic translation.
-    new "Es wurden keine hochladbaren Dateien gefunden. Bitte wählen Sie 'Erstellen' und versuchen Sie es erneut."
+    new "Es wurden keine Dateien zum Hochladen gefunden. Bitte wähle 'Erstellen' und versuche es erneut."
 
     # itch.rpy:99
     old "The butler program was not found."
@@ -817,7 +798,7 @@
     # itch.rpy:108
     old "Please {a=https://itch.io/game/new}create your project{/a}, then add a line like \n{vspace=5}define build.itch_project = \"user-name/game-name\"\n{vspace=5} to options.rpy."
     # Automatic translation.
-    new "Bitte {a=https://itch.io/game/new}erstellen Sie Ihr Projekt{/a}, dann fügen Sie eine Zeile wie \n{vspace=5}define build.itch_project = \"benutzername/spielname\"\n{vspace=5} zu options.rpy."
+    new "Bitte {a=https://itch.io/game/new}erstelle Dein Projekt{/a}, dann füge eine Zeile wie \n{vspace=5}define build.itch_project = \"benutzername/spielname\"\n{vspace=5} in options.rpy ein."
 
     # mobilebuild.rpy:109
     old "{a=%s}%s{/a}"
@@ -881,7 +862,7 @@
 
     # navigation.rpy:249
     old "No TODO comments found.\n\nTo create one, include \"# TODO\" in your script."
-    new "Keine TODO-Kommentare gefunden.\n\nUm einen zu erstellen, bauen Sie „# TODO“ in Ihr Script ein."
+    new "Keine TODO-Kommentare gefunden.\n\nUm einen zu erstellen, baue „# TODO“ in Dein Script ein."
 
     # navigation.rpy:256
     old "The list of names is empty."
@@ -894,37 +875,32 @@
 
     # new_project.rpy:48
     old "Both interfaces have been translated to your language."
-    # Automatic translation.
-    new "Beide Schnittstellen sind in Ihre Sprache übersetzt worden."
+    new "Beide GUI Varianten sind in Deine Sprache übersetzt worden."
 
     # new_project.rpy:50
     old "Only the new GUI has been translated to your language."
-    # Automatic translation.
-    new "Nur die neue grafische Benutzeroberfläche wurde in Ihre Sprache übersetzt."
+    new "Nur die neue GUI wurde in Deine Sprache übersetzt."
 
     # new_project.rpy:52
     old "Only the legacy theme interface has been translated to your language."
-    # Automatic translation.
-    new "Nur die Oberfläche des alten Themas wurde in Ihre Sprache übersetzt."
+    new "Nur die GUI mit dem veralteten Design wurde in Deine Sprache übersetzt."
 
     # new_project.rpy:54
     old "Neither interface has been translated to your language."
-    # Automatic translation.
-    new "Beide Schnittstellen wurden nicht in Ihre Sprache übersetzt."
+    new "Keine der GUI Varianten wurde in Deine Sprache übersetzt."
 
     # new_project.rpy:63
     old "The projects directory could not be set. Giving up."
-    new "Das Projektverzeichnis konnte nicht festgelegt werden."
+    new "Das Projektverzeichnis konnte nicht festgelegt werden. Abbruch."
 
     # new_project.rpy:69
     old "Which interface would you like to use? The new GUI has a modern look, supports wide screens and mobile devices, and is easier to customize. Legacy themes might be necessary to work with older example code.\n\n[language_support!t]\n\nIf in doubt, choose the new GUI, then click Continue on the bottom-right."
-    # Automatic translation.
-    new "Welche Oberfläche möchten Sie verwenden? Die neue Benutzeroberfläche hat ein modernes Aussehen, unterstützt breite Bildschirme und mobile Geräte und lässt sich leichter anpassen. Für die Arbeit mit älterem Beispielcode sind möglicherweise ältere Themen erforderlich.\n\n[language_support!t]\n\nWählen Sie im Zweifelsfall die neue grafische Benutzeroberfläche und klicken Sie dann unten rechts auf Weiter."
+    new "Welche GUI möchtest Du verwenden? Die neue Benutzeroberfläche hat ein modernes Aussehen, unterstützt breite Bildschirme und mobile Geräte und lässt sich leichter anpassen. Das veraltete Design ist möglicherweise für die Arbeit mit älterem Beispielcode erforderlich.\n\n[language_support!t]\n\nWähle im Zweifelsfall die neue GUI und klicke dann unten rechts auf \"Weiter\"."
 
     # new_project.rpy:69
     old "Legacy Theme Interface"
     # Automatic translation.
-    new "Legacy Theme Schnittstelle"
+    new "Veraltetes GUI Design"
 
     # new_project.rpy:90
     old "Choose Project Template"
@@ -932,7 +908,7 @@
 
     # new_project.rpy:108
     old "Please select a template to use for your new project. The template sets the default font and the user interface language. If your language is not supported, choose 'english'."
-    new "Bitte wählen Sie eine Vorlage für Ihr neues Projekt. Die Vorlage legt die Standard-Schriftart fest und die Sprache der Benutzeroberfläche. Wenn Ihre Sprache nicht verfügbar ist, wählen Sie bitte 'english'."
+    new "Bitte wähle eine Vorlage für Dein neues Projekt. Die Vorlage legt die Standard-Schriftart fest und die Sprache der Benutzeroberfläche. Wenn Deine Sprache nicht verfügbar ist, dann wähle bitte 'english' (Englisch)."
 
     # preferences.rpy:64
     old "Launcher Preferences"
@@ -1016,20 +992,19 @@
 
     # project.rpy:47
     old "After making changes to the script, press shift+R to reload your game."
-    new "Nachdem Sie das Skript verändert haben, drücken Sie Shift + R, um Ihr Spiel neuzustarten."
+    new "Nachdem Du das Skript verändert hast, drücke Shift + R, um Dein Spiel neuzustarten."
 
     # project.rpy:47
     old "Press shift+O (the letter) to access the console."
-    new "Drücken Sie Shift + O, um die Konsole aufzurufen."
+    new "Drücke Shift + O, um die Konsole aufzurufen."
 
     # project.rpy:47
     old "Press shift+D to access the developer menu."
-    new "Drücken Sie Shift + D, um das Entwicklermenü aufzurufen."
+    new "Drücke Shift + D, um das Entwicklermenü aufzurufen."
 
     # project.rpy:47
     old "Have you backed up your projects recently?"
-    # Automatic translation.
-    new "Haben Sie in letzter Zeit ein Backup Ihrer Projekte erstellt?"
+    new "Hast Du in letzter Zeit Backups Deiner Projekte erstellt?"
 
     # project.rpy:229
     old "Launching the project failed."
@@ -1037,11 +1012,11 @@
 
     # project.rpy:229
     old "Please ensure that your project launches normally before running this command."
-    new "Bitte stellen Sie sicher, dass Ihr Projekt normal startet, bevor Sie diesen Befehl ausführen."
+    new "Bitte stell sicher, dass Dein Projekt normal startet, bevor Du diesen Befehl ausführst."
 
     # project.rpy:242
     old "Ren'Py is scanning the project..."
-    new "Ren’Py scannt das Projekt..."
+    new "Ren'Py scannt das Projekt..."
 
     # project.rpy:568
     old "Launching"
@@ -1053,7 +1028,7 @@
 
     # project.rpy:597
     old "Please choose the projects directory using the directory chooser.\n{b}The directory chooser may have opened behind this window.{/b}"
-    new "Bitte wählen Sie das Projektverzeichnis mit dem Verzeichnisauswähler.\n{b}Der Verzeichnisauswähler könnte hinter diesem Fenster geöffnet sein.{/b}"
+    new "Bitte wähle das Projektverzeichnis mit dem Verzeichnisauswähler.\n{b}Der Verzeichnisauswähler könnte hinter diesem Fenster geöffnet sein.{/b}"
 
     # project.rpy:597
     old "This launcher will scan for projects in this directory, will create new projects in this directory, and will place built projects into this directory."
@@ -1061,7 +1036,7 @@
 
     # project.rpy:602
     old "Ren'Py has set the projects directory to:"
-    new "Ren’Py hat das Projektverzeichnis verschoben in:"
+    new "Ren'Py hat das Projektverzeichnis verschoben nach:"
 
     # translations.rpy:63
     old "Translations: [project.current.name!q]"
@@ -1095,31 +1070,27 @@
 
     # translations.rpy:175
     old "Replace existing translations"
-    # Automatic translation.
-    new "Ersetzen Sie vorhandene Übersetzungen"
+    new "Vorhandene Übersetzungen ersetzen"
 
     # translations.rpy:176
     old "Reverse languages"
-    # Automatic translation.
-    new "Sprachen umkehren"
+    new "Sprachen tauschen"
 
     # translations.rpy:180
     old "Update Default Interface Translations"
-    # Automatic translation.
-    new "Standardübersetzungen der Schnittstelle aktualisieren"
+    new "Standardübersetzungen der GUI aktualisieren"
 
     # translations.rpy:200
     old "The extract command allows you to extract string translations from an existing project into a temporary file.\n\nThe merge command merges extracted translations into another project."
-    # Automatic translation.
-    new "Mit dem Befehl extract können Sie String-Übersetzungen aus einem bestehenden Projekt in eine temporäre Datei extrahieren.\n\nMit dem Befehl merge werden extrahierte Übersetzungen in einem anderen Projekt zusammengeführt."
+    new "Mit dem Befehl extract kannst Du String-Übersetzungen aus einem bestehenden Projekt in eine temporäre Datei extrahieren.\n\nMit dem Befehl merge werden extrahierte Übersetzungen mit einem anderen Projekt zusammengeführt."
 
     # translations.rpy:224
     old "Ren'Py is generating translations...."
-    new "Ren’Py erstellt Übersetzungen..."
+    new "Ren'Py erstellt Übersetzungen..."
 
     # translations.rpy:235
     old "Ren'Py has finished generating [language] translations."
-    new "Ren’Py hat die Übersetzungen für [language] erstellt."
+    new "Ren'Py hat die Übersetzungen auf \"[language]\" erstellt."
 
     # translations.rpy:248
     old "Ren'Py is extracting string translations..."
@@ -1128,8 +1099,7 @@
 
     # translations.rpy:251
     old "Ren'Py has finished extracting [language] string translations."
-    # Automatic translation.
-    new "Ren'Py hat das Extrahieren der [language] String-Übersetzungen abgeschlossen."
+    new "Ren'Py hat das Extrahieren der String-Übersetzungen auf \"[language]\" abgeschlossen."
 
     # translations.rpy:271
     old "Ren'Py is merging string translations..."
@@ -1138,8 +1108,7 @@
 
     # translations.rpy:274
     old "Ren'Py has finished merging [language] string translations."
-    # Automatic translation.
-    new "Ren'Py hat die Zusammenführung der [language] String-Übersetzungen abgeschlossen."
+    new "Ren'Py hat die Zusammenführung der String-Übersetzungen auf \"[language]\" abgeschlossen."
 
     # translations.rpy:282
     old "Updating default interface translations..."
@@ -1156,32 +1125,27 @@
 
     # translations.rpy:330
     old "Tab-delimited Spreadsheet (dialogue.tab)"
-    # Automatic translation.
-    new "Tabulatorgetrennte Tabellenkalkulation (dialog.tab)"
+    new "Tabulatorgetrennte Tabellenkalkulation (dialogue.tab)"
 
     # translations.rpy:331
     old "Dialogue Text Only (dialogue.txt)"
-    # Automatic translation.
-    new "Nur-Dialog-Text (dialogue.txt)"
+    new "Nur Dialog-Text (dialogue.txt)"
 
     # translations.rpy:344
     old "Strip text tags from the dialogue."
-    # Automatic translation.
-    new "Entfernen Sie Text-Tags aus dem Dialog."
+    new "Text-Tags aus dem Dialog entfernen."
 
     # translations.rpy:345
     old "Escape quotes and other special characters."
-    # Automatic translation.
-    new "Anführungszeichen und andere Sonderzeichen werden ausgeblendet."
+    new "Anführungszeichen und andere Sonderzeichen mit \\ versehen."
 
     # translations.rpy:346
     old "Extract all translatable strings, not just dialogue."
-    # Automatic translation.
-    new "Extrahiert alle übersetzbaren Zeichenfolgen, nicht nur Dialoge."
+    new "Alle übersetzbaren Strings, nicht nur Dialoge, extrahieren."
 
     # translations.rpy:374
     old "Ren'Py is extracting dialogue...."
-    new "Ren’Py extrahiert Dialoge..."
+    new "Ren'Py extrahiert Dialoge..."
 
     # translations.rpy:378
     old "Ren'Py has finished extracting dialogue. The extracted dialogue can be found in dialogue.[persistent.dialogue_format] in the base directory."
@@ -1194,23 +1158,23 @@
 
     # updater.rpy:86
     old "The update channel controls the version of Ren'Py the updater will download. Please select an update channel:"
-    new "Der Aktualisierungskanal kontrolliert die Version, die Ren’py herunterlädt. Bitte wählen Sie einen Aktualisierungskanal:"
+    new "Der Aktualisierungskanal kontrolliert die Version, die Ren'Py herunterlädt. Bitte wähle einen Aktualisierungskanal:"
 
     # updater.rpy:91
     old "Release"
-    new "Veröffentlichungen"
+    new "Veröffentlichung"
 
     # updater.rpy:97
     old "{b}Recommended.{/b} The version of Ren'Py that should be used in all newly-released games."
-    new "{b}Empfohlen.{/b} Die Version von Ren’Py, die für alle neuen Spielveröffentlichungen verwendet werden sollte."
+    new "{b}Empfohlen.{/b} Die Version von Ren'Py, die für alle neuen Spielveröffentlichungen verwendet werden sollte."
 
     # updater.rpy:102
     old "Prerelease"
-    new "Vorveröffentlichungen"
+    new "Vorveröffentlichung"
 
     # updater.rpy:108
     old "A preview of the next version of Ren'Py that can be used for testing and taking advantage of new features, but not for final releases of games."
-    new "Eine Vorschau auf die nächste Version von Ren’Py, die zu Testzwecken und mit neuen Funktionen verwendet werden kann, jedoch nicht für Veröffentlichung von Spielen geeignet ist."
+    new "Eine Vorschau auf die nächste Version von Ren'Py, die zu Testzwecken und mit neuen Funktionen verwendet werden kann, jedoch nicht für Veröffentlichung von Spielen geeignet ist."
 
     # updater.rpy:114
     old "Experimental"
@@ -1218,16 +1182,15 @@
 
     # updater.rpy:120
     old "Experimental versions of Ren'Py. You shouldn't select this channel unless asked by a Ren'Py developer."
-    new "Experimentelle Versionen von Ren’Py. Sie sollten diesen Kanal nur auswählen, wenn Sie von einem Ren’Py-Entwickler dazu aufgefordert werden."
+    new "Experimentelle Versionen von Ren'Py. Du solltest diesen Kanal nur auswählen, wenn Du von einem Ren'Py-Entwickler dazu aufgefordert wirst."
 
     # updater.rpy:126
     old "Nightly"
-    # Automatic translation.
-    new "Nächtliche"
+    new "Nightly"
 
     # updater.rpy:132
     old "The bleeding edge of Ren'Py development. This may have the latest features, or might not run at all."
-    new "Die allerneuste Ren’Py Version. Diese enthält die neusten Funktionen, könnte aber auch überhaupt nicht funktionieren."
+    new "Die allerneuste Ren'Py Version. Diese enthält die neusten Funktionen, könnte aber auch überhaupt nicht funktionieren."
 
     # updater.rpy:152
     old "An error has occured:"
@@ -1239,15 +1202,15 @@
 
     # updater.rpy:156
     old "Ren'Py is up to date."
-    new "Ren’Py ist aktuell"
+    new "Ren'Py ist auf dem neuesten Stand."
 
     # updater.rpy:158
     old "[u.version] is now available. Do you want to install it?"
-    new "[u.version] ist nun verfügbar. Möchten Sie sie installieren?"
+    new "[u.version] ist nun verfügbar. Möchtest Du es installieren?"
 
     # updater.rpy:160
     old "Preparing to download the update."
-    new "Vorbereiten, um die Aktualisierungen herunterzuladen."
+    new "Download der Aktualisierung wird vorbereitet."
 
     # updater.rpy:162
     old "Downloading the update."
@@ -1259,11 +1222,11 @@
 
     # updater.rpy:166
     old "Finishing up."
-    new "Abschließen."
+    new "Räume auf."
 
     # updater.rpy:168
     old "The update has been installed. Ren'Py will restart."
-    new "Die Aktualisierungen wurden installiert. Ren’Py startet neu."
+    new "Die Aktualisierungen wurden installiert. Ren'Py wird jetzt neu gestartet."
 
     # updater.rpy:170
     old "The update has been installed."
@@ -1271,11 +1234,11 @@
 
     # updater.rpy:172
     old "The update was cancelled."
-    new "Die Aktualisierungen wurde abgebrochen."
+    new "Die Aktualisierung wurde abgebrochen."
 
     # updater.rpy:189
     old "Ren'Py Update"
-    new "Ren’Py aktualisieren"
+    new "Ren'Py aktualisieren"
 
     # updater.rpy:195
     old "Proceed"
@@ -1287,18 +1250,15 @@
 
     # game/android.rpy:35
     old "A 64-bit/x64 Java [JDK_REQUIREMENT] Development Kit is required to build Android packages on Windows. The JDK is different from the JRE, so it's possible you have Java without having the JDK.\n\nPlease {a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}download and install the JDK{/a}, then restart the Ren'Py launcher."
-    # Automatic translation.
-    new "Ein 64-bit/x64 Java [JDK_REQUIREMENT] Development Kit ist erforderlich, um Android-Pakete unter Windows zu erstellen. Das JDK unterscheidet sich von der JRE, es ist also möglich, dass Sie Java haben, ohne das JDK zu haben.\n\nBitte laden Sie {a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}herunter und installieren Sie das JDK{/a}, dann starten Sie den Ren'Py Launcher neu."
+    new "Ein 64-bit/x64 Java [JDK_REQUIREMENT] Development Kit ist erforderlich, um Android-Pakete unter Windows zu erstellen. Das JDK unterscheidet sich von der JRE, es ist also möglich, dass Du Java hast, ohne das JDK zu haben.\n\nBitte lade {a=https://www.renpy.org/jdk/[JDK_REQUIREMENT]}herunter und installiere das JDK{/a}, dann starte den Ren'Py Launcher neu."
 
     # game/android.rpy:38
     old "RAPT has been installed, but a bundle key hasn't been configured. Please create a new key, or restore bundle.keystore."
-    # Automatic translation.
-    new "RAPT wurde installiert, aber ein Bundle-Schlüssel wurde nicht konfiguriert. Bitte erstellen Sie einen neuen Schlüssel, oder stellen Sie bundle.keystore wieder her."
+    new "RAPT wurde installiert, aber ein Bundle-Schlüssel wurde nicht konfiguriert. Bitte erstelle einen neuen Schlüssel, oder stelle bundle.keystore wieder her."
 
     # game/android.rpy:40
     old "Please select if you want a Play Bundle (for Google Play), or a Universal APK (for sideloading and other app stores)."
-    # Automatic translation.
-    new "Bitte wählen Sie aus, ob Sie ein Play Bundle (für Google Play) oder eine Universal APK (für Sideloading und andere App Stores) wünschen."
+    new "Bitte wähle aus, ob Du ein Play Bundle (für Google Play) oder eine Universal APK (für Sideloading und andere App Stores) wünschst."
 
     # game/android.rpy:55
     old "Lists the connected devices."
@@ -1369,8 +1329,7 @@
 
     # game/android.rpy:472
     old "Clean"
-    # Automatic translation.
-    new "Sauber"
+    new "Säubern"
 
     # game/android.rpy:569
     old "Wi-Fi Pairing Code"
@@ -1378,28 +1337,23 @@
 
     # game/android.rpy:569
     old "If supported, this can be found in 'Developer options', 'Wireless debugging', 'Pair device with pairing code'."
-    # Automatic translation.
-    new "Falls unterstützt, finden Sie dies unter \"Entwickleroptionen\", \"Drahtloses Debugging\", \"Gerät mit Pairing-Code koppeln\"."
+    new "Falls unterstützt, findest Du dies unter \"Entwickleroptionen\", \"Drahtloses Debugging\", \"Gerät mit Pairing-Code koppeln\"."
 
     # game/android.rpy:576
     old "Pairing Host & Port"
-    # Automatic translation.
-    new "Host und Anschluss koppeln"
+    new "Host & Port koppeln"
 
     # game/android.rpy:592
     old "IP Address & Port"
-    # Automatic translation.
-    new "IP-Adresse und Anschluss"
+    new "IP-Adresse & Port"
 
     # game/android.rpy:592
     old "If supported, this can be found in 'Developer options', 'Wireless debugging'."
-    # Automatic translation.
-    new "Wenn dies unterstützt wird, finden Sie es unter \"Entwickleroptionen\", \"Drahtloses Debugging\"."
+    new "Wenn dies unterstützt wird, findest Du es unter \"Entwickleroptionen\", \"Drahtloses Debugging\"."
 
     # game/android.rpy:608
     old "This can be found in 'List Devices'."
-    # Automatic translation.
-    new "Diese finden Sie unter \"Geräte auflisten\"."
+    new "Dies kannst Du unter \"Geräte auflisten\" finden."
 
     # game/android.rpy:628
     old "Cleaning up Android project."
@@ -1417,19 +1371,19 @@
     # game/androidstrings.rpy:10
     old "Run configure before attempting to build the app."
     # Automatic translation.
-    new "Führen Sie configure aus, bevor Sie versuchen, die Anwendung zu erstellen."
+    new "Führe \"Konfigurieren\" aus, bevor Du versuchst, die Anwendung zu erstellen."
 
     # game/androidstrings.rpy:11
     old "Updating project."
-    new "Aktualisiert Projekt."
+    new "Aktualisiere Projekt."
 
     # game/androidstrings.rpy:12
     old "Creating assets directory."
-    new "Erstellt Asset-Verzeichnis."
+    new "Erstelle Asset-Verzeichnis."
 
     # game/androidstrings.rpy:13
     old "Packaging internal data."
-    new "Verpackt interne Daten."
+    new "Packe interne Daten."
 
     # game/androidstrings.rpy:14
     old "I'm using Gradle to build the package."
@@ -1449,7 +1403,7 @@
 
     # game/androidstrings.rpy:18
     old "Launching app."
-    new "Startet App."
+    new "Starte App."
 
     # game/androidstrings.rpy:19
     old "Launching the app appears to have failed."
@@ -1461,11 +1415,11 @@
 
     # game/androidstrings.rpy:21
     old "What is the full name of your application? This name will appear in the list of installed applications."
-    new "Was ist der vollständige Name Ihrer Applikation? Dieser Name wird in der Liste von installierten Anwendungen erscheinen."
+    new "Was ist der vollständige Name Deiner Applikation? Dieser Name wird in der Liste der installierten Anwendungen erscheinen."
 
     # game/androidstrings.rpy:22
     old "What is the short name of your application? This name will be used in the launcher, and for application shortcuts."
-    new "Was ist der Kurzname Ihrer Applikation? Dieser Name wird im Launcher und für Anwendungsverknüpfungen verwendet."
+    new "Was ist der Kurzname Deiner Applikation? Dieser Name wird im Launcher und für Anwendungsverknüpfungen verwendet."
 
     # game/androidstrings.rpy:23
     old "What is the name of the package?\n\nThis is usually of the form com.domain.program or com.domain.email.program. It may only contain ASCII letters and dots. It must contain at least one dot."
@@ -1504,8 +1458,7 @@
 
     # game/androidstrings.rpy:30
     old "What is the application's version?\n\nThis should be the human-readable version that you would present to a person. It must contain only numbers and dots."
-    # Automatic translation.
-    new "Wie lautet die Version der Anwendung?\n\nDies sollte die für Menschen lesbare Version sein, die Sie einer Person vorlegen würden. Sie darf nur Zahlen und Punkte enthalten."
+    new "Wie lautet die Version der Anwendung?\n\nDies sollte eine für Menschen lesbare Version sein, die Du einer Person mitteilen kannst. Sie darf nur Zahlen und Punkte enthalten."
 
     # game/androidstrings.rpy:31
     old "The version number must contain only numbers and dots."
@@ -1514,8 +1467,7 @@
 
     # game/androidstrings.rpy:32
     old "How much RAM do you want to allocate to Gradle?\n\nThis must be a positive integer number."
-    # Automatic translation.
-    new "Wie viel RAM wollen Sie Gradle zuweisen?\n\nDies muss eine positive ganze Zahl sein."
+    new "Wieviel RAM willst Du Gradle zuweisen?\n\nDies muss eine positive ganze Zahl sein."
 
     # game/androidstrings.rpy:33
     old "The RAM size must contain only numbers."
@@ -1524,8 +1476,7 @@
 
     # game/androidstrings.rpy:34
     old "How would you like your application to be displayed?"
-    # Automatic translation.
-    new "Wie möchten Sie, dass Ihre Bewerbung angezeigt wird?"
+    new "In welchem Format soll dein Programm angezeigt werden?"
 
     # game/androidstrings.rpy:35
     old "In landscape orientation."
@@ -1544,13 +1495,11 @@
 
     # game/androidstrings.rpy:38
     old "Do you want to automatically update the Java source code?"
-    # Automatic translation.
-    new "Möchten Sie den Java-Quellcode automatisch aktualisieren?"
+    new "Möchtest Du den Java-Quellcode automatisch aktualisieren?"
 
     # game/androidstrings.rpy:39
     old "Yes. This is the best choice for most projects."
-    # Automatic translation.
-    new "Ja, dies ist die beste Wahl für die meisten Projekte."
+    new "Ja. Dies ist die beste Wahl für die meisten Projekte."
 
     # game/androidstrings.rpy:40
     old "No. This may require manual updates when Ren'Py or the project configuration changes."
@@ -1564,18 +1513,15 @@
 
     # game/androidstrings.rpy:42
     old "I'm compiling a short test program, to see if you have a working JDK on your system."
-    # Automatic translation.
-    new "Ich kompiliere ein kurzes Testprogramm, um zu sehen, ob Sie ein funktionierendes JDK auf Ihrem System haben."
+    new "Ich kompiliere ein kurzes Testprogramm, um zu sehen, ob Du ein funktionierendes JDK auf Deinem System hast."
 
     # game/androidstrings.rpy:43
     old "I was unable to use javac to compile a test file. If you haven't installed the Java Development Kit yet, please download it from:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nThe JDK is different from the JRE, so it's possible you have Java without having the JDK. Please make sure you installed the 'JavaSoft (Oracle) registry keys'.\n\nWithout a working JDK, I can't continue."
-    # Automatic translation.
-    new "Es ist mir nicht gelungen, mit javac eine Testdatei zu kompilieren. Wenn Sie das Java Development Kit noch nicht installiert haben, laden Sie es bitte herunter von:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nDas JDK unterscheidet sich von der JRE, so dass es möglich ist, dass Sie Java haben, ohne das JDK zu haben. Bitte vergewissern Sie sich, dass Sie die 'JavaSoft (Oracle) Registrierungsschlüssel' installiert haben.\n\nOhne ein funktionierendes JDK kann ich nicht weitermachen."
+    new "Es ist mir nicht gelungen, mit javac eine Testdatei zu kompilieren. Wenn Du das Java Development Kit (JDK) noch nicht installiert hast, lade es bitte herunter:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nDas JDK unterscheidet sich von der JRE, so dass es möglich ist, dass Du Java hast, ohne das JDK zu haben. Bitte vergewissere Dich, dass Du die 'JavaSoft (Oracle) registry keys' installiert hast.\n\nOhne ein funktionierendes JDK kann ich nicht weitermachen."
 
     # game/androidstrings.rpy:44
     old "The version of Java on your computer does not appear to be JDK 8, which is the only version supported by the Android SDK. If you need to install JDK 8, you can download it from:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nYou can also set the JAVA_HOME environment variable to use a different version of Java."
-    # Automatic translation.
-    new "Die Java-Version auf Ihrem Computer scheint nicht JDK 8 zu sein. Dies ist die einzige Version, die vom Android SDK unterstützt wird. Wenn Sie JDK 8 installieren müssen, können Sie es von herunterladen:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nSie können auch die Umgebungsvariable JAVA_HOME setzen, um eine andere Version von Java zu verwenden."
+    new "Die Java-Version auf Deinem Computer scheint nicht JDK 8 zu sein. Dies ist die einzige Version, die vom Android SDK unterstützt wird. Wenn Du JDK 8 installieren musst, kannst Du es hier herunterladen:\n\n{a=https://adoptium.net/?variant=openjdk8}https://adoptium.net/?variant=openjdk8{/a}\n\nDu kannst auch die Umgebungsvariable JAVA_HOME setzen, um eine andere Version von Java zu verwenden."
 
     # game/androidstrings.rpy:45
     old "The JDK is present and working. Good!"
@@ -1589,8 +1535,7 @@
 
     # game/androidstrings.rpy:47
     old "Do you accept the Android SDK Terms and Conditions?"
-    # Automatic translation.
-    new "Akzeptieren Sie die Allgemeinen Geschäftsbedingungen für das Android SDK?"
+    new "Akzeptierst Du die Allgemeinen Geschäftsbedingungen für das Android SDK?"
 
     # game/androidstrings.rpy:48
     old "I'm downloading the Android SDK. This might take a while."
@@ -1629,68 +1574,55 @@
 
     # game/androidstrings.rpy:56
     old "Please enter your name or the name of your organization."
-    # Automatic translation.
-    new "Bitte geben Sie Ihren Namen oder den Namen Ihrer Organisation ein."
+    new "Bitte gib Deinen Namen oder den Namen Deiner Organisation ein."
 
     # game/androidstrings.rpy:57
     old "I can create an application signing key for you. This key is required to create Universal APK for sideloading and stores other than Google Play.\n\nDo you want to create a key?"
-    # Automatic translation.
-    new "Ich kann einen Anwendungssignierungsschlüssel für Sie erstellen. Dieser Schlüssel ist erforderlich, um Universal APK für Sideloading und andere Stores als Google Play zu erstellen.\n\nMöchten Sie einen Schlüssel erstellen?"
+    new "Ich kann einen Schlüssel zur Signierung der Anwendung für Dich erstellen. Dieser Schlüssel ist erforderlich, um Universal APK für Sideloading und andere Stores als Google Play zu erstellen.\n\nSoll ich einen Schlüssel erstellen?"
 
     # game/androidstrings.rpy:58
     old "I will create the key in the android.keystore file.\n\nYou need to back this file up. If you lose it, you will not be able to upgrade your application.\n\nYou also need to keep the key safe. If evil people get this file, they could make fake versions of your application, and potentially steal your users' data.\n\nWill you make a backup of android.keystore, and keep it in a safe place?"
-    # Automatic translation.
-    new "Ich werde den Schlüssel in der Datei android.keystore erstellen.\n\nSie müssen diese Datei sichern. Wenn Sie sie verlieren, können Sie Ihre Anwendung nicht aktualisieren.\n\nAußerdem müssen Sie den Schlüssel sicher aufbewahren. Wenn böse Menschen diese Datei erhalten, könnten sie gefälschte Versionen Ihrer Anwendung erstellen und möglicherweise die Daten Ihrer Benutzer stehlen.\n\nWerden Sie eine Sicherungskopie von android.keystore erstellen und diese an einem sicheren Ort aufbewahren?"
+    new "Ich werde den Schlüssel in der Datei android.keystore erstellen.\n\nDu musst diese Datei sichern. Wenn Du sie verlierst, kannst Du Deine Anwendung nicht aktualisieren.\n\nAußerdem musst Du den Schlüssel sicher aufbewahren. Wenn Menschen mit bösen Absichten diese Datei erhalten, könnten sie gefälschte Versionen Deiner Anwendung erstellen und möglicherweise die Daten Deiner Benutzer stehlen.\n\nWirst Du eine Sicherungskopie von android.keystore erstellen und diese an einem sicheren Ort aufbewahren?"
 
     # game/androidstrings.rpy:59
     old "Could not create android.keystore. Is keytool in your path?"
-    # Automatic translation.
-    new "Konnte android.keystore nicht erstellen. Ist keytool in Ihrem Pfad?"
+    new "Konnte android.keystore nicht erstellen. Ist keytool in Deinem Pfad?"
 
     # game/androidstrings.rpy:60
     old "I've finished creating android.keystore. Please back it up, and keep it in a safe place."
-    # Automatic translation.
-    new "Ich habe die Erstellung von android.keystore abgeschlossen. Bitte sichern Sie ihn und bewahren Sie ihn an einem sicheren Ort auf."
+    new "Ich habe die Erstellung von android.keystore abgeschlossen. Bitte mach eine Kopie und bewahren sie an einem sicheren Ort auf."
 
     # game/androidstrings.rpy:61
     old "I can create a bundle signing key for you. This key is required to build an Android App Bundle (AAB) for upload to Google Play.\n\nDo you want to create a key?"
-    # Automatic translation.
-    new "Ich kann einen Bundle-Signierungsschlüssel für Sie erstellen. Dieser Schlüssel wird benötigt, um ein Android App Bundle (AAB) für den Upload zu Google Play zu erstellen.\n\nMöchten Sie einen Schlüssel erstellen?"
+    new "Ich kann einen Bundle-Signierungsschlüssel für Dich erstellen. Dieser Schlüssel wird benötigt, um ein Android App Bundle (AAB) für den Upload zu Google Play zu erstellen.\n\nSoll ich einen Schlüssel erstellen?"
 
     # game/androidstrings.rpy:62
     old "I will create the key in the bundle.keystore file.\n\nYou need to back this file up. If you lose it, you will not be able to upgrade your application.\n\nYou also need to keep the key safe. If evil people get this file, they could make fake versions of your application, and potentially steal your users' data.\n\nWill you make a backup of bundle.keystore, and keep it in a safe place?"
-    # Automatic translation.
-    new "Ich werde den Schlüssel in der Datei bundle.keystore erstellen.\n\nSie müssen diese Datei sichern. Wenn Sie sie verlieren, können Sie Ihre Anwendung nicht aktualisieren.\n\nAußerdem müssen Sie den Schlüssel sicher aufbewahren. Wenn böse Menschen diese Datei erhalten, könnten sie gefälschte Versionen Ihrer Anwendung erstellen und möglicherweise die Daten Ihrer Benutzer stehlen.\n\nWerden Sie eine Sicherungskopie von bundle.keystore erstellen und diese an einem sicheren Ort aufbewahren?"
+    new "Ich werde den Schlüssel in der Datei bundle.keystore erstellen.\n\nDu musst diese Datei sichern. Wenn Du sie verlierst, kannst Du Deine Anwendung nicht aktualisieren.\n\nAußerdem musst Du den Schlüssel sicher aufbewahren. Wenn Menschen mit bösen Absichten diese Datei erhalten, könnten sie gefälschte Versionen Deiner Anwendung erstellen und möglicherweise die Daten Deiner Benutzer stehlen.\n\nWirst Du eine Sicherungskopie von bundle.keystore erstellen und diese an einem sicheren Ort aufbewahren?"
 
     # game/androidstrings.rpy:63
     old "Could not create bundle.keystore. Is keytool in your path?"
-    # Automatic translation.
-    new "Bundle.keystore konnte nicht erstellt werden. Befindet sich keytool in Ihrem Pfad?"
+    new "Konnte bundle.keystore nicht erstellen. Ist keytool in Deinem Pfad?"
 
     # game/androidstrings.rpy:64
     old "I've opened the directory containing android.keystore and bundle.keystore. Please back them up, and keep them in a safe place."
-    # Automatic translation.
-    new "Ich habe das Verzeichnis mit android.keystore und bundle.keystore geöffnet. Sichern Sie sie bitte und bewahren Sie sie an einem sicheren Ort auf."
+    new "Ich habe das Verzeichnis mit android.keystore und bundle.keystore geöffnet. Bitte mach jeweils eine Kopie und bewahre sie an einem sicheren Ort auf."
 
     # game/androidstrings.rpy:65
     old "It looks like you're ready to start packaging games."
-    # Automatic translation.
-    new "Es sieht so aus, als ob Sie bereit wären, mit dem Verpacken von Spielen zu beginnen."
+    new "Es sieht so aus, als ob Du jetzt bereit bist, mit dem Verpacken von Spielen zu beginnen."
 
     # game/choose_directory.rpy:67
     old "Select Projects Directory"
-    # Automatic translation.
-    new "Verzeichnis der Projekte auswählen"
+    new "Projectverzeichnis auswählen"
 
     # game/choose_directory.rpy:79
     old "The selected projects directory is not writable."
-    # Automatic translation.
-    new "Das ausgewählte Projektverzeichnis ist nicht beschreibbar."
+    new "Das ausgewählte Projektverzeichnis hat keine Schreibrechte."
 
     # game/choose_theme.rpy:508
     old "changing the theme"
-    # Automatic translation.
-    new "Änderung des Themas"
+    new "Änderung des Designs"
 
     # game/distribute.rpy:1217
     old "Signing the Macintosh application...\n(This may take a long time.)"
@@ -1699,8 +1631,7 @@
 
     # game/distribute.rpy:1674
     old "Copying files..."
-    # Automatic translation.
-    new "Kopieren von Dateien..."
+    new "Kopiere Dateien..."
 
     # game/distribute_gui.rpy:157
     old "Build Distributions: [project.current.display_name!q]"
@@ -1719,7 +1650,7 @@
     # game/dmgcheck.rpy:50
     old "This is probably because Ren'Py is running directly from a Macintosh drive image. To fix this, quit this launcher, copy the entire %s folder somewhere else on your computer, and run Ren'Py again."
     # Automatic translation.
-    new "Das liegt wahrscheinlich daran, dass Ren'Py direkt von einem Macintosh-Laufwerk-Image gestartet wird. Um dies zu beheben, beenden Sie dieses Startprogramm, kopieren Sie den gesamten Ordner %s an einen anderen Ort auf Ihrem Computer und starten Sie Ren'Py erneut."
+    new "Das liegt wahrscheinlich daran, dass Ren'Py direkt von einem Macintosh-Laufwerk-Image gestartet wird. Um dies zu beheben, beende dieses Startprogramm, kopiere den gesamten Ordner %s an einen anderen Ort auf Deinem Computer und starte Ren'Py erneut."
 
     # game/editor.rpy:152
     old "A modern editor with many extensions including advanced Ren'Py integration."
@@ -1736,7 +1667,7 @@
 
     # game/editor.rpy:162
     old "Up to 110 MB download required."
-    new "Erfordert herunterladen von bis zu 110 MB."
+    new "Erfordert das Herunterladen von bis zu 110 MB."
 
     # game/editor.rpy:175
     old "A modern and approachable text editor."
@@ -1748,7 +1679,7 @@
 
     # game/editor.rpy:187
     old "Up to 150 MB download required."
-    new "Erfordert herunterladen von bis zu 150 MB."
+    new "Erfordert das Herunterladen von bis zu 150 MB."
 
     # game/editor.rpy:200
     old "jEdit"
@@ -1805,7 +1736,7 @@
 
     # game/gui7.rpy:350
     old "Please enter the width of your game, in pixels."
-    new "Bitte tragen Sie die Breite des Spiels (in Pixel) ein."
+    new "Bitte trag die Breite des Spiels (in Pixel) ein."
 
     # game/gui7.rpy:360
     old "The width must be a number."
@@ -1817,7 +1748,7 @@
 
     # game/gui7.rpy:366
     old "Please enter the height of your game, in pixels."
-    new "Bitte tragen Sie die Höhe des Spiels (in Pixel) ein."
+    new "Bitte trag die Höhe des Spiels (in Pixel) ein."
 
     # game/gui7.rpy:376
     old "The height must be a number."
@@ -1825,13 +1756,11 @@
 
     # game/gui7.rpy:424
     old "creating a new project"
-    # Automatic translation.
-    new "ein neues Projekt erstellen"
+    new "Erstelle neues Projekt"
 
     # game/gui7.rpy:428
     old "activating the new project"
-    # Automatic translation.
-    new "Aktivierung des neuen Projekts"
+    new "Aktiviere das neue Projekt"
 
     # game/install.rpy:33
     old "Could not install [name!t], as a file matching [zipglob] was not found in the Ren'Py SDK directory."
@@ -1851,7 +1780,7 @@
 
     # game/install.rpy:129
     old "Before installing Steam support, please make sure you are a {a=https://partner.steamgames.com/}Steam partner{/a}."
-    new "Stellen Sie sicher, dass sie ein {a=https://partner.steamgames.com/}Steam Partner{/a} sind, bevor Sie Steam-Support installieren."
+    new "Stell sicher, dass Du ein {a=https://partner.steamgames.com/}Steam Partner{/a} bist, bevor Du Steam-Support installierst."
 
     # game/install.rpy:141
     old "Steam support has already been installed."
@@ -1867,7 +1796,7 @@
 
     # game/install.rpy:185
     old "The {a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} adds support for displaying Live2D models. Place CubismSdkForNative-4-{i}version{/i}.zip in the Ren'Py SDK directory, and then click Install. Distributing a game with Live2D requires you to accept a license from Live2D, Inc."
-    new "Die {a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} fügt Support für Live2D-Modelle hinzu. Platzieren Sie CubismSdkForNative-4-{i}version{/i}.zip in das Ren'Py SDK-Verzeichnis, und klicken Sie auf  \"Install\". Ein game mit Live2D zu veröffentlichen erfordert das Akzeptieren einer Lizenz von Live2D, Inc."
+    new "Die {a=https://www.live2d.com/en/download/cubism-sdk/download-native/}Cubism SDK for Native{/a} fügt Support für Live2D-Modelle hinzu. Platziere CubismSdkForNative-4-{i}version{/i}.zip in das Ren'Py SDK-Verzeichnis, und klicke auf \"Install\". Ein Spiel mit Live2D zu veröffentlichen erfordert das Akzeptieren einer Lizenz von Live2D, Inc."
 
     # game/install.rpy:189
     old "Live2D in Ren'Py doesn't support the Web, Android x86_64 (including emulators and Chrome OS), and must be added to iOS projects manually. Live2D must be reinstalled after upgrading Ren'Py or installing Android support."
@@ -1933,7 +1862,7 @@
 
     # game/preferences.rpy:227
     old "Daily check for update"
-    new "Täglich nach Updates schauen"
+    new "Täglich auf Updates prüfen"
 
     # game/preferences.rpy:246
     old "Launcher Theme:"
@@ -1969,20 +1898,19 @@
 
     # game/preferences.rpy:308
     old "Cleaning temporary files..."
-    new "Säubert Temporäre Dateien..."
+    new "Säubere temporäre Dateien..."
 
     # game/preferences.rpy:338
     old "{#in language font}Welcome! Please choose a language"
-    new "{#in language font}Willkommen! Bitte wählen Sie eine Sprache"
+    new "{#in language font}Willkommen! Bitte wähle eine Sprache"
 
     # game/preferences.rpy:373
     old "{#in language font}Start using Ren'Py in [lang_name]"
-    new "{#in language font}Beginnen, Ren'Py auf [lang_name] zu benutzen"
+    new "{#in language font}Benutze Ren'Py auf [lang_name]"
 
     # game/project.rpy:280
     old "This may be because the project is not writeable."
-    # Automatic translation.
-    new "Dies kann daran liegen, dass das Projekt nicht beschreibbar ist."
+    new "Dies kann daran liegen, dass für das Projekt keine Schreibrechte existieren."
 
     # game/translations.rpy:91
     old "Translations: [project.current.display_name!q]"
@@ -2018,13 +1946,11 @@
 
     # game/updater.rpy:77
     old "Nightly (Ren'Py 8, Python 3)"
-    # Automatic translation.
-    new "Nächtlich (Ren'Py 8, Python 3)"
+    new "Nightly (Ren'Py 8, Python 3)"
 
     # game/updater.rpy:78
     old "Nightly (Ren'Py 7, Python 2)"
-    # Automatic translation.
-    new "Nächtlich (Ren'Py 7, Python 2)"
+    new "Nightly (Ren'Py 7, Python 2)"
 
     # game/updater.rpy:107
     old "The update channel controls the version of Ren'Py the updater will download."
@@ -2047,7 +1973,7 @@
 
     # game/updater.rpy:135
     old "%B %d, %Y"
-    new "%B %d, %Y"
+    new "%d. %B %Y"
 
     # game/updater.rpy:214
     old "Fetching the list of update channels"
@@ -2074,11 +2000,11 @@
 
     # game/web.rpy:308
     old "Build and Open in Browser"
-    new "Erstellen und in Browser öffnen"
+    new "Erstellen und im Browser öffnen"
 
     # game/web.rpy:309
     old "Open in Browser"
-    new "In Browser öffnen"
+    new "Im Browser öffnen"
 
     # game/web.rpy:310
     old "Open build directory"
@@ -2087,7 +2013,7 @@
     # game/web.rpy:332
     old "Images and music can be downloaded while playing. A 'progressive_download.txt' file will be created so you can configure this behavior."
     # Automatic translation.
-    new "Bilder und Musik können während der Wiedergabe heruntergeladen werden. Es wird eine Datei \"progressive_download.txt\" erstellt, in der Sie dieses Verhalten konfigurieren können."
+    new "Bilder und Musik können während der Wiedergabe heruntergeladen werden. Es wird eine Datei \"progressive_download.txt\" erstellt, in der Du dieses Verhalten konfigurieren kannst."
 
     # game/web.rpy:336
     old "Current limitations in the web platform mean that loading large images may cause audio or framerate glitches, and lower performance in general. Movies aren't supported."
@@ -2105,14 +2031,14 @@
     # game/web.rpy:348
     old "Before packaging web apps, you'll need to download RenPyWeb, Ren'Py's web support. Would you like to download RenPyWeb now?"
     # Automatic translation.
-    new "Bevor Sie Webanwendungen paketieren können, müssen Sie RenPyWeb herunterladen, die Webunterstützung von Ren'Py. Möchten Sie RenPyWeb jetzt herunterladen?"
+    new "Bevor Du Webanwendungen erstellen kannst, musst Du RenPyWeb herunterladen, die Webunterstützung von Ren'Py. Möchtest Du RenPyWeb jetzt herunterladen?"
 
 translate german strings:
 
     # game/android.rpy:39
     old "RAPT has been installed, but a key hasn't been configured. Please generate new keys, or copy android.keystore and bundle.keystore to the base directory."
     # Automatic translation.
-    new "RAPT wurde installiert, aber ein Schlüssel wurde nicht konfiguriert. Bitte erzeugen Sie neue Schlüssel, oder kopieren Sie android.keystore und bundle.keystore in das Basisverzeichnis."
+    new "RAPT wurde installiert, aber ein Schlüssel wurde nicht konfiguriert. Bitte erzeuge neue Schlüssel, oder kopiere android.keystore und bundle.keystore in das Basisverzeichnis."
 
     # game/android.rpy:46
     old "Attempts to emulate a televison-based Android console.\n\nController input is mapped to the arrow keys, Enter is mapped to the select button, Escape is mapped to the menu button, and PageUp is mapped to the back button."
@@ -2141,8 +2067,7 @@ translate german strings:
 
     # game/androidstrings.rpy:32
     old "How much RAM (in GB) do you want to allocate to Gradle?\nThis must be a positive integer number."
-    # Automatic translation.
-    new "Wie viel RAM (in GB) wollen Sie Gradle zuweisen?\nDies muss eine positive ganze Zahl sein."
+    new "Wie viel RAM (in GB) willst Du Gradle zuweisen?\nDies muss eine positive ganze Zahl sein."
 
     # game/androidstrings.rpy:33
     old "The RAM size must contain only numbers and be positive."
@@ -2152,7 +2077,7 @@ translate german strings:
     # game/androidstrings.rpy:38
     old "Which app store would you like to support in-app purchasing through?"
     # Automatic translation.
-    new "Über welchen App-Store möchten Sie In-App-Käufe unterstützen?"
+    new "Über welchen App-Store möchtest Du In-App-Käufe unterstützen?"
 
     # game/androidstrings.rpy:39
     old "Google Play."
@@ -2184,8 +2109,7 @@ translate german strings:
 
     # game/androidstrings.rpy:69
     old "I found a bundle.keystore file in the rapt directory. Do you want to use this file?"
-    # Automatic translation.
-    new "Ich habe eine bundle.keystore-Datei im rapt-Verzeichnis gefunden. Möchten Sie diese Datei verwenden?"
+    new "Ich habe eine bundle.keystore-Datei im rapt-Verzeichnis gefunden. Soll ich diese Datei verwenden?"
 
     # game/distribute_gui.rpy:231
     old "(DLC)"
@@ -2193,18 +2117,15 @@ translate german strings:
 
     # game/project.rpy:46
     old "Lint checks your game for potential mistakes, and gives you statistics."
-    # Automatic translation.
-    new "Lint prüft Ihr Spiel auf mögliche Fehler und liefert Ihnen Statistiken."
+    new "Lint prüft Dein Spiel auf mögliche Fehler und liefert Dir Statistiken."
 
     # game/web.rpy:485
     old "Creating package..."
-    # Automatic translation.
-    new "Paket erstellen..."
+    new "Erstelle Paket..."
 
 
 translate german strings:
 
     # game/updater.rpy:79
     old "A nightly build of fixes to the release version of Ren'Py."
-    # Automatic translation.
-    new "Ein nächtlicher Build mit Korrekturen für die Release-Version von Ren'Py."
+    new "Ein nightly Build mit Korrekturen für die Release-Version von Ren'Py."

--- a/launcher/game/tl/german/options.rpy
+++ b/launcher/game/tl/german/options.rpy
@@ -8,8 +8,7 @@ translate german strings:
 
     # options.rpy:4
     old "## Lines beginning with two '#' marks are comments, and you shouldn't uncomment them. Lines beginning with a single '#' mark are commented-out code, and you may want to uncomment them when appropriate."
-    # Automatic translation.
-    new "## Zeilen, die mit zwei '#' beginnen, sind Kommentare und sollten nicht auskommentiert werden. Zeilen, die mit einem einzelnen '#' beginnen, sind auskommentierter Code, den Sie ggf. auskommentieren sollten."
+    new "## Zeilen, die mit zwei '#' beginnen, sind Kommentare und sollten nicht auskommentiert werden. Zeilen, die mit einem einzelnen '#' beginnen, sind auskommentierter Code, den Du ggf. auskommentieren kannst."
 
     # options.rpy:10
     old "## Basics"
@@ -33,8 +32,7 @@ translate german strings:
 
     # options.rpy:20
     old "## Determines if the title given above is shown on the main menu screen. Set this to False to hide the title."
-    # Automatic translation.
-    new "## Bestimmt, ob der oben angegebene Titel auf dem Hauptmenübildschirm angezeigt wird. Setzen Sie dies auf False, um den Titel auszublenden."
+    new "## Bestimmt, ob der oben angegebene Titel auf dem Hauptmenübildschirm angezeigt wird. Setze dies auf False, um den Titel auszublenden."
 
     # options.rpy:26
     old "## The version of the game."
@@ -44,7 +42,7 @@ translate german strings:
     # options.rpy:31
     old "## Text that is placed on the game's about screen. To insert a blank line between paragraphs, write \\n\\n."
     # Automatic translation.
-    new "## Text, der auf dem Info-Bildschirm des Spiels erscheint. Um eine Leerzeile zwischen Absätzen einzufügen, schreiben Sie \\n\\n."
+    new "## Text, der auf dem Info-Bildschirm des Spiels erscheint. Um eine Leerzeile zwischen Absätzen einzufügen, schreibe \\n\\n."
 
     # options.rpy:37
     old "## A short name for the game used for executables and directories in the built distribution. This must be ASCII-only, and must not contain spaces, colons, or semicolons."
@@ -53,8 +51,7 @@ translate german strings:
 
     # options.rpy:44
     old "## Sounds and music"
-    # Automatic translation.
-    new "## Klänge und Musik"
+    new "## Ton und Musik"
 
     # options.rpy:46
     old "## These three variables control which mixers are shown to the player by default. Setting one of these to False will hide the appropriate mixer."
@@ -63,13 +60,11 @@ translate german strings:
 
     # options.rpy:55
     old "## To allow the user to play a test sound on the sound or voice channel, uncomment a line below and use it to set a sample sound to play."
-    # Automatic translation.
-    new "## Um dem Benutzer die Möglichkeit zu geben, einen Testton auf dem Ton- oder Sprachkanal abzuspielen, entfernen Sie die Kommentarzeichen in der Zeile unten und verwenden Sie sie, um einen Beispielton abzuspielen."
+    new "## Um dem Benutzer die Möglichkeit zu geben, einen Testton auf dem Ton- oder Sprachkanal abzuspielen, entfernen die Kommentarzeichen in der Zeile unten und verwenden sie, um einen Beispielton abzuspielen."
 
     # options.rpy:62
     old "## Uncomment the following line to set an audio file that will be played while the player is at the main menu. This file will continue playing into the game, until it is stopped or another file is played."
-    # Automatic translation.
-    new "## Uncomment the following line to set an audio file that will be played while the player is at the main menu. Diese Datei wird im Spiel weiter abgespielt, bis sie gestoppt wird oder eine andere Datei abgespielt wird."
+    new "## Entferne das Kommentarzeichen in der folgenden Zeile, damit im Hauptmenü eine Audiodatei abgespielt wird. Diese wird im Spiel so lange weiterlaufen, bis sie gestoppt wird oder eine andere Datei abgespielt wird."
 
     # options.rpy:69
     old "## Transitions"
@@ -98,8 +93,7 @@ translate german strings:
 
     # options.rpy:91
     old "## A variable to set the transition used when the game starts does not exist. Instead, use a with statement after showing the initial scene."
-    # Automatic translation.
-    new "## Eine Variable zum Festlegen des Übergangs, der beim Start des Spiels verwendet wird, existiert nicht. Verwenden Sie stattdessen eine with-Anweisung, nachdem Sie die Anfangsszene gezeigt haben."
+    new "## Eine Variable zum Festlegen des Übergangs, der beim Start des Spiels verwendet wird, existiert nicht. Verwende stattdessen eine with-Anweisung, nachdem Du die Anfangsszene gezeigt hast."
 
     # options.rpy:96
     old "## Window management"
@@ -123,8 +117,7 @@ translate german strings:
 
     # options.rpy:115
     old "## Preference defaults"
-    # Automatic translation.
-    new "## Präferenzvorgaben"
+    new "## Standardwerte für Einstellungen"
 
     # options.rpy:117
     old "## Controls the default text speed. The default, 0, is infinite, while any other number is the number of characters per second to type out."
@@ -134,7 +127,7 @@ translate german strings:
     # options.rpy:123
     old "## The default auto-forward delay. Larger numbers lead to longer waits, with 0 to 30 being the valid range."
     # Automatic translation.
-    new "## Die Standardverzögerung für die automatische Weiterleitung. Größere Zahlen führen zu längeren Wartezeiten, wobei 0 bis 30 der gültige Bereich ist."
+    new "## Die Standardverzögerung für das automatische Blättern. Größere Zahlen führen zu längeren Wartezeiten, wobei 0 bis 30 der gültige Bereich ist."
 
     # options.rpy:129
     old "## Save directory"
@@ -179,8 +172,7 @@ translate german strings:
 
     # options.rpy:155
     old "## This section controls how Ren'Py turns your project into distribution files."
-    # Automatic translation.
-    new "## Dieser Abschnitt steuert, wie Ren'Py Ihr Projekt in Distributionsdateien umwandelt."
+    new "## Dieser Abschnitt steuert, wie Ren'Py Dein Projekt in Distributionsdateien umwandelt."
 
     # options.rpy:160
     old "## The following functions take file patterns. File patterns are case- insensitive, and matched against the path relative to the base directory, with and without a leading /. If multiple patterns match, the first is used."
@@ -209,13 +201,11 @@ translate german strings:
 
     # options.rpy:177
     old "## Classify files as None to exclude them from the built distributions."
-    # Automatic translation.
-    new "## Klassifizieren Sie Dateien als None, um sie von den erstellten Distributionen auszuschließen."
+    new "## Klassifiziere Dateien als None, um sie von den erstellten Distributionen auszuschließen."
 
     # options.rpy:185
     old "## To archive files, classify them as 'archive'."
-    # Automatic translation.
-    new "## Um Dateien zu archivieren, klassifizieren Sie sie als \"Archiv\"."
+    new "## Um Dateien zu archivieren, klassifiziere sie als \"archive\"."
 
     # options.rpy:190
     old "## Files matching documentation patterns are duplicated in a mac app build, so they appear in both the app and the zip file."
@@ -224,8 +214,7 @@ translate german strings:
 
     # options.rpy:196
     old "## A Google Play license key is required to download expansion files and perform in-app purchases. It can be found on the \"Services & APIs\" page of the Google Play developer console."
-    # Automatic translation.
-    new "## Ein Google Play-Lizenzschlüssel ist erforderlich, um Erweiterungsdateien herunterzuladen und In-App-Käufe durchzuführen. Sie finden ihn auf der Seite \"Services & APIs\" in der Google Play-Entwicklerkonsole."
+    new "## Ein Google Play-Lizenzschlüssel ist erforderlich, um Erweiterungsdateien herunterzuladen und In-App-Käufe durchzuführen. Du findest ihn auf der Seite \"Services & APIs\" in der Google Play-Entwicklerkonsole."
 
     # options.rpy:203
     old "## The username and project name associated with an itch.io project, separated by a slash."
@@ -234,8 +223,7 @@ translate german strings:
 
     # gui/game/options.rpy:31
     old "## Text that is placed on the game's about screen. Place the text between the triple-quotes, and leave a blank line between paragraphs."
-    # Automatic translation.
-    new "## Text, der auf dem Info-Bildschirm des Spiels erscheint. Setzen Sie den Text zwischen die dreifachen Anführungszeichen und lassen Sie eine Leerzeile zwischen den Absätzen."
+    new "## Text, der auf dem Info-Bildschirm des Spiels erscheint. Setz den Text zwischen dreifache Anführungszeichen und lass eine Leerzeile zwischen den Absätzen."
 
     # gui/game/options.rpy:47
     old "## These three variables control, among other things, which mixers are shown to the player by default. Setting one of these to False will hide the appropriate mixer."
@@ -253,5 +241,4 @@ translate german strings:
 
     # gui/game/options.rpy:203
     old "## A Google Play license key is required to perform in-app purchases. It can be found in the Google Play developer console, under \"Monetize\" > \"Monetization Setup\" > \"Licensing\"."
-    # Automatic translation.
-    new "## Für In-App-Käufe ist ein Google Play-Lizenzschlüssel erforderlich. Sie finden ihn in der Google Play-Entwicklerkonsole unter \"Monetize\" > \"Monetization Setup\" > \"Licensing\"."
+    new "## Für In-App-Käufe ist ein Google Play-Lizenzschlüssel erforderlich. Du findest ihn in der Google Play-Entwicklerkonsole unter \"Monetize\" > \"Monetization Setup\" > \"Licensing\"."

--- a/launcher/game/tl/german/screens.rpy
+++ b/launcher/game/tl/german/screens.rpy
@@ -1,4 +1,4 @@
-﻿
+
 translate german strings:
 
     # screens.rpy:9
@@ -8,13 +8,11 @@ translate german strings:
 
     # screens.rpy:87
     old "## In-game screens"
-    # Automatic translation.
-    new "## Bildschirme im Spiel"
+    new "## Spielinterne Bildschirme (Screens)"
 
     # screens.rpy:91
     old "## Say screen"
-    # Automatic translation.
-    new "## Sagen Sie Bildschirm"
+    new "## Dialog-Bildschirm"
 
     # screens.rpy:93
     old "## The say screen is used to display dialogue to the player. It takes two parameters, who and what, which are the name of the speaking character and the text to be displayed, respectively. (The who parameter can be None if no name is given.)"
@@ -32,8 +30,7 @@ translate german strings:
 
     # screens.rpy:169
     old "## Input screen"
-    # Automatic translation.
-    new "## Eingabebildschirm"
+    new "## Eingabe-Bildschirm"
 
     # screens.rpy:171
     old "## This screen is used to display renpy.input. The prompt parameter is used to pass a text prompt in."
@@ -51,13 +48,11 @@ translate german strings:
 
     # screens.rpy:205
     old "## Choice screen"
-    # Automatic translation.
-    new "## Auswahlbildschirm"
+    new "## Auswahl- oder Entscheidungs-Bildschirm"
 
     # screens.rpy:207
     old "## This screen is used to display the in-game choices presented by the menu statement. The one parameter, items, is a list of objects, each with caption and action fields."
-    # Automatic translation.
-    new "## Dieser Bildschirm wird verwendet, um die Auswahlmöglichkeiten im Spiel anzuzeigen, die von der Menüanweisung präsentiert werden. Der eine Parameter, items, ist eine Liste von Objekten, jedes mit Beschriftung und Aktionsfeldern."
+    new "## Dieser Bildschirm wird verwendet, um die Auswahlmöglichkeiten im Spiel anzuzeigen, die von der Menüanweisung präsentiert werden. Der Parameter \"items\" ist eine Liste von Objekten, jedes mit Beschriftung und Aktionsfeldern."
 
     # screens.rpy:211
     old "## http://www.renpy.org/doc/html/screen_special.html#choice"
@@ -65,13 +60,11 @@ translate german strings:
 
     # screens.rpy:221
     old "## When this is true, menu captions will be spoken by the narrator. When false, menu captions will be displayed as empty buttons."
-    # Automatic translation.
-    new "## Wenn dies wahr ist, werden die Menübeschriftungen vom Sprecher gesprochen. Bei \"false\" werden die Menübeschriftungen als leere Schaltflächen angezeigt."
+    new "## Bei \"True\" werden die Menübeschriftungen vom Erzähler gesprochen. Bei \"False\" werden die Menübeschriftungen als leere Schaltflächen angezeigt."
 
     # screens.rpy:244
     old "## Quick Menu screen"
-    # Automatic translation.
-    new "## Bildschirm Schnellmenü"
+    new "## Schnellmenü-Bildschirm"
 
     # screens.rpy:246
     old "## The quick menu is displayed in-game to provide easy access to the out-of-game menus."
@@ -84,12 +77,11 @@ translate german strings:
 
     # screens.rpy:262
     old "History"
-    # Automatic translation.
-    new "Geschichte"
+    new "Dialogverlauf"
 
     # screens.rpy:263
     old "Skip"
-    new "Spulen"
+    new "Vorspulen"
 
     # screens.rpy:264
     old "Auto"
@@ -105,7 +97,7 @@ translate german strings:
 
     # screens.rpy:267
     old "Q.Load"
-    new "S. Laden"
+    new "S.Laden"
 
     # screens.rpy:268
     old "Prefs"
@@ -133,7 +125,7 @@ translate german strings:
     # screens.rpy:316
     old "Load"
     # Automatic translation.
-    new "Laden Sie"
+    new "Laden"
 
     # screens.rpy:318
     old "Preferences"
@@ -205,13 +197,11 @@ translate german strings:
 
     # screens.rpy:539
     old "## About screen"
-    # Automatic translation.
-    new "## Über den Bildschirm"
+    new "## Info-Bildschirm"
 
     # screens.rpy:541
     old "## This screen gives credit and copyright information about the game and Ren'Py."
-    # Automatic translation.
-    new "## Dieser Bildschirm enthält Kredit- und Copyright-Informationen über das Spiel und Ren'Py."
+    new "## Dieser Bildschirm enthält Würdigungen und Copyright-Informationen über das Spiel und Ren'Py."
 
     # screens.rpy:544
     old "## There's nothing special about this screen, and hence it also serves as an example of how to make a custom screen."
@@ -220,7 +210,6 @@ translate german strings:
 
     # screens.rpy:551
     old "## This use statement includes the game_menu screen inside this one. The vbox child is then included inside the viewport inside the game_menu screen."
-    # Automatic translation.
     new "## Diese Anweisung schließt den Bildschirm game_menu in diesen Bildschirm ein. Das vbox-Kind wird dann in das Viewport innerhalb des game_menu-Bildschirms aufgenommen."
 
     # screens.rpy:561
@@ -234,23 +223,20 @@ translate german strings:
 
     # screens.rpy:567
     old "Made with {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
-    # Automatic translation.
-    new "Hergestellt mit {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only] .\n\n[renpy.license!t]"
+    new "Erstellt mit {a=https://www.renpy.org/}Ren'Py{/a} [renpy.version_only].\n\n[renpy.license!t]"
 
     # screens.rpy:570
     old "## This is redefined in options.rpy to add text to the about screen."
-    # Automatic translation.
     new "## Dies wird in options.rpy neu definiert, um dem Info-Bildschirm Text hinzuzufügen."
 
     # screens.rpy:582
     old "## Load and Save screens"
-    # Automatic translation.
-    new "## Bildschirme laden und speichern"
+    new "## Spielstände-Bildschirm"
 
     # screens.rpy:584
     old "## These screens are responsible for letting the player save the game and load it again. Since they share nearly everything in common, both are implemented in terms of a third screen, file_slots."
     # Automatic translation.
-    new "## Diese Bildschirme sind dafür verantwortlich, dass der Spieler das Spiel speichern und wieder laden kann. Da sie fast alles gemeinsam haben, sind beide in Form eines dritten Bildschirms, file_slots, implementiert."
+    new "## Der load and save Bildschirm sind dafür verantwortlich, dass der Spieler das Spiel speichern und wieder laden kann. Da sie fast alles gemeinsam haben, sind beide in Form eines dritten Bildschirms, file_slots, implementiert."
 
     # screens.rpy:588
     old "## https://www.renpy.org/doc/html/screen_special.html#save https://www.renpy.org/doc/html/screen_special.html#load"
@@ -263,13 +249,11 @@ translate german strings:
 
     # screens.rpy:607
     old "Automatic saves"
-    # Automatic translation.
-    new "Automatisch speichern"
+    new "Automatische Speicherstände"
 
     # screens.rpy:607
     old "Quick saves"
-    # Automatic translation.
-    new "Schnelles Speichern"
+    new "Schnellspeicherstände"
 
     # screens.rpy:613
     old "## This ensures the input will get the enter event before any of the buttons do."
@@ -283,12 +267,11 @@ translate german strings:
 
     # screens.rpy:649
     old "{#file_time}%A, %B %d %Y, %H:%M"
-    new "{#file_time}%A, %B %d %Y, %H:%M"
+    new "{#file_time}%A, %d. %B %Y, %H:%M"
 
     # screens.rpy:649
     old "empty slot"
-    # Automatic translation.
-    new "leerer Steckplatz"
+    new "leerer Speicherplatz"
 
     # screens.rpy:657
     old "## Buttons to access other pages."
@@ -305,7 +288,7 @@ translate german strings:
 
     # screens.rpy:670
     old "{#quick_page}Q"
-    new "{#quick_page}Q"
+    new "{#quick_page}S"
 
     # screens.rpy:676
     old ">"
@@ -314,12 +297,12 @@ translate german strings:
     # screens.rpy:711
     old "## Preferences screen"
     # Automatic translation.
-    new "## Bildschirm Präferenzen"
+    new "## Einstellungs-Bildschirm"
 
     # screens.rpy:713
     old "## The preferences screen allows the player to configure the game to better suit themselves."
     # Automatic translation.
-    new "## Der Einstellungsbildschirm ermöglicht es dem Spieler, das Spiel so zu konfigurieren, dass es besser zu ihm passt."
+    new "## Der Einstellungs-Bildschirm ermöglicht es dem Spieler, das Spiel so zu konfigurieren, dass es besser zu ihm passt."
 
     # screens.rpy:716
     old "## https://www.renpy.org/doc/html/screen_special.html#preferences"
@@ -345,7 +328,7 @@ translate german strings:
     # screens.rpy:745
     old "Disable"
     # Automatic translation.
-    new "Deaktivieren Sie"
+    new "Deaktivieren"
 
     # screens.rpy:746
     old "Left"
@@ -359,12 +342,11 @@ translate german strings:
 
     # screens.rpy:752
     old "Unseen Text"
-    # Automatic translation.
-    new "Unsichtbarer Text"
+    new "Ungesehener Text"
 
     # screens.rpy:753
     old "After Choices"
-    new "Nach Auswahl"
+    new "Nach Entscheidungen"
 
     # screens.rpy:754
     old "Transitions"
@@ -389,7 +371,7 @@ translate german strings:
 
     # screens.rpy:785
     old "Sound Volume"
-    new "Soundlautstärke"
+    new "Geräuschlautstärke"
 
     # screens.rpy:791
     old "Test"
@@ -406,8 +388,7 @@ translate german strings:
 
     # screens.rpy:882
     old "## History screen"
-    # Automatic translation.
-    new "## Bildschirm Geschichte"
+    new "## Dialogverlauf-Bildschirm"
 
     # screens.rpy:884
     old "## This is a screen that displays the dialogue history to the player. While there isn't anything special about this screen, it does have to access the dialogue history stored in _history_list."
@@ -420,8 +401,7 @@ translate german strings:
 
     # screens.rpy:894
     old "## Avoid predicting this screen, as it can be very large."
-    # Automatic translation.
-    new "## Vermeiden Sie es, diesen Bildschirm vorherzusehen, da er sehr groß sein kann."
+    new "## Vermeide es, diesen Bildschirm via \"predict\" vorberechnen zu lassen, da er sehr groß sein kann."
 
     # screens.rpy:905
     old "## This lays things out properly if history_height is None."
@@ -430,8 +410,7 @@ translate german strings:
 
     # screens.rpy:914
     old "## Take the color of the who text from the Character, if set."
-    # Automatic translation.
-    new "## Übernimmt die Farbe des Wer-Textes aus dem Zeichen, falls festgelegt."
+    new "## Übernimmt die Farbe des who-Textes des Charakters, falls vorhanden."
 
     # screens.rpy:921
     old "The dialogue history is empty."
@@ -470,17 +449,17 @@ translate german strings:
     # screens.rpy:1004
     old "Advances dialogue and activates the interface."
     # Automatic translation.
-    new "Erweitert den Dialog und aktiviert die Schnittstelle."
+    new "Bringt den Dialog voran und aktiviert die Schnittstelle."
 
     # screens.rpy:1007
     old "Space"
     # Automatic translation.
-    new "Weltraum"
+    new "Leertaste"
 
     # screens.rpy:1008
     old "Advances dialogue without selecting choices."
     # Automatic translation.
-    new "Bringt den Dialog voran, ohne eine Auswahl zu treffen."
+    new "Bringt den Dialog voran ohne eine Auswahl zu treffen."
 
     # screens.rpy:1011
     old "Arrow Keys"
@@ -490,12 +469,12 @@ translate german strings:
     # screens.rpy:1012
     old "Navigate the interface."
     # Automatic translation.
-    new "Navigieren Sie durch die Schnittstelle."
+    new "Navigiert durch die Schnittstelle."
 
     # screens.rpy:1015
     old "Escape"
     # Automatic translation.
-    new "Flucht"
+    new "ESC"
 
     # screens.rpy:1016
     old "Accesses the game menu."
@@ -509,8 +488,7 @@ translate german strings:
 
     # screens.rpy:1020
     old "Skips dialogue while held down."
-    # Automatic translation.
-    new "Überspringt Dialoge, wenn Sie die Taste gedrückt halten."
+    new "Überspringt Dialoge, wenn Du die Taste gedrückt hältst."
 
     # screens.rpy:1023
     old "Tab"
@@ -519,27 +497,27 @@ translate german strings:
     # screens.rpy:1024
     old "Toggles dialogue skipping."
     # Automatic translation.
-    new "Schaltet das Überspringen von Dialogen ein."
+    new "Schaltet das Überspringen von Dialogen ein/aus."
 
     # screens.rpy:1027
     old "Page Up"
     # Automatic translation.
-    new "Seite oben"
+    new "Seite hoch"
 
     # screens.rpy:1028
     old "Rolls back to earlier dialogue."
     # Automatic translation.
-    new "Kehrt zu einem früheren Dialog zurück."
+    new "Springt zu einem früheren Dialog zurück."
 
     # screens.rpy:1031
     old "Page Down"
     # Automatic translation.
-    new "Seite unten"
+    new "Seite runter"
 
     # screens.rpy:1032
     old "Rolls forward to later dialogue."
     # Automatic translation.
-    new "Weiter geht's mit einem späteren Dialog."
+    new "Springt zu einem späteren Dialog vor."
 
     # screens.rpy:1036
     old "Hides the user interface."
@@ -554,12 +532,12 @@ translate german strings:
     # screens.rpy:1044
     old "Toggles assistive {a=https://www.renpy.org/l/voicing}self-voicing{/a}."
     # Automatic translation.
-    new "Schaltet das Hilfsmittel {a=https://www.renpy.org/l/voicing}selbststimmend{/a} um."
+    new "Schaltet unterstützende {a=https://www.renpy.org/l/voicing}Automatische Spracherzeugung{/a} ein/aus."
 
     # screens.rpy:1050
     old "Left Click"
     # Automatic translation.
-    new "Links klicken"
+    new "Linksklick"
 
     # screens.rpy:1054
     old "Middle Click"
@@ -573,8 +551,7 @@ translate german strings:
 
     # screens.rpy:1062
     old "Mouse Wheel Up"
-    # Automatic translation.
-    new "Mausrad nach oben\nKlicken Sie auf Rollback Seite"
+    new "Mausrad nach oben\nKlicke auf Rollback Seite"
 
     # screens.rpy:1066
     old "Mouse Wheel Down"
@@ -589,12 +566,12 @@ translate german strings:
     # screens.rpy:1074
     old "Advance dialogue and activates the interface."
     # Automatic translation.
-    new "Erweitert den Dialog und aktiviert die Schnittstelle."
+    new "Springt zu einem späteren Dialog vor und aktiviert die Schnittstelle."
 
     # screens.rpy:1078
     old "Roll back to earlier dialogue."
     # Automatic translation.
-    new "Gehen Sie zu einem früheren Dialog zurück."
+    new "Springt zu einem früheren Dialog zurück."
 
     # screens.rpy:1081
     old "Right Shoulder"
@@ -603,8 +580,7 @@ translate german strings:
 
     # screens.rpy:1082
     old "Roll forward to later dialogue."
-    # Automatic translation.
-    new "Spulen Sie vor zu einem späteren Dialog."
+    new "Spult zu einem späteren Dialog vor."
 
     # screens.rpy:1085
     old "D-Pad, Sticks"
@@ -617,8 +593,7 @@ translate german strings:
 
     # screens.rpy:1090
     old "Access the game menu."
-    # Automatic translation.
-    new "Rufen Sie das Spielmenü auf."
+    new "Ruft das Spielmenü auf."
 
     # screens.rpy:1093
     old "Y/Top Button"
@@ -628,7 +603,7 @@ translate german strings:
     # screens.rpy:1096
     old "Calibrate"
     # Automatic translation.
-    new "Kalibrieren Sie"
+    new "Kalibrieren"
 
     # screens.rpy:1124
     old "## Additional screens"
@@ -637,8 +612,7 @@ translate german strings:
 
     # screens.rpy:1128
     old "## Confirm screen"
-    # Automatic translation.
-    new "## Bildschirm bestätigen"
+    new "## Bestätigungs-Bildschirm"
 
     # screens.rpy:1130
     old "## The confirm screen is called when Ren'Py wants to ask the player a yes or no question."
@@ -652,7 +626,7 @@ translate german strings:
     # screens.rpy:1137
     old "## Ensure other screens do not get input while this screen is displayed."
     # Automatic translation.
-    new "## Stellen Sie sicher, dass andere Bildschirme keine Eingaben erhalten, während dieser Bildschirm angezeigt wird."
+    new "## Stell sicher, dass andere Bildschirme keine Eingaben erhalten, während dieser Bildschirm angezeigt wird."
 
     # screens.rpy:1161
     old "Yes"
@@ -664,13 +638,12 @@ translate german strings:
 
     # screens.rpy:1164
     old "## Right-click and escape answer \"no\"."
-    # Automatic translation.
-    new "## Klicken Sie mit der rechten Maustaste und geben Sie die Antwort \"Nein\" ein."
+    new "## Ein Rechtsklick oder [ESC] beantworten jeweils mit \"Nein\"."
 
     # screens.rpy:1191
     old "## Skip indicator screen"
     # Automatic translation.
-    new "## Indikatorbildschirm überspringen"
+    new "## Vorspul-Symbol Bildschirm"
 
     # screens.rpy:1193
     old "## The skip_indicator screen is displayed to indicate that skipping is in progress."
@@ -683,18 +656,16 @@ translate german strings:
 
     # screens.rpy:1208
     old "Skipping"
-    # Automatic translation.
-    new "Überspringen"
+    new "Vorspulen"
 
     # screens.rpy:1215
     old "## This transform is used to blink the arrows one after another."
-    # Automatic translation.
-    new "## Diese Transformation wird verwendet, um die Pfeile nacheinander zu blinken."
+    new "## Dieses Transform wird verwendet, um die Pfeile nacheinander blinken zu lassen."
 
     # screens.rpy:1247
     old "## Notify screen"
     # Automatic translation.
-    new "## Bildschirm benachrichtigen"
+    new "## Benachrichtigungsbildschirm"
 
     # screens.rpy:1249
     old "## The notify screen is used to show the player a message. (For example, when the game is quicksaved or a screenshot has been taken.)"
@@ -736,8 +707,7 @@ translate german strings:
 
     # screens.rpy:1406
     old "## Mobile Variants"
-    # Automatic translation.
-    new "## Mobile Varianten"
+    new "## Varianten für Mobilgeräte"
 
     # screens.rpy:1413
     old "## Since a mouse may not be present, we replace the quick menu with a version that uses fewer and bigger buttons that are easier to touch."
@@ -755,12 +725,11 @@ translate german strings:
     # gui/game/screens.rpy:114
     old "## If there's a side image, display it above the text. Do not display on the phone variant - there's no room."
     # Automatic translation.
-    new "## Wenn es ein Seitenbild gibt, zeigen Sie es über dem Text an. Nicht auf der Telefonvariante anzeigen - dort ist kein Platz."
+    new "## Wenn es ein Seitenbild gibt, wird es über dem Text angezeigt. Allerdings nicht auf der Smartphone-Variante - dort ist kein Platz."
 
     # gui/game/screens.rpy:120
     old "## Make the namebox available for styling through the Character object."
-    # Automatic translation.
-    new "## Machen Sie das Namensfeld für die Gestaltung durch das Character-Objekt verfügbar."
+    new "## Macht das Namensfeld für die Gestaltung durch das Character-Objekt verfügbar."
 
     # gui/game/screens.rpy:173
     old "## https://www.renpy.org/doc/html/screen_special.html#input"
@@ -772,8 +741,7 @@ translate german strings:
 
     # gui/game/screens.rpy:241
     old "## Ensure this appears on top of other screens."
-    # Automatic translation.
-    new "## Stellen Sie sicher, dass dies über den anderen Bildschirmen erscheint."
+    new "## Stellt sicher, dass dies vor allen anderen Bildschirmen erscheint."
 
     # gui/game/screens.rpy:280
     old "## Main and Game Menu Screens"
@@ -801,8 +769,7 @@ translate german strings:
 
     # gui/game/screens.rpy:429
     old "## Reserve space for the navigation section."
-    # Automatic translation.
-    new "## Reservieren Sie Platz für den Navigationsbereich."
+    new "## Reserviert Platz für den Navigationsbereich."
 
     # gui/game/screens.rpy:608
     old "## The page name, which can be edited by clicking on a button."
@@ -812,7 +779,7 @@ translate german strings:
     # gui/game/screens.rpy:668
     old "## range(1, 10) gives the numbers from 1 to 9."
     # Automatic translation.
-    new "## bereich(1, 10) liefert die Zahlen von 1 bis 9."
+    new "## range(1, 10) liefert die Zahlen von 1 bis 9."
 
     # gui/game/screens.rpy:676
     old "Upload Sync"
@@ -826,7 +793,6 @@ translate german strings:
 
     # gui/game/screens.rpy:921
     old "## This determines what tags are allowed to be displayed on the history screen."
-    # Automatic translation.
     new "## Hier wird festgelegt, welche Tags auf dem Verlaufsbildschirm angezeigt werden dürfen."
 
     # gui/game/screens.rpy:1049
@@ -845,7 +811,6 @@ translate german strings:
 
     # gui/game/screens.rpy:1248
     old "## We have to use a font that has the BLACK RIGHT-POINTING SMALL TRIANGLE glyph in it."
-    # Automatic translation.
     new "## Wir müssen eine Schriftart verwenden, die die Glyphe BLACK RIGHT-POINTING SMALL TRIANGLE enthält."
 
     # gui/game/screens.rpy:1296
@@ -859,13 +824,12 @@ translate german strings:
 
     # gui/game/screens.rpy:1410
     old "## Bubble screen"
-    # Automatic translation.
-    new "## Blasenbildschirm"
+    new "## Sprechblasen-Bildschirm"
 
     # gui/game/screens.rpy:1412
     old "## The bubble screen is used to display dialogue to the player when using speech bubbles. The bubble screen takes the same parameters as the say screen, must create a displayable with the id of \"what\", and can create displayables with the \"namebox\", \"who\", and \"window\" ids."
     # Automatic translation.
-    new "## Der Sprechblasenbildschirm wird verwendet, um dem Spieler einen Dialog anzuzeigen, wenn Sprechblasen verwendet werden. Der Sprechblasenbildschirm benötigt die gleichen Parameter wie der Sprechblasenbildschirm, muss ein Displayable mit der Id \"what\" erstellen und kann Displayables mit den Ids \"namebox\", \"who\" und \"window\" erstellen."
+    new "## Der Sprechblasenbildschirm wird verwendet, um dem Spieler einen Dialog anzuzeigen, wenn Sprechblasen verwendet werden. Er benötigt die gleichen Parameter wie der Dialog-Bildschirm, muss ein Displayable mit der Id \"what\" erstellen und kann Displayables mit den Ids \"namebox\", \"who\" und \"window\" erstellen."
 
     # gui/game/screens.rpy:1417
     old "## https://www.renpy.org/doc/html/bubble.html#bubble-screen"
@@ -875,6 +839,6 @@ translate german strings:
 
     # gui/game/screens.rpy:411
     old "## The scroll parameter can be None, or one of \"viewport\" or \"vpgrid\". This screen is intended to be used with one or more children, which are transcluded (placed) inside it."
-    # Automatic translation.
-    new "## Der Parameter scroll kann None oder einer der Parameter \"viewport\" oder \"vpgrid\" sein. Dieser Bildschirm soll mit einem oder mehreren Kindern verwendet werden, die in ihn eingeschlossen (platziert) werden."
+    new "## Der Parameter scroll kann None oder einer der Parameter \"viewport\" oder \"vpgrid\" sein. Dieser Bildschirm sollte mit einem oder mehreren Unterobjekten verwendet werden, die in ihn eingeschlossen (platziert) werden."
+
 

--- a/launcher/game/tl/german/script.rpym
+++ b/launcher/game/tl/german/script.rpym
@@ -1,17 +1,16 @@
-﻿# Sie können das Skript Ihres Spiels in dieser Datei platzieren.
+﻿# Du kannst das Skript für Dein Spiel in diese Datei schreiben.
 
-# Bestimmen Sie Grafiken unterhalb dieser Zeile, indem Sie die "Image-Statements" verwenden.
+# Unterhalb dieser Zeile kannst Du Bilder definieren, indem Du das Wort "image" verwendest
 # z. B. image eileen happy = "eileen_happy.png"
 
-# Bestimmen Sie Charaktere, die in diesem Spiel verwendet werden.
+# Erstelle hier Charaktere, die in Deinem Spiel auftauchen werden
 define e = Character('Eileen', color="#c8ffc8")
-
 
 # Hier beginnt das Spiel.
 label start:
 
     e "Du hast ein neues Ren'Py Spiel erstellt."
 
-    e "Sobald du eine Geschichte, Bilder und Musik hinzufügst, kannst du es für alle veröffentlichen!"
+    e "Sobald Du eine Geschichte, Bilder und Musik hinzufügst, kannst Du es für alle veröffentlichen!"
 
     return


### PR DESCRIPTION
I mostly fixed bad auto translations and changed formal speech to informal speech, because it is more natural and usually shorter in German. I also fixed some manual translations that I don't feel happy about and changed special symbols like ’ to the standard '.