### PR TITLE
Mention screen calling labels in Special Labels

### DIFF
--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -236,6 +236,14 @@ The following labels are used by Ren'Py:
     cancelled (it's assumed the hide has occurred). Otherwise, the hide
     continues.
 
+Ren'Py also uses the following labels to show some of the :doc:`special screens <screen_special>`:
+
+* ``main_menu_screen``
+* ``load_screen``
+* ``save_screen``
+* ``preferences_screen``
+* ``joystick_preferences_screen``
+
 Labels & Control Flow Functions
 -------------------------------
 


### PR DESCRIPTION
Most internal labels start with an underscore and can be easily told apart from regular labels. 
There are couple labels that don't. All are defined under common/_layout/ and thus Ren'Py throws a "defined twice" exception should someone try to define their own with the same name, but I figured it would be nice to have them briefly mentioned in the docs nonetheless.