### PR TITLE
Implement creating rpa archives in subdirectories

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -943,6 +943,15 @@ fix_dlc("renios", "renios")
                 arcfn = arcname + ".rpa"
                 arcpath = self.temp_filename(arcfn)
 
+                # Create new directories leading to the new archive file relative to the tmp root
+                # if the archive's name indicates it should be in a subdirectory
+                arc_relpath = os.path.relpath(arcpath, self.project.tmp)
+                arc_subdir = os.path.dirname(arc_relpath)
+
+                if arc_subdir:
+                    abs_subdir = os.path.join(self.project.tmp, arc_subdir)
+                    os.makedirs(abs_subdir, exist_ok=True)
+
                 af = archiver.Archive(arcpath)
 
                 fll = len(self.file_lists[arcname])

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -399,7 +399,8 @@ def main():
         archives.sort()
 
         for archive in archives:
-            base = archive.stem
+            arc_relpath = archive.relative_to(dn)
+            base = os.path.join(arc_relpath.parent, arc_relpath.stem)
             renpy.config.archives.append(base)
 
     renpy.config.archives.reverse()

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -400,7 +400,10 @@ def main():
 
         for archive in archives:
             arc_relpath = archive.relative_to(dn)
-            base = os.path.join(arc_relpath.parent, arc_relpath.stem)
+            base = arc_relpath.stem
+            if arc_relpath.parent != Path("."):
+                base = os.path.join(arc_relpath.parent, arc_relpath.stem)
+
             renpy.config.archives.append(base)
 
     renpy.config.archives.reverse()


### PR DESCRIPTION
This ensures that any subdirectories between the requested rpa archive path and project root are built before creating the rpa file.

Example build using a modified `the_question`:

```diff
the_question/game/options.rpy
@@ -192,6 +192,12 @@ init python:
     build.classify('**/#**', None)
     build.classify('**/thumbs.db', None)
 
+    build.archive("arc_png")
+    build.classify("game/images/*.png", "arc_png")
+
+    build.archive("assets/jpg")
+    build.classify("game/images/*.jpg", "assets/jpg")
+
     ## To archive files, classify them as 'archive'.
 
     # build.classify('game/**.png', 'archive')
```

Build:

```text
> ./renpy.exe launcher distribute the_question
Scanning project files...
Archiving files... - 8 of 8
Archiving files... - 4 of 4
Scanning Ren'Py files...
Writing the pc zip package. - 1713 of 1713
Writing the linux tar.bz2 package. - 1697 of 1697
Writing the mac app-zip package. - 1702 of 1702
Writing the win zip package. - 1705 of 1705
Writing the market bare-zip package. - 2711 of 2711
All packages have been built.

Due to the presence of permission information, unpacking and repacking the Linux and Macintosh distributions on Windows is not supported.
```

Output:

```text
> tree the_question-7.0-dists/the_question-7.0-pc/ -P "*.rpa"
the_question-7.0-dists/the_question-7.0-pc/
├── game
│   ├── arc_png.rpa
│   ├── assets
│   │   └── jpg.rpa
│   ├── cache
...
```

This is a draft because this only solves half of the problem. Testing shows that Ren'py also doesn't see rpa files in subdirectories: 

![image](https://github.com/user-attachments/assets/5e9282b0-8647-49e3-8909-ce757bfe3c8c)

Ren'py doesn't "scan" for rpa archives though, they're stored in a variable. But in-game, `renpy.config.archives` is just `['arc_png']`, so it's not looking for `assets/jpg.rpa` at all.

- [ ] Fix: add rpas in subdirectories to archives list

Resolves #6101.