### PR TITLE
mark imported function / variable as `pure` / `const` in the importing store

### DIFF
--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -168,6 +168,29 @@ def pure(fn):
 
     return fn
 
+def import_from(from_module, in_module, *names):
+    """
+    This function is called after each `from from_module import name` statement,
+    to make sure that if `from_module.name` is a const / pure value, `in_module.name` is marked const / pure as well.
+    """
+    if from_module.startswith("store."):
+        from_module = from_module[6:]
+    
+    if in_module.startswith("store."):
+        in_module = in_module[6:]
+    
+    for name in names:
+        fullname = f"{from_module}.{name}"
+
+        if fullname in not_constants:
+            continue
+
+        fullname_after_import = f"{in_module}.{name}"
+
+        if fullname in pure_functions:
+            pure(fullname_after_import)
+        elif fullname in constants:
+            const(fullname_after_import)
 
 class Control(object):
     """

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -806,10 +806,12 @@ class WrapNode(ast.NodeTransformer):
         
         args = [ ]
 
+        # name of the module we're importing from
         args.append(
             ast.Constant(namespace)
         )
 
+        # name of the module we're importing into
         args.append(
             ast.Name(
                 id="__name__",
@@ -817,21 +819,27 @@ class WrapNode(ast.NodeTransformer):
             )
         )
 
+        # what we are importing
         args.extend([
             ast.Constant(name)
             for name in names
         ])
+
+        renpy_pyanalysis_import_from = \
+        ast.Attribute(
+            value=ast.Attribute(
+                value=ast.Name(id="renpy", ctx=ast.Load()),
+                attr="pyanalysis",
+                ctx=ast.Load()
+            ),
+            attr="import_from",
+            ctx=ast.Load()
+        )
         
         rv.append(
             ast.Expr(
                 value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Attribute(
-                            value=ast.Name(id="renpy", ctx=ast.Load()),
-                            attr="pyanalysis",
-                            ctx=ast.Load()),
-                        attr="import_from",
-                        ctx=ast.Load()),
+                    func=renpy_pyanalysis_import_from,
                     args=args,
                     keywords=[]
                 )

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -776,6 +776,34 @@ class WrapNode(ast.NodeTransformer):
         node.cases = [self.wrap_match_case(i) for i in node.cases]
         return node
 
+    def visit_ImportFrom(self, node):
+        namespace = node.module
+
+        for alias in node.names:
+            name = alias.asname or alias.name
+            fullname = f"{namespace}.{name}"
+
+            if fullname.startswith("store."):
+                fullname = fullname[6:]
+                        
+            if fullname not in renpy.pyanalysis.not_constants:
+                STORE_NAME_THIS_IMPORT_IS_FROM = "???" # TODO get the module name
+
+                after_import_fullname = f"{STORE_NAME_THIS_IMPORT_IS_FROM}.{name}"
+
+                # renpy.pure and renpy.const
+                # aren't actually called yet
+                # since we're jut parsing the tree
+                # TODO
+                if fullname in renpy.pyanalysis.pure_functions:
+                    renpy.pyanalysis.pure(after_import_fullname)
+                    pass
+
+                elif fullname in renpy.pyanalysis.constants:
+                    renpy.pyanalysis.const(after_import_fullname)
+                    pass
+
+        return node
 
 wrap_node = WrapNode()
 


### PR DESCRIPTION
when the function / variable has been marked as `pure` / `const`

the idea is that
```rpy

init python in my_store:
    @renpy.pure
    def my_pure_function(): pass

    my_const = 1
    renpy.const("my_store.my_const")

init python in my_other_store:
    from store.my_store import my_pure_function, my_const
```
doesn't mark `my_other_store.my_pure_function` as `pure`, nor `my_other_store.my_const` as `const`

you could do that manually, of course, but it's not practical when you have a lot of things to import


PR is a draft because of 3 things:

- [x] how do we get the name of the module we're importing from?
- [x] how do we know if the thing being imported is marked? (since we're just parsing a tree)
- [x] this doesn't handle `*` imports

for n°1, when compiling an `init python`, we could set a variable to the store's name, which we could grab in visit_ImportFrom

for n°2, one way of doing it would be to add a tuple of (fullname, after_import_fullname) to a list somewhere, and then loop over these tuples after every `init python` has executed, to check if `fullname` is a constant value.

i'll let you guys decide this