### PR TITLE
input: Improve rendering of caret

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1545,7 +1545,7 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
         def set_content(content):
 
             if content == "":
-                content = " "
+                content = "\u200b"
 
             if editable:
                 l = len(content)

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -508,9 +508,6 @@ class DisplayableSegment(object):
 
         self.width, self.height = rend.get_size()
 
-        if isinstance(d, renpy.display.behavior.CaretBlink):
-            self.width = 0
-
         self.hyperlink = ts.hyperlink
         self.cps = ts.cps
         self.ruby_top = ts.ruby_top
@@ -530,7 +527,7 @@ class DisplayableSegment(object):
         glyph.character = 0xfffc
         glyph.ascent = 0
         glyph.line_spacing = h
-        glyph.advance = w
+        glyph.advance = 0 if isinstance(self.d, renpy.display.behavior.CaretBlink) else w
         glyph.width = w
         glyph.shader = self.shader
 
@@ -1227,7 +1224,7 @@ class Layout(object):
                 if isinstance(i[0], (TextSegment, SpaceSegment, DisplayableSegment)):
                     return
 
-            line.extend(tss[-1].subsegment(u"\u200B")) # type: ignore
+            line.extend(tss[-1].subsegment("\u200b")) # type: ignore
 
         for type, text in tokens: # @ReservedAssignment
 
@@ -1246,9 +1243,8 @@ class Layout(object):
 
                 elif type == TEXT:
 
-                    if (text_displayable.mask is not None):
-                        if text != " ":
-                            text = text_displayable.mask * len(text)
+                    if text_displayable.mask is not None and text != "\u200b":
+                        text = text_displayable.mask * len(text)
 
                     line.extend(self.create_text_segments(text, tss[-1], style))
 


### PR DESCRIPTION
Fixes #5929

Logic here is that `advance` is the starting point of the next character, while `width` is the size of the "ink", and while we do not wish to after the position of the next character, we do still want this glyph to have correct bounds so the eventual render can be sized appropriately.

---

This change ensures that there is always space in the input render for the caret (based on its actual width), while retaining the current behaviour where shifting the caret left and right does not impact the layout of the surrounding text.

This allows us to go back to using a zero-width space as a sentinel in empty inputs (to ensure their correct height) thus avoiding ambiguity between a sentinel space and a user-provided space (which resulted in undesirable behaviour in masked inputs if the first character input by a user was a space).

---

While testing this I did observe some character jitter when moving the caret left and right, however it after further investigation it appears to be a regression that got introduced somewhere between 8.1 and 8.2, for which I'll file a separate issue.