### PR TITLE
First bit of PEP 657 in RenPy

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -253,6 +253,7 @@ name_blacklist = {
     "renpy.exports.sdl_dll",
     "renpy.sl2.slast.serial",
     "renpy.gl2.gl2draw.default_position",
+    "renpy.lexer._python_updatecache",
     }
 
 class Backup(_object):

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -509,50 +509,69 @@ init python:
 
         return "\n".join(rv)
 
-    def __format_parse_errors(s):
+    def __format_parse_errors(errors: list[str]):
+        """
+        Takes list of ParseError messages and transforms it
+        to string of sane length to be used as child of viewport.
+        """
+
         import re
 
-        rv = ""
+        rv = []
+        rv_len = 0
+        for error in errors:
+            lines = error.split("\n")
 
-        lines = s.split("\n")
-        lines = __limit_lines(lines)
-        len_lines = len(lines)
+            # Do not count first line in total to include those as much as
+            # possible.
+            rv.append(re.sub(
+                r'(File "(.*)", line (\d+))',
+                r'{a=edit:\3:\2}\1{/a}',
+                lines.pop(0)))
 
-        ln = 0
+            error_rv = []
+            error_len = 0
+            for line in lines:
+                # In case we have single insanely lengthy single error.
+                error_len += len(line)
+                if error_len > 65536:
+                    error_rv.clear()
+                    break
 
-        while ln < len_lines:
-            line = lines[ln]
-            ln += 1
+                if set(line.strip()) == {"^"}:
+                    idx = line.find("^")
+                    count = line.count("^", idx)
 
-            if ln < len_lines and lines[ln].endswith("^"):
-                highlight = len(lines[ln]) - 1
-                ln += 1
-            else:
-                highlight = -1
+                    prev_line = error_rv[-1]
 
-            pos = 0
+                    line = prev_line[:idx]
 
-            for c in line:
-                if pos == highlight:
-                    rv += u"{color=#c00}\u2192{/color}"
-                    highlight = -1
+                    if count == 1:
+                        if len(prev_line) < idx + count:
+                            mark = "\u2190"
+                        else:
+                            mark = "\u2192"
+                            count = 0
+                    else:
+                        mark = prev_line[idx:idx + count]
+                    line += "{b}{color=#a00}"
+                    line += mark
+                    line += "{/color}{/b}"
+                    line += prev_line[idx + count:]
 
-                pos += 1
+                    error_rv[-1] = line
+                    continue
 
-                if c == "{":
-                    rv += "{{"
-                else:
-                    rv += c
+                error_rv.append(line)
 
-            if highlight > 0:
-                rv += u"{color=#c00}\u2190{/color}"
+            rv_len += error_len
+            if rv_len > 1048576:
+                break
 
-            rv += "\n"
+            rv.extend(error_rv)
+            rv.append("")
 
-
-        rv = re.sub(r'(File "(.*)", line (\d+))', r'{a=edit:\3:\2}\1{/a}', rv)
-
-        return rv
+        return "\n".join(rv)
 
     class _EditFile(Action):
         def __init__(self, filename, line=1):
@@ -787,7 +806,7 @@ screen _exception:
     key "console" action __EnterConsole()
 
 # The screen that is used for error handling.
-screen _parse_errors:
+screen _parse_errors(errors, error_fn, reload_action):
     modal True
     layer config.interface_layer
     zorder 1090

--- a/renpy/display/error.py
+++ b/renpy/display/error.py
@@ -22,7 +22,7 @@
 # This file contains code to handle GUI-based error reporting.
 
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
+from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
 
 
 import os
@@ -143,7 +143,7 @@ def report_exception(short, full, traceback_fn):
             reload_action=reload_action,
             ignore_action=ignore_action,
             traceback_fn=traceback_fn,
-            )
+        )
 
         renpy.display.im.ignored_images |= renpy.display.im.images_to_ignore
 
@@ -162,7 +162,7 @@ def report_exception(short, full, traceback_fn):
         raise
 
 
