### PR TITLE
Fix to _in_current_store behaviour for ATLTransform

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -1203,9 +1203,12 @@ class Transform(Container):
         child = self.child._in_current_store()
         if child is self.child:
             return self
-        rv = self()
+
+        # This forestalls any _duplicate attempts while building the transform.
+        child._unique()
+
+        rv = self(child=child)
         rv.take_execution_state(self)
-        rv.child = child
         rv._unique()
 
         return rv


### PR DESCRIPTION
When not passed a `child` argument, `ATLTransform.__call__` will presume to use `self.child` which is not desired during `_in_current_store`.

To avoid this, rather than building the transform and then injecting the child, we instead pass the child explicitly. Additionally, we call `_unique` on the child prior to passing it into the transform in order to forestall any `_duplicate` attempts during the build process. This best matches existing behaviour where we would call `_unique` on the transform (and thus its child) immediately after injection.