### PR TITLE
Doc changes - Colormatrix, Audio, general cleanup

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -1733,7 +1733,7 @@ def Character(name=NotSet, kind=None, **properties):
     `retain`
         If not true, an unused tag is generated for each line of dialogue,
         and the screens are shown non-transiently. Call :func:`renpy.clear_retain`
-        to remove all retaint screens. This is almost always used with
+        to remove all retained screens. This is almost always used with
         :doc:`bubble`.
 
     Keyword arguments beginning with ``show_`` have the prefix

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -245,8 +245,8 @@ def queue_event(name, up=False, **kwargs):
     names in :var:`config.keymap`, or a list of such names.
 
     `up`
-        This should be false when the event begins (for example, when a keyboard
-        button is pressed.) It should be true when the event ends (when the
+        This should be False when the event begins (for example, when a keyboard
+        button is pressed.) It should be True when the event ends (when the
         button is released.)
 
     The event is queued at the time this function is called. This function will

--- a/renpy/exports/contextexports.py
+++ b/renpy/exports/contextexports.py
@@ -143,15 +143,15 @@ def scry():
     following fields:
 
     `nvl_clear`
-        Is true if an ``nvl clear`` statement will execute before the
+        Is True if an ``nvl clear`` statement will execute before the
         next interaction.
 
     `say`
-        Is true if an ``say`` statement will execute before the
+        Is True if an ``say`` statement will execute before the
         next interaction.
 
     `menu_with_caption`
-        Is true if a ``menu`` statement with a caption will execute
+        Is True if a ``menu`` statement with a caption will execute
         before the next interaction.
 
     `who`

--- a/renpy/exports/displayexports.py
+++ b/renpy/exports/displayexports.py
@@ -1092,8 +1092,8 @@ def reset_physical_size():
 
     Attempts to set the size of the physical window to the size specified
     using :var:`renpy.config.physical_height` and :var:`renpy.config.physical_width`,
-    or the size set using :var:`renpy.config.screen_width` and :var:`renpy.config.screen_height`
-    if not set.
+    or, if those are not set, the size set using :var:`renpy.config.screen_width`
+    and :var:`renpy.config.screen_height`.
     """
 
     set_physical_size((renpy.config.physical_width or renpy.config.screen_width, renpy.config.physical_height or renpy.config.screen_height))
@@ -1252,7 +1252,7 @@ def is_start_interact():
     """
     :doc: other
 
-    Returns true if restart_interaction has not been called during the current
+    Returns True if restart_interaction has not been called during the current
     interaction. This can be used to determine if the interaction is just being
     started, or has been restarted.
     """
@@ -1421,7 +1421,7 @@ def render_to_surface(d, width=None, height=None, st=0.0, at=None, resize=False)
         The displayable or Render to render. If a Render, `width`, `height`, `st`, and `at` are ignored.
 
     `width`
-        The width to offer `d`, in virtual pixesl. If None, :var:`config.screen_width`.
+        The width to offer `d`, in virtual pixels. If None, :var:`config.screen_width`.
 
     `height`
         The height to offer `d`, in virtual pixels. If None, :var:`config.screen_height`.
@@ -1430,7 +1430,7 @@ def render_to_surface(d, width=None, height=None, st=0.0, at=None, resize=False)
         The time of the render, in the shown timebase.
 
     `at`
-        The time of the rendem in the animation timebase. If None, `st` is used.
+        The time of the render in the animation timebase. If None, `st` is used.
 
     `resize`
         If True, the surface will be resized to the virtual size of the displayable or render. This

--- a/renpy/exports/platformexports.py
+++ b/renpy/exports/platformexports.py
@@ -83,7 +83,7 @@ def invoke_in_thread(fn, *args, **kwargs):
     stopped when Ren'Py is shutting down.
 
     This thread is very limited in what it can do with the Ren'Py API.
-    Changing store variables is allowed, as are calling calling the following
+    Changing store variables is allowed, as are calling the following
     functions:
 
     * :func:`renpy.restart_interaction`

--- a/renpy/exports/predictexports.py
+++ b/renpy/exports/predictexports.py
@@ -149,7 +149,7 @@ def predicting():
     """
     :doc: other
 
-    Returns true if Ren'Py is currently in a predicting phase.
+    Returns True if Ren'Py is currently in a predicting phase.
     """
 
     return renpy.display.predict.predicting

--- a/renpy/exports/restartexports.py
+++ b/renpy/exports/restartexports.py
@@ -115,14 +115,14 @@ def quit(relaunch=False, status=0, save=False): # @ReservedAssignment
     This causes Ren'Py to exit entirely.
 
     `relaunch`
-        If true, Ren'Py will run a second copy of itself before quitting.
+        If True, Ren'Py will run a second copy of itself before quitting.
 
     `status`
         The status code Ren'Py will return to the operating system.
         Generally, 0 is success, and positive integers are failure.
 
     `save`
-        If true, the game is saved in :var:`_quit_slot` before Ren'Py
+        If True, the game is saved in :var:`_quit_slot` before Ren'Py
         terminates.
     """
 

--- a/sphinx/source/audio.rst
+++ b/sphinx/source/audio.rst
@@ -45,17 +45,67 @@ for the given music files to be played as the main and game menu music,
 respectively.
 
 In-game, the usual way to play music and sound in Ren'Py is using
-the three music/sound statements.
+the three music/sound statements. Audio files can either be provided directly
+as strings, or as defined names within the audio namespace.
 
+.. _audio-namespace:
+
+Audio Directory and Namespace
+-----------------------------
+
+When Ren'Py searches for an audio file used by audio statements or functions, it
+will start inside the ``game`` directory. If the provided file is not found there,
+it will also look in the ``game/audio`` directory. For example::
+
+    play music "opening.ogg"
+
+will first look for :file:`game/opening.ogg`. If not found, Ren'Py will look for
+:file:`game/audio/opening.ogg`. This is consistent with audio files in further
+subdirectories. The following statement::
+
+    play music "my_music/opening.ogg"
+
+will first look for :file:`game/my_music/opening.ogg`, before looking for
+:file:`game/audio/my_music/opening.ogg` if the former is not found.
+
+Files found in the ``game/audio`` directory, **as well as its subdirectories**, that end with
+a supported extension (currently, .wav, .mp2, .mp3, .ogg, and .opus) are also automatically
+placed by Ren'Py into the audio namespace. This means that :file:`game/audio/Town_theme.ogg`
+can be played with::
+
+    play music town_theme
+
+The usable name is determined by stripping the extension and forcing the rest of
+the filename to lower case. This is only the case for audio files with names that
+can be expressed as Python variables, for example: :file:`my song.mp3`, :file:`8track.opus`,
+or :file:`this-is-a-song.ogg` will not work. Additionally, if two or more files would
+end up defined under the same name, only the first file (determined alphabetically by its path
+and filename, extension included) will be defined. 
+
+When a file isn't placed automatically into the audio namespace, either due to
+an incompatible name or being inside a different directory, it can still be placed
+there manually with the define statement.
+
+For example, one can write::
+
+    define audio.sunflower = "my_music/sun-flower-slow-jam.ogg"
+
+and then use::
+
+    play music sunflower
+
+The ``play`` and ``queue`` statements always evaluate their arguments in the
+audio namespace. Functions do not, meaning they will not work with ``sunflower``,
+but will work with ``audio.sunflower`` instead.
 
 .. _play-statement:
 
 Play Statement
 --------------
 
-The ``play`` statement is used to play sound and music. If a file is
-currently playing on a normal channel, it is interrupted and replaced with
-the new file.
+The ``play`` statement is the most common way used to play sound and music.
+If a file is currently playing on a normal channel, it is interrupted and
+replaced with the new file.
 
 The name of a channel is expected following the keyword ``play``.
 (Usually, this is either "sound", "music", "voice", or "audio"). This is
@@ -182,7 +232,7 @@ advanced (rarely used) features.
 Partial Playback
 ----------------
 
-Ren'Py supports partial of audio files. This is done by putting a playback
+Ren'Py supports partial playback of audio files. This is done by putting a playback
 specification, enclosed in angle brackets, at the start of the file.
 The partial playback specification should consist of alternating
 property name and value pairs, with every thing separated by spaces.
@@ -295,48 +345,6 @@ desired. This can be used to delay the start of a sound file. For example::
         play audio [ "<silence .5>", "boom.opus" ]
 
 Will play silence for half a second, and then an explosion sound.
-
-
-.. _audio-namespace:
-
-Audio Namespace and Directory
------------------------------
-
-The ``play`` and ``queue`` statements evaluate their arguments in the
-audio namespace. This means it is possible to use the define statement
-to provide an alias for an audio file.
-
-For example, one can write::
-
-    define audio.sunflower = "music/sun-flower-slow-jam.ogg"
-
-and then use::
-
-    play music sunflower
-
-Ren'Py will also automatically place sound files in the audio namespace,
-if found in the ``game/audio`` directory. Files in this directory with a
-supported extension (currently, .wav, .mp2, .mp3, .ogg, and .opus) have the
-extension stripped, the rest of the filename forced to lower case, and are
-placed into the audio namespace.
-
-Note that just because a file is placed into the audio namespace, that doesn't
-mean it can be used. So while you could play a file named :file:`opening_song.ogg`
-by writing::
-
-    play music opening_song
-
-some filenames can't be accessed this way, as their names are not expressable
-as Python variables. For example, :file:`my song.mp3`, :file:`8track.opus`, and
-:file:`this-is-a-song.ogg` won't work.
-
-When searching for an audio file, if the file is not found, Ren'Py will look
-in the audio directory. For example::
-
-    play music "opening.ogg"
-
-will first look for :file:`game/opening.ogg`. If not found, Ren'Py will look for
-:file:`game/audio/opening.ogg`.
 
 
 Actions

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -74,8 +74,9 @@ Auto-Forward Mode
 .. var:: config.afm_callback = None
 
     If not None, a Python function that is called to determine if it
-    is safe to auto-forward. The intent is that this can be used by a
-    voice system to disable auto-forwarding when a voice is playing.
+    is safe to auto-forward. If None, an internal function is used to 
+    disable auto-forwarding when a voice is playing, unless :var:`preferences.wait_voice`
+    is set to False.
 
 .. var:: config.afm_characters = 250
 
@@ -364,7 +365,7 @@ Display
     edges drawn when aspect ratio of the window (or monitor in
     fullscreen mode) does not match the aspect ratio of the game.
 
-.. var:: config.gl_lod_bias = -0.5
+.. var:: config.gl_lod_bias = -0.6
 
     The default value of the :ref:`u_lod_bias <u-lod-bias>` uniform,
     which controls the mipmap level Ren'Py uses.
@@ -768,11 +769,11 @@ Media (Music, Sound, and Video)
     The name of the audio channel used by :func:`renpy.play`,
     :propref:`hover_sound`, and :propref:`activate_sound`.
 
-.. var:: config.preserve_volume_when_muted = False
+.. var:: config.preserve_volume_when_muted = True
 
-    If False, the default, the volume of channels are shown as 0 and
+    If False, the volume of channels are shown as 0 and
     changing it disables mute when the channel is mute.
-    Otherwise, It is shown and adjustable while keeping mute.
+    If True, the default, it is shown and adjustable while keeping mute.
 
 .. var:: config.single_movie_channel = None
 
@@ -806,12 +807,13 @@ Media (Music, Sound, and Video)
 
     This allows large movie files to be hosted on a different server
     than the rest of the game.
+..
+    Lez's comment: This is a TODO variable, look bottom of _audio.js
+    .. var:: config.web_video_prompt = _("Touch to play the video.")
 
-.. var:: config.web_video_prompt = _("Touch to play the video.")
-
-    On Mobile Safari on iOS, by default, the player will need to click to play
-    a movie with sound. This variable gives the message that's used to prompt
-    players to click.
+        On Mobile Safari on iOS, by default, the player will need to click to play
+        a movie with sound. This variable gives the message that's used to prompt
+        players to click.
 
 .. var:: config.webaudio_required_types = [ "audio/ogg", "audio/mpeg", ... ]
 
@@ -929,7 +931,7 @@ Paths
     :var:`config.save_directory`, which generates the default value for this
     if it is not set during a ``python early`` block.
 
-.. var:: config.search_prefixes = [ "", "images/", ... ]
+.. var:: config.search_prefixes = [ "", ... ]
 
     A list of prefixes that are prepended to filenames that are searched
     for.
@@ -1619,7 +1621,7 @@ Skipping
 
     Set this to True to allow fast skipping outside of developer mode.
 
-.. var:: config.skip_delay = 75
+.. var:: config.skip_delay = 5
 
     The amount of time that dialogue will be shown for, when skipping
     statements using ctrl, in milliseconds. (Although it's nowhere
@@ -1928,7 +1930,7 @@ Translation
     While this defaults to False, it's set to True when :func:`gui.init`
     is called.
 
-.. var:: config.defer_tl_scripts = Fasle
+.. var:: config.defer_tl_scripts = False
 
     When True, avoids loading scripts in the tl directory until the
     language is selected. See :ref:`deferred-translations`.
@@ -2021,7 +2023,7 @@ Voice
 
     See above.
 
-.. var:: config.emphasize_audio_volume = 0.5
+.. var:: config.emphasize_audio_volume = 0.8
 
     See above.
 

--- a/sphinx/source/displayables.rst
+++ b/sphinx/source/displayables.rst
@@ -12,7 +12,7 @@ displayables can be used in many ways.
 * Assignment to certain style properties.
 
 When a Ren'Py function or variable expects a displayable, there are
-five things that can be provided:
+several things that can be provided:
 
 * An object of type Displayable, created by calling one of the
   functions given below.

--- a/sphinx/source/label.rst
+++ b/sphinx/source/label.rst
@@ -266,7 +266,7 @@ state of the game. Contexts include:
 * the audio that is playing or queued.
 
 Most of the time there is only one context at play, and only one instance of each
-of these elements exists. This changes when entering the main or game game menus;
+of these elements exists. This changes when entering the main or game menus;
 everything above can be changed, and will be restored when leaving the menu
 context. Some of these changes are automatic, like the screens layer being
 cleared when entering a context.

--- a/sphinx/source/matrixcolor.rst
+++ b/sphinx/source/matrixcolor.rst
@@ -21,19 +21,20 @@ an opaque white pixel will have the value (1.0, 1.0, 1.0, 1.0), a 50% transparen
 red pixel will have the value (0.5, 0.0, 0.0, 0.5), and a transparent pixel
 will have the value (0.0, 0.0, 0.0, 0.0).
 
-Premultiplied alph allows Ren'Py to scale images
+Premultiplied alpha allows Ren'Py to scale images
 up and down without causing dark artifacts that come from representing
 colors more directly. Scaling images is similar to averaging two pixels
 together. Without premultiplied alpha, we might have a solid white pixel
 and a transparent pixel - (1.0, 1.0, 1.0, 1.0) and (0.0, 0.0, 0.0, 0.0),
-respectively. Average those together gets (0.5, 0.5, 0.5, 0.5).
-But that's not right - averaging solid white and transparent black should
-get 50% opaque white, not 50% opaque gray.
+respectively. Average those together gets (0.5, 0.5, 0.5, 0.5), representing
+50% opaque gray in the straight alpha system. 
 
-In the premultiplied alpha system, the starting value is the same, and so is the
-result - except now, (0.5, 0.5, 0.5, 0.5) has been pre-defined to be 50% opaque
-white. By storing colors in this way, Ren'Py can draw them to the screen
-correctly, and not get weird artifacts when scaling.
+However, since a fully transparent pixel doesn't really have
+any color, it shouldn't affect the resulting color, either - only the resulting
+transparency. In the premultiplied alpha system, the starting values are the same,
+and so is the result - except now, (0.5, 0.5, 0.5, 0.5) has been pre-defined to
+be 50% opaque white. By storing colors in this way, Ren'Py can draw them to the
+screen correctly, and not get weird artifacts when scaling.
 
 Using a Matrix to Change Colors
 -------------------------------

--- a/sphinx/source/other.rst
+++ b/sphinx/source/other.rst
@@ -29,7 +29,7 @@ Ren'Py Version
 
 .. var:: renpy.version_name
 
-    A human readable version name, of the form "Example Version."
+    A human-readable version name, of the form "Example Version."
 
 .. var:: renpy.license
 

--- a/sphinx/source/quickstart.rst
+++ b/sphinx/source/quickstart.rst
@@ -125,8 +125,9 @@ line of narration.
 
 To try this out, from the top screen of the launcher select "My Question"
 project, and then choose "script.rpy" from under Edit File. If this is
-your first time, Ren'Py will ask you to select an editor (we recommend
-Editra for first time creators), and will download the editor you choose.
+your first time, Ren'Py will ask you to select an editor. We recommend Visual
+Studio Code for new creators - in addition to being a solid choice, the launcher
+can also download it for you.
 Then it will open the script file in the editor.
 
 Once the editor opens, erase everything in :file:`script.rpy`. We're starting

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -385,7 +385,7 @@ More usually, the font used for dialogue is set with :var:`gui.text_font`.
 The font used for system text, like the exception screen, the accessibility menu,
 and the gui menu, can be customized with :var:`gui.system_font`. The system font
 should be able to express both ASCII and the translated language. Together, these
-can be customized with.
+can be customized with::
 
     translate piglatin python:
         gui.text_font = "stonecutter.ttf"


### PR DESCRIPTION
## Colormatrix
Edited the explanation of "premultiplied alpha" slightly to be more newbie friendly, while hopefully keeping it technically correct.

## Audio
Rewrote "Audio Namespace and Directory" into "Audio Directory and Namespace". More user friendly section allowed it to be moved to the top of Audio doc page, keeping it consistent with "Displaying Images" doc page. 

## General cleanup
- Some typos
- Removed Editra from Quickstart page and recommended VSCode instead
- Corrected default values of config variables
- Commented out `config.web_video_prompt` (see #6133 ).