-def report_parse_errors(errors, error_fn):
+def report_parse_errors(errors: list[str], error_fn: str) -> bool:
     """
     Reports an exception to the user. Returns True if the exception should
     be raised by the normal reporting mechanisms. Otherwise, should raise
@@ -174,7 +174,7 @@ def report_parse_errors(errors, error_fn):
 
     error_dump()
 
-    if renpy.game.args.command != "run": # @UndefinedVariable
+    if renpy.game.args.command != "run":
         return True
 
     if "RENPY_SIMPLE_EXCEPTIONS" in os.environ:
@@ -199,7 +199,7 @@ def report_parse_errors(errors, error_fn):
             reload_action=reload_action,
             errors=errors,
             error_fn=error_fn,
-            )
+        )
 
     except renpy.game.CONTROL_EXCEPTIONS:
         raise
@@ -208,3 +208,5 @@ def report_parse_errors(errors, error_fn):
         renpy.display.log.write("While handling exception:")
         renpy.display.log.exception()
         raise
+
+    return False

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -20,8 +20,8 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals # type: ignore
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
+from __future__ import division, absolute_import, with_statement, print_function, unicode_literals  # type: ignore
+from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
 
 from typing import Any
 
@@ -90,61 +90,74 @@ def _updatecache(filename: str, module_globals: dict[str, Any] | None = None) ->
 linecache.updatecache = _updatecache
 
 
-class ParseError(Exception):
+class ParseError(SyntaxError):
+    """
+    Special exception type for syntax errors in Ren'Py.
+    This exception includes syntax errors of Python code, converted to
+    appropriate report style, and Ren'Py own syntax errors in user script.
+    """
 
-    def __init__(self, filename, number, msg, line=None, pos=None, first=False):
-        message = u"File \"%s\", line %d: %s" % (unicode_filename(filename), number, msg)
+    _message: str | None = None
 
-        if line:
-            if isinstance(line, list):
-                line = "".join(line)
+    def __init__(
+        self,
+        message: str,
+        filename: str,
+        lineno: int,
+        offset: int | None = None,
+        text: str | None = None,
+        end_lineno: int | None = None,
+        end_offset: int | None = None,
+    ):
+        super().__init__(message, (
+            unicode_filename(filename),
+            lineno, offset,
+            text,
+            end_lineno, end_offset))
 
-            lines = line.split('\n')
+    @property
+    def message(self) -> str:
+        """
+        Fully formatted message of the error close to the result of
+        `traceback.print_exception_only`.
+        """
+        if self._message is None:
+            message = f'File "{self.filename}", line {self.lineno}: {self.msg}'
+            if self.text is not None:
+                # Neither Python nor this class does not support multiline syntax error code.
+                # Just strip the first line of provided code.
+                text = self.text.split("\n")[0]
 
-            if '"""' in lines[0]:
-                pass
-            elif "'''" in lines[0]:
-                pass
-            elif len(lines) > 1:
-                open_string = None
-                i = 0
+                # Remove ending escape chars, so we can render it.
+                text = text.rstrip()
 
-                while i < len(lines[0]):
-                    c = lines[0][i]
+                # And also replace any escape chars at the start with an indent.
+                message += f'\n    {text.lstrip()}'
 
-                    if c == "\\":
-                        i += 1
-                    elif c == open_string:
-                        open_string = None
-                    elif open_string:
-                        pass
-                    elif c == '`' or c == '\'' or c == '"':
-                        open_string = c
+                if self.offset is not None:
+                    offset = self.offset
 
-                    i += 1
-
-                if open_string:
-                    message += "\n(Perhaps you left out a %s at the end of the first line.)" % open_string
-
-            for l in lines:
-                message += "\n    " + l
-
-                if pos is not None:
-                    if pos <= len(l):
-                        message += "\n    " + " " * pos + "^"
-                        pos = None
+                    # Fallback to single caret for cases end_offset is before offset.
+                    if self.end_offset is None or self.end_offset <= offset:
+                        end_offset = offset + 1
                     else:
-                        pos -= len(l)
+                        end_offset = self.end_offset
 
-                if first:
-                    break
+                    left_spaces = len(text) - len(text.lstrip())
+                    offset -= left_spaces
+                    end_offset -= left_spaces
 
-        self.message = message
+                    if offset >= 1:
+                        caret_space = ' ' * (offset - 1)
+                        carets = '^' * (end_offset - offset)
+                        message += f"\n    {caret_space}{carets}"
 
-        Exception.__init__(self, message)
+            for note in getattr(self, "__notes__", ()):
+                message += f"\n{note}"
 
-    def __unicode__(self):
-        return self.message
+            self._message = message
+
+        return self._message
 
     def defer(self, queue):
         renpy.parser.deferred_parse_errors[queue].append(self.message)
@@ -370,7 +383,8 @@ def list_logical_lines(filename, filedata=None, linenumber=1, add_lines=False):
             c = data[pos]
 
             if c == u'\t':
