### PR TITLE
Prevent MultipleDict masking builtins during interpolation

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -310,7 +310,7 @@ class MultipleDict(object):
             if key in d:
                 return d[key]
 
-        raise NameError("Name '{}' is not defined.".format(key))
+        raise KeyError("Name '{}' is not defined.".format(key))
 
     def __contains__(self, key):
         for d in self.dicts:


### PR DESCRIPTION
Fixes #5981

When scopes are stacked in [`substitute`](https://github.com/renpy/renpy/blob/9d4fd5aef1f0c49918d394759fd6ceb1ac0b9dfd/renpy/substitutions.py#L371) the resulting `MultipleDict` instance would fail to meet the expectation from Python proper that missing keys raise a `KeyError` (rather than a `NameError`). During `eval` this would unintentionally prevent access to `builtins`.

Switching to the `collections` module's `ChainMap` would have been ideal here, as it serves the same purpose, and being Python managed it's more likely to retain compatibility with `eval` in future. Unfortunately however it's not available in Python 2. A separate PR to make that change in readiness for 8.4 will be submitted shortly.

The problem and difference is illustrated in the REPL reproduction below.
```
> renpy.python.py_eval('len', {}, {})
<built-in function len>

> renpy.python.py_eval('len', {}, renpy.substitutions.MultipleDict({}))
NameError: Name 'len' is not defined.

# After this change:

> renpy.python.py_eval('len', {}, renpy.substitutions.MultipleDict({}))
<built-in function len>
```