### PR TITLE
Fully compat transform pos-only parameters (at the parser level)

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1414,7 +1414,7 @@ simple_box_reverse = False
 # Should we revert to the right/bottom-alignment for non-simple reversed boxes?
 box_reverse_align = False
 
-# If True, positional-only parameters are allowed in ATL transform signatures.
+# If True, positional-only parameters are treated as pos-or-kw in ATL transform signatures.
 atl_pos_only = False
 
 # A map from font name to the hinting for the font.


### PR DESCRIPTION
This requires the atl_pos_only config to be set very early in order to work. It's probably not actually the case, since the 00compat code does not execute in an early block. So it may require to either add an early treatment for that config variable in the 00compat file, or to directly check the early_script_version config variable in the parser, which is dirty.