### PR TITLE
Unrestrain crop

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -307,7 +307,7 @@ init -1100 python:
             config.containers_pass_transform_events.clear()
             config.say_replace_event = False
             config.screens_never_cancel_hide = False
-            config.limit_transform_crop = False
+            config.limit_transform_crop = "only_float"
 
         if _compat_versions(version, (7, 7, 1), (8, 2, 1)):
             config.fill_shrinks_frame = True
@@ -320,7 +320,7 @@ init -1100 python:
             bubble.clear_retain_statements = [ ]
             if not _compat_versions(version, (7, 6, 99), (8, 1, 99)):
                 config.box_reverse_align = True
-                config.limit_transform_crop = "compat"
+                config.limit_transform_crop = True
 
 
     # The version of Ren'Py this script is intended for, or

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1497,8 +1497,8 @@ translate_ignore_who = [ ]
 # The layer built-in screens exist on.
 interface_layer = "screens"
 
-# Should Transform crop be limited to the size of the image being cropped?
-limit_transform_crop = True
+# Should Transform crop be limited to the width and height of the image being cropped?
+limit_transform_crop = False
 
 
 

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -121,16 +121,13 @@ def relative_for_crop(n, base, limit):
 
     ltc = renpy.config.limit_transform_crop
 
-    if not ltc:
+    if ltc == "only_float" and isinstance(n, (int, absolute)):
         # before 8.2 / 7.7
-        if isinstance(n, (int, absolute)):
-            return n
-        else:
-            return min(int(absolute.compute_raw(n, base)), limit)
+        return n
 
     rv = int(absolute.compute_raw(n, base))
 
-    if ltc == "compat":
+    if ltc:
         # 8.2 / 7.7
         return min(rv, limit)
 

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -119,21 +119,24 @@ def relative_for_crop(n, base, limit):
     while a float is interpreted as a fraction of the limit).
     """
 
-    if renpy.config.limit_transform_crop:
+    ltc = renpy.config.limit_transform_crop
 
-        rv = min(int(absolute.compute_raw(n, base)), limit)
-
-        if renpy.config.limit_transform_crop != "compat":
-            rv = max(0, rv)
-
-        return rv
-
-    else:
+    if not ltc:
+        # before 8.2 / 7.7
         if isinstance(n, (int, absolute)):
             return n
         else:
             return min(int(absolute.compute_raw(n, base)), limit)
 
+    else:
+        # 8.2 / 7.7 +
+        rv = min(int(absolute.compute_raw(n, base)), limit)
+
+        if ltc != "compat":
+            # 8.3 / 7.8 +
+            rv = max(0, rv)
+
+        return rv
 
 cdef class RenderTransform:
     """

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -128,14 +128,14 @@ def relative_for_crop(n, base, limit):
         else:
             return min(int(absolute.compute_raw(n, base)), limit)
 
+    rv = int(absolute.compute_raw(n, base))
+
+    if ltc == "compat":
+        # 8.2 / 7.7
+        return min(rv, limit)
+
     else:
-        # 8.2 / 7.7 +
-        rv = min(int(absolute.compute_raw(n, base)), limit)
-
-        if ltc != "compat":
-            # 8.3 / 7.8 +
-            rv = max(0, rv)
-
+        # 8.3 / 7.8 +
         return rv
 
 cdef class RenderTransform:

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -112,9 +112,10 @@ To disable this, in a file named 01nomunge.rpy in your game directory, write::
 
     define config.munge_in_strings = False
 
-**Cropping Outside the Bounds of a Displayable** The behavior of cropping a displayable with a box
-larger than the displayable has changed. As of this release, the behavior is to crop to the intersection
-of the crop rectangle and the displayable.
+**Cropping Outside the Bounds of a Displayable** The behavior of cropping a
+displayable with a box larger than the displayable has changed. As of this
+release, values passed to :func:`Crop`, :tpref:`crop`, :tpref:`corner1` and
+:tpref:`corner2` are not bound by the original boundaries of the displayable.
 
 In 8.2.x and 7.7.x releases of Ren'Py, the behavior was to crop the right/bottom of the displayable,
 but unconstrain the left/top. This behavior can be restored by adding to your game::
@@ -125,8 +126,6 @@ Before 8.2 and 7.7, the behavior was to crop the right/bottom of the displayable
 float, and leave left/top unconstrained. This behavior can be restored by adding to your game::
 
     define config.limit_transform_crop = False
-
-Cropping outside of the bounds of a displayable is not recommended.
 
 
 

--- a/sphinx/source/incompatible.rst
+++ b/sphinx/source/incompatible.rst
@@ -120,12 +120,12 @@ release, values passed to :func:`Crop`, :tpref:`crop`, :tpref:`corner1` and
 In 8.2.x and 7.7.x releases of Ren'Py, the behavior was to crop the right/bottom of the displayable,
 but unconstrain the left/top. This behavior can be restored by adding to your game::
 
-    define config.limit_transform_crop = "compat"
+    define config.limit_transform_crop = True
 
 Before 8.2 and 7.7, the behavior was to crop the right/bottom of the displayable if the value was a
 float, and leave left/top unconstrained. This behavior can be restored by adding to your game::
 
