### PR TITLE
Launcher Folders

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -102,39 +102,82 @@ screen front_page:
 # This is used by front_page to display the list of known projects on the screen.
 screen front_page_project_list:
 
+    $ folders = project.manager.folders
     $ projects = project.manager.projects
     $ templates = project.manager.templates
 
     vbox:
 
-        if templates and persistent.show_templates:
-
-            for p in templates:
-
-                textbutton _("[p.name!q] (template)"):
-                    action project.Select(p)
-                    alt _("Select project [text].")
-                    style "l_list"
-
-            null height 12
-
         if projects:
-
+            text "Projects"
             for p in projects:
 
-                textbutton "[p.name!q]":
+                textbutton _(f"[p.display_name]" if p.display_name else "[p.name!q]"):
                     action project.Select(p)
                     alt _("Select project [text].")
                     style "l_list"
 
-            null height 12
+            null height 6
 
-        textbutton _("Tutorial") action project.SelectTutorial() style "l_list" alt _("Select project [text].")
-        textbutton _("The Question") action project.Select("the_question") style "l_list" alt _("Select project [text].")
+        if folders:
+            for pf in folders:
+
+                button:
+                    if pf.hidden:
+                        hover_background REVERSE_HOVER
+                        xfill True
+                        hbox:
+                            spacing 5
+                            add "folder_closed"
+                            text pf.name.capitalize() color IDLE hover_color REVERSE_TEXT bold True yalign 0.5
+
+                    else:
+                        hover_background REVERSE_IDLE
+                        xfill True
+                        hbox:
+                           spacing 5
+                           add "folder_open"
+                           text pf.name.capitalize() color HOVER hover_color REVERSE_TEXT bold True yalign 0.5
+
+                    action project.CollapseFolder(pf)
+
+                if not pf.hidden:
+                    for p in pf.projects:
+                        textbutton _(f"[p.display_name]" if p.display_name else "[p.name!q]"):
+                            action project.Select(p)
+                            alt _("Select project [text].")
+                            style "l_list"
+                            xoffset 10
+
+            null height 6
+
+        if persistent.show_tutorial_projects:
+            button:
+                if persistent.collapsed_folders["Tutorials"]:
+                    hover_background REVERSE_HOVER
+                    xfill True
+                    hbox:
+                        spacing 5
+                        add "folder_closed"
+                        text "Tutorials" color IDLE hover_color REVERSE_TEXT bold True yalign 0.5
+                else:
+                    hover_background REVERSE_IDLE
+                    xfill True
+                    hbox:
+                       spacing 5
+                       add "folder_open"
+                       text "Tutorials" color HOVER hover_color REVERSE_TEXT bold True yalign 0.5
+
+                action ToggleDict(persistent.collapsed_folders, "Tutorials")
+
+            if not persistent.collapsed_folders["Tutorials"]:
+                textbutton _("Tutorial") action project.SelectTutorial() style "l_list" alt _("Select project [text].")
+                textbutton _("The Question") action project.Select("the_question") style "l_list" alt _("Select project [text].")
 
 
 # This is used for the right side of the screen, which is where the project-specific
 # buttons are.
+
 screen front_page_project:
 
     $ p = project.current

--- a/launcher/game/images/folder.svg
+++ b/launcher/game/images/folder.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 800 800">
+  <!-- Generator: Adobe Illustrator 29.1.0, SVG Export Plug-In . SVG Version: 2.1.0 Build 142)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #fff;
+        stroke: #000;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 66.7px;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M100,566.7V233.3c0-36.8,29.8-66.7,66.7-66.7h152.9c8.8,0,17.3,3.5,23.6,9.8l56.9,56.9h233.3c36.8,0,66.7,29.8,66.7,66.7v266.7c0,36.8-29.8,66.7-66.7,66.7H166.7c-36.8,0-66.7-29.8-66.7-66.7Z"/>
+</svg>

--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2025 Tom Rothamel <pytom@bishoujo.us>
+﻿# Copyright 2004-2024 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -23,6 +23,7 @@ default persistent.show_edit_funcs = True
 default persistent.windows_console = False
 default persistent.lint_options = set()
 default persistent.use_web_doc = False
+default persistent.show_tutorial_projects = True
 
 init python:
     from math import ceil
@@ -252,6 +253,7 @@ screen preferences():
                             add HALF_SPACER
 
                             textbutton _("Show edit file section") style "l_checkbox" action ToggleField(persistent, "show_edit_funcs")
