### PR TITLE
Fix size tag preventing outer tags from closing

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1406,7 +1406,8 @@ class Layout(object):
                     if value[0] in "+-":
                         push().size += int(value)
                     elif value[0] == "*":
-                        push().size = int(float(value[1:]) * push().size)
+                        ts = push()
+                        ts.size = int(float(value[1:]) * ts.size)
                     else:
                         push().size = int(value)
 


### PR DESCRIPTION
This removes the second `push()` when handling the size tag, which was preventing the outermost tag from properly closing. Examples of the behavior this should fix:

```rpy
label start:

    "{b}Bold, {size=*2}large and bold,{/size}{/b} still bold."

    "{i}{u}{b}Styled, {size=*2}large and styled{/size}{/b}{/u}{/i}, still italic."

    "{size=*1.5}1.5x large, {size=*2}3x large,{/size}{/size} still 1.5x large."
```