### PR TITLE
Update lint to use py_compile function

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -192,7 +192,7 @@ def try_compile(where, expr, additional=None):
     """
 
     try:
-        renpy.python.py_compile_eval_bytecode(expr)
+        renpy.python.py_compile(expr, 'eval')
     except Exception:
         report("'%s' could not be compiled as a python expression, %s.", expr, where)
         if additional:


### PR DESCRIPTION
Lint still uses a function removed when the [bytecode cache was improved](https://github.com/renpy/renpy/commit/fe02e12192d74f448f3b49b1193ef4a9ea676623).