### PR TITLE
fix link to pyjnius docs

### DIFF
--- a/sphinx/source/android.rst
+++ b/sphinx/source/android.rst
@@ -335,7 +335,7 @@ android-downloading.jpg
 Pyjnius
 =======
 
-When running on Android, a version of the `Pyjnius <https://pyjnius.readthedocs.io/en/stable/>`__
+When running on Android, a version of the `Pyjnius <https://pyjnius.readthedocs.io/en/latest/>`__
 library is available. This allows advanced creators to call into the Android
 libraries.
 


### PR DESCRIPTION
Seems the original URL refering to "stable" doesn't exist anymore, this updates it to direct to "latest" instead.