### PR TITLE
fix(render): do not match displayable if mouse is in default position

### DIFF
--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -1413,7 +1413,7 @@ cdef class Render:
                         if mask_result:
                             rv = d, arg, screen
 
-                elif xo <= x < xo + w and yo <= y < yo + h:
+                elif xo <= x < xo + w and yo <= y < yo + h and (x != 0 or y != 0):
                     rv = d, arg, screen
 
                 if rv is not None:


### PR DESCRIPTION
In some cases, the projected location is (0,0) instead of being out of the displayable. This notably happens when using `zoom 0` on a button (e.g.: in a choice screen), which results in the "invisible" displayable always taking the focus.

This creates a "dead pixel" in the top left corner of all displayable to accomodate the fact that this location is the default in most "error cases".

For example, the error occurs with the following "setup" and no visible choice can take focus (the invisible one has the focus and will be selected on click) before the `pause` time elapses and the third choice becomes visible (uncommenting the `alpha` lines also "solves" the issue, however it is not an obvious or natural fix for the developper):

```py

transform choice_button_transform(time_offset = 0):
    zoom (1. if time_offset <= 0 else 0.)
    #alpha 0.
    pause max(0, time_offset)
    #alpha 1.
    linear (0.5 * int(time_offset > 0)) zoom 1.

screen choice(items):
    style_prefix "choice"
    vbox:
        for i, choice in enumerate(items):
            textbutton choice.caption:
                id i
                default_focus 5-i
                at choice_button_transform(choice.kwargs.get('time_offset', 0))
                action choice.kwargs.get('action', choice.action)

label start:
    menu:
        "aze":
            "azeqsd"
        "vze":
            "vzeqsd"
        "qze" (time_offset = 3):
            "qzeqsd"
```
