### PR TITLE
gl2: Fix virtual_size access when creating uniforms

### DIFF
--- a/renpy/gl2/gl2shader.pyx
+++ b/renpy/gl2/gl2shader.pyx
@@ -22,6 +22,7 @@
 from renpy.uguu.gl cimport *
 from libc.stdlib cimport malloc, free
 
+from renpy.gl2.gl2draw cimport GL2Draw
 from renpy.gl2.gl2mesh cimport Mesh
 from renpy.gl2.gl2texture cimport GLTexture
 from renpy.display.matrix cimport Matrix
@@ -335,6 +336,7 @@ cdef class Program:
 
     def missing(self, kind, name):
         cdef GLfloat viewport[4]
+        cdef GL2Draw cdraw
 
         if name == "u_lod_bias":
             self.set_uniform("u_lod_bias", float(renpy.config.gl_lod_bias))
@@ -348,7 +350,8 @@ cdef class Program:
         elif name == "u_drawable_size":
             self.set_uniform("u_drawable_size", renpy.display.draw.drawable_viewport[2:])
         elif name == "u_virtual_size":
-            self.set_uniform("u_virtual_size", renpy.display.draw.virtual_size)
+            cdraw = renpy.display.draw
+            self.set_uniform("u_virtual_size", cdraw.virtual_size)
         else:
             raise Exception("Shader {} has not been given {} {}.".format(self.name, kind, name))
 


### PR DESCRIPTION
Fixes https://github.com/renpy/renpy/issues/6060.

Presumably this never worked since it was added speculatively to maybe help with #5642. Given that no one's wanted it until now (at least not enough to notice it didn't work), and if the motivating case for #6060 is better solved by the solution to #6061, then it's possible that removal might be a better option.