### PR TITLE
allow 'Open Directory' and 'Edit File' customization on renpy launch screen #2467

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -158,12 +158,8 @@ screen front_page_project:
 
                 frame style "l_indent":
                     has vbox
-
-                    textbutton "game" action OpenDirectory(os.path.join(p.path, "game"), absolute=True)
-                    textbutton "base" action OpenDirectory(os.path.join(p.path, "."), absolute=True)
-                    textbutton "images" action OpenDirectory(os.path.join(p.path, "game/images"), absolute=True)
-                    textbutton "audio" action OpenDirectory(os.path.join(p.path, "game/audio"), absolute=True)
-                    textbutton "gui" action OpenDirectory(os.path.join(p.path, "game/gui"), absolute=True)
+                    for button_name, path in p.data["renpy_launcher"]["open_directory"].items():
+                        textbutton button_name action OpenDirectory(os.path.join(p.path, path), absolute=True)
 
             vbox:
                 if persistent.show_edit_funcs:
@@ -173,10 +169,8 @@ screen front_page_project:
                     frame style "l_indent":
                         has vbox
 
-                        textbutton "script.rpy" action editor.Edit("game/script.rpy", check=True)
-                        textbutton "options.rpy" action editor.Edit("game/options.rpy", check=True)
-                        textbutton "gui.rpy" action editor.Edit("game/gui.rpy", check=True)
-                        textbutton "screens.rpy" action editor.Edit("game/screens.rpy", check=True)
+                        for button_name, path in p.data["renpy_launcher"]["edit_file"].items():
+                            textbutton button_name action editor.Edit(path, check=True)
 
                         if editor.CanEditProject():
                             textbutton _("Open project") action editor.EditProject()

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -123,6 +123,25 @@ init python in project:
         def update_data(self):
             data = self.data
 
+            data.setdefault("renpy_launcher",
+            {
+                "open_directory":
+                {
+                    "game": "game",
+                    "base": ".",
+                    "images": "game/images",
+                    "audio": "game/audio",
+                    "gui": "game/gui"
+                },
+                "edit_file":
+                {
+                    "script.rpy": "game/script.rpy",
+                    "options.rpy": "game/options.rpy",
+                    "gui.rpy": "game/gui.rpy",
+                    "screens.rpy": "game/screens.rpy"
+                }
+            })
+
             data.setdefault("build_update", False)
             data.setdefault("packages", [ "pc", "mac" ])
             data.setdefault("add_from", True)


### PR DESCRIPTION
Addresses issue https://github.com/renpy/renpy/issues/2467

A Visual Novel developer wanted to customize their renpy launch screen because they do not use the default locations for their file structure. This PR allows a Visual Novel developer to customize their renpy launch screen via editing their project.json file. The defaults values are:

```
{
    "renpy_launcher":
    {
        "open_directory":
        {
            "game": "game",
            "base": ".",
            "images": "game/images",
            "audio": "game/audio",
            "gui": "game/gui"
        },
        "edit_file":
        {
            "script.rpy": "game/script.rpy",
            "options.rpy": "game/options.rpy",
            "gui.rpy": "game/gui.rpy",
            "screens.rpy": "game/screens.rpy"
        }
    }
}
```