### PR TITLE
Fix syncfs call while a rename is in progress

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -499,8 +499,8 @@ def autosave_thread_function(take_screenshot):
                 renpy.exports.take_screenshot(background=True)
 
             save("_auto", mutate_flag=True, extra_info=extra_info)
-            cycle_saves(prefix, renpy.config.autosave_slots)
-            rename_save("_auto", prefix + "1")
+            cycle_saves(prefix, renpy.config.autosave_slots, sync=False)
+            rename_save("_auto", prefix + "1", sync=True)
 
             autosave_counter = 0
             did_autosave = True
@@ -840,7 +840,7 @@ def unlink_save(filename):
     clear_slot(filename)
 
 
-def rename_save(old, new):
+def rename_save(old, new, sync=True):
     """
     :doc: loadsave
 
@@ -848,7 +848,7 @@ def rename_save(old, new):
     exist.)
     """
 
-    location.rename(old, new)
+    location.rename(old, new, sync=sync)
 
     clear_slot(old)
     clear_slot(new)
@@ -866,7 +866,7 @@ def copy_save(old, new):
     clear_slot(new)
 
 
-def cycle_saves(name, count):
+def cycle_saves(name, count, sync=True):
     """
     :doc: loadsave
 
@@ -878,7 +878,11 @@ def cycle_saves(name, count):
     """
 
     for i in range(count - 1, 0, -1):
-        rename_save(name + str(i), name + str(i + 1))
+        rename_save(name + str(i), name + str(i + 1), sync=False)
+
+    if sync:
+        # Only sync once for all the saves
+        location.sync()
 
 ################################################################################
 # Cache

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -305,7 +305,7 @@ class FileLocation(object):
             self.sync()
             self.scan()
 
-    def rename(self, old, new):
+    def rename(self, old, new, sync=True):
         """
         If old exists, renames it to new.
         """
@@ -323,7 +323,8 @@ class FileLocation(object):
             safe_rename(old_tmp, new)
             renpy.util.expose_file(new)
 
-            self.sync()
+            if sync:
+                self.sync()
             self.scan()
 
     def copy(self, old, new):


### PR DESCRIPTION
`FS.syncfs()` is asynchronous, so if the FS changes while this function hasn't complete, it can fail. This is what happens in #5725: each call to `save()`, `cycle_saves()` and `rename_save()` trigger multiple calls to `FS.syncfs()`, so when the final renaming happens, the FS state has changed since the previous calls to `FS.syncfs()`, so they fail and the error messages show up.

Calling `FS.syncfs()` is expensive, so it should only be called once at the end of `autosave_thread_function()` anyway. So this is what this commit does.
That also removes the apparition of the "warning: X FS.syncfs operations in flight at once, probably just doing extra work" messages for autosaves. They still show up for quicksaves though, but that's probably a smaller problem.

Fix #5725.