### PR TITLE
Patch compat ATL pos-only behavior

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -583,6 +583,9 @@ class ATLTransformBase(renpy.object.Object):
         signature = self.parameters
         child = None
 
+        if renpy.config.atl_pos_only_as_pos_or_kw:
+            signature = signature.with_pos_only_as_pos_or_kw()
+
         present_kinds = {p.kind for p in signature.parameters.values()}
 
         child_param = signature.parameters.get("child", None)

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -298,7 +298,6 @@ init -1100 python:
         if _compat_versions(version, (7, 6, 99), (8, 1, 99)):
             config.simple_box_reverse = True
             build.itch_channels = list(build.itch_channels.items())
-            config.atl_pos_only = True
             style.default.shaper = "freetype"
             config.mixed_position = False
             config.drag_group_add_top = False
@@ -318,6 +317,7 @@ init -1100 python:
         if _compat_versions(version, (7, 7, 99), (8, 2, 99)):
             config.character_callback_compat = True
             bubble.clear_retain_statements = [ ]
+            config.atl_pos_only_as_pos_or_kw = True
             if not _compat_versions(version, (7, 6, 99), (8, 1, 99)):
                 config.box_reverse_align = True
                 config.limit_transform_crop = True

--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -298,6 +298,8 @@ init -1100 python:
         if _compat_versions(version, (7, 6, 99), (8, 1, 99)):
             config.simple_box_reverse = True
             build.itch_channels = list(build.itch_channels.items())
+            config.atl_pos_only = True
+            config.atl_pos_only_as_pos_or_kw = True
             style.default.shaper = "freetype"
             config.mixed_position = False
             config.drag_group_add_top = False
@@ -317,7 +319,6 @@ init -1100 python:
         if _compat_versions(version, (7, 7, 99), (8, 2, 99)):
             config.character_callback_compat = True
             bubble.clear_retain_statements = [ ]
-            config.atl_pos_only_as_pos_or_kw = True
             if not _compat_versions(version, (7, 6, 99), (8, 1, 99)):
                 config.box_reverse_align = True
                 config.limit_transform_crop = True

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1417,6 +1417,9 @@ box_reverse_align = False
 # If True, positional-only parameters are allowed in ATL transform signatures.
 atl_pos_only = False
 
+# If True, positional-only parameters in ATL transform signatures are treated as pos-or-keyword.
+atl_pos_only_as_pos_or_kw = False
+
 # A map from font name to the hinting for the font.
 font_hinting = { None : "auto" }
 

--- a/renpy/parameter.py
+++ b/renpy/parameter.py
@@ -213,6 +213,22 @@ class Signature(object):
                     continue
                 mapp[name] = val
 
+    def with_pos_only_as_pos_or_kw(self):
+        """
+        Returns a new Signature object where positional-only parameters are
+        turned into positional-or-keyword parameters.
+        """
+        new_params = []
+        itparams = iter(self.parameters.values())
+        for param in itparams:
+            if param.kind == Parameter.POSITIONAL_ONLY:
+                new_params.append(param.replace(kind=Parameter.POSITIONAL_OR_KEYWORD))
+            else:
+                new_params.append(param)
+                new_params.extend(itparams)
+                break
+        return Signature(new_params)
+
     def apply(self, args, kwargs, ignore_errors=False, partial=False, apply_defaults=True):
         """
         Takes args and kwargs, and returns a mapping corresponding to the
@@ -524,5 +540,5 @@ class ArgumentInfo(renpy.object.Object):
         return "<ArgumentInfo {}>".format(self)
 
 
-EMPTY_PARAMETERS = ParameterInfo()
+EMPTY_PARAMETERS = Signature()
 EMPTY_ARGUMENTS = ArgumentInfo([ ], None, None)


### PR DESCRIPTION
This fixes (sort-of) the #5237 in that it doesn't correctly reflect and reproduce the buggy previous behavior. As such, it should be shipped in 8.3, along with that already-merged update (which it compats). The only difference would be when an old game defines a pos-only parameter in a transform and then passes it a parameter by keyword - but that's a weirdly nonsense thing to to.

This issue does not re-authorize pos-only parameters, which are still forbidden at the parser except in compat mode), as that is the responsibility of #5592, which can be merged after 8.3.