### PR TITLE
Fix an obvious undefined variable error

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -308,6 +308,7 @@ let video_start = (c) => {
 };
 
 let video_pause = (c) => {
+    const p = c.playing;
     if (p.started === null) {
         return;
     }


### PR DESCRIPTION
Fixes `Uncaught ReferenceError: p is not defined`