### PR TITLE
Use raw strings for docstrings that contain unescaped slashes

### DIFF
--- a/renpy/common/00action_menu.rpy
+++ b/renpy/common/00action_menu.rpy
@@ -141,7 +141,7 @@ init -1500 python:
 
     @renpy.pure
     class Continue(Action, DictEquality):
-        """
+        r"""
         :doc: menu_action
 
         Causes the last save to be loaded.

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -272,7 +272,7 @@ init -1500 python:
 
     @renpy.pure
     class ScreenVariableValue(__GenericValue):
-        """
+        r"""
         :doc: value
         :args: {args}
 
@@ -314,7 +314,7 @@ init -1500 python:
 
     # unpure
     class LocalVariableValue(DictValue):
-        """
+        r"""
         :doc: value
         :args: {args}
 

--- a/renpy/common/00definitions.rpy
+++ b/renpy/common/00definitions.rpy
@@ -111,7 +111,7 @@ init -1400 python:
 
     # This defines a family of move transitions, using the old-style methods.
     def move_transitions(prefix, delay, time_warp=None, in_time_warp=None, out_time_warp=None, old=False, layers=[ 'master' ], **kwargs):
-        """
+        r"""
         :doc: transition_family
 
         This defines a family of :class:`move transitions <MoveTransition>`,

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -255,7 +255,7 @@ init -1150 python in gui:
     button_image_extension = ".png"
 
     def button_properties(kind):
-        """
+        r"""
         :doc: gui
 
         Given a `kind` of button, returns a dictionary giving standard style

--- a/renpy/common/00inputvalues.rpy
+++ b/renpy/common/00inputvalues.rpy
@@ -130,7 +130,7 @@ init -1510 python:
             self.returnable = returnable
 
     class ScreenVariableInputValue(__GenericInputValue):
-        """
+        r"""
         :doc: input_value
         :args: {args}
 
@@ -249,7 +249,7 @@ init -1510 python:
 
     # not pure
     class LocalVariableInputValue(DictInputValue):
-        """
+        r"""
         :doc: input_value
         :args: {args}
 


### PR DESCRIPTION
Running lint on "The Question" in nightlies surfaces these Python warnings which are due to unescaped backslashes in docstrings of various common files.

```
Python Warnings:

renpy/common/00action_menu.rpy:123: SyntaxWarning: invalid escape sequence '\d'
  screen = self.screen or store._game_menu_screen

renpy/common/00barvalues.rpy:254: SyntaxWarning: invalid escape sequence '\ '
  class VariableValue(FieldValue):

renpy/common/00barvalues.rpy:296: SyntaxWarning: invalid escape sequence '\ '
  self.variable = variable

renpy/common/00definitions.rpy:11: SyntaxWarning: invalid escape sequence '\ '
  # The above copyright notice and this permission notice shall be

renpy/common/00gui.rpy:237: SyntaxWarning: invalid escape sequence '\_'
  prefs[self.name] = self.b

renpy/common/00inputvalues.rpy:112: SyntaxWarning: invalid escape sequence '\ '
  return None

renpy/common/00inputvalues.rpy:231: SyntaxWarning: invalid escape sequence '\ '
  `dict`
```