### PR TITLE
doc: Fix code block in cds.rst

### DIFF
--- a/sphinx/source/cds.rst
+++ b/sphinx/source/cds.rst
@@ -51,7 +51,9 @@ For example, the above behaviour, but written as a CDS::
 
         def lint_random(parsed_object):
             for i in parsed_object:
-                renpy.error(renpy.check_text_tags(i.what))
+                    check = renpy.check_text_tags(i.block[0].what)
+                    if check:
+                        renpy.error(check)
 
 
         renpy.register_statement(


### PR DESCRIPTION
When linting the code block from [Creator-Defined Statements ](https://www.renpy.org/doc/html/cds.html):

```sh
renpy game lint
```

I received the error:

```
While running game code:
  File "examples/_creator_defined_statements.rpy", line 21, in lint_random
    renpy.error(renpy.check_text_tags(i.what))
AttributeError: 'SubParse' object has no attribute 'what'
```