### PR TITLE
no seen labels, images, audio in replays

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -715,8 +715,9 @@ class Channel(object):
         with lock:
 
             for filename in filenames:
-                filename, _, _ = self.split_filename(filename, False)
-                renpy.game.persistent._seen_audio[str(filename)] = True # type: ignore
+                if renpy.exports.is_seen_allowed():
+                    filename, _, _ = self.split_filename(filename, False)
+                    renpy.game.persistent._seen_audio[str(filename)] = True # type: ignore
 
             if not loop_only:
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1503,6 +1503,8 @@ interface_layer = "screens"
 # Should Transform crop be limited to the width and height of the image being cropped?
 limit_transform_crop = False
 
+# Enforce the old behavior of marking lables, images and audio seen even in replays.
+force_replay_seen = False
 
 
 del os

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1503,8 +1503,8 @@ interface_layer = "screens"
 # Should Transform crop be limited to the width and height of the image being cropped?
 limit_transform_crop = False
 
-# Enforce the old behavior of marking lables, images and audio seen even in replays.
-force_replay_seen = False
+# Marking labels, images and audio in replays as seen is not allowed.
+no_replay_seen = False
 
 
 del os

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -654,8 +654,9 @@ class Context(renpy.object.Object):
                 renpy.store._kwargs = e.kwargs
 
             if self.seen:
-                renpy.game.persistent._seen_ever[self.current] = True # type: ignore
-                renpy.game.seen_session[self.current] = True
+                if renpy.exports.is_seen_allowed():
+                    renpy.game.persistent._seen_ever[self.current] = True # type: ignore
+                    renpy.game.seen_session[self.current] = True
 
             renpy.plog(2, "    end {} ({}:{})", type_node_name, this_node.filename, this_node.linenumber)
 

--- a/renpy/exports/__init__.py
+++ b/renpy/exports/__init__.py
@@ -484,6 +484,7 @@ from renpy.exports.persistentexports import (
     mark_image_unseen,
     save_persistent,
     is_seen,
+    is_seen_allowed,
 )
 
 from renpy.exports.platformexports import (

--- a/renpy/exports/displayexports.py
+++ b/renpy/exports/displayexports.py
@@ -492,7 +492,8 @@ def show(name, at_list=[ ], layer=None, what=None, zorder=None, tag=None, behind
         img._unique()
 
     # Update the list of images we have ever seen.
-    renpy.game.persistent._seen_images[tuple(str(i) for i in name)] = True
+    if renpy.exports.is_seen_allowed():
+        renpy.game.persistent._seen_images[tuple(str(i) for i in name)] = True
 
     if tag and munge_name:
         name = (tag,) + name[1:]

--- a/renpy/exports/persistentexports.py
+++ b/renpy/exports/persistentexports.py
@@ -167,7 +167,7 @@ def is_seen_allowed():
     """
     :doc: other
 
-    Returns true if outside a replay or forced by :var:`config.force_replay_seen`.
+    Returns False only if in a replay and no seen events allowed by setting :var:`config.no_replay_seen` to True.
     """
 
-    return not renpy.store._in_replay or renpy.config.force_replay_seen
+    return not (renpy.store._in_replay and renpy.config.no_replay_seen)

--- a/renpy/exports/persistentexports.py
+++ b/renpy/exports/persistentexports.py
@@ -161,3 +161,13 @@ def is_seen(ever=True):
     """
 
     return renpy.game.context().seen_current(ever)
+
+
+def is_seen_allowed():
+    """
+    :doc: other
+
+    Returns true if outside a replay or forced by :var:`config.force_replay_seen`.
+    """
+
+    return not renpy.store._in_replay or renpy.config.force_replay_seen


### PR DESCRIPTION
i don't think labels, images and audio files should be marked as seen in replays. basically all other variables are local to that context.
for instance developer would be able now to temporarily unlock content of a replay gallery for higher tier patrons without actually changing the seen status of a label. to preserve the old behavior one can set the new config var to True.