### PR TITLE
Fix video playing if config.web_video_base URL is cross-origin

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -405,6 +405,7 @@ renpyAudio.queue = (channel, file, name,  paused, fadein, tight, start, end, rel
         if (c.video_el === null) {
             c.video_el = document.createElement('video');
             c.video_el.style.display = 'none';
+            c.video_el.crossOrigin = 'anonymous';
             c.video_el.playsInline = true;  // For autoplay on Safari
             document.body.appendChild(c.video_el);
 


### PR DESCRIPTION
When `config.web_video_base` is set with an absolute URL to another origin, modern browsers won't load the video with an error:

> The HTMLMediaElement passed to createMediaElementSource has a cross-origin resource, the node will output silence.

For CORS to work:
1. The server serving the resources should have a `access-control-allow-origin: *` header.
2. The `video` element should have `crossorigin="anonymous"` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin).

This PR adds such an attribute to the `video`.

