### PR TITLE
Only ignore .rpe files if they are not explicitly tracked

### DIFF
--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -153,7 +153,6 @@ init -1500 python in build:
         ("*.dll", None),
         ("*.manifest", None),
         ("*.keystore", None),
-        ( "**.rpe", None),
         ( "**.rpe.py", None),
 
         ("update.pem", None),
@@ -223,6 +222,7 @@ init -1500 python in build:
     base_patterns = [ ]
 
     late_base_patterns = pattern_list([
+        ( "**.rpe", None),
         (".*", None),
         ("**", "all")
         ])

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -222,7 +222,6 @@ init -1500 python in build:
     base_patterns = [ ]
 
     late_base_patterns = pattern_list([
-        ( "**.rpe", None),
         (".*", None),
         ("**", "all")
         ])


### PR DESCRIPTION
Some games make use of .rpe files to extend Ren'Py's capabilities and/or embed game-specific python libraries. This makes it possible to keep this kind of game working while still removing rpe files by default.

I have at least two such cases:

* A game that uses a custom archive format and augments Ren'Py with support for it
* Games that use my Epic Games integration for Ren'Py ( https://github.com/Ayowel/renpy-epicgames-eos )