### PR TITLE
Live2D.blend_opacity wasn't usable

### DIFF
--- a/renpy/gl2/live2d.py
+++ b/renpy/gl2/live2d.py
@@ -907,6 +907,12 @@ class Live2D(renpy.display.displayable.Displayable):
 
         self.common.model.blend_parameter(name, blend, value, weight)
 
+    def blend_opacity(self, name, blend, value, weight=1.0):
+        if blend not in ("Add", "Multiply", "Overwrite"):
+            raise Exception("Unknown blend mode {!r}".format(blend))
+
+        self.common.model.blend_opacity(name, blend, value, weight)
+
     def render(self, width, height, st, at):
 
         common = self.common


### PR DESCRIPTION
looks like you forgot to put this code here?

i've been using `live2d.blend_parameter` in my `update_function`, but `live2d.blend_opacity` threw an error saying it didn't exist until i added this code. now it exists and works fine