### PR TITLE
Skip seen text based on translation identifiers (#5628)

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2475,11 +2475,6 @@ class Translate(Node):
             next_node(self.next)
             raise Exception("Translation nodes cannot be run directly.")
 
-        if self.identifier not in renpy.game.persistent._seen_translates: # type: ignore
-            renpy.game.persistent._seen_translates.add(self.identifier) # type: ignore
-            renpy.game.seen_translates_count += 1
-            renpy.game.new_translates_count += 1
-
         next_node(self.lookup())
 
         renpy.game.context().translate_identifier = self.identifier
@@ -2555,11 +2550,6 @@ class TranslateSay(Say):
 
         if self.language is None:
 
-            if self.identifier not in renpy.game.persistent._seen_translates: # type: ignore
-                renpy.game.persistent._seen_translates.add(self.identifier) # type: ignore
-                renpy.game.seen_translates_count += 1
-                renpy.game.new_translates_count += 1
-
             # Potentially, jump to a translation.
             node = self.lookup()
 
@@ -2572,8 +2562,8 @@ class TranslateSay(Say):
         Say.execute(self)
 
         # Perform the equivalent of an endtranslate block.
-        renpy.game.context().translate_identifier = None
-        renpy.game.context().alternate_translate_identifier = None
+        #renpy.game.context().translate_identifier = None
+        #renpy.game.context().alternate_translate_identifier = None
 
     def predict(self):
         node = self.lookup()
@@ -2609,8 +2599,8 @@ class EndTranslate(Node):
     def execute(self):
         next_node(self.next)
 
-        renpy.game.context().translate_identifier = None
-        renpy.game.context().alternate_translate_identifier = None
+        #renpy.game.context().translate_identifier = None
+        #renpy.game.context().alternate_translate_identifier = None
 
 
 class TranslateString(Node):

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -657,6 +657,12 @@ class Context(renpy.object.Object):
                 renpy.game.persistent._seen_ever[self.current] = True # type: ignore
                 renpy.game.seen_session[self.current] = True
 
+                tlid = renpy.game.context().translate_identifier
+                if tlid is not None and tlid not in renpy.game.persistent._seen_translates: # type: ignore
+                    renpy.game.persistent._seen_translates.add(tlid) # type: ignore
+                    renpy.game.seen_translates_count += 1
+                    renpy.game.new_translates_count += 1
+
             renpy.plog(2, "    end {} ({}:{})", type_node_name, this_node.filename, this_node.linenumber)
 
         if self.rollback and renpy.game.log:
@@ -906,7 +912,13 @@ class Context(renpy.object.Object):
         else:
             seen = renpy.game.seen_session
 
-        return self.current in seen
+        if self.current in seen:
+            return True
+
+        if renpy.game.context().translate_identifier in renpy.game.persistent._seen_translates:
+            return True
+
+        return False
 
     def do_deferred_rollback(self):
         """


### PR DESCRIPTION
- Skip node if the current translation_identifier was previously seen: this allows the player to skip through texts that were seen in a previous playthrough, even when the developer mistakenly deletes or regenerates .rpyc files while preparing a game update, which changes node identifiers and breaks the list of previously seen nodes.

  Limitation: only applies to translatable content, so not to e.g. image displays.

  This is still a solid QoL improvement for the player, who needn't remember each and every path they might have already gone through in the previous game update/"episode" months/years ago.

- Translations are now considered seen *after* we progress to the next node (as with seen nodes), not when we execute them; this avoids skipping all texts unconditionally in the above, and also de-duplicates the counting code.

- FIXME: ctx.translation_identifier is not reset so it can be used by the above; this probably should be fixed but currently allows discussing this first proof-of-concept.

Fixes #5628

What do you think of this approach? :)