### PR TITLE
doc: fix python dependencies list for copy/paste

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ To return to this virtualenv later, run::
 
 After activating the virtualenv, install additional dependencies::
 
-    pip install -U "setuptools cython<3.0.0 future six typing pefile requests ecdsa"
+    pip install -U setuptools "cython<3.0.0" future six typing pefile requests ecdsa
 
 Then, install pygame_sdl2 by running the following commands::
 


### PR DESCRIPTION
Pip outputs a parameter format error when using the `pip install` command as documented. This fixes it so that it works as expected.