### PR TITLE
[Web] Only call syncfs once from MultiLocation functions

### DIFF
--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -408,16 +408,11 @@ init -1500 python:
                     layout.yesno_screen(layout.OVERWRITE_SAVE, FileSave(self.name, False, False, self.page, cycle=self.cycle, slot=self.slot, action=self.action))
                     return
 
-            try:
-                renpy.savelocation.pause_syncfs()
-
+            with renpy.savelocation.SyncfsLock():
                 if self.cycle:
                     renpy.renpy.loadsave.cycle_saves(__slotname("", self.page, self.slot), config.quicksave_slots)
 
                 renpy.save(fn, extra_info=save_name)
-
-            finally:
-                renpy.savelocation.resume_syncfs()
 
             renpy.restart_interaction()
 

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -488,7 +488,7 @@ def autosave_thread_function(take_screenshot):
 
     try:
 
-        try:
+        with renpy.savelocation.SyncfsLock():
 
             if renpy.config.auto_save_extra_info:
                 extra_info = renpy.config.auto_save_extra_info()
@@ -498,8 +498,6 @@ def autosave_thread_function(take_screenshot):
             if take_screenshot:
                 renpy.exports.take_screenshot(background=True)
 
-            renpy.savelocation.pause_syncfs()
-
             save("_auto", mutate_flag=True, extra_info=extra_info)
             cycle_saves(prefix, renpy.config.autosave_slots)
             rename_save("_auto", prefix + "1")
@@ -507,12 +505,11 @@ def autosave_thread_function(take_screenshot):
             autosave_counter = 0
             did_autosave = True
 
-        except Exception:
-            pass
+    except Exception:
+        pass
 
     finally:
         autosave_not_running.set()
-        renpy.savelocation.resume_syncfs()
 
 
 def autosave():

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -599,9 +599,14 @@ class MultiLocation(object):
         return rv
 
     def save_persistent(self, data):
+        pause_syncfs()
 
-        for l in self.active_locations():
-            l.save_persistent(data)
+        try:
+            for l in self.active_locations():
+                l.save_persistent(data)
+
+        finally:
+            resume_syncfs()
 
     def unlink_persistent(self):
 

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -510,9 +510,10 @@ class MultiLocation(object):
 
         saved = False
 
-        for l in self.active_locations():
-            l.save(slotname, record)
-            saved = True
+        with SyncfsLock():
+            for l in self.active_locations():
+                l.save(slotname, record)
+                saved = True
 
         if not saved:
             raise Exception("Not saved - no valid save locations.")
@@ -585,22 +586,25 @@ class MultiLocation(object):
         if not renpy.config.save:
             return
 
-        for l in self.active_locations():
-            l.unlink(slotname)
+        with SyncfsLock():
+            for l in self.active_locations():
+                l.unlink(slotname)
 
     def rename(self, old, new):
         if not renpy.config.save:
             return
 
-        for l in self.active_locations():
-            l.rename(old, new)
+        with SyncfsLock():
+            for l in self.active_locations():
+                l.rename(old, new)
 
     def copy(self, old, new):
         if not renpy.config.save:
             return
 
-        for l in self.active_locations():
-            l.copy(old, new)
+        with SyncfsLock():
+            for l in self.active_locations():
+                l.copy(old, new)
 
     def load_persistent(self):
         rv = [ ]
@@ -616,9 +620,9 @@ class MultiLocation(object):
                 l.save_persistent(data)
 
     def unlink_persistent(self):
-
-        for l in self.active_locations():
-            l.unlink_persistent()
+        with SyncfsLock():
+            for l in self.active_locations():
+                l.unlink_persistent()
 
     def scan(self):
         # This should scan everything, as a scan can help decide if a

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -72,6 +72,18 @@ def resume_syncfs():
         syncfs()
 
 
+class SyncfsLock(object):
+    """
+    Context to pause then resume the filesystem sync.
+    """
+    def __enter__(self):
+        pause_syncfs()
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        resume_syncfs()
+
+
 def syncfs():
     """
     Syncs the filesystem.
@@ -599,14 +611,9 @@ class MultiLocation(object):
         return rv
 
     def save_persistent(self, data):
-        pause_syncfs()
-
-        try:
+        with SyncfsLock():
             for l in self.active_locations():
                 l.save_persistent(data)
-
-        finally:
-            resume_syncfs()
 
     def unlink_persistent(self):
 


### PR DESCRIPTION
With Ren'Py default config, multiple `MultiLocation` functions call a related function on 2 different instances of `FileLocation` (one for "savedir" and one for "sync"). Some of these `FileLocation`'s functions call `synfc()`, so the warning message "2 FS.syncfs operations in flight at once, probably just doing extra work" shows up. This commit prevents that.

My main goal was to fix the problem for `MultiLocation.save_persistent()`, but since it appears for other functions, it probably does not harm to fix these as well (using a context for concision).

On a side note, emscripten 3.1.61 (05/31/24) introduces [an auto mode to persist the FS data](https://github.com/emscripten-core/emscripten/pull/21938) so that it is not needed anymore to call `syncfs()`. 