-                raise ParseError(filename, number, "Tab characters are not allowed in Ren'Py scripts.")
+                raise ParseError("Tab characters are not allowed in Ren'Py scripts.",
+                                 filename, number)
 
             if c == u'\n' and not parendepth:
 
@@ -510,10 +524,19 @@ def list_logical_lines(filename, filedata=None, linenumber=1, add_lines=False):
             pos = end
 
             if (pos - startpos) > 65536:
-                raise ParseError(filename, start_number, "Overly long logical line. (Check strings and parenthesis.)", line=line, first=True)
+                err = ParseError(
+                    "Overly long logical line.",
+                    filename, start_number,
+                    text="".join(line))
+                err.add_note("Check strings and parenthesis.")
+                raise err
 
     if line:
-        raise ParseError(filename, start_number, "is not terminated with a newline. (Check strings and parenthesis.)", line=line, first=True)
+        err = ParseError("is not terminated with a newline.",
+                         filename, start_number,
+                         text="".join(line))
+        err.add_note("Check strings and parenthesis.")
+        raise err
 
     return rv
 
@@ -537,6 +560,8 @@ def depth_split(l):
     return depth, l[index:]
 
 # i, min_depth -> block, new_i
+
+
 def gll_core(lines, i, min_depth):
     """
     Recursively groups lines into blocks.
@@ -561,7 +586,9 @@ def gll_core(lines, i, min_depth):
             depth = line_depth
 
         if depth != line_depth:
-            raise ParseError(filename, number, "Indentation mismatch.")
+            raise ParseError(
+                "Indentation mismatch.",
+                filename, number, text=text)
 
         # Advance to the next line.
         i += 1
@@ -572,6 +599,7 @@ def gll_core(lines, i, min_depth):
         rv.append((filename, number, rest, block))
 
     return rv, i
+
 
 def group_logical_lines(lines):
     """
@@ -587,7 +615,9 @@ def group_logical_lines(lines):
         filename, number, text = lines[0]
 
         if depth_split(text)[0] != 0:
-            raise ParseError(filename, number, "Unexpected indentation at start of file.")
+            raise ParseError(
+                "Unexpected indentation at start of file.",
+                filename, number, text=text)
 
     return gll_core(lines, 0, 0)[0]
 
@@ -836,7 +866,12 @@ class Lexer(object):
         if (self.line == -1) and self.block:
             self.filename, self.number, self.text, self.subblock = self.block[0]
 
-        raise ParseError(self.filename, self.number, msg, self.text, self.pos)
+        raise ParseError(
+            msg,
+            self.filename,
+            self.number,
+            self.pos,
+            self.text)
 
     def deferred_error(self, queue, msg):
         """
@@ -850,7 +885,10 @@ class Lexer(object):
         if (self.line == -1) and self.block:
             self.filename, self.number, self.text, self.subblock = self.block[0]
 
-        ParseError(self.filename, self.number, msg, self.text, self.pos).defer(queue)
+        ParseError(
+            msg, self.filename,
+            self.number, self.pos + 1,
+            self.text).defer(queue)
 
     def eol(self):
         """
@@ -905,7 +943,8 @@ class Lexer(object):
 
         init = self.init or init
 
-        return Lexer(self.subblock, init=init, init_offset=self.init_offset, global_label=self.global_label, monologue_delimiter=self.monologue_delimiter, subparses=self.subparses)
+        return Lexer(self.subblock, init=init, init_offset=self.init_offset, global_label=self.global_label,
+                     monologue_delimiter=self.monologue_delimiter, subparses=self.subparses)
 
     def string(self):
         """
@@ -961,7 +1000,7 @@ class Lexer(object):
             # Collapse runs of whitespace into single spaces.
             s = re.sub(r'[ \n]+', ' ', s)
 
-            s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s) # type: ignore
+            s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s)  # type: ignore
 
         return s
 
@@ -1040,7 +1079,7 @@ class Lexer(object):
                 else:
                     s = re.sub(r' +', ' ', s)
 
-                s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s) # type: ignore
+                s = re.sub(r'\\(u([0-9a-fA-F]{1,4})|.)', dequote, s)  # type: ignore
 
                 rv.append(s)
 
@@ -1056,7 +1095,7 @@ class Lexer(object):
 
         return self.match(r'(\+|\-)?\d+')
 
-    def float(self): # @ReservedAssignment
+    def float(self):
         """
         Tries to parse a number (float). Returns a string containing the
         number, or None.
