### PR TITLE
Fix the ATL part of the tutorial to show the correct example code

### DIFF
--- a/tutorial/game/tutorial_atl.rpy
+++ b/tutorial/game/tutorial_atl.rpy
@@ -545,11 +545,10 @@ label tutorial_atl:
 
     e "If we were to write repeat 2 instead, the animation would loop twice, then stop."
 
-    show example atl_image1
+    show example atl_image2
     show eileen animated once
 
     e "Omitting the repeat statement means that the animation stops once we reach the end of the block of ATL code."
-
 
     show example atl_with
     show bg atl transitions


### PR DESCRIPTION
In the "Tutorial" > "Transforms and Animation", there is a section that demonstrated that `repeat` can take an integer argument.

However, the `alt_image1` example code is shown twice on lines 543 and 548 for two different examples.

Line 548, should be changed to show the `alt_image2` example code which removed the `repeat 2` line from the previous example, showing that the animation will only happen once.