### PR TITLE
docs: Update persistent._clear with current behavior

### DIFF
--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -95,8 +95,7 @@ Persistent Functions
     `progress`
         If true, also resets progress data that Ren'Py keeps.
 
-    Note that this will delete all persistent data, and will not re-apply
-    defaults until Ren'Py restarts.
+    Note that this will re-apply defaults.
 
 .. include:: inc/persistent
 


### PR DESCRIPTION
9df57291d68fa259033a51a5b8b502eece6dd985 (via #5000) changes the behavior of `persistent._clear` to re-apply default values, which makes the existing documentation wrong. Re-applying to default values and "resets the persistent data" already makes it clear enough that the data in memory is being "deleted" (which could instead also be interpreted as immediately deleting the persistent file on disk).