### PR TITLE
Update `nearrect` documentation

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2416,11 +2416,18 @@ class NearRect(Container):
 
     `rect`
         The rectangle to place the child near.
+    
+    `focus`
+        Passed to `GetFocusRect`. The special name "tooltop" will retrieve the
+        rect of last displayable to set a tooltip. If present, overrides `rect`.
 
     `preferred_side`
         One of "left", "top", "right", "bottom" to prefer that position for
         the nearrect. If there is not room on one side, the opposite side is
         used. By default, the preferred side is "bottom".
+    
+    `prefer_top`
+        Deprecated. Equivalent to passing `preferred_side="top"`
 
     `invert_offsets`
         If True and there isn't enough space on the preferred side, multiply the

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -1114,9 +1114,23 @@ Nearrect takes the following properties:
     Passing "tooltip" to this uses the location of the last displayable that
     was focused while displaying a tooltip.
 
+    If present, overrides `rect`
+
+.. screen-property:: preferred_side
+    
+    One of ``"left"``, ``"top"``, ``"right"``, ``"bottom"`` to prefer that
+    position for the nearrect. If there is not room on one side, the opposite
+    side is used. By default, the preferred side is "bottom".
+
 .. screen-property:: prefer_top
 
-    If given, positioning the child above the focus rect is preferred.
+    Deprecated. Equivalent to ``preferred_side "top"``
+
+.. screen-property:: invert_offsets
+        
+    If True and there isn't enough space on the preferred side, multiply
+    xoffset and yoffset by -1 since the child will be on the opposite side of
+    the rectangle. False by default.
 
 It also takes:
 
@@ -1124,21 +1138,26 @@ It also takes:
 * :ref:`position-style-properties`
 
 
-Nearrect differs from the other layouts in that it positions its child near
-the given rectangle, rather than inside it. The child is first rendered with
-the full width available, and the maximum of the height above and height below
-the rectangle. The y position is then computed as followed.
+Nearrect differs from the other layouts in that it positions its child near the
+given rectangle, rather than inside it. For a `preferred_side` of ``"top"`` or
+``"bottom"`` (resp. ``"left"``, ``"right"``), the child is first rendered with
+the full width (resp. height) available, and the maximum of the height
+(resp. width) above and below the rectangle. The y position (resp. x position)
+is then computed as followed.
 
-* If the child will fit above the rectangle and `prefer_top` is given, the child
-  is positioned directly above the rectangle.
-* Otherwise, if the child can fit below the rectangle, it's positioned directly
-  below the rectangle.
-* Otherwise, the child is positioned directly above the rectangle.
+* If the child will fit on the `preferred_side` of the rectangle, the child is
+  positioned directly adjacent to the rectangle.
+* Otherwise, if the child can fit opposite the `preferred_side` of the
+  rectangle, it's positioned there.
+* Otherwise, the child is positioned directly adjacent to the rectangles's
+  `preferred_side`.
 
-The x positioning is computed using the normal rules, using the :propref:`xpos`
-and :propref:`xanchor` properties of the child, and properties that set them,
-such as :propref:`xalign`. The pos properties are relative to the x coordinate
-of the rectangle, and in the case of a floating point number, the width.
+The x positioning (resp. y position) is computed using the normal rules, using
+the :propref:`xpos` and :propref:`xanchor` properties (resp. :propref:`ypos`,
+:propref:`yanchor`) of the child, and properties that set them, such as
+:propref:`xalign`. The pos properties are relative to the x coordinate
+(resp. y coordinate) of the rectangle, and in the case of a floating point
+number, the width (resp. height).
 
 At the end of positioning, the :propref:`xoffset` and :propref:`yoffset`
 properties are applied as normal.


### PR DESCRIPTION
https://www.renpy.org/doc/html/screens.html#nearrect is missing documentation for the properties `preferred_side` and `invert_offsets` added in #5114 . Additionally, `class Nearrect` is missing documentation for the `focus` keyword.

This PR also contains a first stab at updating the layout description to account for the fact it can now run in either axis as appropriate.

Apologies if the documentation contains any build errors, I currently have no way to build it.