### PR TITLE
Don't overrule focus override for max focus

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -463,7 +463,7 @@ def before_interact(roots):
 
     # When increasing the default focus, and the user is not using the mouse,
     # switch to the default.
-    if should_max_default and (max_default > old_max_default):
+    if not explicit and should_max_default and (max_default > old_max_default):
         current = max_default_focus
         set_grab(None)
         set_focused(max_default_focus, None, max_default_screen)


### PR DESCRIPTION
This fixes an issue wherein the user wants to set the focus on a screen, but the request is overridden by Ren'Py's default_focus system forcing the largest default_focus to be focused instead.