### PR TITLE
Fix a few remaining issues with input carets

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1546,28 +1546,26 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
 
         def set_content(content):
 
+            if content == "":
+                # Use ZWSP to force correct vertical size using font style.
+                content = "\u200b"
+
             if editable:
-                l = len(content)
-                caret_content = [
+                self.set_text([
                     self.prefix,
-                    content[0:self.caret_pos].replace("{", "{{"),
+                    content[:self.caret_pos].replace("{", "{{"),
                     edit_text,
                     caret,
-                    content[self.caret_pos:l].replace("{", "{{"),
+                    content[self.caret_pos:].replace("{", "{{"),
                     self.suffix
-                    ]
+                    ])
 
             else:
-                caret_content = [
+                self.set_text([
                     self.prefix,
                     content.replace("{", "{{"),
                     self.suffix
-                ]
-
-            if not content:
-                caret_content.append("{space=1}")
-
-            self.set_text(caret_content)
+                ])
 
             if isinstance(self.caret, CaretBlink):
                 self.caret.st_base = self.st

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1116,9 +1116,9 @@ class Button(renpy.display.layout.Window):
         # If we have a child, try passing the event to it. (For keyboard
         # events, this only happens if we're focused.)
         if (not (ev.type in KEY_EVENTS)) or self.style.key_events:
-                rv = super(Button, self).event(ev, x, y, st)
-                if rv is not None:
-                    return rv
+            rv = super(Button, self).event(ev, x, y, st)
+            if rv is not None:
+                return rv
         else:
 
             # Used to prevent keymaps (the key statement) from reacting to
@@ -1478,7 +1478,9 @@ class Input(renpy.text.text.Text): # @UndefinedVariable
             if i.endswith("color"):
                 caretprops[i] = v
 
-        caret = renpy.display.image.Solid(xysize=(1, renpy.store.preferences.font_size), style=style, **caretprops)
+        caret = renpy.display.image.Solid(
+            xysize=(1, renpy.store.preferences.font_size),
+            style=style, **caretprops)
 
         if caret_blink:
             caret = CaretBlink(caret, caret_blink)

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1384,7 +1384,7 @@ class CaretBlink(renpy.display.displayable.Displayable):
         st -= self.st_base
 
         cr = renpy.display.render.render(self.caret, width, height, st, at)
-        rv = renpy.display.render.Render(1, height)
+        rv = renpy.display.render.Render(cr.width, height)
 
         ttl = self.caret_blink - st % self.caret_blink
 

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1243,7 +1243,7 @@ class Layout(object):
 
                 elif type == TEXT:
 
-                    if (text_displayable.mask is not None):
+                    if text_displayable.mask is not None and text != "\u200b":
                         text = text_displayable.mask * len(text)
 
                     line.extend(self.create_text_segments(text, tss[-1], style))

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1224,7 +1224,7 @@ class Layout(object):
                 if isinstance(i[0], (TextSegment, SpaceSegment, DisplayableSegment)):
                     return
 
-            line.extend(tss[-1].subsegment(u"\u200B")) # type: ignore
+            line.extend(tss[-1].subsegment("\u200b")) # type: ignore
 
         for type, text in tokens: # @ReservedAssignment
 


### PR DESCRIPTION
First issue is that if a caret displayable with a width greater than 1px was provided via a style, the pixel_width property was unable to correctly constrain it within the bounds of the input because it's parent's width was always being reported as 1. This was needed way back to minimise disruption caused by the caret to the text layout, but we have a better solution to this now.

The second issue is that after https://github.com/renpy/renpy/commit/4a1182cdd522aedb71617a8e902c208749da7061 the height of empty inputs is no longer based on the font style, with the result being that the height jumps up and down between when the input is empty and when it contains at least one character. This restores the previous solution to this issue.