### PR TITLE
Suggestions for cslots

### DIFF
--- a/experimental/cslots/cslots.pyx
+++ b/experimental/cslots/cslots.pyx
@@ -1,0 +1,1 @@
+../../renpy/cslots.pyx

--- a/experimental/cslots/test_cslots.py
+++ b/experimental/cslots/test_cslots.py
@@ -4,16 +4,16 @@ import pickle
 from cslots import Object, Slot, IntegerSlot
 
 class C1(Object):
-    str1 : Slot[str|None] = Slot(None)
-    int1 : IntegerSlot = IntegerSlot(0)
+    str1 : str|None = None
+    int1 : int = 0
 
     def __init__(self, str1=None, int1=1):
         self.str1 = str1
         self.int1 = int1
 
 class C2(C1):
-    str2 : Slot[str|None] = Slot(None)
-    int2 : IntegerSlot = IntegerSlot(0)
+    str2 : str|None = None
+    int2 : int = 0
 
     def __init__(self, str1=None, int1=0, str2=None, int2=0):
         self.str1 = str1

--- a/renpy/cslots.pyx
+++ b/renpy/cslots.pyx
@@ -357,17 +357,14 @@ cdef class Slot:
 
 cdef class IntegerSlot(Slot):
 
-    cdef long long default_int_value
-
     def __init__(self, default_value=0):
         super(IntegerSlot, self).__init__(default_value)
-        self.default_int_value = default_value
 
     def __set__(self, CObject instance, unsigned int value):
 
         cdef Value v
 
-        if value == self.default_int_value:
+        if value == self.default_value:
             v.object = NULL
         else:
             v.integer = (value << 1) | INTEGER_FLAG

--- a/renpy/cslots.pyx
+++ b/renpy/cslots.pyx
@@ -370,7 +370,7 @@ cdef class IntegerSlot(Slot):
             v.integer = (value << 1) | INTEGER_FLAG
 
         if instance.index_count & COMPRESSED_FLAG:
-            raise AttributeError("Cannot set a value on a compressed object.")
+            instance._decompress()
 
         if self.number >= instance.index_count & INDEX_COUNT_MASK:
             raise AttributeError("Slot number is too large for object.")


### PR DESCRIPTION
I'll preface this by noting that my Cython and C knowledge is pretty low on the ground, so these are changes that seem to make _logical_ sense, but others will have to determine whether they make _practical_ sense.

- Make it easy to continue using the experimental tests while the cslots feature is still in development.
- Remove `default_int_value` as it appears to be a duplicate value store, and isn't strictly needed in the one place it is used.
- Allow `IntegerSlot` descriptors to re-open a compressed object automatically, matching behaviour of the generic `Slot` descriptor.