### PR TITLE
fix bug that adds 1 second to each successive parallel build

### DIFF
--- a/launcher/game/package_formats.rpy
+++ b/launcher/game/package_formats.rpy
@@ -384,3 +384,5 @@ init python in distribute:
         for i in parallel_threads:
             if i.done:
                 i.done()
+
+        parallel_threads.clear()


### PR DESCRIPTION
When experimenting with parallelizing all game builds performed via the GUI, every build took +1 second longer than the previous one, until RenPy was restarted. This change fixes that bug.