### PR TITLE
doc: Fix example in dialogue.rst

### DIFF
--- a/sphinx/source/dialogue.rst
+++ b/sphinx/source/dialogue.rst
@@ -61,7 +61,7 @@ the ``[`` character begins a substitution. To use them in dialogue,
 double them. It may also be necessary to precede a quote with a
 backslash to prevent it from closing the string. For example::
 
-       "I walked past a sign saying, \"Let's give it 100%!\""
+       "I walked past a sign saying, \"Let's give it 100%%!\""
 
 It's also possible to use a proxy function instead of a character
 object. More details about this in :ref:`this section <say-proxy>`.


### PR DESCRIPTION
Fixed the example dialogue that causes an error by doubling the percentage sign `%`:

![Screenshot 2024-08-26 at 1 43 36 PM](https://github.com/user-attachments/assets/077597a0-7474-48ec-a0f0-87d7a3003f91)