+                            textbutton _("Show tutorial projects") style "l_checkbox" action ToggleField(persistent, "show_tutorial_projects")
                             textbutton _("Large fonts") style "l_checkbox" action [ ToggleField(persistent, "large_print"), renpy.utter_restart ]
 
                             if interface.local_doc_exists:

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2025 Tom Rothamel <pytom@bishoujo.us>
+# Copyright 2004-2025 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -40,6 +40,12 @@ init python in project:
 
     if persistent.blurb is None:
         persistent.blurb = 0
+
+    # NOTE
+    # Added this persistent variable to retain any
+    # previous folder that was collapsed or shown
+    if persistent.collapsed_folders is None:
+        persistent.collapsed_folders = {'Tutorials':False}
 
     project_filter = [ i.strip() for i in os.environ.get("RENPY_PROJECT_FILTER", "").split(":") if i.strip() ]
 
@@ -464,6 +470,26 @@ init python in project:
 
             return os.access(self.path, os.W_OK)
 
+    class ProjectFolder(object):
+        """
+        This handles the folder name and the projects within
+        this folder.
+        """
+
+        def __init__(self, name):
+            # The folder name.
+            self.name = name
+
+            # Normal projects, in alphabetical order by lowercase name.
+            self.projects = [ ]
+
+            # Controls wether the folder is collapsed or shown.
+            self.hidden = True
+
+        # NOTE
+        # Vague function name but context is self explanatory
+        def add(self, p):
+            self.projects.append(p)
 
     class ProjectManager(object):
         """
@@ -475,6 +501,9 @@ init python in project:
 
             # The projects directory.
             self.projects_directory = ""
+
+            # NOTE: Folder of projects, in alphabetical order by lowercase name.
+            self.folders = [ ]
 
             # Normal projects, in alphabetical order by lowercase name.
             self.projects = [ ]
@@ -515,6 +544,7 @@ init python in project:
 
             self.projects_directory = persistent.projects_directory
 
+            self.folders = [ ]
             self.projects = [ ]
             self.templates = [ ]
             self.all_projects = [ ]
@@ -525,6 +555,8 @@ init python in project:
 
             self.scan_directory(config.renpy_base)
 
+            # NOTE: Added `self.folders` that holds the ProjectFolder objects
+            self.folders.sort(key=lambda p : p.name.lower())
             self.projects.sort(key=lambda p : p.name.lower())
             self.templates.sort(key=lambda p : p.name.lower())
 
@@ -538,20 +570,100 @@ init python in project:
 
             current = self.get_tutorial()
 
+        # NOTE
+        # Turned this `has_game` function part of the class as static
+        # Because it was used in a few places due the changes.
+        @staticmethod
+        def has_game(dn):
+            return os.path.isdir(os.path.join(dn, "game"))
+
+        # NOTE
+        # This function remove any folder that was saved
+        # that doesn't exist anymore in `self.projects_directory`
+        def clear_collapsed_folders(self):
+            prefix = os.path.normpath(self.projects_directory)
+
+            for name in [*persistent.collapsed_folders.keys()]:
+                dpath = os.path.join(prefix, name)
+
+                if not os.path.isdir(dpath) and not "Tutorials":
+                    persistent.collapsed_folders.pop(name)
+
+        # NOTE
+        # This function is similar to `find_basedir` but instead it looks inside
+        # The folder the user linked renpy to look for projects
+        def find_folder_projects(self, d):
+
+            nd = os.path.normpath(d)
+            prefix = os.path.normpath(self.projects_directory)
+
+            if nd.startswith(prefix):
+                fpath, fname = os.path.split(nd)
+                full_path = os.path.join(fpath, fname)
+
+                pf = ProjectFolder(fname)
+
+                # If the key was found in `persistent.collapsed_folders`
+                # uses the value stored there
+                try:
+                    pf.hidden = persistent.collapsed_folders[fname]
+
+                except KeyError:
+                    pf.hidden = (fname != "master")
+
+                # NOTE
+                # Effectively almost the same as `scan_directory_direct`
+                # but we ignore files that don't contain any `game/` folder.
+
+                for pdir in util.listdir(full_path):
+                    ppath = os.path.join(full_path, pdir)
+
+                    if not os.path.isdir(ppath):
+                        continue
+
+                    if not self.has_game(ppath):
+                        continue
+
+                    if ppath in self.scanned:
+                        continue
+
+                    self.scanned.add(ppath)
+
+                    # Get the name of the project
+                    name = os.path.split(ppath)[1]
+
+                    # We have a project directory, so create a Project.
+                    p = Project(ppath, name)
+
+                    # Adds the project to the ProjectFolder
+                    pf.add(p)
+
+                    self.all_projects.append(p)
+
+                if not pf.hidden and not pf.projects:
+                    pf.hidden = True
+
+                # Return None if the project folder is emtpy.
+                if not pf.projects:
+                    return None
+
+                # Return the project folder object.
+                return pf
+
+            return None
+
 
         def find_basedir(self, d):
             """
             Try to find a project basedir in d.
             """
 
-            def has_game(dn):
-                return os.path.isdir(os.path.join(dn, "game"))
-
-            if has_game(d):
+            if self.has_game(d):
                 return d
 
             dn = os.path.join(d, "Contents", "Resources", "autorun")
-            if has_game(dn):
+
+            if self.has_game(dn):
                 return dn
 
             for dn in os.listdir(d):
@@ -560,7 +672,7 @@ init python in project:
 
                 dn = os.path.join(d, dn, "Contents", "Resources", "autorun")
 
-                if has_game(dn):
+                if self.has_game(dn):
                     return dn
 
             return None
@@ -609,37 +721,52 @@ init python in project:
             if not os.path.isdir(ppath):
                 return
 
+            # NOTE
+            # This is where heavy changes were made, Instead of returning right away
+            # now the code checks if the folder inside the `self.projects_directory`
+            # is a game folder, if not it looks if the folder has subfolders that
+            # could be a project
             try:
-                ppath = self.find_basedir(ppath)
+                if self.has_game(ppath):
+                    p_path = self.find_basedir(ppath)
+
+                    if p_path in self.scanned:
+                        return
+
+                    self.scanned.add(p_path)
+
+                    # We have a project directory, so create a Project.
+                    p = Project(p_path, name)
+
+                    if project_filter and (p.name not in project_filter):
+                        return
+
+                    project_type = p.data.get("type", "normal")
+
+                    if project_type == "hidden":
+                        pass
+
+                    elif project_type == "template":
+                        self.projects.append(p)
+                        self.templates.append(p)
+
+                    else:
+                        self.projects.append(p)
+
+                    self.all_projects.append(p)
+
+                else:
+                    self.clear_collapsed_folders()
+
+                    pf = self.find_folder_projects(ppath)
+
+                    if pf is None:
+                        return
+
+                    self.folders.append(pf)
+
             except Exception:
                 return
-
-            if ppath is None:
-                return
-
-            if ppath in self.scanned:
-                return
-
-            self.scanned.add(ppath)
-
-            # We have a project directory, so create a Project.
-            p = Project(ppath, name)
-
-            if project_filter and (p.name not in project_filter):
-                return
-
-            project_type = p.data.get("type", "normal")
-
-            if project_type == "hidden":
-                pass
-            elif project_type == "template":
-                self.projects.append(p)
-                self.templates.append(p)
-            else:
-                self.projects.append(p)
-
-            self.all_projects.append(p)
-
 
         def get(self, name):
             """
