### PR TITLE
set and show the various skipping states

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -1216,11 +1216,15 @@ screen skip_indicator():
         hbox:
             spacing gui.scale(6)
 
-            text _("Skipping")
+            text f"{get_skip_string()}"
 
             text "▸" at delayed_blink(0.0, 1.0) style "skip_triangle"
             text "▸" at delayed_blink(0.2, 1.0) style "skip_triangle"
             text "▸" at delayed_blink(0.4, 1.0) style "skip_triangle"
+
+init python:
+    def get_skip_string():
+        return f'{_("Fast Skipping") if config.skipping == "fast" else _("Skipping")}'
 
 
 ## This transform is used to blink the arrows one after another.

--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -301,15 +301,15 @@ init -1500 python:
                 return
 
             if self.confirm:
-                if self.fast:
+                if self.fast and config.skipping in ["slow", None]:
                     if _preferences.skip_unseen:
                         layout.yesno_screen(layout.FAST_SKIP_UNSEEN, Skip(True))
                     else:
                         layout.yesno_screen(layout.FAST_SKIP_SEEN, Skip(True))
-                else:
+                    return
+                elif not self.fast and config.skipping in ["fast", None]:
                     layout.yesno_screen(layout.SLOW_SKIP, Skip(False))
-
-                return
+                    return
 
             if renpy.context()._menu:
                 if self.fast:
@@ -317,12 +317,10 @@ init -1500 python:
                 else:
                     renpy.jump("_return_skipping")
             else:
-
-                if not config.skipping:
-                    if self.fast:
-                        config.skipping = "fast"
-                    else:
-                        config.skipping = "slow"
+                if self.fast and config.skipping in ["slow", None]:
+                    config.skipping = "fast"
+                elif not self.fast and config.skipping in ["fast", None]:
+                    config.skipping = "slow"
                 else:
                     config.skipping = None
 

--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -238,7 +238,7 @@ init -1600 python:
         if not renpy.store._skipping:
             return
 
-        if not config.skipping:
+        if config.skipping in ["fast", None]:
             config.skipping = "slow"
         else:
             config.skipping = None

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1042,12 +1042,12 @@ class Button(renpy.display.layout.Window):
     def is_selected(self):
         if self.selected is not None:
             return self.selected
-        return is_selected(self.action)
+        return is_selected(self.action) or is_selected(self.alternate)
 
     def is_sensitive(self):
         if self.sensitive is not None:
             return self.sensitive
-        return is_sensitive(self.action)
+        return is_sensitive(self.action) or is_sensitive(self.alternate)
 
     def per_interact(self):
 


### PR DESCRIPTION
i simply don't understand what's wrong with the ability to change slow to fast skipping and vice versa, hence my changes. however to get the default `get_selected` method of `class Skip()` to work also for fast skipping i had to add the alternate action to the `is_selected` method of `class Button()` (also added to `is_sensitive`). i'm not sure if problems may arise because of it, but shouldn't a valid alternate action also lead to a selected / sensitive state? if that's not desired a simple `return config.skipping` in the `get_selected` method of `class Skip()` should also work.