### PR TITLE
Do not kill Renders that cache the last video frame on Web

### DIFF
--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -501,6 +501,7 @@ def mark_sweep():
     cdef list worklist
     cdef int i
     cdef Render r, j
+    cdef object o
 
     worklist = [ ]
 
@@ -527,6 +528,12 @@ def mark_sweep():
 
     for r in cache_renders:
         r.mark = True
+
+    if renpy.emscripten:
+        # Do not kill Renders that cache the last video frame
+        for o in renpy.display.video.texture.values():
+            if isinstance(o, Render):
+                o.mark = True
 
     for r in live_renders:
         if not r.mark:

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -244,6 +244,9 @@ def get_movie_texture_web(channel, mask_channel, side_mask, mipmap):
         new = True
     else:
         tex = texture.get(channel, None)
+        if isinstance(tex, renpy.display.render.Render) and tex.killed:
+            # Render has been killed so it cannot be re-used
+            texture[channel] = tex = None
         new = False
 
     return tex, new

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -244,9 +244,6 @@ def get_movie_texture_web(channel, mask_channel, side_mask, mipmap):
         new = True
     else:
         tex = texture.get(channel, None)
-        if isinstance(tex, renpy.display.render.Render) and tex.killed:
-            # Render has been killed so it cannot be re-used
-            texture[channel] = tex = None
         new = False
 
     return tex, new


### PR DESCRIPTION
When the next video frame is not ready, the previous one is returned by `get_movie_texture_web()`. Normally, this is just a GLTexture instance, but when using a mask, that frame is a Render instance instead. The problem is that Render instances get killed soon after they have been drawn, so `get_movie_texture_web()` returns a dead instance when re-using the previous frame which causes a crash because of missing uniforms when drawing the screen.

Ideally, we should prevent the Render from being killed as long as it is part of `renpy.display.video.texture`, but I'm not sure how to do that (maybe visiting that dict in [`mark_sweep()`](https://github.com/renpy/renpy/blob/77aaeaa51445a0f0d3eddd26741a23e8b7876b0e/renpy/display/render.pyx#L493)?). At least with this PR, there is no more crash, but maybe it introduces flickering (I did not see any though).

Fix #6050 