### PR TITLE
Optimise startup file scan

### DIFF
--- a/renpy/display/error.py
+++ b/renpy/display/error.py
@@ -68,7 +68,7 @@ def init_display():
 
     if not renpy.game.interface:
         renpy.display.core.Interface()
-        renpy.loader.index_archives()
+        renpy.loader.index_files()
         renpy.display.im.cache.init()
 
     renpy.game.interface.start()

--- a/renpy/exports/displayexports.py
+++ b/renpy/exports/displayexports.py
@@ -745,9 +745,6 @@ def image_size(im):
     using the image cache. This can be slow.
     """
 
-    # Index the archives, if we haven't already.
-    renpy.loader.index_archives()
-
     im = renpy.easy.displayable(im)
 
     if not isinstance(im, renpy.display.im.Image):

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -364,17 +364,20 @@ def main():
     renpy.config.searchpath = renpy.__main__.predefined_searchpath(renpy.config.commondir) # E1101 @UndefinedVariable
 
     # Load Ren'Py extensions.
-    for dir in [ renpy.config.renpy_base ] + renpy.config.searchpath + [ os.path.join(renpy.config.gamedir, "libs") ]: # @ReservedAssignment
+    search = (renpy.config.renpy_base,
+              *renpy.config.searchpath,
+              os.path.join(renpy.config.gamedir, "libs"))
 
-        if not os.path.isdir(dir):
+    for path in search:
+        if not os.path.isdir(path):
             continue
 
-        for fn in sorted(os.listdir(dir)):
+        for fn in sorted(os.listdir(path)):
             if fn.lower().endswith(".rpe"):
-                load_rpe(dir + "/" + fn)
+                load_rpe(path + "/" + fn)
 
-            if fn.lower().endswith(".rpe.py"):
-                load_rpe_py(dir + "/" + fn)
+            elif fn.lower().endswith(".rpe.py"):
+                load_rpe_py(path + "/" + fn)
 
     # Generate a list of extensions for each archive handler.
     archive_extensions = [ ]

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -379,44 +379,8 @@ def main():
             elif fn.lower().endswith(".rpe.py"):
                 load_rpe_py(path + "/" + fn)
 
-    # Generate a list of extensions for each archive handler.
-    archive_extensions = [ ]
-    for handler in renpy.loader.archive_handlers:
-        for ext in handler.get_supported_extensions():
-            if not (ext in archive_extensions):
-                archive_extensions.append(ext)
-
-    # Find archives.
-    for dn in renpy.config.searchpath:
-
-        dn = Path(dn)
-
-        if not dn.is_dir():
-            continue
-
-        archives = [ ]
-
-        for ext in archive_extensions:
-            archives.extend(dn.glob(f"**/*{ext}"))
-
-        archives.sort()
-
-        for archive in archives:
-            arc_relpath = archive.relative_to(dn)
-            base = arc_relpath.stem
-            if arc_relpath.parent != Path("."):
-                base = os.path.join(arc_relpath.parent, arc_relpath.stem)
-
-        archives.sort()
-
-        for archive in archives:
-            base = archive.stem
-            renpy.config.archives.append(base)
-
-    renpy.config.archives.reverse()
-
-    # Initialize archives.
-    renpy.loader.index_archives()
+    # Initialize file indexes.
+    renpy.loader.index_files()
 
     # Start auto-loading.
     renpy.loader.auto_init()
@@ -478,8 +442,8 @@ def main():
                     # This perhaps shouldn't happen since either .rpy or .rpyc should exist
                     pass
 
-        # Update script files list, so that it doesn't contain removed .rpyc's
-        renpy.loader.cleardirfiles()
+        # Reindex files so that .rpyc's are cleared out.
+        renpy.loader.index_files()
         renpy.game.script.scan_script_files()
 
     # Load all .rpy files.
@@ -594,13 +558,6 @@ def main():
         renpy.savelocation.init()
         renpy.loadsave.init()
         log_clock("Reloading save slot metadata")
-
-        # Index the archive files. We should not have loaded an image
-        # before this point. (As pygame will not have been initialized.)
-        # We need to do this again because the list of known archives
-        # may have changed.
-        renpy.loader.index_archives()
-        log_clock("Index archives")
 
         # Check some environment variables.
         renpy.game.less_memory = "RENPY_LESS_MEMORY" in os.environ


### PR DESCRIPTION
Fixes #6135.

---

## Overview

**Old behaviour**
- Load extensions.
- Deep glob each directory in `config.searchpath` looking for archives.
- Set `config.archives` to stems of the found archives, throwing away the full path and extension.
- Index archives
  - Use trial and error to try and locate the archives we just globbed in `config.searchpath` directories.
  - Use trial and error to match the header of a found archive to a handler.
  - Store the relative path of the archive and its index.
- `listfilesdir`
  - Compile file lists (including a full scan of `config.searchpath` directories).
- Load from archive
  - Use trial and error to find archive in `config.searchpath`.

**New behaviour**
- Load extensions (nominal improvements, see first commit).
- Index files
  - Trigger `listfilesdir`
  - Collect archive file paths during filesystem scan.
  - Load archive indexes as the first step to scanning archives.
    - Uses file paths found in previous step rather than re-searching for them.
    - Uses extension to identify which handlers are viable.
    - Uses trial and error to match the header of archive to a handler (only tries viable handlers from previous step).
    - Stores full path of the archive and its index.
- Load from archive
  - Uses full path without needing to search for archive location.

## Notes

- Introduces an internal `ArchiveHandlers` class to store archive handlers.
  - Exposes a `spec` method used to get handler information pertinent to a given file extension.
  - This avoids recalculation of inferred information, such as the max header size for a given extension.
- Removes re-indexing during boot as the list of available archives is now effectively immutable (because we'd have found all possible archives already).
- `config.archives` is retained, but is effectively read-only.

## Speed

On my system (Linux, ext4), against a project with ~30k files:

| | Early init took |
|---------------|--------:|
| `8.3.4` | 1.49s |
| `8.4.0.25020502+nightly` | 4028 ms |
| This branch | 734 ms |