### PR TITLE
make project.json easier for humans to read

### DIFF
--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -116,7 +116,7 @@ init python in project:
 
             try:
                 with open(os.path.join(self.path, "project.json"), "w") as f:
-                    json.dump(self.data, f)
+                    json.dump(self.data, f, indent=2)
             except Exception:
                 self.load_data()
 


### PR DESCRIPTION
This change makes it easier for humans to read the `project.json` file.

Before this change, `project.json` looks like this:

```
{"build_update": false, "packages": ["linux"], "add_from": true, "force_recompile": true, "android_build": "Release", "tutorial": false, "renamed_all": true, "renamed_steam": true}
```

After this change, `project.json` looks like this:

```
{
  "build_update": false,
  "packages": [
    "linux"
  ],
  "add_from": true,
  "force_recompile": true,
  "android_build": "Release",
  "tutorial": false,
  "renamed_all": true,
  "renamed_steam": true
}
```