### PR TITLE
transitions in screen actions

### DIFF
--- a/renpy/common/00action_control.rpy
+++ b/renpy/common/00action_control.rpy
@@ -131,7 +131,7 @@ init -1500 python:
             renpy.show_screen(self.screen, *self.args, **self.kwargs)
 
             if self.transition is not None:
-                renpy.transition(self.transition)
+                renpy.transition(self.transition, layer=self.kwargs.get("_layer", None))
 
             renpy.restart_interaction()
 
@@ -166,13 +166,15 @@ init -1500 python:
             renpy.predict_screen(self.screen, *self.args, **self.kwargs)
 
         def __call__(self):
-            if renpy.get_screen(self.screen, layer=self.kwargs.get("_layer", None)):
-                renpy.hide_screen(self.screen, layer=self.kwargs.get("_layer", None))
+            layer=self.kwargs.get("_layer", None)
+            
+            if renpy.get_screen(self.screen, layer=layer):
+                renpy.hide_screen(self.screen, layer=layer)
             else:
                 renpy.show_screen(self.screen, *self.args, **self.kwargs)
 
             if self.transition is not None:
-                renpy.transition(self.transition)
+                renpy.transition(self.transition, layer=layer)
 
             renpy.restart_interaction()
 
@@ -239,10 +241,13 @@ init -1500 python:
 
                 renpy.hide_screen(cs.screen_name, layer=cs.layer, immediately=self.immediately)
 
+                if self.transition is not None:
+                    renpy.transition(self.transition, layer=cs.layer)
+
             else:
                 renpy.hide_screen(self.screen, layer=self._layer, immediately=self.immediately)
 
-            if self.transition is not None:
-                renpy.transition(self.transition)
+                if self.transition is not None:
+                    renpy.transition(self.transition, layer=self._layer)
 
             renpy.restart_interaction()

--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -180,13 +180,19 @@ init -1500 python:
         :doc: other_action
 
         Causes `transition` to occur.
+
+        `layer`
+            This is passed as the layer argument to :func:`renpy.transition`.
         """
 
-        def __init__(self, transition):
+        layer = None
+
+        def __init__(self, transition, layer=None):
             self.transition = transition
+            self.layer = layer
 
         def __call__(self):
-            renpy.transition(self.transition)
+            renpy.transition(self.transition, layer=self.layer)
             renpy.restart_interaction()
 
     @renpy.pure


### PR DESCRIPTION
various screen Actions() now use their _layer/layer arguments in renpy.transition() to actually have transitions on these layers.