@@ -1178,7 +1217,7 @@ class Lexer(object):
                 self.pos = oldpos
                 return None
 
-        if (rv in KEYWORDS ) or (rv in IMAGE_KEYWORDS):
+        if (rv in KEYWORDS) or (rv in IMAGE_KEYWORDS):
             self.pos = oldpos
             return None
 
@@ -1196,7 +1235,6 @@ class Lexer(object):
             return False
 
         old_pos = self.pos
-
 
         # Delimiter.
         start = self.match(r'[urfURF]*("""|\'\'\'|"|\')')
@@ -1293,7 +1331,7 @@ class Lexer(object):
         if not pe:
             self.error("expected python_expression")
 
-        rv = self.expr(pe.strip(), expr) # E1101
+        rv = self.expr(pe.strip(), expr)
 
         return rv
 
@@ -1679,8 +1717,9 @@ def ren_py_to_rpy(text: str, filename: str | None) -> str:
             raise Exception('In {!r}, there are no """renpy blocks, so every line is ignored.'.format(filename))
 
         if state == RENPY:
-            raise Exception('In {!r}, there is a """renpy block at line {} that is not terminated by """.'.format(filename,
-                                                                                                                open_linenumber))
+            raise Exception(
+                'In {!r}, there is a """renpy block at line {} that is not terminated by """.'.format(
+                    filename, open_linenumber))
 
     rv = "\n".join(result)
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -43,7 +43,6 @@ from renpy.lexer import (
     munge_filename,
     elide_filename,
     unelide_filename,
-    get_line_text,
     SubParse,
 )
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1772,8 +1772,10 @@ def report_parse_errors():
     full_text = ""
 
     f, error_fn = renpy.error.open_error_file("errors.txt", "w")
+
+    screen_parse_errors = []
     with f:
-        f.write("\ufeff") # BOM
+        f.write("\ufeff")  # BOM
 
         print("I'm sorry, but errors were detected in your script. Please correct the", file=f)
         print("errors listed below, and try again.", file=f)
@@ -1790,6 +1792,8 @@ def report_parse_errors():
             print("", file=f)
             print(i, file=f)
 
+            screen_parse_errors.append(i)
+
             try:
                 print("")
                 print(i)
@@ -1800,7 +1804,7 @@ def report_parse_errors():
         print("Ren'Py Version:", renpy.version, file=f)
         print(str(time.ctime()), file=f)
 
