### PR TITLE
Fix type error when style attributes are None

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -827,7 +827,13 @@ class Layout(object):
 
             # Figure out the line height, line spacing, and the y coordinate of each
             # glyph.
-            l, y = textsupport.place_vertical(par_glyphs, y, self.scale_int(style.line_spacing), self.scale_int(style.line_leading), self.scale_int(style.ruby_line_leading))
+            l, y = textsupport.place_vertical(
+                par_glyphs, 
+                y, 
+                self.scale_int(style.line_spacing) or 0, 
+                self.scale_int(style.line_leading) or 0, 
+                self.scale_int(style.ruby_line_leading) or 0
+            )
             lines.extend(l)
 
             # Figure out the indent of the next paragraph.


### PR DESCRIPTION
# Fix type error

`scale_int` may return `None` but `textsupport.place_vertical` expects `int` type. This PR ensures we pass `int=0` to `textsupport.place_vertical` instead of None.

## how to reproduce the error

Have a style with `ruby_line_leading = None`, which is allowed.

When starting the game, this will result in:

```File "renpy-8.2.3-sdk/renpy/text/text.py", line 766, in __init__
    l, y = textsupport.place_vertical(par_glyphs, y, line_spacing_scaled, line_leading_scaled, ruby_line_leading_scaled)
  File "textsupport.pyx", line 677, in renpy.text.textsupport.place_vertical
TypeError: an integer is required
```