### PR TITLE
Small clean up of Windows platform checks

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -199,7 +199,7 @@ def get_windows_version() -> tuple[int, int]:
 
 
 if platform.win32_ver()[0]:
-    windows = bool(get_windows_version())
+    windows = True
 elif os.environ.get("RENPY_PLATFORM", "").startswith("ios"):
     ios = True
 elif platform.mac_ver()[0]:

--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -187,9 +187,6 @@ cdef class GL2Draw:
         visible_w = info.current_w
         visible_h = info.current_h
 
-        if renpy.windows:
-            visible_h -= 102
-
         # Determine the visible area of the current head.
         bounds = pygame.display.get_display_bounds(0)
 


### PR DESCRIPTION
- Took @Kassy2048's suggestion from https://github.com/renpy/renpy/issues/6067#issuecomment-2575906582 to skip the Windows version check, since we already know we're on Windows, and that's all we care about in `__init__`.
- Revisited 919e22059b327063d95ea4c754b0ebb566261aae to remove the conditional block completely as it was intended to only apply to version 7 of Windows and older, and with support dropped the whole condition block is no longer relevant.

Potentially the whole `get_windows_version` function could be removed, _if_ it's not considered part of the public API. It doesn't appear to be documented, and running it on Linux (and I suspect any non-Windows platform) yields `(10, 0)` so any use it did have seems like it would be limited.