-    renpy.display.error.report_parse_errors(full_text, error_fn)
+    renpy.display.error.report_parse_errors(screen_parse_errors, error_fn)
 
     try:
         if renpy.game.args.command == "run" or renpy.game.args.errors_in_editor: # type: ignore

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1100,22 +1100,12 @@ def py_compile(source, mode, filename='<none>', lineno=1, ast_node=False, cache=
 
         try:
             with save_warnings():
-                # filename should not be a valid file name, so Python tokenizer
-                # function 'get_error_line_from_tokenizer_buffers' does not try
-                # to read from the file to get the size of the buffer of error
-                # line.
-                tree = compile(source, "<tree>", py_mode, ast.PyCF_ONLY_AST | flags, 1)
+                tree = compile(source, filename, py_mode, ast.PyCF_ONLY_AST | flags, 1)
         except SyntaxError as orig_e:
-            # Set back filename to correct one.
-            # For what it worth, '_PyPegen_raise_error_known_location'
-            # fixes lineno, col_offset and end_col_offset, but not end_lineno.
-            # We don't use it, so whatever.
-            orig_e.filename = filename
-
             try:
                 fixed_source = renpy.compat.fixes.fix_tokens(source)
                 with save_warnings():
-                    tree = compile(fixed_source, "<tree>", py_mode, ast.PyCF_ONLY_AST | flags, 1)
+                    tree = compile(fixed_source, filename, py_mode, ast.PyCF_ONLY_AST | flags, 1)
             except Exception:
                 raise orig_e
 

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1100,13 +1100,22 @@ def py_compile(source, mode, filename='<none>', lineno=1, ast_node=False, cache=
 
         try:
             with save_warnings():
-                tree = compile(source, filename, py_mode, ast.PyCF_ONLY_AST | flags, 1)
+                # filename should not be a valid file name, so Python tokenizer
+                # function 'get_error_line_from_tokenizer_buffers' does not try
+                # to read from the file to get the size of the buffer of error
+                # line.
+                tree = compile(source, "<tree>", py_mode, ast.PyCF_ONLY_AST | flags, 1)
         except SyntaxError as orig_e:
+            # Set back filename to correct one.
+            # For what it worth, '_PyPegen_raise_error_known_location'
+            # fixes lineno, col_offset and end_col_offset, but not end_lineno.
+            # We don't use it, so whatever.
+            orig_e.filename = filename
 
             try:
                 fixed_source = renpy.compat.fixes.fix_tokens(source)
                 with save_warnings():
-                    tree = compile(fixed_source, filename, py_mode, ast.PyCF_ONLY_AST | flags, 1)
+                    tree = compile(fixed_source, "<tree>", py_mode, ast.PyCF_ONLY_AST | flags, 1)
             except Exception:
                 raise orig_e
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -572,12 +572,13 @@ class Script(object):
                     if renpy.config.allow_duplicate_labels:
                         return
 
+                    import linecache
                     self.duplicate_labels.append(
                         u'The label {} is defined twice, at File "{}", line {}:\n{}and File "{}", line {}:\n{}'.format(
                             bad_name, old_node.filename, old_node.linenumber,
-                            renpy.lexer.get_line_text(old_node.filename, old_node.linenumber),
+                            linecache.getline(old_node.filename, old_node.linenumber),
                             bad_node.filename, bad_node.linenumber,
-                            renpy.lexer.get_line_text(bad_node.filename, bad_node.linenumber),
+                            linecache.getline(bad_node.filename, bad_node.linenumber),
                         ))
 
         self.update_bytecode()

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -1009,18 +1009,14 @@ class Script(object):
                 i.bytecode = renpy.python.py_compile(i.source, i.mode, filename=i.filename, lineno=i.linenumber, py=i.py, hashcode=i.hashcode)
 
             except SyntaxError as e:
-
-                text = e.text
-
-                if text is None:
-                    text = ''
-
+                assert e.filename is not None
+                assert e.lineno is not None
                 pem = renpy.parser.ParseError(
-                    filename=e.filename,
-                    number=e.lineno,
-                    msg=e.msg,
-                    line=text,
-                    pos=e.offset)
+                    e.msg,
+                    e.filename,
+                    e.lineno, e.offset,
+                    e.text,
+                    e.end_lineno, e.end_offset)
 
                 renpy.parser.parse_errors.append(pem.message)
 

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -172,9 +172,9 @@ class ScriptTranslator(object):
                         old_node = self.default_translates[n.identifier]
 
                         err = renpy.lexer.ParseError(
-                            n.filename, n.linenumber,
                             f"Line with id {n.identifier} appears twice. "
-                            f"The other line is {old_node.filename}:{old_node.linenumber}")
+                            f"The other line is {old_node.filename}:{old_node.linenumber}",
+                            n.filename, n.linenumber,)
                         err.defer("duplicate_id")
 
                     self.default_translates[n.identifier] = n


### PR DESCRIPTION
This PR improves how RenPy reports parse errors in Python code (this can later be expanded to RenPy code).

Before:
![image](https://github.com/user-attachments/assets/0ca0a27d-ca82-4800-92e1-913c6dcd3317)

After:
![image](https://github.com/user-attachments/assets/d9adb444-6145-43c8-848e-2606690c41be)

---
Parse errors screen now automatically highlights error part of parse error if its message has more that one caret, e.g.
```
I'm sorry, but errors were detected in your script. Please correct the
errors listed below, and try again.


File "game/script.rpy", line 41: did you forget parentheses around the comprehension target?
    [x, y for x, y in zip([1, 2, 3], [3, 2, 1])]
     ^^^^

File "game/script.rpy", line 45: Generator expression must be parenthesized
    bar(1, i for i in range(3), 2)
           ^^^^^^^^^^^^^^^^^^^

File "game/script.rpy", line 48: cannot assign to True
    True = False
    ^^^^

File "game/script.rpy", line 51: expected '('
    def foo:
           ^

File "game/script.rpy", line 55: expected '('
    def foo
           ^

Ren'Py Version: Ren'Py 8.4.0.0+unofficial
Sun Nov  3 00:37:15 2024
```
---
This PR adds 3 backward incompatible changes in RenPy internal code:
1. Removes `renpy.lexer.get_line_text` which can be replaced with `linecache.getline`, which can be added back.
2. Changes order of parameters of `renpy.lexer.ParseError` so it is in line with `SyntaxError`, can be changed back.
3. `renpy.display.error.report_parse_errors` and `screen _parse_errors` now takes list of error messages instead of joined string, so it know where one error ends and the other starts.