### PR TITLE
Update viewport.py

### DIFF
--- a/renpy/display/viewport.py
+++ b/renpy/display/viewport.py
@@ -584,6 +584,9 @@ class Viewport(renpy.display.layout.Container):
                 self.xadjustment.end_animation(instantly=True)
                 self.yadjustment.end_animation(instantly=True)
 
+                if not renpy.display.focus.get_focused():
+                    renpy.display.focus.set_grab(self)
+
                 ignore_event = True
 
         rv = super(Viewport, self).event(ev, x, y, st)


### PR DESCRIPTION
this should fix #6087 (dragging of nested viewports).

however, i don't see a way to fix scrolling of nested viewports via mousewheel also, now that a viewport is no longer focusable with a mouse (`rv.add_focus(self, renpy.display.render.Render.NO_MOUSE_FOCUS, 0, 0, width, height)`).
on the other hand, i don't know if that would be very practical at all. so currently only the outer viewport makes use of the `mouseweel` property.

<details>

<summary>tested with...</summary>

```renpy
label main_menu:
    return

init python:
    config.per_frame_screens.append('sc_test')

screen sc_test():

    default draggable = True

    # https://github.com/renpy/renpy/issues/5968
    frame modal True:
        background "#000"
        xsize 1.0
        ysize 1.0

        text "MODAL":
            align (.5, .5)
            size 512
            color "#fff1"

    vbox:
        xalign 1.0
        spacing 10

        python:
            grab = renpy.display.focus.get_grab()
            is_focused = grab and grab.is_focused()

        textbutton "Draggable: [draggable]":
            xalign 1.0
            keysym 'K_d'
            action ToggleScreenVariable('draggable')

        text f"Grab: {grab}":
            xalign 1.0
            size 18

        text f"Focused: {is_focused}":
            xalign 1.0
            size 18

    ############################################################################
    # Drag + Viewport

    # https://github.com/renpy/renpy/issues/5776

    drag:

        frame:
            background "#3338"
            padding (0, 0)
            xysize (400, 400)

            viewport:
                mousewheel 'vertical'
                draggable draggable
                yinitial .5
                xysize (300, 400)

                frame:
                    background "#3338"
                    padding (0, 0)
                    xysize (300, 800)

                    text "A lot of text that can be scrolled... " * 30:
                        size 24

            text "DRAG":
                align (.925, .5)
                size 18


    ############################################################################
    # Drag + Viewport + Bar

    # Not sure if this is supposed to work:
    # https://github.com/renpy/renpy/issues/5776#issuecomment-2390568876

    drag:
        ypos 500

        frame:
            background "#3338"
            padding (0, 0)
            xysize (400, 400)

            hbox:
                viewport id 'viewport':
                    mousewheel 'vertical'
                    draggable draggable
                    yinitial .5
                    xysize (300, 400)

                    frame:
                        background "#3338"
                        padding (0, 0)
                        xysize (300, 800)

                        text "A lot of text that can be scrolled... " * 30:
                            size 24

                # works if it's outside the viewport
                vbar:
                    xsize 20
                    ysize 1.0
                    xalign 1.0
                    value YScrollValue('viewport')

            text "DRAG":
                align (.925, .5)
                size 18


    ############################################################################
    # Drag + Viewport + Bar

    # the same but with scrollbars property
    # https://github.com/renpy/renpy/issues/5776#issuecomment-2390568876

    drag:
        ypos 500
        xalign 1.

        frame:
            background "#3338"
            padding (0, 0)
            xysize (400, 400)

            viewport:
                mousewheel 'vertical'
                draggable draggable
                scrollbars "vertical"
                yinitial .5
                xysize (318, 400)

                frame:
                    background "#3338"
                    padding (0, 0)
                    xysize (300, 800)

                    text "A lot of text that can be scrolled... " * 30:
                        size 24

            text "DRAG":
                align (.925, .5)
                size 18


    ############################################################################
    # Viewport inside Viewport

    # BUG: Unable to drag viewport inside another viewport.
    # should work now as expected

    frame:
        background "#333"
        padding (0, 0)
        align (.5, .5)
        xsize 600
        ysize 900

        has viewport
        mousewheel 'vertical'
        draggable draggable
        yinitial .5

        has vbox
        spacing 10

        for post in range(10):

            # Post
            frame:
                background "#fff3"
                padding (0, 0)
                xsize 1.0
                ysize 500

                text "Post #[post]":
                    size 32
                    color "#fff"

                # Clickable image
                button:
                    background "#f1aeae"
                    xsize .65
                    ysize 1.0
                    action Notify("Image.")

                    text "Clickable image":
                        align (.5, .5)
                        size 32
                        color "#fff"

                # Comment section
                text "Comments:":
                    xalign 1.0

                viewport:
                    mousewheel 'vertical'
                    if post % 2:
                        scrollbars "vertical"
                    draggable draggable
                    yinitial .5
                    xsize .35
                    ysize .9
                    xalign 1.0
                    yalign 1.0

                    has vbox
                    xsize 1.0

                    for comment in range(30):

                        # Comment
                        frame:
                            background "#bebebe"
                            padding (0, 0)
                            xsize 1.0

                            text "Comment #[comment]":
                                size 24
                                color "#fff"

label start:
    call screen sc_test()
```

</details>