@@ -828,6 +955,18 @@ init python in project:
             manager.scan()
             renpy.restart_interaction()
 
+    # NOTE: Action class for ProjectFolder
+    class CollapseFolder(Action):
+        def __init__(self, pf):
+            self.pf = pf
+
+        def __call__(self):
+            self.pf.hidden = not self.pf.hidden
+            persistent.collapsed_folders[self.pf.name] = self.pf.hidden
+            renpy.restart_interaction()
+
+        def get_selected(self):
+            return (not self.pf.hidden)
 
     manager.scan()
 

--- a/launcher/game/style.rpy
+++ b/launcher/game/style.rpy
@@ -1,4 +1,4 @@
-﻿# Copyright 2004-2025 Tom Rothamel <pytom@bishoujo.us>
+﻿# Copyright 2004-2024 Tom Rothamel <pytom@bishoujo.us>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -100,11 +100,7 @@ init -1 python:
     PATTERN = "images/pattern.png"
 
     # A displayable used for the background of everything.
-    BACKGROUND = "background"
-
-    # A displayable used for the background of windows
-    # containing commands, preferences, and navigation info.
-    WINDOW = Frame("window", 0, 0, tile=True)
+    BACKGROUND = Fixed(Solid(REVERSE_TEXT), xsize=800, ysize=600)
 
     # A displayable used for the background of the projects list.
     PROJECTS_WINDOW = Null()
@@ -120,6 +116,13 @@ init -1 python:
 
     # The color of input text.
     INPUT_COLOR = "#d86b45"