-    define config.limit_transform_crop = False
+    define config.limit_transform_crop = "only_float"
 
 
 

--- a/sphinx/source/transform_properties.rst
+++ b/sphinx/source/transform_properties.rst
@@ -362,9 +362,11 @@ Cropping and Resizing
     :default: None
 
     If not None, causes the displayable to be cropped to the given box. The box
-    is specified as a tuple of (x, y, width, height). All values can expand
-    outside of the bounds of the original image, though width and height must be
-    positive.
+    is specified as a tuple of (x, y, width, height), with x and y being the
+    coordinates of the box's top-left corner relative to the top-left corner of
+    the child. All values can expand outside of the bounds of the original
+    image, with the area outside being transparent, though width and height must
+    be positive.
 
     If corners and crop are given, crop takes priority over corners.
 
@@ -383,8 +385,8 @@ Cropping and Resizing
     :default: None
 
     If not None, gives the lower-right corner of the crop box. The values can
-    expand outside of the bounds of the original image. Crop takes priority over
-    corners.
+    expand outside of the bounds of the original image, but they should not be
+    inferior to :tpref:`corner1`. Crop takes priority over corners.
 
 .. transform-property:: xysize
 

--- a/sphinx/source/transform_properties.rst
+++ b/sphinx/source/transform_properties.rst
@@ -362,7 +362,9 @@ Cropping and Resizing
     :default: None
 
     If not None, causes the displayable to be cropped to the given box. The box
-    is specified as a tuple of (x, y, width, height).
+    is specified as a tuple of (x, y, width, height). width and height must be
+    positive, but x and y can be negative. All values can expand outside of the
+    bounds of the original image.
 
     If corners and crop are given, crop takes priority over corners.
 
@@ -371,16 +373,18 @@ Cropping and Resizing
     :type: None or (position, position)
     :default: None
 
-    If not None, gives the upper-left corner of the crop box. Crop takes
-    priority over corners.
+    If not None, gives the upper-left corner of the crop box. The values can
+    expand outside of the bounds of the original image. Crop takes priority over
+    corners.
 
 .. transform-property:: corner2
 
     :type: None or (position, position)
     :default: None
 
-    If not None, gives the lower-right corner of the crop box. Crop takes
-    priority over corners.
+    If not None, gives the lower-right corner of the crop box. The values can
+    expand outside of the bounds of the original image. Crop takes priority over
+    corners.
 
 .. transform-property:: xysize
 

--- a/sphinx/source/transform_properties.rst
+++ b/sphinx/source/transform_properties.rst
@@ -362,9 +362,9 @@ Cropping and Resizing
     :default: None
 
     If not None, causes the displayable to be cropped to the given box. The box
-    is specified as a tuple of (x, y, width, height). width and height must be
-    positive, but x and y can be negative. All values can expand outside of the
-    bounds of the original image.
+    is specified as a tuple of (x, y, width, height). All values can expand
+    outside of the bounds of the original image, though width and height must be
+    positive.
 
     If corners and crop are given, crop takes priority over corners.
 

--- a/sphinx/source/transform_properties.rst
+++ b/sphinx/source/transform_properties.rst
@@ -372,8 +372,7 @@ Cropping and Resizing
     :default: None
 
     If not None, gives the upper-left corner of the crop box. Crop takes
-    priority over corners. When a float, and crop_relative is enabled, this is
-    relative to the size of the child.
+    priority over corners.
 
 .. transform-property:: corner2
 
@@ -381,8 +380,7 @@ Cropping and Resizing
     :default: None
 
     If not None, gives the lower-right corner of the crop box. Crop takes
-    priority over corners. When a float, and crop_relative is enabled, this is
-    relative to the size of the child.
+    priority over corners.
 
 .. transform-property:: xysize
 
@@ -597,14 +595,14 @@ Deprecated Transform Properties
     :type: boolean
     :default: True
 
-    If False, float components of :tpref:`crop` are interpreted as an absolute
-    number of pixels, instead of a fraction of the width and height of the
-    source image.
+    If False, float components of :tpref:`crop`, :tpref:`corner1` and
+    :tpref:`corner2` are interpreted as an absolute number of pixels, instead of
+    a fraction of the width and height of the source image.
 
     If an absolute number of pixel is to be expressed, :func:`absolute`
-    instances should be provided to the :tpref:`crop` property instead of using
-    the crop_relative property. If necessary, values of dubious type can be
-    wrapped in the :func:`absolute` callable.
+    instances should be provided to these properties instead of using the
+    crop_relative property. If necessary, values of dubious type can be wrapped
+    in the :func:`absolute` callable.
 
 .. transform-property:: size
 


### PR DESCRIPTION
Using crop to expand a displayable's area makes a lot of sense, though in an abstract way.
It's a partially incompatible change, sure, but that has to happen in any case because of my mistake.

Crop in general sets the new size of the child and from what coordinates (relative to the child) it starts.
Sure, that's a bit more abstract than cropping, but the same can be said of negative values for xzoom and yzoom : it makes sense when you get your mind around it, and there is a real use for it : flipping images.
There's a use in this case too, for adding padding around an image and setting a final size for the image, irrespective of its actual start size. I'm not sure of an way to do that differently.