### PR TITLE
Audit uses of py2to3 compatibility functions.

### DIFF
--- a/launcher/game/choose_theme.rpy
+++ b/launcher/game/choose_theme.rpy
@@ -24,7 +24,6 @@ init python:
     import codecs
     import re
     import sys
-    import future.utils
 
     def theme_names():
         """
@@ -98,7 +97,7 @@ init python:
             return
 
         renpy.style.restore(style_backup)
-        future.utils.exec_(theme_data.THEME[theme][scheme], globals(), globals())
+        exec(theme_data.THEME[theme][scheme], globals(), globals())
 
         # Rebuild the style cache.
         renpy.style.rebuild(False)
@@ -168,8 +167,8 @@ init python:
 
     def list_logical_lines(filename):
         """
-         This reads in filename, and turns it into a list of logical
-         lines.
+        This reads in filename, and turns it into a list of logical
+        lines.
         """
 
         f = codecs.open(filename, "rb", "utf-8")
@@ -188,7 +187,7 @@ init python:
             # The line that we're building up.
             line = ""
 
-           # The number of open parenthesis there are right now.
+            # The number of open parenthesis there are right now.
             parendepth = 0
 
             # Looping over the characters in a single logical line.

--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -894,7 +894,10 @@ fix_dlc("renios", "renios")
             if not os.path.exists(path):
                 raise Exception("{} does not exist.".format(path))
 
-            if isinstance(file_list, basestring):
+            if isinstance(file_list, bytes):
+                raise Exception("File lists must be str, not bytes.")
+
+            if isinstance(file_list, str):
                 file_list = file_list.split()
 
             f = File(name, path, False, executable)
@@ -907,7 +910,10 @@ fix_dlc("renios", "renios")
             Adds an empty directory to the file lists.
             """
 
-            if isinstance(file_list, basestring):
+            if isinstance(file_list, bytes):
+                raise Exception("File lists must be str, not bytes.")
+
+            if isinstance(file_list, str):
                 file_list = file_list.split()
 
             f = File(name, None, True, False)
@@ -1778,8 +1784,9 @@ fix_dlc("renios", "renios")
             reporter.info(_("Recompiling all rpy files into rpyc files..."))
             project.launch([ "compile", "--keep-orphan-rpyc" ], wait=True)
 
-        files = [fn + "c" for fn in project.script_files()
-                 if fn.startswith("game/") and project.exists(fn + "c")]
+        files = [
+            fn + "c" for fn in project.script_files()
+            if fn.startswith("game/") and project.exists(fn + "c")]
         len_files = len(files)
 
         if not files:

--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -894,9 +894,6 @@ fix_dlc("renios", "renios")
             if not os.path.exists(path):
                 raise Exception("{} does not exist.".format(path))
 
-            if isinstance(file_list, bytes):
-                raise Exception("File lists must be str, not bytes.")
-
             if isinstance(file_list, str):
                 file_list = file_list.split()
 
@@ -909,9 +906,6 @@ fix_dlc("renios", "renios")
             """
             Adds an empty directory to the file lists.
             """
-
-            if isinstance(file_list, bytes):
-                raise Exception("File lists must be str, not bytes.")
 
             if isinstance(file_list, str):
                 file_list = file_list.split()

--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -987,7 +987,7 @@ fix_dlc("renios", "renios")
                     script_version_txt = self.temp_filename("script_version.txt")
 
                     with open(script_version_txt, "w") as f:
-                        f.write(unicode(repr(renpy.renpy.version_tuple[:-1])))
+                        f.write(repr(renpy.renpy.version_tuple[:-1]))
 
                     self.add_file("all", "game/script_version.txt", script_version_txt)
 

--- a/launcher/game/mobilebuild.rpy
+++ b/launcher/game/mobilebuild.rpy
@@ -91,7 +91,7 @@ init -1 python:
         def log(self, msg):
             with open(self.filename, "a") as f:
                 f.write("\n")
-                f.write(unicode(msg))
+                f.write(msg)
                 f.write("\n")
 
         def info(self, prompt):

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -685,7 +685,7 @@ init python in project:
                 The label to jump to when clicked.
             """
 
-            if isinstance(p, basestring):
+            if isinstance(p, str):
                 p = manager.get(p)
 
             self.project = p
@@ -773,7 +773,7 @@ init python in project:
         def __init__(self, p=None):
             if p is None:
                 self.project = current
-            elif isinstance(p, basestring):
+            elif isinstance(p, str):
                 self.project = manager.get(p)
             else:
                 self.project = p

--- a/launcher/game/util.rpy
+++ b/launcher/game/util.rpy
@@ -55,7 +55,7 @@ init -1 python in util:
 
         for subdir, directories, files in os.walk(directory):
             for fn in directories:
-                if not isinstance(fn, unicode):
+                if not isinstance(fn, str):
                     continue
 
                 fullfn = os.path.join(subdir, fn)
@@ -66,7 +66,7 @@ init -1 python in util:
                 yield relfn, True
 
             for fn in files:
-                if not isinstance(fn, unicode):
+                if not isinstance(fn, str):
                     continue
 
                 fullfn = os.path.join(subdir, fn)

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -232,7 +232,7 @@ def interpolate(t, a, b, typ):
     """
 
     # Deal with booleans, nones, etc.
-    if b is None or isinstance(b, (bool, basestring, renpy.display.matrix.Matrix, renpy.display.transform.Camera)):
+    if b is None or isinstance(b, (bool, str, bytes, renpy.display.matrix.Matrix, renpy.display.transform.Camera)):
         if t >= 1.0:
             return b
         else:

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -230,7 +230,7 @@ def interpolate(t, a, b, typ):
     """
 
     # Deal with booleans, nones, etc.
-    if b is None or isinstance(b, (bool, str, bytes, renpy.display.matrix.Matrix, renpy.display.transform.Camera)):
+    if b is None or isinstance(b, (bool, str, renpy.display.matrix.Matrix, renpy.display.transform.Camera)):
         if t >= 1.0:
             return b
         else:

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -139,8 +139,6 @@ class position(object):
             return self * (1/other)
         return NotImplemented
 
-    __div__ = __truediv__ # PY2
-
     def __pos__(self):
         return position(renpy.display.core.absolute(self.absolute), float(self.relative))
 
@@ -953,7 +951,7 @@ class RawBlock(RawStatement):
         old_exception_info = renpy.game.exception_info
         try:
             block = self.compile(Context({}))
-        except RuntimeError:  # PY3: RecursionError
+        except RecursionError:
             raise Exception("This transform refers to itself in a cycle.")
         except Exception:
             self.constant = NOT_CONST

--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -27,9 +27,6 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-
-from future.utils import raise_
-
 import time
 import pygame_sdl2 # @UnusedImport
 import os
@@ -116,16 +113,18 @@ class AudioData(str):
         play sound easteregg
     """
 
-    def __new__(cls, data, filename):
+    data: bytes
+
+    def __new__(cls, data: bytes, filename: str):
         rv = str.__new__(cls, filename)
-        rv.data = data # type: ignore
+        rv.data = data
         return rv
 
     def __init__(self, data, filename):
         pass
 
     def __reduce__(self):
-        return(AudioData, (self.data, str(self))) # type: ignore
+        return(AudioData, (self.data, str(self)))
 
 
 class QueueEntry(object):
@@ -545,7 +544,7 @@ class Channel(object):
                     continue
 
                 if isinstance(topq.filename, AudioData):
-                    topf = io.BytesIO(topq.filename.data) # type: ignore
+                    topf = io.BytesIO(topq.filename.data)
                 else:
                     topf = load(filename)
                     if topf is AudioNotReady:
@@ -1194,7 +1193,7 @@ def periodic_pass():
 
 
 # The exception that's been thrown by the periodic thread.
-periodic_exc = None
+periodic_exc: Exception | None = None
 
 # Should we run the periodic thread now?
 run_periodic = False
@@ -1225,8 +1224,8 @@ def periodic_thread_main():
 
             try:
                 periodic_pass()
-            except Exception:
-                periodic_exc = sys.exc_info()
+            except Exception as e:
+                periodic_exc = e
 
 
 def periodic():
@@ -1246,7 +1245,7 @@ def periodic():
             exc = periodic_exc
             periodic_exc = None
 
-            raise_(exc[0], exc[1], exc[2])
+            raise exc
 
         run_periodic = True
         periodic_condition.notify()

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -93,7 +93,7 @@ def play(filenames, channel="music", loop=None, fadeout=None, synchro_start=None
     if filenames is None:
         return
 
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, str):
         filenames = [ filenames ]
 
     if get_pause(channel=channel):
