### PR TITLE
add option to skip until scene change #4489

### DIFF
--- a/gui/game/screens.rpy
+++ b/gui/game/screens.rpy
@@ -750,6 +750,7 @@ screen preferences():
                     style_prefix "check"
                     label _("Skip")
                     textbutton _("Unseen Text") action Preference("skip", "toggle")
+                    textbutton _("Scene Changes") action Preference("after scene changes", "toggle")
                     textbutton _("After Choices") action Preference("after choices", "toggle")
                     textbutton _("Transitions") action InvertSelected(Preference("transitions", "toggle"))
 

--- a/gui/game/testcases.rpy
+++ b/gui/game/testcases.rpy
@@ -30,6 +30,9 @@
     "Unseen Text"
     "Unseen Text"
 
+    "Scene Changes"
+    "Scene Changes"
+
     "After Choices"
     "After Choices"
 

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1239,6 +1239,9 @@ class Scene(Node):
         next_node(self.next)
         statement_name("scene")
 
+        if renpy.config.skipping == "slow" and not renpy.game.preferences.skip_after_scene_changes:
+            renpy.config.skipping = None
+
         renpy.config.scene(self.layer)
 
         if self.imspec:

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -132,6 +132,10 @@ init -1500 python:
 
         * Preference("begin skipping") - Starts skipping.
 
+        * Preference("Scene Changes", "skip") - Skip after scene change.
+        * Preference("Scene Changes", "stop") - Stop skipping after scene change.
+        * Preference("Scene Changes", "toggle") - Toggle skipping after scene change.
+
         * Preference("after choices", "skip") - Skip after choices.
         * Preference("after choices", "stop") - Stop skipping after choices.
         * Preference("after choices", "toggle") - Toggle skipping after choices.
@@ -362,6 +366,15 @@ init -1500 python:
             elif name == _("begin skipping"):
 
                 return Skip()
+
+            elif name == _("after scene changes"):
+
+                if value == "keep skipping" or value == "keep" or value == "skip":
+                    return SetField(_preferences, "skip_after_scene_changes", True)
+                elif value == "stop skipping" or value == "stop":
+                    return SetField(_preferences, "skip_after_scene_changes", False)
+                elif value == "toggle":
+                    return ToggleField(_preferences, "skip_after_scene_changes"), _("skip after scene changes")
 
             elif name == _("after choices"):
 

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -124,6 +124,8 @@ Preference("video_image_fallback", False)
 
 Preference("skip_after_choices", False)
 
+Preference("skip_after_scene_changes", False)
+
 # A map from channel name to the current volume (between 0 and 1).
 Preference("volumes", { })
 
@@ -239,6 +241,7 @@ class Preferences(renpy.object.Object):
         transitions = 2
         video_image_fallback = False
         skip_after_choices = False
+        skip_after_scene_changes = False
         volumes = {}
         mute = {}
         joymap = {}

--- a/the_question/game/screens.rpy
+++ b/the_question/game/screens.rpy
@@ -778,6 +778,7 @@ screen preferences():
                     style_prefix "check"
                     label _("Skip")
                     textbutton _("Unseen Text") action Preference("skip", "toggle")
+                    textbutton _("Scene Changes") action Preference("after scene changes", "toggle")
                     textbutton _("After Choices") action Preference("after choices", "toggle")
                     textbutton _("Transitions") action InvertSelected(Preference("transitions", "toggle"))
 

--- a/tutorial/game/screens.rpy
+++ b/tutorial/game/screens.rpy
@@ -756,6 +756,7 @@ screen preferences():
                     style_prefix "check"
                     label _("Skip")
                     textbutton _("Unseen Text") action Preference("skip", "toggle")
+                    textbutton _("Scene Changes") action Preference("after scene changes", "toggle")
                     textbutton _("After Choices") action Preference("after choices", "toggle")
                     textbutton _("Transitions") action InvertSelected(Preference("transitions", "toggle"))
 


### PR DESCRIPTION
Addresses issue https://github.com/renpy/renpy/issues/4489

A Visual Novel developer wanted an option to have skip mode end whenever the scene changes. This PR adds that option.

![Screenshot from 2024-08-26 17-06-09](https://github.com/user-attachments/assets/06f24662-1045-49eb-aea7-78780dd334f6)

This PR only adds the scene change option for PC. It also only adds the option in English. Therefore, there are two follow-up issues:
1. Add translations for "Scene Changes"
2. Add the "Scene Change" option for other platforms.