### PR TITLE
Fixes some typos found in docs.

### DIFF
--- a/sphinx/source/bubble.rst
+++ b/sphinx/source/bubble.rst
@@ -31,7 +31,7 @@ associated with the speech bubble. For the default speech bubble, the
 different properties control the position of the speech bubble tail.
 
 Once you've changed the area or properties for a character (or group of
-characters with the same image tage), those properties remain set until
+characters with the same image tags), those properties remain set until
 changed again, or until the next scene statement.
 
 When the area or properties are being set on the current line of dialogue,
@@ -108,7 +108,7 @@ The ``bubble`` namespace contains the following variables:
 .. var:: bubble.properties = { ... }
 
     These are properties, apart from the area, that can be used to customize
-    the speech bubble. This is a map from the name of a set of proprerties
+    the speech bubble. This is a map from the name of a set of properties
     to a dictionary of properties and values. These properties supersede those
     given to the character, and are then supplied to the ``bubble`` screen.
 
@@ -162,7 +162,7 @@ The ``bubble`` namespace contains the following variables:
 
     If not None, this should be a function that takes an image tag, and returns
     a list or tuple of property names that should be used for that image tag, in
-    the order those names should be cycled through. This takes precendence over
+    the order those names should be cycled through. This takes precedence over
     bubble.properties_order, and can be used to customize the list of bubble
     properties by character.
 

--- a/sphinx/source/cdd.rst
+++ b/sphinx/source/cdd.rst
@@ -328,7 +328,7 @@ the implicit `self` parameter.
         If set to True:
 
         * All of the children of this displayable are rendered to textures.
-        * A mesh the size of the first child is assocated with this displayable.
+        * A mesh the size of the first child is associated with this displayable.
         * A model is created with the mesh, shaders, uniforms, and properties
           associated with this Render.
 

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -536,7 +536,7 @@ It also takes:
 * :ref:`window-style-properties`
 * :ref:`button-style-properties`
 
-It takes one children. If zero, two, or more children are supplied,
+It takes one child. If zero, two, or more children are supplied,
 they are implicitly added to a fixed, which is added to the button.
 
 
@@ -569,7 +569,7 @@ This takes the following properties:
 
 .. screen-property:: modal
 
-    By default, the dimiss is modal, preventing events from being processed
+    By default, the dismiss is modal, preventing events from being processed
     by displayables "behind" it.
 
 
@@ -601,7 +601,7 @@ Here's an example of dismiss being used::
                 xalign 0.5
                 action Return()
 
-See also how dismiss is used in conjuction with :ref:`nearrect <sl-nearrect>`.
+See also how dismiss is used in conjunction with :ref:`nearrect <sl-nearrect>`.
 
 .. _sl-fixed:
 
@@ -971,7 +971,7 @@ keysyms. It takes two properties:
 
     If true, the default, the event will capture, and will not be
     processed by other displayables. If false and the action does
-    not end the interaction, the event will be procssed by other
+    not end the interaction, the event will be processed by other
     displayables.
 
 It takes no children.

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -137,7 +137,7 @@ It should be noted that:
 
 - the order in which the flags are given does not change the result : ``!cl``
   will do just the same as ``!lc``.
-- Supplementarly exclamation marks will be ignored, and will not circumvent
+- Supplementary exclamation marks will be ignored, and will not circumvent
   the previous rule : ``!l!c`` will do the same as ``!c!l`` or ``!cl``.
 
 The transformations are done in the following order:
@@ -329,8 +329,8 @@ Tags that apply to all text are:
 .. text-tag:: noalt
 
     The noalt tag prevents text from being spoken by the text-to-speech
-    system. This is often used in conjuction with the alt tag, to provide
-    accessible and visual optiopns  ::
+    system. This is often used in conjunction with the alt tag, to provide
+    accessible and visual options  ::
 
        g "Good to see you! {noalt}<3{/noalt}{alt}heart{/alt}"
 
@@ -520,7 +520,7 @@ Style Text Tags
 Ren'Py supports text tags that access styles. These are text tags
 where the tag name is empty. In this case, the argument
 is taken to be the name of a style. For example, the {=mystyle} tag
-will acces the ``mystyle`` style.
+will access the ``mystyle`` style.
 
 The text between the tag and the corresponding closing tag has the following
 properties set to those defined in the style:
@@ -869,7 +869,7 @@ There are two text tags that support the use of variable fonts.
 
         "This is {instance=heavy}heavy{/instance} text."
 
-    When the instance tag is used, the axis properties are overriden.
+    When the instance tag is used, the axis properties are overridden.
 
 .. text-tag:: axis
 

--- a/sphinx/source/thequestion.txt
+++ b/sphinx/source/thequestion.txt
@@ -6,7 +6,7 @@ Script of The Question
 ======================
 
 This is the main script.rpy file of The Question. For the full code of
-The Question, open it in the Ren'Py lanucher, or visit
+The Question, open it in the Ren'Py launcher, or visit
 https://github.com/renpy/renpy/tree/master/the_question .
 
 ::

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -40,7 +40,7 @@ Python identifiers (starts with a letter or underscore, followed by
 letters, numbers, and underscores).
 
 When the None language is selected, most of Ren'Py's translation
-functionality is disabled, with the notable exception of Renpy's
+functionality is disabled, with the notable exception of Ren'Py's
 internal built-in strings, from the accessibility menu for example.
 Theses strings are not found in your project's code, yet they will
 still be included in the distributed version of the game. You can

--- a/sphinx/source/updater.rst
+++ b/sphinx/source/updater.rst
@@ -124,7 +124,7 @@ can be used to customize the screen:
 
       The current state of the updater. See the example above for possible
       values and their meanings. The values are all constants on the Updater
-      obect.
+      object.
 
    .. attribute:: message
 


### PR DESCRIPTION
Hi guys, 👋
this is just a single-commit fixing some typos I've found when reading Ren'Py docs.