### PR TITLE
fix: function property of `TransformMatrix`

### DIFF
--- a/renpy/common/00matrixtransform.rpy
+++ b/renpy/common/00matrixtransform.rpy
@@ -67,15 +67,15 @@ init -1400 python:
 
     class OffsetMatrix(TransformMatrix, DictEquality):
         nargs = 3
-        function = Matrix.offset
+        function = staticmethod(Matrix.offset)
         __doc__ = TransformMatrix._document(Matrix.offset)
 
     class RotateMatrix(TransformMatrix, DictEquality):
         nargs = 3
-        function = Matrix.rotate
+        function = staticmethod(Matrix.rotate)
         __doc__ = TransformMatrix._document(Matrix.rotate)
 
     class ScaleMatrix(TransformMatrix, DictEquality):
         nargs = 3
-        function = Matrix.scale
+        function = staticmethod(Matrix.scale)
         __doc__ = TransformMatrix._document(Matrix.scale)


### PR DESCRIPTION
In `python3.12`, the `function` method is `bound` rather than `built-in` after init.

Related to raising `Cython` - https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
```
binding (True / False), default=True

    Controls whether free functions behave more like Python’s CFunctions
    (e.g. [len()](https://docs.python.org/3/library/functions.html#len)) or, when set to True,
    more like Python’s functions. When enabled, functions will bind to an instance when looked up as a class attribute (hence the name)
    and will emulate the attributes of Python functions, including introspections like argument names and annotations.

    Changed in version 3.0.0: Default changed from False to True
```

![image](https://github.com/user-attachments/assets/4ed67be8-5b5a-4897-8f44-0969d0a76a89)
![image](https://github.com/user-attachments/assets/301c24a9-61fe-4363-9ec4-4f49b6bc16b9)
![image](https://github.com/user-attachments/assets/813db490-9db0-420c-b60c-bab480d05839)

```python
OffsetMatrix(0, 0, 0)(None, 1)
```

```
Traceback (most recent call last):
  File "renpy/common/00console.rpy", line 1087, in run
    has vbox
    ^^^^^^^
  File "/home/tichq/Downloads/renpy-8.4.0.24122402+nightly-sdk/renpy/python.py", line 1220, in py_eval
    return py_eval_bytecode(code, globals, locals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tichq/Downloads/renpy-8.4.0.24122402+nightly-sdk/renpy/python.py", line 1213, in py_eval_bytecode
    return eval(bytecode, globals, locals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<none>", line 1, in <module>
  File "renpy/common/00matrixtransform.rpy", line 50, in __call__
    return self.function(*self.args)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "renpy/display/matrix.pyx", line 388, in renpy.display.matrix.Matrix.offset
TypeError: offset() takes exactly 3 positional arguments (4 given)
```