+
+    # A displayable used for the background of windows
+    # containing commands, preferences, and navigation info.
+    WINDOW = Frame(Fixed(Solid(REVERSE_IDLE, xsize=4, xalign=0), Solid(INFO_WINDOW, xsize=794, xalign=1.0), xsize=800, ysize=600), 0, 0, tile=True)
+
+    # Controls the folder displayable, 0.0 should be used for light backgrounds and 1.0 for dark.
+    FOLDER_MATRIX = 0.0
 
     if persistent.theme == 'dark':
         # The color of non-interactive text.
@@ -164,49 +167,8 @@ init -1 python:
         # containing commands, preferences, and navigation info.
         WINDOW = Frame(Fixed(Solid(REVERSE_IDLE, xsize=4, xalign=0), Solid(INFO_WINDOW, xsize=794, xalign=1.0), xsize=800, ysize=600), 0, 0, tile=True)
 
-    elif persistent.theme == 'clear':
-
-        # The color of non-interactive text.
-        TEXT = "#545454"
-
-        # Colors for buttons in various states.
-        IDLE = "#42637b"
-        HOVER = "#d86b45"
-        DISABLED = "#808080"
-
-        # Colors for reversed text buttons (selected list entries).
-        REVERSE_IDLE = "#78a5c5"
-        REVERSE_HOVER = "#d86b45"
-        REVERSE_TEXT = "#ffffff"
-
-        # Colors for the scrollbar thumb.
-        SCROLLBAR_IDLE = "#dfdfdf"
-        SCROLLBAR_HOVER = "#d86b45"
-
-        # An image used as a separator pattern.
-        PATTERN = "images/pattern.png"
-
-        # A displayable used for the background of everything.
-        BACKGROUND = Fixed(Solid(REVERSE_TEXT), xsize=800, ysize=600)
-
-        # A displayable used for the background of the projects list.
-        PROJECTS_WINDOW = Null()
-
-        # A displayable used the background of information boxes.
-        INFO_WINDOW = "#f9f9f9"
-
-        # Colors for the titles of information boxes.
-        ERROR_COLOR = "#d15353"
-        INFO_COLOR = "#545454"
-        INTERACTION_COLOR = "#d19753"
-        QUESTION_COLOR = "#d19753"
-
-        # The color of input text.
-        INPUT_COLOR = "#d86b45"
-
-        # A displayable used for the background of windows
-        # containing commands, preferences, and navigation info.
-        WINDOW = Frame(Fixed(Solid(REVERSE_IDLE, xsize=4, xalign=0), Solid(INFO_WINDOW, xsize=794, xalign=1.0), xsize=800, ysize=600), 0, 0, tile=True)
+        # Controls the folder displayable, 0.0 should be used for light backgrounds and 1.0 for dark.
+        FOLDER_MATRIX = 1.0
 
     elif persistent.theme == 'custom':
 
@@ -252,7 +214,22 @@ init -1 python:
         # containing commands, preferences, and navigation info.
         WINDOW = custom_window
 
+        # Controls the folder displayable, 0.0 should be used for light backgrounds and 1.0 for dark.
+        FOLDER_MATRIX = custom_folder
 
+# Images used by the launcher for folders
+
+image folder_closed:
+    on idle:
+        Transform("images/folder.svg", xysize=(25,25), matrixcolor=TintMatrix(IDLE))
+    on hover:
+        Transform("images/folder.svg", xysize=(25,25), matrixcolor=InvertMatrix(value=FOLDER_MATRIX))
+
+image folder_open:
+    on idle:
+        Transform("images/folder.svg", xysize=(25,25), matrixcolor=TintMatrix(HOVER))
+    on hover:
+        Transform("images/folder.svg", xysize=(25,25), matrixcolor=InvertMatrix(value=FOLDER_MATRIX))
 
 init 1 python:
 
@@ -422,7 +399,7 @@ style l_indent_margin is l_indent:
 
 # Lists.
 style l_list is l_default:
-    left_padding HALF_INDENT
+    left_padding INDENT
     xfill True
     selected_background REVERSE_IDLE
     selected_hover_background REVERSE_HOVER


### PR DESCRIPTION
This adds the following:

- Support for folders in the launcher for Projects, Libraries and Templates.  Folders only appear to the user if they have libraries or templates, by default they will not appear.
- Adds a new project type, "Libraries".  Uses the same JSON file method as Templates.
- Cleans up the "clear" launcher style and integrates it into the standard light mode.
- Adds preferences for showing/hiding the default projects (The Question and Tutorial) as well as Templates (This was already in the code, just unused).
- Adds one 646 byte image for the folder icon.