### PR TITLE
Fix order of attempting to load presplash images

### DIFF
--- a/renpy/display/presplash.py
+++ b/renpy/display/presplash.py
@@ -89,13 +89,13 @@ def start(basedir, gamedir):
     if "RENPY_LESS_UPDATES" in os.environ:
         return
 
-    presplash_fn = find_file("presplash", root=gamedir)
+    foreground_fn = find_file("presplash_foreground", root=gamedir)
+    background_fn = find_file("presplash_background", root=gamedir)
 
-    if not presplash_fn:
-        foreground_fn = find_file("presplash_foreground", root=gamedir)
-        background_fn = find_file("presplash_background", root=gamedir)
+    if not foreground_fn or not background_fn:
+        presplash_fn = find_file("presplash", root=gamedir)
 
-        if not foreground_fn or not background_fn:
+        if not presplash_fn:
             return
 
     if renpy.windows:
@@ -108,11 +108,11 @@ def start(basedir, gamedir):
 
     global progress_bar
 
-    if presplash_fn:
-        presplash = pygame_sdl2.image.load(presplash_fn)
-    else:
+    if foreground_fn and background_fn:
         presplash = ProgressBar(foreground_fn, background_fn) # type: ignore
         progress_bar = presplash
+    else:
+        presplash = pygame_sdl2.image.load(presplash_fn)
 
     global window
 
@@ -137,14 +137,15 @@ def start(basedir, gamedir):
         pos=(x, y),
         shape=shape)
 
-    if presplash_fn:
-        presplash = presplash.convert_alpha(window.get_surface())
-        window.get_surface().blit(presplash, (0, 0))
-    else:
+    if foreground_fn and background_fn:
         presplash.convert_alpha(window.get_surface())
         presplash.draw(window.get_surface(), 0)
+    else:
+        presplash = presplash.convert_alpha(window.get_surface())
+        window.get_surface().blit(presplash, (0, 0))
 
     window.update()
+
 
 
 # The last time the progress bar was updated.

--- a/renpy/display/presplash.py
+++ b/renpy/display/presplash.py
@@ -147,7 +147,6 @@ def start(basedir, gamedir):
     window.update()
 
 
-
 # The last time the progress bar was updated.
 last_pump_time = 0
 


### PR DESCRIPTION
Checks for foreground+background first, before falling back to the single presplash image, instead of the other way around, to match [behavior in the documentation](https://www.renpy.org/doc/html/splashscreen_presplash.html#adding-a-progress-bar).