### PR TITLE
Remove disused internal function

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -161,43 +161,6 @@ experimental = "RENPY_EXPERIMENTAL" in os.environ
 
 import platform
 
-
-def get_windows_version() -> tuple[int, int]:
-    """
-    When called on windows, returns the windows version.
-    """
-
-    import ctypes
-
-    class OSVERSIONINFOEXW(ctypes.Structure):
-        _fields_ = [('dwOSVersionInfoSize', ctypes.c_ulong),
-                    ('dwMajorVersion', ctypes.c_ulong),
-                    ('dwMinorVersion', ctypes.c_ulong),
-                    ('dwBuildNumber', ctypes.c_ulong),
-                    ('dwPlatformId', ctypes.c_ulong),
-                    ('szCSDVersion', ctypes.c_wchar * 128),
-                    ('wServicePackMajor', ctypes.c_ushort),
-                    ('wServicePackMinor', ctypes.c_ushort),
-                    ('wSuiteMask', ctypes.c_ushort),
-                    ('wProductType', ctypes.c_byte),
-                    ('wReserved', ctypes.c_byte)]
-
-    try:
-
-        os_version = OSVERSIONINFOEXW() # type: ignore
-        os_version.dwOSVersionInfoSize = ctypes.sizeof(os_version)
-        retcode = ctypes.windll.Ntdll.RtlGetVersion(ctypes.byref(os_version)) # type: ignore
-
-        # On failure, assume we have a newer version of windows
-        if retcode != 0:
-            return (10, 0)
-
-        return (os_version.dwMajorVersion, os_version.dwMinorVersion) # type: ignore
-
-    except Exception:
-        return (10, 0)
-
-
 if platform.win32_ver()[0]:
     windows = True
 elif os.environ.get("RENPY_PLATFORM", "").startswith("ios"):


### PR DESCRIPTION
This was previously used to make allowances for Windows 7 and below, however those conditions have been dropped along with Windows 7 support and so there's no need to keep this function around.

API wise, I've looked through the docs and to the best of my knowledge it's completely undocumented and was only ever intended to be used internally during boot.