### PR TITLE
Make `renpy.ast` more polymorphic.

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -343,9 +343,6 @@ class Node(renpy.location.Location):
 
         return None
 
-    # get_init is only present on statements that define it.
-    get_init = None  # type: ignore
-
     def chain(self, next: Node | None) -> None:
         """
         This is called with the Node node that should be followed after
@@ -379,9 +376,6 @@ class Node(renpy.location.Location):
         """
         Called when the module is loaded.
         """
-
-    # early_execute is only present on statements that define it.
-    early_execute = None  # type: ignore
 
     def predict(self) -> list[Node | None]:
         """

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2904,6 +2904,14 @@ class TranslateSay(Say):
     alternate: str | None
     language: str | None
 
+    @property
+    def after(self):
+        return self.next
+
+    @property
+    def block(self) -> list[Node]:
+        return [self]
+
     def __init__(
         self,
         loc,
@@ -2935,13 +2943,9 @@ class TranslateSay(Say):
 
     def chain(self, next):
         Say.chain(self, next)
-        self.after = next
 
     def replace_next(self, old, new):
         Say.replace_next(self, old, new)
-
-        if self.after is old:
-            self.after = new
 
     def lookup(self) -> Node:
         return renpy.game.script.translator.lookup_translate(

--- a/renpy/exports/scriptexports.py
+++ b/renpy/exports/scriptexports.py
@@ -102,13 +102,10 @@ def load_module(name, **kwargs):
     renpy.game.contexts.append(context)
 
     context.make_dynamic(kwargs)
-    renpy.store.__dict__.update(kwargs) # @UndefinedVariable
+    renpy.store.__dict__.update(kwargs)
 
-    for _prio, node in initcode: # @UnusedVariable
-        if isinstance(node, renpy.ast.Node):
-            renpy.game.context().run(node)
-        else:
-            node()
+    for _prio, node in initcode:
+        node.execute_init()
 
     context.pop_all_dynamic()
 
@@ -146,10 +143,7 @@ def load_string(s, filename="<string>"):
         renpy.game.contexts.append(context)
 
         for _prio, node in initcode:
-            if isinstance(node, renpy.ast.Node):
-                renpy.game.context().run(node)
-            else:
-                node()
+            node.execute_init()
 
         context.pop_all_dynamic()
         renpy.game.contexts.pop()
@@ -199,10 +193,7 @@ def load_language(language):
         renpy.game.contexts.append(context)
 
         for _prio, node in initcode:
-            if isinstance(node, renpy.ast.Node):
-                renpy.game.context().run(node)
-            else:
-                node()
+            node.execute_init()
 
         context.pop_all_dynamic()
         renpy.game.contexts.pop()

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -915,120 +915,104 @@ def check_image_manipulators():
 
 
 def check_unreachables(all_nodes):
-
-    def add_block(block):
-        next = block[0]
-        if next in unreachable:
-            to_check.add(next)
-
-    def add_names(names):
-        for name in names:
-
-            if name is None:
-                continue
-
-            if name is True:
-                continue
-
-            if isinstance(name, renpy.lexer.SubParse):
-                if name.block:
-                    add_block(name.block)
-                continue
-
-            node = renpy.game.script.lookup(name)
-
-            if node is None:
-                continue
-
-            if node in unreachable:
-                to_check.add(node)
+    from renpy.ast import (
+        get_reachable_nodes,
+        Node,
+        Label,
+        Init,
+        TranslateBlock,
+        UserStatement,
+        EarlyPython,
+        Translate,
+        TranslateSay,
+        Return,
+        EndTranslate,
+        RPY,
+    )
 
     # All nodes, outside of common.
     all_nodes = [node for node in all_nodes if not common(node)]
 
     # Unreachable nodes - this set shrinks as nodes become reachable.
-    unreachable = set(all_nodes)
+    unreachable = set[Node](all_nodes)
 
     # Weakly reachable nodes - nodes that are reachable, but don't
     # make their next reachable.
-    weakly_reachable = set()
+    weakly_reachable = set[Node]()
 
     # The worklist of reachable nodes that haven't been checked yet.
-    to_check = set()
+    to_check = []
 
     for node in all_nodes:
-        if isinstance(node, (renpy.ast.EarlyPython, renpy.ast.Label)):
-            to_check.add(node)
+        if isinstance(node, Label):
+            # All labels are reachable because arbitary expression can
+            # renpy.call or renpy.jump to them.
+            to_check.append(node)
 
-        elif isinstance(node, renpy.ast.Translate):
-            if node.language is not None:
-                to_check.add(node)
+        elif isinstance(node, (Init, TranslateBlock)):
+            # Init and TranslateBlock nodes are ment to be unreachable from
+            # runtime code, but the block of these ones is always reachable,
+            # either by simply running the game, or changing the langauge.
+            if node.block:
+                to_check.append(node.block[0])
 
-        elif isinstance(node, renpy.ast.TranslateSay):
-            if node.language is not None:
-                to_check.add(node)
-
-        elif isinstance(node, (renpy.ast.Init, renpy.ast.TranslateBlock)):
-            # the block of these ones is always reachable, but their next is reachable only if they are themselves reachable
-            add_block(node.block)
+            # Their `next` is reachable only if they are themselves reachable
+            # from the other nodes.
             weakly_reachable.add(node)
-            # Init and TranslateBlock nodes are meant to be unreachable, but we had to check them
-            # because if they are reachable, what follows them is too and must not be flagged as unreachable
 
-        elif isinstance(node, (renpy.ast.Return, renpy.ast.EndTranslate)):
+        elif isinstance(node, EarlyPython):
+            # python early outside of init block is common, and reachable
+            # but in that case its next is only reachable if it is itself
+            # reachable.
             weakly_reachable.add(node)
-            # the auto-generated Return at the end of every file is hard to segregate from the other Return nodes, so we don't check Return nodes
-            # EndTranslate nodes can't be manually created, so it makes no sense to show them to the user in the first place,
-            # and EndTranslate nodes from explicit translate blocks are naturally unreachable
 
-        elif isinstance(node, renpy.ast.UserStatement):
-            reach = node.reachable(False)
-
-            if True in reach:
+        elif isinstance(node, (Translate, TranslateSay)):
+            # If a block with missing id exists, it is orpahn translation.
+            # We don't report it there, but later in the lint.
+            if node.language is not None:
                 weakly_reachable.add(node)
 
-            add_names(reach)
+        elif isinstance(node, (Return, EndTranslate)):
+            weakly_reachable.add(node)
+            # the auto-generated Return at the end of every file is hard to
+            # segregate from the other Return nodes, so we don't check Return nodes
+            # EndTranslate nodes can't be manually created, so it makes no sense
+            # to show them to the user in the first place, and EndTranslate
+            #  nodes from explicit translate blocks are naturally unreachable
 
-        elif isinstance(node, renpy.ast.RPY):
+        elif isinstance(node, UserStatement):
+            for name in node.reachable(False):
+                if name is None:
+                    continue
+
+                if name is True:
+                    weakly_reachable.add(node)
+                    continue
+
+                if isinstance(name, renpy.lexer.SubParse):
+                    if name.block:
+                        to_check.append(name.block[0])
+                    continue
+
+                node = renpy.game.script.lookup(name)
+
+                if node is None:
+                    continue
+
+                if node in unreachable:
+                    to_check.append(node)
+
+        elif isinstance(node, RPY):
             weakly_reachable.add(node)
 
-    while to_check:
-        node = to_check.pop() # type: Any
-        unreachable.remove(node)
+    reachable = get_reachable_nodes(to_check)
 
-        if isinstance(node, renpy.ast.While):
-            add_block(node.block)
+    unreachable -= set(reachable)
+    unreachable -= weakly_reachable
 
-        elif isinstance(node, renpy.ast.Menu):
-            all_cond = True
-
-            for (_l, condition, block) in node.items:
-                if block is not None:
-                    add_block(block)
-                if condition == "True":
-                    # "True" is the default value when no condition is specified
-                    all_cond = False
-
-            if not all_cond:
-                # if there's only returns or jumps in the menu choices,
-                # the next of the menu is only reachable if every choice is disabled and the menu gets skipped
-                # if not, the blocks will lead us there eventually
-                continue
-
-        elif isinstance(node, renpy.ast.If):
-            for (_c, block) in node.entries:
-                add_block(block)
-
-        elif isinstance(node, renpy.ast.UserStatement):
-            add_names(node.reachable(True))
-            continue
-
-        next = node.next
-        if next in unreachable:
-            to_check.add(next)
-
-    locations = sorted(set((node.filename, node.linenumber) for node in (unreachable - weakly_reachable)))
-    problems = [ (filename, linenumber, "") for filename, linenumber in locations ]
+    locations = {(node.filename, node.linenumber) for node in unreachable}
+    locations = sorted(locations)
+    problems = [(filename, linenumber, "") for filename, linenumber in locations]
     problem_listing("Unreachable Statements:", problems)
 
 

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -535,19 +535,14 @@ def main():
 
             renpy.game.initcode_ast_id = id_
 
-            if isinstance(node, renpy.ast.Node):
-                node_start = time.time()
+            node_start = time.time()
 
-                renpy.game.context().run(node)
+            node.execute_init()
 
-                node_duration = time.time() - node_start
+            node_duration = time.time() - node_start
 
-                if node_duration > renpy.config.profile_init:
-                    renpy.display.log.write(" - Init at %s:%d took %.5f s.", node.filename, node.linenumber, node_duration)
-
-            else:
-                # An init function.
-                node()
+            if node_duration > renpy.config.profile_init:
+                renpy.display.log.write(f" - Init at {node.filename}:{node.linenumber} took {node_duration:.2f}s.")
 
         renpy.game.exception_info = 'After initialization, but before game start.'
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -151,8 +151,8 @@ class Script(object):
 
         self.duplicate_labels = [ ]
 
-        # A list of initcode, priority, statement pairs.
-        self.initcode = [ ]
+        # A list of (initcode priority, statement) pairs.
+        self.initcode: list[tuple[int, renpy.ast.Node]] = []
 
         # A set of (fn, dir) tuples for scripts that have already been
         # loaded.
@@ -385,6 +385,7 @@ class Script(object):
         Loads a module with the provided name and inserts its
         initcode into the script current initcode
         """
+
         module_initcode = self.load_module(name)
         if not module_initcode:
             return
@@ -400,7 +401,7 @@ class Script(object):
 
         # Since script initcode and module initcode are both sorted,
         # we can use heap to merge them
-        new_tail = current_tail +  module_initcode
+        new_tail = current_tail + module_initcode
         new_tail.sort(key=lambda i: i[0])
 
         self.initcode[merge_id:] = new_tail
@@ -580,8 +581,8 @@ class Script(object):
             self.namemap[name] = node
 
             # Add any init nodes to self.initcode.
-            if init := node.get_init():
-                initcode.append(init)
+            if (priority := node.get_init()) is not None:
+                initcode.append((priority, node))
 
             node.early_execute()
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -498,7 +498,7 @@ class Script(object):
         # All of the statements found in file, regardless of nesting
         # depth.
 
-        all_stmts = [ ]
+        all_stmts: list[renpy.ast.Node] = []
         for i in stmts:
             i.get_children(all_stmts.append)
 
@@ -580,13 +580,10 @@ class Script(object):
             self.namemap[name] = node
 
             # Add any init nodes to self.initcode.
-            if node.get_init:
-                init = node.get_init()
-                if init:
-                    initcode.append(init)
+            if init := node.get_init():
+                initcode.append(init)
 
-            if node.early_execute:
-                node.early_execute()
+            node.early_execute()
 
         if self.all_stmts is not None:
             self.all_stmts.extend(all_stmts)

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -160,8 +160,8 @@ def register(
 
     `translation_strings`
         A function that is called with the parsed block. It's expected to
-        return a list of strings, which are then reported as being available
-        to be translated.
+        return a list of strings or tuples of (string line number, string),
+        which are then reported as being available to be translated.
 
     `force_begin_rollback`
         This should be set to true on statements that are likely to cause the

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -121,87 +121,61 @@ class ScriptTranslator(object):
 
         return len(self.default_translates)
 
-    def take_translates(self, nodes):
+    def take_translates(self, nodes: list[renpy.ast.Node]):
         """
         Takes the translates out of the flattened list of statements, and stores
         them into the dicts above.
         """
 
-        label = None
-
         if not nodes:
             return
 
-        TranslatePython = renpy.ast.TranslatePython
-        TranslateBlock = renpy.ast.TranslateBlock
-        TranslateEarlyBlock = renpy.ast.TranslateEarlyBlock
-        Menu = renpy.ast.Menu
-        UserStatement = renpy.ast.UserStatement
-        Translate = renpy.ast.Translate
-        TranslateSay = renpy.ast.TranslateSay
+        from renpy.ast import (
+            TranslatePython,
+            TranslateBlock,
+            TranslateEarlyBlock,
+            Translate,
+            TranslateSay,
+        )
 
         filename = renpy.lexer.unelide_filename(nodes[0].filename)
         filename = os.path.normpath(os.path.abspath(filename))
+
+        label = None
 
         for n in nodes:
 
             if not n.translation_relevant:
                 continue
 
-            if n.name.__class__ is not tuple:
-                if isinstance(n.name, basestring):
-                    label = n.name
+            if isinstance(n.name, str):
+                label = n.name
 
-            type_n = n.__class__
-
-            if type_n is TranslatePython:
+            if isinstance(n, TranslatePython):
                 if n.language is not None:
                     self.languages.add(n.language)
                 self.python[n.language].append(n)
 
-            elif type_n is TranslateEarlyBlock:
+            elif isinstance(n, TranslateEarlyBlock):
                 if n.language is not None:
                     self.languages.add(n.language)
                 self.early_block[n.language].append(n)
 
-            elif type_n is TranslateBlock:
+            elif isinstance(n, TranslateBlock):
                 if n.language is not None:
                     self.languages.add(n.language)
                 self.block[n.language].append(n)
 
-            elif type_n is Menu:
-
-                for i in n.items:
-                    s = i[0]
-
-                    if renpy.config.old_substitutions:
-                        s = s.replace("%%", "%")
-
-                    if s is None:
-                        continue
-
-                    self.additional_strings[filename].append((n.linenumber, s))
-
-            elif type_n is UserStatement:
-
-                strings = n.call("translation_strings")
-
-                if strings is None:
-                    continue
-
-                for s in strings:
-                    self.additional_strings[filename].append((n.linenumber, s))
-
-            elif type_n is Translate or type_n is TranslateSay:
-
+            elif isinstance(n, (Translate, TranslateSay)):
                 if n.language is None:
                     if n.identifier in self.default_translates:
                         old_node = self.default_translates[n.identifier]
 
-                        renpy.lexer.ParseError(n.filename, n.linenumber, "Line with id %s appears twice. The other line is %s:%d" % (
-                                    n.identifier,
-                                    old_node.filename, old_node.linenumber)
-                                    ).defer("duplicate_id")
+                        err = renpy.lexer.ParseError(
+                            n.filename, n.linenumber,
+                            f"Line with id {n.identifier} appears twice. "
+                            f"The other line is {old_node.filename}:{old_node.linenumber}")
+                        err.defer("duplicate_id")
 
                     self.default_translates[n.identifier] = n
                     self.file_translates[filename].append((label, n))
@@ -209,6 +183,10 @@ class ScriptTranslator(object):
                     self.languages.add(n.language)
                     self.language_translates[n.identifier, n.language] = n
                     self.chain_worklist.append((n.identifier, n.language))
+
+            else:
+                for line in n.get_translation_strings():
+                    self.additional_strings[filename].append(line)
 
     def chain_translates(self):
         """

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -255,6 +255,27 @@ class ScriptTranslator(object):
         else:
             return tl.block[0]
 
+    def get_all_translates(self, identifier: str):
+        """
+        Return a dict of all existing translates for the given identifier.
+
+        The dict keys are language names, or None for the default language.
+        """
+
+        identifier = identifier.replace('.', '_')
+        language = renpy.game.preferences.language
+
+        rv: dict[str | None, renpy.ast.Translate | renpy.ast.TranslateSay] = {}
+
+        for language in self.languages:
+            try:
+                rv[language] = self.language_translates[(identifier, language)]
+            except KeyError:
+                pass
+
+        rv[None] = self.default_translates[identifier]
+        return rv
+
     def get_translate_info(self, identifier, language):
 
         identifier = identifier.replace('.', '_')


### PR DESCRIPTION
In this PR I add following changes in `renpy.ast`:
1. Add type hints and documentation for some fields and functions of the module.
2. Make `Node.get_init` and `Node.early_execute` to always exist. They do not appear in flame graph, so such calls take less time than `cProfile` clock resolution.
3. Change `Node.get_init` to return integer priority to call of `self.execute_init` when init code executes, instead of tuple of `priority, Node or Callable`. This simplifies meaning of initcode of script and most importantly, allow to perform `config.profile_init` check on `UserStatement` nodes, which if implemented badly may take more time than developer intended.
4. Remove `after` and `block` slots from `TranslateSay` and implement them as `self.next` and `[]` properties. (Probably need to add empty setters for backward compatibility?)
6. Add `Node.get_translation_strings` which return list of `linenumber, string` tuples for `ScriptTranslator.additional_strings` and changed how `Menu` provides line numbers for menu options. It was line number of menu itself before, now it is previous line of first statement in menu option block. Also `register_statement` `translation_strings` function may now return list of such tuples. This is because for big menus or user statements, if you want some context, it was annoying to jump to the statement itself and then scroll or search for the string you just saw in translation.
7. Add `Node.get_reachable` method, that return list of nodes that this node can set in its `execute` and implement it for all of types.
8. Add `get_reachable_nodes` function that takes list of start nodes and optional function to validate/filter reached nodes, and return list of all reached nodes. That allow to write custom lint functions like search for unnecessary hides/attribute changes or smarter `config.predict_statements_callback`.