@@ -200,7 +200,7 @@ def queue(filenames, channel="music", loop=None, clear_queue=True, fadein=0, tig
         filenames = [ ]
         loop = False
 
-    if isinstance(filenames, basestring):
+    if isinstance(filenames, str):
         filenames = [ filenames ]
 
     if renpy.config.skipping == "fast":

--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -144,7 +144,7 @@ def play(channel, file, name, synchro_start=False, fadein=0, tight=False, start=
     """
 
     try:
-        if not isinstance(file, basestring):
+        if not isinstance(file, str):
             file = file.raw.name
     except Exception:
         if renpy.config.debug_sound:
@@ -170,7 +170,7 @@ def queue(channel, file, name, synchro_start=False, fadein=0, tight=False, start
     """
 
     try:
-        if not isinstance(file, basestring):
+        if not isinstance(file, str):
             file = file.raw.name
     except Exception:
         if renpy.config.debug_sound:

--- a/renpy/character.py
+++ b/renpy/character.py
@@ -259,7 +259,10 @@ def compute_widget_properties(who_args, what_args, window_args, properties, vari
 
         d = d.copy()
 
-        if isinstance(style, basestring):
+        if isinstance(style, bytes):
+            raise Exception("Style name must be str, not bytes.")
+
+        if isinstance(style, str):
 
             if multiple is not None:
                 style = "block{}_multiple{}_{}".format(multiple[0], multiple[1], style)
@@ -354,7 +357,10 @@ def show_display_say(who, what, who_args={}, what_args={}, window_args={},
 
     def merge_style(style, properties):
 
-        if isinstance(style, basestring):
+        if isinstance(style, bytes):
+            raise Exception("Style name must be str, not bytes.")
+
+        if isinstance(style, str):
             style = getattr(renpy.store.style, style)
 
         if variant is not None:
@@ -1362,8 +1368,8 @@ class ADVCharacter(object):
         if not (self.condition is None or renpy.python.py_eval(self.condition)):
             return True
 
-        if not isinstance(what, basestring):
-            raise Exception("Character expects its what argument to be a string, got %r." % (what,))
+        if not isinstance(what, str):
+            raise Exception(f"Character expects its what argument to be a string, got {what!r}.")
 
         if renpy.store._side_image_attributes_reset:
             renpy.store._side_image_attributes = None
@@ -1463,7 +1469,7 @@ class ADVCharacter(object):
                     self.do_done(who, what)
 
                 # Finally, log this line of dialogue.
-                if who and isinstance(who, basestring):
+                if who and isinstance(who, str):
                     renpy.exports.log(who)
 
                 renpy.exports.log(what)

--- a/renpy/character.py
+++ b/renpy/character.py
@@ -259,9 +259,6 @@ def compute_widget_properties(who_args, what_args, window_args, properties, vari
 
         d = d.copy()
 
-        if isinstance(style, bytes):
-            raise Exception("Style name must be str, not bytes.")
-
         if isinstance(style, str):
 
             if multiple is not None:
@@ -356,9 +353,6 @@ def show_display_say(who, what, who_args={}, what_args={}, window_args={},
                 renpy.ui.text(who, **who_args)
 
     def merge_style(style, properties):
-
-        if isinstance(style, bytes):
-            raise Exception("Style name must be str, not bytes.")
 
         if isinstance(style, str):
             style = getattr(renpy.store.style, style)

--- a/renpy/color.py
+++ b/renpy/color.py
@@ -135,7 +135,10 @@ class Color(tuple):
         if color is not None:
             c = color
 
-            if isinstance(c, basestring):
+            if isinstance(c, bytes):
+                c = c.decode("utf-8")
+
+            if isinstance(c, str):
                 if c[0] == '#':
                     c = c[1:]
 
@@ -164,7 +167,7 @@ class Color(tuple):
                 else:
                     raise Exception("Color string {!r} must be 3, 4, 6, or 8 hex digits long.".format(c))
 
-                return tuple.__new__(cls, (r, g, b, a)) # type: ignore
+                return tuple.__new__(cls, (r, g, b, a))
 
             if isinstance(c, Color):
                 return c
@@ -192,7 +195,7 @@ class Color(tuple):
             b = int(rgb[2] * 255)
             a = int(alpha * 255)
 
-            rv = tuple.__new__(cls, (r, g, b, a)) # type: ignore
+            rv = tuple.__new__(cls, (r, g, b, a))
             rv._rgb = rgb
             rv._hls = hls
             rv._hsv = hsv
@@ -204,7 +207,7 @@ class Color(tuple):
         if color is None:
             return None
 
-        raise Exception("Not a color: %r" % (color,))
+        raise Exception(f"Not a color: {color!r}")
 
     @property
     def hexcode(self):
@@ -356,7 +359,7 @@ class Color(tuple):
         `other` may be a string, Color or an HSV tuple.
         """
 
-        if isinstance(other, basestring):
+        if isinstance(other, (bytes, str)):
             other = Color(other, alpha=self.alpha)
         elif not isinstance(other, Color):
             other = Color(hsv=other, alpha=self.alpha)
@@ -377,7 +380,7 @@ class Color(tuple):
         `other` may be a string, Color or an HLS tuple.
         """
 
-        if isinstance(other, basestring):
+        if isinstance(other, (bytes, str)):
             other = Color(other, alpha=self.alpha)
         elif not isinstance(other, Color):
             other = Color(hls=other, alpha=self.alpha)

--- a/renpy/color.py
+++ b/renpy/color.py
@@ -135,9 +135,6 @@ class Color(tuple):
         if color is not None:
             c = color
 
-            if isinstance(c, bytes):
-                c = c.decode("utf-8")
-
             if isinstance(c, str):
                 if c[0] == '#':
                     c = c[1:]
@@ -359,7 +356,7 @@ class Color(tuple):
         `other` may be a string, Color or an HSV tuple.
         """
 
-        if isinstance(other, (bytes, str)):
+        if isinstance(other, str):
             other = Color(other, alpha=self.alpha)
         elif not isinstance(other, Color):
             other = Color(hsv=other, alpha=self.alpha)
@@ -380,7 +377,7 @@ class Color(tuple):
         `other` may be a string, Color or an HLS tuple.
         """
 
-        if isinstance(other, (bytes, str)):
+        if isinstance(other, str):
             other = Color(other, alpha=self.alpha)
         elif not isinstance(other, Color):
             other = Color(hls=other, alpha=self.alpha)

--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -121,13 +121,14 @@ python early hide:
         else:
             channel = "music"
 
-        renpy.music.play(_audio_eval(p["file"]),
-                         fadeout=eval(p["fadeout"]),
-                         fadein=eval(p["fadein"]),
-                         channel=channel,
-                         loop=p.get("loop", None),
-                         if_changed=p.get("if_changed", False),
-                         relative_volume=eval(p.get("volume", "1.0")))
+        renpy.music.play(
+            _audio_eval(p["file"]),
+            fadeout=eval(p["fadeout"]),
+            fadein=eval(p["fadein"]),
+            channel=channel,
+            loop=p.get("loop", None),
+            if_changed=p.get("if_changed", False),
+            relative_volume=eval(p.get("volume", "1.0")))
 
     def predict_play_music(p):
         if renpy.emscripten or os.environ.get('RENPY_SIMULATE_DOWNLOAD', False):
@@ -150,19 +151,20 @@ python early hide:
             file = [ file ]
 
         for fn in file:
-            if isinstance(fn, basestring):
+            if isinstance(fn, str):
                 try:
                     if not renpy.music.playable(fn, channel):
                         renpy.error("%r is not loadable" % fn)
                 except Exception:
                     pass
 
-    renpy.register_statement('play music',
-                              parse=parse_play_music,
-                              execute=execute_play_music,
-                              predict=predict_play_music,
-                              lint=lint_play_music,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'play music',
+        parse=parse_play_music,
+        execute=execute_play_music,
+        predict=predict_play_music,
+        lint=lint_play_music,
+        warp=warp_audio)
 
     # From here on, we'll steal bits of other statements when defining other
     # statements.
@@ -225,11 +227,12 @@ python early hide:
             )
 
 
-    renpy.register_statement('queue music',
-                              parse=parse_queue_music,
-                              execute=execute_queue_music,
-                              lint=lint_play_music,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'queue music',
+        parse=parse_queue_music,
+        execute=execute_queue_music,
+        lint=lint_play_music,
+        warp=warp_audio)
 
     def parse_stop_music(l):
         channel = None
@@ -263,10 +266,11 @@ python early hide:
 
         renpy.music.stop(fadeout=eval(p["fadeout"]), channel=channel)
 
-    renpy.register_statement('stop music',
-                              parse=parse_stop_music,
-                              execute=execute_stop_music,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'stop music',
+        parse=parse_stop_music,
+        execute=execute_stop_music,
+        warp=warp_audio)
 
 
     # Sound statements. They share alot with the equivalent music
@@ -298,21 +302,23 @@ python early hide:
         if loop is None:
             loop = config.default_sound_loop
 
-        renpy.sound.play(_audio_eval(p["file"]),
-                         fadeout=fadeout,
-                         fadein=eval(p["fadein"]),
-                         loop=loop,
-                         channel=channel,
-                         relative_volume=eval(p.get("volume", "1.0")))
+        renpy.sound.play(
+            _audio_eval(p["file"]),
+            fadeout=fadeout,
+            fadein=eval(p["fadein"]),
+            loop=loop,
+            channel=channel,
+            relative_volume=eval(p.get("volume", "1.0")))
 
     def lint_play_sound(p, lint_play_music=lint_play_music):
         return lint_play_music(p, channel="sound")
 
-    renpy.register_statement('play sound',
-                              parse=parse_play_music,
-                              execute=execute_play_sound,
-                              lint=lint_play_sound,
-                              warp=warp_sound)
+    renpy.register_statement(
+        'play sound',
+        parse=parse_play_music,
+        execute=execute_play_sound,
+        lint=lint_play_sound,
+        warp=warp_sound)
 
     def execute_queue_sound(p):
         if p["channel"] is not None:
@@ -334,11 +340,12 @@ python early hide:
             )
 
 
-    renpy.register_statement('queue sound',
-                              parse=parse_queue_music,
-                              execute=execute_queue_sound,
-                              lint=lint_play_sound,
-                              warp=warp_sound)
+    renpy.register_statement(
+        'queue sound',
+        parse=parse_queue_music,
+        execute=execute_queue_sound,
+        lint=lint_play_sound,
+        warp=warp_sound)
 
     def execute_stop_sound(p):
         if p["channel"] is not None:
@@ -350,10 +357,11 @@ python early hide:
 
         renpy.sound.stop(fadeout=fadeout, channel=channel)
 
-    renpy.register_statement('stop sound',
-                              parse=parse_stop_music,
-                              execute=execute_stop_sound,
-                              warp=warp_sound)
+    renpy.register_statement(
+        'stop sound',
+        parse=parse_stop_music,
+        execute=execute_stop_sound,
+        warp=warp_sound)
 
 
     # Generic play/queue/stop statements. These take a channel name as
@@ -409,24 +417,27 @@ python early hide:
         if not renpy.music.channel_defined(channel):
             renpy.error("channel %r is not defined" % channel)
 
-    renpy.register_statement('play',
-                              parse=parse_play_generic,
-                              execute=execute_play_music,
-                              predict=predict_play_music,
-                              lint=lint_play_generic,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'play',
+        parse=parse_play_generic,
+        execute=execute_play_music,
+        predict=predict_play_music,
+        lint=lint_play_generic,
+        warp=warp_audio)
 
-    renpy.register_statement('queue',
-                              parse=parse_queue_generic,
-                              execute=execute_queue_music,
-                              lint=lint_play_generic,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'queue',
+        parse=parse_queue_generic,
+        execute=execute_queue_music,
+        lint=lint_play_generic,
+        warp=warp_audio)
 
-    renpy.register_statement('stop',
-                              parse=parse_stop_generic,
-                              execute=execute_stop_music,
-                              lint=lint_stop_generic,
-                              warp=warp_audio)
+    renpy.register_statement(
+        'stop',
+        parse=parse_stop_generic,
+        execute=execute_stop_music,
+        lint=lint_stop_generic,
+        warp=warp_audio)
 
 
 
@@ -461,10 +472,11 @@ python early hide:
         else:
             renpy.pause()
 
-    renpy.register_statement('pause',
-                              parse=parse_pause,
-                              lint=lint_pause,
-                              execute=execute_pause)
+    renpy.register_statement(
+        'pause',
+        parse=parse_pause,
+        lint=lint_pause,
+        execute=execute_pause)
 
 
 ##############################################################################
@@ -708,22 +720,25 @@ python early hide:
             renpy.error("Screen is being hidden on unknown layer %s." % layer)
 
 
-    renpy.register_statement("show screen",
-                              parse=parse_show_call_screen,
-                              execute=execute_show_screen,
-                              predict=predict_screen,
-                              lint=lint_show_call_screen,
-                              warp=warp_true)
+    renpy.register_statement(
+        "show screen",
+        parse=parse_show_call_screen,
+        execute=execute_show_screen,
+        predict=predict_screen,
+        lint=lint_show_call_screen,
+        warp=warp_true)
 
-    renpy.register_statement("call screen",
-                              parse=parse_show_call_screen,
-                              execute=execute_call_screen,
-                              predict=predict_screen,
-                              lint=lint_show_call_screen,
-                              force_begin_rollback=True)
+    renpy.register_statement(
+        "call screen",
+        parse=parse_show_call_screen,
+        execute=execute_call_screen,
+        predict=predict_screen,
+        lint=lint_show_call_screen,
+        force_begin_rollback=True)
 
-    renpy.register_statement("hide screen",
-                              parse=parse_hide_screen,
-                              execute=execute_hide_screen,
-                              lint=lint_hide_screen,
-                              warp=warp_true)
+    renpy.register_statement(
+        "hide screen",
+        parse=parse_hide_screen,
+        execute=execute_hide_screen,
+        lint=lint_hide_screen,
+        warp=warp_true)

--- a/renpy/common/00action_audio.rpy
+++ b/renpy/common/00action_audio.rpy
@@ -192,7 +192,7 @@ init -1500 python:
 
 
         def __init__(self, mixer, mute):
-            if isinstance(mixer, basestring):
+            if isinstance(mixer, str):
                 mixer = [ mixer ]
 
             self.mixers = mixer
@@ -225,7 +225,7 @@ init -1500 python:
 
 
         def __init__(self, mixer):
-            if isinstance(mixer, basestring):
+            if isinstance(mixer, str):
                 mixer = [ mixer ]
 
             self.mixers = mixer

--- a/renpy/common/00action_file.rpy
+++ b/renpy/common/00action_file.rpy
@@ -592,7 +592,7 @@ init -1500 python:
         if page is None:
             return
 
-        page = unicode(page)
+        page = str(page)
 
         for i in renpy.list_slots(__slotname(page, r'\d+')):
             renpy.predict(renpy.slot_screenshot(i))
@@ -957,7 +957,7 @@ init -1500 python:
 
         `newest`
             Set to true to mark the quicksave as the newest save.
-         """
+        """
 
         rv = [ FileSave(1, page="quick", confirm=False, cycle=True, newest=newest, action=Notify(message)) ]
 

--- a/renpy/common/00build.rpy
+++ b/renpy/common/00build.rpy
@@ -42,7 +42,7 @@ init -1500 python in build:
             return s
         elif isinstance(s, list):
             return s
-        elif isinstance(s, basestring):
+        elif isinstance(s, str):
             return s.split()
 
         raise Exception("Expected a string, list, or None.")

--- a/renpy/common/00gallery.rpy
+++ b/renpy/common/00gallery.rpy
@@ -344,7 +344,7 @@ init -1500 python:
                 A string giving a Python expression.
             """
 
-            if not isinstance(expression, basestring):
+            if not isinstance(expression, str):
                 raise Exception("Gallery condition must be a string containing an expression.")
 
             self.unlockable.conditions.append(__GalleryArbitraryCondition(expression))

--- a/renpy/common/00layeredimage.rpy
+++ b/renpy/common/00layeredimage.rpy
@@ -86,7 +86,7 @@ python early in layeredimage:
 
             image = "_".join(parts)
 
-        if isinstance(image, basestring) and (image_format is not None):
+        if isinstance(image, str) and (image_format is not None):
             image = image_format.format(name=name, image=image)
 
         return image

--- a/renpy/common/00library.rpy
+++ b/renpy/common/00library.rpy
@@ -190,7 +190,7 @@ init -1700 python:
 
             if who is None:
                 who = narrator
-            elif isinstance(who, basestring):
+            elif isinstance(who, str):
                 who = Character(who, kind=name_only)
 
             return who

--- a/renpy/common/00preferences.rpy
+++ b/renpy/common/00preferences.rpy
@@ -282,7 +282,7 @@ init -1500 python:
 
         name = name.lower()
 
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value = value.lower()
 
         def get():

--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -424,7 +424,7 @@ init -1500 python in updater:
                     self.log.flush()
 
             except Exception as e:
-                self.message = _type(e).__name__ + ": " + unicode(e)
+                self.message = _type(e).__name__ + ": " + str(e)
                 self.can_cancel = False
                 self.can_proceed = True
                 self.state = self.ERROR

--- a/renpy/common/00updater.rpy
+++ b/renpy/common/00updater.rpy
@@ -41,7 +41,6 @@ init -1500 python in updater:
     import zlib
     import codecs
     import io
-    import future.utils
 
     def urlopen(url):
         import requests
@@ -1054,9 +1053,9 @@ init -1500 python in updater:
             if "RENPY_TEST_MONKEYPATCH" in os.environ:
                 with open(os.environ["RENPY_TEST_MONKEYPATCH"], "r") as f:
                     monkeypatch = f.read()
-                    future.utils.exec_(monkeypatch, globals(), globals())
+                    exec(monkeypatch, globals(), globals())
             elif verified and "monkeypatch" in self.updates:
-                future.utils.exec_(self.updates["monkeypatch"], globals(), globals())
+                exec(self.updates["monkeypatch"], globals(), globals())
 
         def add_dlc_state(self, name):
 

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -549,7 +549,7 @@ python early hide:
         _voice.seen_in_lint = True
 
         fn = _try_eval(fn, 'voice filename')
-        if not isinstance(fn, basestring):
+        if not isinstance(fn, str):
             return
 
         try:
@@ -560,12 +560,13 @@ python early hide:
         if not renpy.music.playable(fn, 'voice'):
             renpy.error('voice file %r is not playable' % fn)
 
-    renpy.statements.register('voice',
-                              parse=parse_voice,
-                              execute=execute_voice,
-                              predict=predict_voice,
-                              lint=lint_voice,
-                              translatable=True)
+    renpy.statements.register(
+        'voice',
+        parse=parse_voice,
+        execute=execute_voice,
+        predict=predict_voice,
+        lint=lint_voice,
+        translatable=True)
 
     def parse_voice_sustain(l):
         if not l.eol():
@@ -576,7 +577,8 @@ python early hide:
     def execute_voice_sustain(parsed):
         voice_sustain()
 
-    renpy.statements.register('voice sustain',
-                              parse=parse_voice_sustain,
-                              execute=execute_voice_sustain,
-                              translatable=True)
+    renpy.statements.register(
+        'voice sustain',
+        parse=parse_voice_sustain,
+        execute=execute_voice_sustain,
+        translatable=True)

--- a/renpy/common/00voice.rpy
+++ b/renpy/common/00voice.rpy
@@ -327,7 +327,7 @@ init -1500 python:
                     if tlid is None:
                         continue
 
-                    if isinstance(config.auto_voice, (str, unicode)):
+                    if isinstance(config.auto_voice, str):
                         fn = config.auto_voice.format(id=tlid)
                     else:
                         fn = config.auto_voice(tlid)

--- a/renpy/common/_compat/mainmenu.rpym
+++ b/renpy/common/_compat/mainmenu.rpym
@@ -54,7 +54,7 @@ label _library_main_menu:
 
         for i, (text, clicked, enabled) in enumerate(config.main_menu):
 
-            if isinstance(clicked, (bytes, str)):
+            if isinstance(clicked, str):
                 clicked = ui.jumpsoutofcontext(clicked)
 
             if config.main_menu_positions:

--- a/renpy/common/_compat/mainmenu.rpym
+++ b/renpy/common/_compat/mainmenu.rpym
@@ -54,7 +54,7 @@ label _library_main_menu:
 
         for i, (text, clicked, enabled) in enumerate(config.main_menu):
 
-            if isinstance(clicked, basestring):
+            if isinstance(clicked, (bytes, str)):
                 clicked = ui.jumpsoutofcontext(clicked)
 
             if config.main_menu_positions:

--- a/renpy/common/_compat/preferences.rpym
+++ b/renpy/common/_compat/preferences.rpym
@@ -403,7 +403,7 @@ init python:
 
     def _joystick_take_binding(binding, key):
 
-        if not isinstance(binding, (bytes, str)):
+        if not isinstance(binding, str):
             if key in _preferences.joymap:
                 del _preferences.joymap[key]
         else:

--- a/renpy/common/_compat/preferences.rpym
+++ b/renpy/common/_compat/preferences.rpym
@@ -403,7 +403,7 @@ init python:
 
     def _joystick_take_binding(binding, key):
 
-        if not isinstance(binding, basestring):
+        if not isinstance(binding, (bytes, str)):
             if key in _preferences.joymap:
                 del _preferences.joymap[key]
         else:

--- a/renpy/common/_layout/classic_joystick_preferences.rpym
+++ b/renpy/common/_layout/classic_joystick_preferences.rpym
@@ -77,7 +77,7 @@ init python:
 
     def _joystick_take_binding(binding, key):
 
-        if not isinstance(binding, basestring):
+        if not isinstance(binding, (bytes, str)):
             if key in _preferences.joymap:
                 del _preferences.joymap[key]
         else:

--- a/renpy/common/_layout/classic_joystick_preferences.rpym
+++ b/renpy/common/_layout/classic_joystick_preferences.rpym
@@ -77,7 +77,7 @@ init python:
 
     def _joystick_take_binding(binding, key):
 
-        if not isinstance(binding, (bytes, str)):
+        if not isinstance(binding, str):
             if key in _preferences.joymap:
                 del _preferences.joymap[key]
         else:

--- a/renpy/common/_layout/classic_main_menu.rpym
+++ b/renpy/common/_layout/classic_main_menu.rpym
@@ -63,7 +63,7 @@ label main_menu_screen:
 
             # This checks to see if clicked is a string. If so, we want clicked
             # to jump us out of the current context.
-            if isinstance(clicked, basestring):
+            if isinstance(clicked, (bytes, str)):
                 clicked=ui.jumpsoutofcontext(clicked)
 
             # Create each button.

--- a/renpy/common/_layout/classic_main_menu.rpym
+++ b/renpy/common/_layout/classic_main_menu.rpym
@@ -63,7 +63,7 @@ label main_menu_screen:
 
             # This checks to see if clicked is a string. If so, we want clicked
             # to jump us out of the current context.
-            if isinstance(clicked, (bytes, str)):
+            if isinstance(clicked, str):
                 clicked=ui.jumpsoutofcontext(clicked)
 
             # Create each button.

--- a/renpy/common/_layout/grouped_main_menu.rpym
+++ b/renpy/common/_layout/grouped_main_menu.rpym
@@ -72,7 +72,7 @@ label main_menu_screen:
 
             # This checks to see if clicked is a string. If so, we want clicked
             # to jump us out of the current context.
-            if isinstance(clicked, basestring):
+            if isinstance(clicked, (bytes, str)):
                 clicked=ui.jumpsoutofcontext(clicked)
 
             # Create each button.

--- a/renpy/common/_layout/grouped_main_menu.rpym
+++ b/renpy/common/_layout/grouped_main_menu.rpym
@@ -72,7 +72,7 @@ label main_menu_screen:
 
             # This checks to see if clicked is a string. If so, we want clicked
             # to jump us out of the current context.
-            if isinstance(clicked, (bytes, str)):
+            if isinstance(clicked, str):
                 clicked=ui.jumpsoutofcontext(clicked)
 
             # Create each button.

--- a/renpy/common/_layout/imagemap_main_menu.rpym
+++ b/renpy/common/_layout/imagemap_main_menu.rpym
@@ -81,7 +81,7 @@ label main_menu_screen:
             if not eval(enabled):
                 act = None
 
-            if isinstance(act, (bytes, str)):
+            if isinstance(act, str):
                 act = ui.jumpsoutofcontext(act)
 
             ime.button(name, act, False)

--- a/renpy/common/_layout/imagemap_main_menu.rpym
+++ b/renpy/common/_layout/imagemap_main_menu.rpym
@@ -81,7 +81,7 @@ label main_menu_screen:
             if not eval(enabled):
                 act = None
 
-            if isinstance(act, basestring):
+            if isinstance(act, (bytes, str)):
                 act = ui.jumpsoutofcontext(act)
 
             ime.button(name, act, False)

--- a/renpy/compat/__init__.py
+++ b/renpy/compat/__init__.py
@@ -92,7 +92,7 @@ renpy.update_path()
 ################################################################################
 # String (text and binary) types and functions.
 
-basestring = (str, bytes)
+basestring = (str, )
 pystr = str
 unicode = str
 str = builtins.str

--- a/renpy/compat/__init__.py
+++ b/renpy/compat/__init__.py
@@ -64,7 +64,6 @@ import io
 import sys
 import operator
 
-python_open = open
 
 ################################################################################
 # Determine if this is Python2.
@@ -74,14 +73,9 @@ PY2 = False
 ################################################################################
 # Make open mimic Python 3.
 
+python_open = open
 open = builtins.open
-
-
-def compat_open(*args, **kwargs):
-    if (sys._getframe(1).f_code.co_flags & 0xa000) == 0xa000:
-        return open(*args, **kwargs)
-    else:
-        return python_open(*args, **kwargs)
+compat_open = open
 
 
 ################################################################################

--- a/renpy/compat/fixes.py
+++ b/renpy/compat/fixes.py
@@ -206,9 +206,6 @@ def fix_tokens(source):
 
     try:
 
-        if PY2:
-            return source
-
         bio = io.BytesIO(source.encode("utf-8"))
         tokens = list(tokenize.tokenize(bio.readline))
 
@@ -272,9 +269,6 @@ def fix_ast(tree):
 
     These are fixes that apply at the AST level.
     """
-
-    if PY2:
-        return tree
 
     try:
 

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -676,7 +676,7 @@ cdef class RenderTransform:
             #cameras is rotated in z, y, x order.
             #It is because rotating stage in x, y, z order means rotating a camera in z, y, x order.
             #rotating around z axis isn't rotating around the center of the screen when rotating camera in x, y, z order.
-            v_len = math.sqrt(a**2 + b**2 + c**2) # math.hypot is better in py3.8+
+            v_len = math.hypot(a, b, c)
             if v_len == 0:
                 xpoi = ypoi = zpoi = 0
             else:
@@ -786,7 +786,7 @@ cdef class RenderTransform:
             start_pos = (xplacement + manchorx, yplacement + manchory, state.zpos)
 
             a, b, c = ( float(e - s) for s, e in zip(start_pos, poi) )
-            v_len = math.sqrt(a**2 + b**2 + c**2) # math.hypot is better in py3.8+
+            v_len = math.hypot(a, b, c)
             if v_len == 0:
                 xpoi = ypoi = 0
             else:

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -938,7 +938,7 @@ cdef class RenderTransform:
         # Shaders and uniforms.
         if state.shader is not None:
 
-            if isinstance(state.shader, basestring):
+            if isinstance(state.shader, str):
                 rv.add_shader(state.shader)
             else:
                 for name in state.shader:

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2839,7 +2839,7 @@ class OnEvent(renpy.display.displayable.Displayable):
         self.action = action
 
     def is_event(self, event):
-        if isinstance(self.event_name, basestring):
+        if isinstance(self.event_name, str):
             return self.event_name == event
         else:
             return event in self.event_name

--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -257,12 +257,6 @@ class absolute(float):
         return absolute(absolute.compute_raw(value, room))
 
 for fn in (
-    '__coerce__', # PY2
-    '__div__', # PY2
-    '__long__', # PY2
-    '__nonzero__', # PY2
-    '__rdiv__', # PY2
-
     '__abs__',
     '__add__',
     # '__bool__', # non-float
@@ -303,11 +297,10 @@ for fn in (
     # 'hex', # non-float
     # 'is_integer', # non-float
 ):
-    f = getattr(float, fn, None)
-    if f is not None: # for PY2-only and PY3-only methods
-        setattr(absolute, fn, absolute_wrap(f))
+    f = getattr(float, fn)
+    setattr(absolute, fn, absolute_wrap(f))
 
-del absolute_wrap, fn, f # type: ignore
+del absolute_wrap, fn, f  # type: ignore
 
 
 

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -2024,7 +2024,7 @@ def image(arg, loose=False, **properties):
     if isinstance(arg, ImageBase):
         return arg
 
-    elif isinstance(arg, basestring):
+    elif isinstance(arg, str):
         return Image(arg, **properties)
 
     elif isinstance(arg, renpy.display.image.ImageReference):

--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -1200,13 +1200,14 @@ def ramp(start, end):
     rv = ramp_cache.get((start, end), None)
     if rv is None:
 
-        chars = [ ]
+        chars: list[int] = [ ]
 
         for i in range(0, 256):
             i = i / 255.0
-            chars.append(bchr(int(end * i + start * (1.0 - i))))
+            i = end * i + start * (1.0 - i)
+            chars.append(int(i))
 
-        rv = b"".join(chars)
+        rv = bytes(chars)
         ramp_cache[start, end] = rv
 
     return rv

--- a/renpy/display/image.py
+++ b/renpy/display/image.py
@@ -581,7 +581,7 @@ class DynamicImage(renpy.display.displayable.Displayable):
 
         self._uses_scope = False
 
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             if ("[prefix_" in name):
                 self._duplicatable = True
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1596,7 +1596,7 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
         super(DynamicDisplayable, self).__init__()
         self.child = None
 
-        if isinstance(function, (bytes, str)):
+        if isinstance(function, str):
             args = (function, )
             kwargs = { }
             function = dynamic_displayable_compat
@@ -1889,8 +1889,6 @@ class Side(Container):
 
         if isinstance(positions, str):
             positions = positions.split()
-        elif isinstance(positions, bytes):
-            raise Exception("Side positions must be str, not bytes.")
 
         seen = set()
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1596,8 +1596,8 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
         super(DynamicDisplayable, self).__init__()
         self.child = None
 
-        if isinstance(function, basestring):
-            args = (function,)
+        if isinstance(function, (bytes, str)):
+            args = (function, )
             kwargs = { }
             function = dynamic_displayable_compat
 
@@ -1887,8 +1887,10 @@ class Side(Container):
 
         super(Side, self).__init__(style=style, **properties)
 
-        if isinstance(positions, basestring):
+        if isinstance(positions, str):
             positions = positions.split()
+        elif isinstance(positions, bytes):
+            raise Exception("Side positions must be str, not bytes.")
 
         seen = set()
 

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -109,7 +109,7 @@ class ScreenProfile(renpy.object.Object):
         self.const = const
 
         if name is not None:
-            if isinstance(name, basestring):
+            if isinstance(name, str):
                 name = tuple(name.split())
                 profile[name] = self
 
@@ -123,7 +123,7 @@ def get_profile(name):
         A string or tuple.
     """
 
-    if isinstance(name, basestring):
+    if isinstance(name, str):
         name = tuple(name.split())
 
     if name in profile:
@@ -219,12 +219,12 @@ class Screen(renpy.object.Object):
                  roll_forward=None):
 
         # The name of this screen.
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             name = tuple(name.split())
 
         self.name = name
 
-        if (variant is None) or isinstance(variant, basestring):
+        if variant is None or isinstance(variant, str):
             variant = [ variant ]
 
         for v in variant:
@@ -872,7 +872,7 @@ def get_all_screen_variants(name):
     order.
     """
 
-    if isinstance(name, basestring):
+    if isinstance(name, str):
         name = tuple(name.split())
 
     name = name[0]
@@ -1082,7 +1082,7 @@ def get_screen_layer(name):
     Returns the layer that the screen with `name` is part of.
     """
 
-    if not isinstance(name, basestring):
+    if not isinstance(name, str):
         name = name[0]
 
     screen = get_screen_variant(name)
@@ -1139,8 +1139,8 @@ def get_screen(name, layer=None, tag_only=False):
     if layer is None:
         layer = get_screen_layer(name)
 
-    if isinstance(name, basestring):
-        name = (name,)
+    if isinstance(name, str):
+        name = (name, )
 
     sl = renpy.exports.scene_lists()
 

--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -306,13 +306,11 @@ def draw_special(what, dest, x, y):
 
         ramplen = what.operation_parameter
 
-        from itertools import repeat
+        ramp = b"\x00" * 256
 
-        ramp = bytes([
-            *repeat(0, 256),
-            *(255 * i // ramplen for i in range(ramplen)),
-            *repeat(255, 256),
-        ])
+        ramp += bytes([255 * i // ramplen for i in range(ramplen)])
+
+        ramp += b"\xff" * 256
 
         step = int(what.operation_complete * (256 + ramplen))
         ramp = ramp[step:step + 256]

--- a/renpy/display/swdraw.py
+++ b/renpy/display/swdraw.py
@@ -306,12 +306,13 @@ def draw_special(what, dest, x, y):
 
         ramplen = what.operation_parameter
 
-        ramp = b"\x00" * 256
+        from itertools import repeat
 
-        for i in range(0, ramplen):
-            ramp += bchr(255 * i // ramplen)
-
-        ramp += b"\xff" * 256
+        ramp = bytes([
+            *repeat(0, 256),
+            *(255 * i // ramplen for i in range(ramplen)),
+            *repeat(255, 256),
+        ])
 
         step = int(what.operation_complete * (256 + ramplen))
         ramp = ramp[step:step + 256]

--- a/renpy/display/tts.py
+++ b/renpy/display/tts.py
@@ -216,7 +216,7 @@ def init():
 
     for pattern, replacement in renpy.config.tts_substitutions:
 
-        if isinstance(pattern, basestring):
+        if isinstance(pattern, str):
             pattern = r'\b' + re.escape(pattern) + r'\b'
             pattern = re.compile(pattern, re.IGNORECASE)
             replacement = replacement.replace("\\", "\\\\")

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -424,7 +424,7 @@ class Movie(renpy.display.displayable.Displayable):
         If `name` is a list of strings, checks if any filenames is loadable.
         """
 
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             m = re.match(r'<.*>(.*)$', name)
             if m:
                 name = m.group(1)

--- a/renpy/dump.py
+++ b/renpy/dump.py
@@ -128,7 +128,7 @@ def dump(error):
         filename = n.filename
         line = n.linenumber
 
-        if not isinstance(name, basestring):
+        if not isinstance(name, str):
             continue
 
         if not name_filter(name, filename):

--- a/renpy/easy.py
+++ b/renpy/easy.py
@@ -21,8 +21,7 @@
 
 """Functions that make the user's life easier."""
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
+from __future__ import annotations
 
 from typing import Any
 
@@ -56,64 +55,21 @@ def lookup_displayable_prefix(d):
     return displayable(fn(arg))
 
 
-def displayable_or_none(d, scope=None, dynamic=True): # type: (Any, dict|None, bool) -> renpy.display.displayable.Displayable|None
-
-    if isinstance(d, renpy.display.displayable.Displayable):
-        return d
+def displayable_or_none(
+    d: Any,
+    scope: dict[str, Any] | None = None,
+    dynamic: bool = True) -> renpy.display.displayable.Displayable | None:
 
     if d is None:
         return d
 
-    if isinstance(d, basestring):
-        if not d:
-            raise Exception("An empty string cannot be used as a displayable.")
-        elif ("[" in d) and renpy.config.dynamic_images and dynamic:
-            return renpy.display.image.DynamicImage(d, scope=scope)
-
-        rv = lookup_displayable_prefix(d)
-
-        if rv is not None:
-            return rv
-        elif d[0] == '#':
-            return renpy.store.Solid(d)
-        elif "." in d:
-            return renpy.store.Image(d)
-        else:
-            return renpy.store.ImageReference(tuple(d.split()))
-
-    if isinstance(d, Color):
-        return renpy.store.Solid(d) # type: ignore
-
-    if isinstance(d, list):
-        return renpy.display.image.DynamicImage(d, scope=scope) # type: ignore
-
-    # We assume the user knows what he's doing in this case.
-    if hasattr(d, '_duplicate'):
-        return d
-
-    if d is True or d is False:
-        return d
-
-    raise Exception("Not a displayable: %r" % (d,))
-
-
-def displayable(d, scope=None): # type(d, dict|None=None) -> renpy.display.displayable.Displayable|None
-    """
-    :doc: udd_utility
-    :name: renpy.displayable
-
-    This takes `d`, which may be a displayable object or a string. If it's
-    a string, it converts that string into a displayable using the usual
-    rules.
-    """
-
     if isinstance(d, renpy.display.displayable.Displayable):
         return d
 
-    if isinstance(d, basestring):
+    if isinstance(d, str):
         if not d:
             raise Exception("An empty string cannot be used as a displayable.")
-        elif ("[" in d) and renpy.config.dynamic_images:
+        elif ("[" in d) and renpy.config.dynamic_images and dynamic:
             return renpy.display.image.DynamicImage(d, scope=scope)
 
         rv = lookup_displayable_prefix(d)
@@ -138,12 +94,33 @@ def displayable(d, scope=None): # type(d, dict|None=None) -> renpy.display.displ
         return d
 
     if d is True or d is False:
-        return d
+        return d  # type: ignore
 
-    raise Exception("Not a displayable: %r" % (d,))
+    raise Exception(f"Not a displayable: {d!r}")
 
 
-def dynamic_image(d, scope=None, prefix=None, search=None): # type: (Any, dict|None, str|None, list|None) -> renpy.display.displayable.Displayable|None
+def displayable(d: Any, scope: dict[str, Any] | None = None) -> renpy.display.displayable.Displayable:
+    """
+    :doc: udd_utility
+    :name: renpy.displayable
+
+    This takes `d`, which may be a displayable object or a string. If it's
+    a string, it converts that string into a displayable using the usual
+    rules.
+    """
+
+    rv = displayable_or_none(d, scope=scope, dynamic=True)
+
+    if rv is None:
+        raise Exception(f"Not a displayable: {d!r}")
+
+    return rv
+
+
+def dynamic_image(
+    d: Any, scope: dict[str, Any] | None = None,
+    prefix: str | None = None, search: list[str] | None = None,
+)-> renpy.display.displayable.Displayable | None:
     """
     Substitutes a scope into `d`, then returns a displayable.
 
@@ -173,7 +150,7 @@ def dynamic_image(d, scope=None, prefix=None, search=None): # type: (Any, dict|N
 
     for i in d:
 
-        if not isinstance(i, basestring):
+        if not isinstance(i, str):
             continue
 
         if (prefix is not None) and ("[prefix_" in i):

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -613,22 +613,29 @@ class Context(renpy.object.Object):
 
                     short, full, traceback_fn = renpy.error.report_exception(e, editor=False)
 
+                    handled = False
                     try:
-                        handled = False
-
                         if self.exception_handler is not None:
                             self.exception_handler(short, full, traceback_fn)
                             handled = True
                         elif renpy.config.exception_handler is not None:
                             handled = renpy.config.exception_handler(short, full, traceback_fn)
 
-                        if not handled:
-                            if renpy.display.error.report_exception(short, full, traceback_fn):
-                                raise
-                    except renpy.game.CONTROL_EXCEPTIONS as ce:
-                        raise ce
+                        if not handled and not renpy.display.error.report_exception(
+                            short,
+                            full,
+                            traceback_fn
+                        ):
+                            handled = True
+
+                    except renpy.game.CONTROL_EXCEPTIONS:
+                        raise
                     except Exception:
-                        raise e from None
+                        pass
+
+                    # Raise original exception.
+                    if not handled:
+                        raise
 
                 node = self.next_node
 

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -25,8 +25,6 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-from future.utils import reraise
-
 import sys
 import time
 
@@ -613,7 +611,6 @@ class Context(renpy.object.Object):
                 except Exception as e:
                     self.translate_interaction = None
 
-                    exc_info = sys.exc_info()
                     short, full, traceback_fn = renpy.error.report_exception(e, editor=False)
 
                     try:
@@ -631,7 +628,7 @@ class Context(renpy.object.Object):
                     except renpy.game.CONTROL_EXCEPTIONS as ce:
                         raise ce
                     except Exception:
-                        reraise(exc_info[0], exc_info[1], exc_info[2])
+                        raise e from None
 
                 node = self.next_node
 

--- a/renpy/exports/commonexports.py
+++ b/renpy/exports/commonexports.py
@@ -31,7 +31,7 @@ def renpy_pure(fn):
 
     name = fn
 
-    if not isinstance(name, basestring):
+    if not isinstance(name, str):
         name = fn.__name__
 
     pure("renpy." + name)

--- a/renpy/exports/debugexports.py
+++ b/renpy/exports/debugexports.py
@@ -77,7 +77,7 @@ def log(msg):
         return
 
     try:
-        msg = unicode(msg)
+        msg = str(msg)
     except Exception:
         pass
 
@@ -100,7 +100,7 @@ def log(msg):
 
         for line in msg.split('\n'):
             line = textwrap.fill(line, renpy.config.log_width)
-            line = unicode(line)
+            line = str(line)
             wrapped.append(line)
 
         wrapped = '\n'.join(wrapped)

--- a/renpy/exports/displayexports.py
+++ b/renpy/exports/displayexports.py
@@ -268,7 +268,7 @@ def _find_image(layer, key, name, what):
     # If a specific image is requested, use it.
     if what is not None:
 
-        if isinstance(what, basestring):
+        if isinstance(what, str):
             what = tuple(what.split())
 
         return name, what
@@ -768,7 +768,7 @@ def get_at_list(name, layer=None):
     If `layer` is None, uses the default layer for the given tag.
     """
 
-    if isinstance(name, basestring):
+    if isinstance(name, str):
         name = tuple(name.split())
 
     tag = name[0]

--- a/renpy/exports/inputexports.py
+++ b/renpy/exports/inputexports.py
@@ -37,7 +37,7 @@ def web_input(prompt, default='', allow=None, exclude='{}', length=None, mask=Fa
     prompt = renpy.text.extras.filter_text_tags(prompt, allow=set())
 
     roll_forward = renpy.exports.roll_forward_info()
-    if not isinstance(roll_forward, basestring):
+    if not isinstance(roll_forward, str):
         roll_forward = None
 
     # use previous data in rollback
@@ -128,7 +128,7 @@ def input(prompt, default='', allow=None, exclude='{}', length=None, with_none=N
     renpy.exports.mode('input')
 
     roll_forward = renpy.exports.roll_forward_info()
-    if not isinstance(roll_forward, basestring):
+    if not isinstance(roll_forward, str):
         roll_forward = None
 
     # use previous data in rollback

--- a/renpy/exports/platformexports.py
+++ b/renpy/exports/platformexports.py
@@ -45,7 +45,7 @@ def variant(name):
     returns True if any of the variants would.
     """
 
-    if isinstance(name, basestring):
+    if isinstance(name, str):
         return name in renpy.config.variants
     else:
         for n in name:

--- a/renpy/exports/predictexports.py
+++ b/renpy/exports/predictexports.py
@@ -45,7 +45,7 @@ def expand_predict(d):
     Use the fnmatch function to expland `d` for the purposes of prediction.
     """
 
-    if not isinstance(d, basestring):
+    if not isinstance(d, str):
         return [ d ]
 
     if not "*" in d:

--- a/renpy/exports/sayexports.py
+++ b/renpy/exports/sayexports.py
@@ -37,7 +37,7 @@ class TagQuotingDict(object):
         if key in store:
             rv = store[key]
 
-            if isinstance(rv, basestring):
+            if isinstance(rv, str):
                 rv = rv.replace("{", "{{")
 
             return rv
@@ -60,7 +60,7 @@ def predict_say(who, what):
     if who is None:
         who = renpy.store.narrator # type: ignore
 
-    if isinstance(who, basestring):
+    if isinstance(who, str):
         return renpy.store.predict_say(who, what)
 
     predict = getattr(who, 'predict', None)
@@ -126,7 +126,7 @@ def say(who, what, *args, **kwargs):
     if renpy.config.say_arguments_callback:
         args, kwargs = renpy.config.say_arguments_callback(who, *args, **kwargs)
 
-    if isinstance(who, basestring):
+    if isinstance(who, str):
         renpy.store.say(who, what, *args, **kwargs)
     else:
         who(what, *args, **kwargs)

--- a/renpy/exports/scriptexports.py
+++ b/renpy/exports/scriptexports.py
@@ -53,7 +53,7 @@ def get_all_labels():
     rv = [ ]
 
     for i in renpy.game.script.namemap:
-        if isinstance(i, basestring):
+        if isinstance(i, str):
             rv.append(i)
 
     return renpy.revertable.RevertableSet(rv)

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -1454,14 +1454,13 @@ class Lexer(object):
         object, which is called directly.
         """
 
-        if isinstance(thing, basestring):
-            name = name or thing
+        if isinstance(thing, str):
             rv = self.match(thing)
         else:
             rv = thing(**kwargs)
 
         if rv is None:
-            if isinstance(thing, basestring):
+            if isinstance(thing, str):
                 name = name or thing
             else:
                 name = name or thing.__func__.__name__

--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -343,12 +343,13 @@ check_file_cache = { }
 
 def check_file(what, fn, directory=None):
 
-    if not isinstance(fn, basestring):
+    if not isinstance(fn, str):
         return
 
     present = check_file_cache.get(fn, None)
     if present is True:
         return
+
     if present is False:
         report("%s uses file '%s', which is not loadable.", what.capitalize(), fn)
         return

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -337,7 +337,7 @@ def scandirfiles():
 
     def add(dn, fn, files, seen):
 
-        fn = unicode(fn)
+        fn = str(fn)
 
         if fn in seen:
             return

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -412,22 +412,14 @@ def save(slotname, extra_info='', mutate_flag=False, include_screenshot=True):
     try:
         dump((roots, renpy.game.log), logf)
     except Exception as e:
+        if not mutate_flag and e.args:
+            try:
+                bad = find_bad_reduction(roots, renpy.game.log)
+                e.args = (e.args[0] + f' (perhaps {bad})', *e.args[1:])
+            except Exception:
+                pass
 
-        if mutate_flag:
-            raise e from None
-
-        try:
-            bad = find_bad_reduction(roots, renpy.game.log)
-        except Exception:
-            raise e from None
-
-        if bad is None:
-            raise e from None
-
-        if e.args:
-            e.args = (e.args[0] + f' (perhaps {bad})', *e.args[1:])
-
-        raise e from None
+        raise
 
     if mutate_flag and renpy.revertable.mutate_flag:
         raise SaveAbort()

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -412,12 +412,14 @@ def save(slotname, extra_info='', mutate_flag=False, include_screenshot=True):
     try:
         dump((roots, renpy.game.log), logf)
     except Exception as e:
-        if not mutate_flag and e.args:
-            try:
-                bad = find_bad_reduction(roots, renpy.game.log)
+        if mutate_flag or not e.args:
+            raise
+
+        try:
+            if bad := find_bad_reduction(roots, renpy.game.log):
                 e.args = (e.args[0] + f' (perhaps {bad})', *e.args[1:])
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         raise
 

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -64,11 +64,17 @@ def save_dump(roots, log):
         if isinstance(o, (int, float, type(None), types.ModuleType, type)):
             o_repr = repr(o)
 
-        elif isinstance(o, basestring):
+        elif isinstance(o, str):
             if len(o) <= 80:
                 o_repr = repr(o)
             else:
-                o_repr = repr(o[:80]) + "..."
+                o_repr = repr(o[:40] + "..." + o[-40:])
+
+        elif isinstance(o, bytes):
+            if len(o) <= 80:
+                o_repr = repr(o)
+            else:
+                o_repr = repr(o[:40] + b"..." + o[-40:])
 
         elif isinstance(o, (tuple, list)):
             o_repr = "<" + o.__class__.__name__ + ">"
@@ -125,7 +131,7 @@ def save_dump(roots, log):
                 reduction = [ ]
                 o_repr_cache[ido] = "BAD REDUCTION " + o_repr
 
-            if isinstance(reduction, basestring):
+            if isinstance(reduction, str):
                 o_repr_cache[ido] = o.__module__ + '.' + reduction
                 size = 1
 

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -24,10 +24,6 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-from future.utils import reraise
-
-from typing import Optional
-
 import io
 import zipfile
 import re
@@ -409,25 +405,23 @@ def save(slotname, extra_info='', mutate_flag=False, include_screenshot=True):
     logf = io.BytesIO()
     try:
         dump((roots, renpy.game.log), logf)
-    except Exception:
-
-        t, e, tb = sys.exc_info()
+    except Exception as e:
 
         if mutate_flag:
-            reraise(t, e, tb)
+            raise e from None
 
         try:
             bad = find_bad_reduction(roots, renpy.game.log)
         except Exception:
-            reraise(t, e, tb)
+            raise e from None
 
         if bad is None:
-            reraise(t, e, tb)
+            raise e from None
 
         if e.args:
-            e.args = (e.args[0] + ' (perhaps {})'.format(bad),) + e.args[1:]
+            e.args = (e.args[0] + f' (perhaps {bad})', *e.args[1:])
 
-        reraise(t, e, tb)
+        raise e from None
 
     if mutate_flag and renpy.revertable.mutate_flag:
         raise SaveAbort()

--- a/renpy/memory.py
+++ b/renpy/memory.py
@@ -108,11 +108,17 @@ def cycle_finder(o, name):
         if isinstance(o, (int, float, type(None), types.ModuleType, type)):
             o_repr = repr(o)
 
-        elif isinstance(o, basestring):
+        elif isinstance(o, str):
             if len(o) <= 80:
-                o_repr = repr(o).encode("utf-8")
+                o_repr = repr(o)
             else:
-                o_repr = repr(o[:80] + "...").encode("utf-8")
+                o_repr = repr(o[:40] + "..." + o[-40:])
+
+        elif isinstance(o, bytes):
+            if len(o) <= 80:
+                o_repr = repr(o)
+            else:
+                o_repr = repr(o[:40] + b"..." + o[-40:])
 
         elif isinstance(o, (tuple, list)):
             o_repr = "<" + o.__class__.__name__ + ">"

--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -153,7 +153,7 @@ def pure(fn):
 
     name = fn
 
-    if not isinstance(name, basestring):
+    if not isinstance(name, str):
         name = fn.__name__
 
         module = fn.__module__

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1231,9 +1231,8 @@ def raise_at_location(e, loc):
 
     node = ast.parse("raise e", filename)
     ast.increment_lineno(node, line - 1)
-    code = compile(node, filename, 'exec') #type: ignore
+    code = compile(node, filename, 'exec')
 
-    # PY3 - need to change to exec().
     exec(code, { "e" : e })
 
 

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1202,7 +1202,10 @@ def py_eval_bytecode(bytecode, globals=None, locals=None): # @ReservedAssignment
 
 
 def py_eval(code, globals=None, locals=None): # @ReservedAssignment
-    if isinstance(code, basestring):
+    if isinstance(code, bytes):
+        code = code.decode("utf-8", "python_strict")
+
+    if isinstance(code, str):
         code = py_compile(code, 'eval')
 
     return py_eval_bytecode(code, globals, locals)

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1202,9 +1202,6 @@ def py_eval_bytecode(bytecode, globals=None, locals=None): # @ReservedAssignment
 
 
 def py_eval(code, globals=None, locals=None): # @ReservedAssignment
-    if isinstance(code, bytes):
-        code = code.decode("utf-8", "python_strict")
-
     if isinstance(code, str):
         code = py_compile(code, 'eval')
 

--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -147,9 +147,13 @@ def reached(obj, reachable, wait):
     except Exception:
         pass
 
+    # Strings and bytes are not containers.
+    if isinstance(obj, (str, bytes)):
+        return
+
     # Below this, we only consider containers with a defined size.
     try:
-        if (not len(obj)) or isinstance(obj, basestring):
+        if not len(obj):
             return
     except Exception:
         return
@@ -536,7 +540,7 @@ class RollbackLog(renpy.object.Object):
                 ignore = False
             elif self.current.retain_after_load:
                 ignore = False
-            elif isinstance(context.current, basestring) and not isinstance(self.current.context.current, basestring):
+            elif isinstance(context.current, str) and not isinstance(self.current.context.current, str):
                 # This will start a new rollback on reaching a label, if the current rollback isn't at a label.
                 ignore = False
         else:

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -560,7 +560,7 @@ class Script(object):
                 bad_node = node
                 old_node = self.namemap[name]
 
-                if not isinstance(bad_name, basestring):
+                if not isinstance(bad_name, str):
 
                     raise ScriptError("Name %s is defined twice, at %s:%d and %s:%d." %
                                       (repr(bad_name),

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -275,7 +275,7 @@ def convert(value, conv, scope):
         return value
 
     # All conversion symbols below assume we have a string.
-    if not isinstance(value, basestring):
+    if not isinstance(value, str):
         value = str(value)
 
     if 't' in conv:
@@ -320,7 +320,7 @@ def substitute(s, scope=None, force=False, translate=True):
     occurred, or False if no substitution occurred.
     """
 
-    if not isinstance(s, basestring):
+    if not isinstance(s, str):
         s = str(s)
 
     if translate:

--- a/renpy/substitutions.py
+++ b/renpy/substitutions.py
@@ -284,8 +284,8 @@ def convert(value, conv, scope):
     if 'i' in conv:
         try:
             value = interpolate(value, scope)
-        except RuntimeError: # PY3 RecursionError
-            raise ValueError('Substitution {!r} refers to itself in a loop.'.format(value))
+        except RecursionError:
+            raise ValueError(f'Substitution {value!r} refers to itself in a loop.')
 
     if 'q' in conv:
         value = value.replace('{', '{{')

--- a/renpy/test/testexecution.py
+++ b/renpy/test/testexecution.py
@@ -64,7 +64,7 @@ def take_name(name):
     if node is None:
         return
 
-    if isinstance(name, basestring):
+    if isinstance(name, str):
         labels.add(name)
 
 

--- a/renpy/text/extras.py
+++ b/renpy/text/extras.py
@@ -315,7 +315,7 @@ def thaic90(s):
     """
     Reencodes `s` to the Thai C90 encoding, which is used by Thai-specific
     fonts to combine base characters, upper vowels, lower vowls, and tone marks
-    into singe precomposed characters in thje unicode private use area.
+    into singe precomposed characters in the unicode private use area.
     """
 
 

--- a/renpy/text/shader.py
+++ b/renpy/text/shader.py
@@ -116,8 +116,8 @@ class TextShader(object):
             doc=None):
 
         # A tuple of shaders to apply to text.
-        if isinstance(shader, basestring):
-            self.shader = (shader,)
+        if isinstance(shader, str):
+            self.shader = (shader, )
         else:
             self.shader = tuple(shader)
 
@@ -294,7 +294,7 @@ def parse_textshader(o):
     if isinstance(o, TextShader):
         return o
 
-    if isinstance(o, basestring):
+    if isinstance(o, str):
 
         # Combine multiple shaders separated by "|".
         if "|" in o:

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -2041,7 +2041,7 @@ class Text(renpy.display.displayable.Displayable):
 
             # Check that the text is all text-able things.
             for i in text:
-                if not isinstance(i, (basestring, renpy.display.displayable.Displayable)):
+                if not isinstance(i, (str, renpy.display.displayable.Displayable)):
                     if renpy.config.developer:
                         raise Exception("Cannot display {0!r} as text.".format(i))
                     else:
@@ -2129,8 +2129,8 @@ class Text(renpy.display.displayable.Displayable):
         s = ""
 
         for i in self.text:
-            if isinstance(i, basestring):
-                s += i # type: ignore
+            if isinstance(i, str):
+                s += i
 
             if len(s) > 25:
                 s = s[:24] + u"\u2026"
@@ -2145,8 +2145,8 @@ class Text(renpy.display.displayable.Displayable):
         s = u""
 
         for i in self.text:
-            if isinstance(i, basestring):
-                s += i # type: ignore
+            if isinstance(i, str):
+                s += i
 
         return s
 
@@ -2195,13 +2195,10 @@ class Text(renpy.display.displayable.Displayable):
 
         # Perform substitution as necessary.
         for i in text:
-            if isinstance(i, basestring):
+            if isinstance(i, str):
                 if substitute is not False:
                     i, did_sub = renpy.substitutions.substitute(i, scope, substitute) # type: ignore
                     uses_scope = uses_scope or did_sub
-
-                if isinstance(i, bytes):
-                    i = str(i, "utf-8", "replace")
 
             new_text.append(i)
 
@@ -2335,7 +2332,7 @@ class Text(renpy.display.displayable.Displayable):
 
         for i in self.text:
 
-            if not isinstance(i, basestring):
+            if not isinstance(i, str):
                 continue
 
             rv.append(i)
@@ -2821,9 +2818,6 @@ class Text(renpy.display.displayable.Displayable):
 
             if isinstance(i, str):
                 tokens.extend(textsupport.tokenize(i))
-
-            elif isinstance(i, basestring):
-                tokens.extend(textsupport.tokenize(str(i)))
 
             elif isinstance(i, renpy.display.displayable.Displayable):
                 tokens.append((DISPLAYABLE, i))

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1574,7 +1574,7 @@ class Layout(object):
         l = [ ]
 
         for ts, s in p:
-            s, direction = log2vis(unicode(s), direction)
+            s, direction = log2vis(str(s), direction)
             l.append((ts, s))
 
         rtl = (direction == RTL or direction == WRTL)

--- a/renpy/ui.py
+++ b/renpy/ui.py
@@ -864,9 +864,9 @@ def menu(menuitems,
                 text = choice_chosen_style
                 button = choice_chosen_button_style
 
-            if isinstance(button, basestring):
+            if isinstance(button, str):
                 button = getattr(renpy.game.style, button)
-            if isinstance(text, basestring):
+            if isinstance(text, str):
                 text = getattr(renpy.game.style, text)
 
             button = button[label]
@@ -893,7 +893,7 @@ def imagemap_compat(ground,
                     button_style='hotspot',
                     **properties):
 
-    if isinstance(button_style, basestring):
+    if isinstance(button_style, str):
         button_style = getattr(renpy.game.style, button_style)
 
     fixed(style=style, **properties)
@@ -1075,7 +1075,7 @@ def _bar(*args, **properties):
             else:
                 style = value.get_style()[0]
 
-            if isinstance(style, basestring):
+            if isinstance(style, str):
                 style = prefixed_style(style)
 
             properties["style"] = style
@@ -1435,8 +1435,8 @@ returns = renpy.curry.curry(_returns)
 
 def _jumps(label, transition=None):
 
-    if isinstance(transition, basestring):
-        transition = getattr(renpy.config, transition) # type: ignore
+    if isinstance(transition, str):
+        transition = getattr(renpy.config, transition)
 
     if transition is not None:
         renpy.exports.transition(transition)


### PR DESCRIPTION
Changes in this PR commit by commit
1. Removes uses of `future.utils` functions. Now RenPy codebase does not depend on this package.
2. Removes all uses of `basestring`. Most of the time it already raises some obscure exception. In some cases I raise explicit error with simple error message, in other cases decode from bytes. If both bytes and str are valid I replaced with explicit `(str, bytes)`.
3. Removed the rest uses of PY2 constant, and updated all places I have found that had some cooment like `update when python 3 is here`.
4. Replaced uses of `unicode` with `str`, and `bchr` with construction of bytes from list of integers.

I think after this PR it is safe to replace
```
from __future__ import division, absolute_import, with_statement, print_function, unicode_literals # type: ignore
from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
```
with
```
from __future__ import annotations
```
And force string annotations everywhere, because PEP 649 in 3.14 will do it anyway, so if there is dependency on runtime evaluation of type hints, we get the error early.