### PR TITLE
Bar property update & addition

### DIFF
--- a/renpy/sl2/sldisplayables.py
+++ b/renpy/sl2/sldisplayables.py
@@ -272,6 +272,7 @@ Keyword("changed")
 Keyword("hovered")
 Keyword("unhovered")
 Keyword("released")
+Keyword("thumb_align")
 add(bar_properties)
 
 
@@ -306,6 +307,7 @@ Keyword("changed")
 Keyword("hovered")
 Keyword("unhovered")
 Keyword("released")
+Keyword("thumb_align")
 add(bar_properties)
 
 # Omit autobar. (behavior)

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -457,6 +457,13 @@ data. It takes the following properties:
     An action to run when the bar button is released. This will be invoked
     even if the bar has not changed its value.
 
+.. screen-property:: thumb_align
+
+    The alignment of the bar thumb, relative to the bar. If the bar and
+    thumb are different sizes - for example, the thumb is taller than the
+    height of a horizontal bar - thumb_align can be set to 0.5 so the centers
+    of the bar and thumb are aligned.
+
 One of `value` or `adjustment` must be given. In addition, this
 function takes:
 

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -1055,11 +1055,14 @@ left and right sides are used.
     If not None, this is a displayable that is drawn over the break
     between the sides of the bar.
 
-.. style-property:: thumb_offset int
+.. style-property:: thumb_offset int or tuple of (int, int)
 
     The amount that by which the thumb overlaps the bars, in
     pixels. To have the left and right bars continue unbroken, set
-    this to half the width of the thumb in pixels.
+    this to half the width of the thumb in pixels. This may also be
+    a tuple, in which case the first number is used for the left/top
+    thumb offset, and the second number is used for the right/bottom
+    thumb offset.
 
 .. style-property:: mouse string
 


### PR DESCRIPTION
This PR does the following:

1) Updates `thumb_offset` to optionally take a tuple instead of an integer. If provided a tuple, the first number is used to offset the left/top of the bar, and the second number is used for the right/bottom. This is helpful for bars whose thumb is asymmetrical, such as a half-circle. In particular, it avoids issues with semi-transparent image overlap (in general or when using ATL or transitions). It is backwards-compatible with the regular integer value.

https://github.com/user-attachments/assets/293e33dc-9331-47b3-916c-a96264cff8d0

https://github.com/user-attachments/assets/94614917-c43f-4d2c-af47-dba9d229f613

2) Adds a `thumb_align` property to bars. This solves an incredibly common issue which occurs when the bar's thumb is larger than the bar images. Most people want the center and thumb of the bar to be aligned. This provides a simple in-engine solution, rather than forcing players to adjust their bar images in an image editor.

Default behavior (and the behavior of `thumb_align 0.0`, which is the default property so it's backwards-compatible:
![image](https://github.com/user-attachments/assets/dae31a74-18b8-474d-8f1c-86e9a2c5e91b)

The results of `thumb_align 0.5`, which aligns the thumb and bar images.
![image](https://github.com/user-attachments/assets/079fbb8f-c804-4323-847d-c64b9575a31e)

I have only added `thumb_align` as a screen property, not as a style one, though I'd be happy if it were added as a style property. Feel free to let me know if there are any particular changes you'd like made, or to adjust the PR before it goes into the engine.