### PR TITLE
docs: restrict the cython version and add setuptools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ To return to this virtualenv later, run::
 
 After activating the virtualenv, install additional dependencies::
 
-    pip install -U cython future six typing pefile requests ecdsa
+    pip install -U "setuptools cython<3.0.0 future six typing pefile requests ecdsa"
 
 Then, install pygame_sdl2 by running the following commands::
 


### PR DESCRIPTION
I have quite new ubuntu 24.04 in wsl2 and I tried to install it following the readme and found few issues which I'm fixing here:

- The setuptools were missing, so it's worth adding them when other stuff gets installed
- Cython 3 is out for quite some time and it's not compatible with `pygame_sdl2` at all. 

This is the log of my attempt
<details>

```bash
(renpy) (base) racinsky@PRGA-010501:/mnt/c/Projects/others/renpy/pygame_sdl2$ python setup.py install
pygame_sdl2.error is out of date.
pygame_sdl2.color is out of date.
pygame_sdl2.controller is out of date.
pygame_sdl2.rect is out of date.
pygame_sdl2.rwobject is out of date.

Error compiling Cython file:
------------------------------------------------------------
...
            sf.base = base
            sf.length = length
            sf.tell = 0

            rv = SDL_AllocRW()
            rv.size = subfile_size
                      ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:453:22: Cannot assign type 'Sint64 (SDL_RWops *) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'subfile_size'.

Error compiling Cython file:
------------------------------------------------------------
...
            sf.length = length
            sf.tell = 0

            rv = SDL_AllocRW()
            rv.size = subfile_size
            rv.seek = subfile_seek
                      ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:454:22: Cannot assign type 'Sint64 (SDL_RWops *, Sint64, int) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *, Sint64, int) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'subfile_seek'.

Error compiling Cython file:
------------------------------------------------------------
...
            sf.tell = 0

            rv = SDL_AllocRW()
            rv.size = subfile_size
            rv.seek = subfile_seek
            rv.read = subfile_read
                      ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:455:22: Cannot assign type 'size_t (SDL_RWops *, void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'subfile_read'.

Error compiling Cython file:
------------------------------------------------------------
...
            rv = SDL_AllocRW()
            rv.size = subfile_size
            rv.seek = subfile_seek
            rv.read = subfile_read
            rv.write = NULL
            rv.close = subfile_close
                       ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:457:23: Cannot assign type 'int (SDL_RWops *) except? -1 nogil' to 'int (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'subfile_close'.

Error compiling Cython file:
------------------------------------------------------------
...
        raise IOError("{!r} is not a filename or file-like object.".format(filelike))

    Py_INCREF(filelike)

    rv = SDL_AllocRW()
    rv.size = python_size
              ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:474:14: Cannot assign type 'Sint64 (SDL_RWops *) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'python_size'.

Error compiling Cython file:
------------------------------------------------------------
...

    Py_INCREF(filelike)

    rv = SDL_AllocRW()
    rv.size = python_size
    rv.seek = python_seek
              ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:475:14: Cannot assign type 'Sint64 (SDL_RWops *, Sint64, int) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *, Sint64, int) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'python_seek'.

Error compiling Cython file:
------------------------------------------------------------
...
    Py_INCREF(filelike)

    rv = SDL_AllocRW()
    rv.size = python_size
    rv.seek = python_seek
    rv.read = python_read
              ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:476:14: Cannot assign type 'size_t (SDL_RWops *, void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'python_read'.

Error compiling Cython file:
------------------------------------------------------------
...

    rv = SDL_AllocRW()
    rv.size = python_size
    rv.seek = python_seek
    rv.read = python_read
    rv.write = python_write
               ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:477:15: Cannot assign type 'size_t (SDL_RWops *, const void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, const void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'python_write'.

Error compiling Cython file:
------------------------------------------------------------
...
    rv = SDL_AllocRW()
    rv.size = python_size
    rv.seek = python_seek
    rv.read = python_read
    rv.write = python_write
    rv.close = python_close
               ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:478:15: Cannot assign type 'int (SDL_RWops *) except? -1 nogil' to 'int (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'python_close'.

Error compiling Cython file:
------------------------------------------------------------
...
        bf.base = <Uint8 *> bf.view.buf
        bf.here = bf.base
        bf.stop = bf.base + bf.view.len

        rw = SDL_AllocRW()
        rw.size = buffile_size
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:711:18: Cannot assign type 'Sint64 (SDL_RWops *) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'buffile_size'.

Error compiling Cython file:
------------------------------------------------------------
...
        bf.here = bf.base
        bf.stop = bf.base + bf.view.len

        rw = SDL_AllocRW()
        rw.size = buffile_size
        rw.seek = buffile_seek
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:712:18: Cannot assign type 'Sint64 (SDL_RWops *, Sint64, int) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *, Sint64, int) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'buffile_seek'.

Error compiling Cython file:
------------------------------------------------------------
...
        bf.stop = bf.base + bf.view.len

        rw = SDL_AllocRW()
        rw.size = buffile_size
        rw.seek = buffile_seek
        rw.read = buffile_read
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:713:18: Cannot assign type 'size_t (SDL_RWops *, void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'buffile_read'.

Error compiling Cython file:
------------------------------------------------------------
...

        rw = SDL_AllocRW()
        rw.size = buffile_size
        rw.seek = buffile_seek
        rw.read = buffile_read
        rw.write = buffile_write
                   ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:714:19: Cannot assign type 'size_t (SDL_RWops *, const void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, const void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'buffile_write'.

Error compiling Cython file:
------------------------------------------------------------
...
        rw = SDL_AllocRW()
        rw.size = buffile_size
        rw.seek = buffile_seek
        rw.read = buffile_read
        rw.write = buffile_write
        rw.close = buffile_close
                   ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:715:19: Cannot assign type 'int (SDL_RWops *) except? -1 nogil' to 'int (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'buffile_close'.

Error compiling Cython file:
------------------------------------------------------------
...
        sf.b = to_rwops(b)
        sf.split = SDL_RWsize(sf.a)
        sf.tell = 0

        rw = SDL_AllocRW()
        rw.size = splitfile_size
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:743:18: Cannot assign type 'Sint64 (SDL_RWops *) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'splitfile_size'.

Error compiling Cython file:
------------------------------------------------------------
...
        sf.split = SDL_RWsize(sf.a)
        sf.tell = 0

        rw = SDL_AllocRW()
        rw.size = splitfile_size
        rw.seek = splitfile_seek
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:744:18: Cannot assign type 'Sint64 (SDL_RWops *, Sint64, int) except? -1 nogil' to 'Sint64 (*)(SDL_RWops *, Sint64, int) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'splitfile_seek'.

Error compiling Cython file:
------------------------------------------------------------
...
        sf.tell = 0

        rw = SDL_AllocRW()
        rw.size = splitfile_size
        rw.seek = splitfile_seek
        rw.read = splitfile_read
                  ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:745:18: Cannot assign type 'size_t (SDL_RWops *, void *, size_t, size_t) except? -1 nogil' to 'size_t (*)(SDL_RWops *, void *, size_t, size_t) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'splitfile_read'.

Error compiling Cython file:
------------------------------------------------------------
...
        rw = SDL_AllocRW()
        rw.size = splitfile_size
        rw.seek = splitfile_seek
        rw.read = splitfile_read
        rw.write = NULL
        rw.close = splitfile_close
                   ^
------------------------------------------------------------

src/pygame_sdl2/rwobject.pyx:747:19: Cannot assign type 'int (SDL_RWops *) except? -1 nogil' to 'int (*)(SDL_RWops *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of 'splitfile_close'.

Command '['cython', '--3str', '-X', 'profile=False', '-X', 'embedsignature=True', '-Iinclude', '-Igen3', '-a', 'src/pygame_sdl2/rwobject.pyx', '-o', 'gen3/pygame_sdl2.rwobject.c']' returned non-zero exit status 1.

(renpy) (base) racinsky@PRGA-010501:/mnt/c/Projects/others/renpy/pygame_sdl2$ pip freeze
certifi==2024.8.30
charset-normalizer==3.4.0
Cython==3.0.11
ecdsa==0.19.0
future==1.0.0
idna==3.10
pefile==2024.8.26
requests==2.32.3
setuptools==75.1.0
six==1.16.0
typing==3.7.4.3
urllib3==2.2.3
```

</details>

Installing the older cython fixed the issue and I was able to compile.