### PR TITLE
store the total size for grids

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -435,6 +435,9 @@ class Grid(Container):
 
     allow_underfull = None
 
+    total_width = 0
+    total_height = 0
+
     def __init__(self, cols, rows, padding=None,
                  transpose=False,
                  style='grid',
@@ -464,6 +467,9 @@ class Grid(Container):
 
         self.transpose = transpose
         self.allow_underfull = allow_underfull
+
+        self.total_width = 0
+        self.total_height = 0
 
     def render(self, width, height, st, at):
 
@@ -523,8 +529,8 @@ class Grid(Container):
         if self.style.yfill:
             cheight = renheight
 
-        width = cwidth * cols + xspacing * (cols - 1) + left_margin + right_margin
-        height = cheight * rows + yspacing * (rows - 1) + top_margin + bottom_margin
+        self.total_width = width = cwidth * cols + xspacing * (cols - 1) + left_margin + right_margin
+        self.total_height = height = cheight * rows + yspacing * (rows - 1) + top_margin + bottom_margin
 
         rv = renpy.display.render.Render(width, height)
 

--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -610,6 +610,9 @@ class VPGrid(Viewport):
 
     allow_underfull = None
 
+    total_width = 0
+    total_height = 0
+
     def __init__(self, cols=None, rows=None,
                  transpose=None,
                  style="vpgrid",
@@ -628,6 +631,9 @@ class VPGrid(Viewport):
         self.grid_rows = rows
         self.grid_transpose = transpose
         self.allow_underfull = allow_underfull
+
+        self.total_width = 0
+        self.total_height = 0
 
     def render(self, width, height, st, at):
 
@@ -689,6 +695,9 @@ class VPGrid(Viewport):
         if self.style.yfill:
             th = child_height
             ch = (th - (rows - 1) * yspacing - top_margin - bottom_margin) // rows
+
+        self.total_width  = tw
+        self.total_height = th
 
         cxo, cyo, width, height = self.update_offsets(tw, th, st)
         cxo += left_margin


### PR DESCRIPTION
and vpgrids


the point of this is for creators making cdds not have to cv paste the entire `render` method to get the full size.

not sure where it should be documented (or if it should be documented at all) so im keeping this as a draft for now. 