### PR TITLE
Handle newest_mtime initialized as None while determining newest game save

### DIFF
--- a/renpy/common/_layout/classic_load_save.rpym
+++ b/renpy/common/_layout/classic_load_save.rpym
@@ -244,7 +244,7 @@ init python:
                     screenshot = _file_picker_process_screenshot(screenshot)
                     save_info[fn] = (extra_info, screenshot, mtime)
 
-                    if not fn.startswith("auto-") and mtime > newest_mtime:
+                    if not fn.startswith("auto-") and (newest_mtime is None or mtime > newest_mtime):
                         newest = fn
                         newest_mtime = mtime
 


### PR DESCRIPTION
Found logical error that prevented one ancient VN from viewing manual saves. Fix is plain and simple.