### PR TITLE
Fix UnboundLocalError: local variable 'keyboard_mode' referenced befo…

### DIFF
--- a/renpy/common/00steam.rpy
+++ b/renpy/common/00steam.rpy
@@ -720,6 +720,7 @@ init -1499 python in _renpysteam:
 
     def keyboard_periodic():
 
+        global keyboard_mode
         global keyboard_showing
         global keyboard_primed
         global keyboard_shift


### PR DESCRIPTION
if keyboard_mode == "always":
UnboundLocalError: local variable 'keyboard_mode' referenced before assignment.