### PR TITLE
Switch from MultipleDict to collections.ChainMap

### DIFF
--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -30,6 +30,7 @@ import string
 import os
 import re
 import sys
+import collections
 
 
 update_translations = "RENPY_UPDATE_TRANSLATIONS" in os.environ
@@ -301,26 +302,6 @@ def convert(value, conv, scope):
     return value
 
 
-class MultipleDict(object):
-
-    def __init__(self, *dicts):
-        self.dicts = dicts
-
-    def __getitem__(self, key):
-        for d in self.dicts:
-            if key in d:
-                return d[key]
-
-        raise KeyError("Name '{}' is not defined.".format(key))
-
-    def __contains__(self, key):
-        for d in self.dicts:
-            if key in d:
-                return True
-
-        return False
-
-
 def substitute(s, scope=None, force=False, translate=True):
     """
     Performs translation and formatting on `s`, as necessary.
@@ -368,7 +349,7 @@ def substitute(s, scope=None, force=False, translate=True):
     if len(dicts) == 1:
         variables = dicts[0]
     else:
-        variables = MultipleDict(*dicts)
+        variables = collections.ChainMap(*dicts)
 
     try:
         s = interpolate(s, variables) # type: ignore


### PR DESCRIPTION
Originally intended as a fix for #5981, but postponed due to Python 2 compatibility requirements.

In the original issue, when scopes were stacked in [`substitute`](https://github.com/renpy/renpy/blob/9d4fd5aef1f0c49918d394759fd6ceb1ac0b9dfd/renpy/substitutions.py#L371) the resulting `MultipleDict` instance would fail to meet the expectation from Python proper that `KeyError`s be raised for missing keys (it was previously raising `NameError`s). During `eval` this was unintentionally preventing access to `builtins`.

Switching to the `collections` module's `ChainMap` serves the same purpose, but as it's Python managed it's more likely to retain compatibility with `eval` in future, and less code for us to worry about.

The compatible behaviour with `MultipleDict` is illustrated in the REPL reproduction below.
```
> renpy.python.py_eval('len(foo) + bar', {}, renpy.substitutions.MultipleDict({'foo': 'hello'}, {'foo': None, 'bar': 2}))
7

> renpy.python.py_eval('len(foo) + bar', {}, collections.ChainMap({'foo': 'hello'}, {'foo': None, 'bar': 2}))
7
```