### PR TITLE
Add right_to_left and bottom_to_top Grid properties.

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -432,6 +432,7 @@ class Grid(Container):
                  transpose=False,
                  style='grid',
                  allow_underfull=None,
+                 *,
                  right_to_left=False,
                  bottom_to_top=False,
                  **properties):
@@ -488,6 +489,10 @@ class Grid(Container):
         top_margin = compute_raw(self.style.top_margin, height)
         bottom_margin = compute_raw(self.style.bottom_margin, height)
 
+        # For convenience and speed.
+        cols = self.cols
+        rows = self.rows
+
         # Generates a gridmap list containing (col, row) tuples of intended position
         # for each child.
         gridmap = self.generate_gridmap()
@@ -498,9 +503,9 @@ class Grid(Container):
         renheight = height
 
         if self.style.xfill:
-            renwidth = (width - (self.cols - 1) * xspacing - left_margin - right_margin) // self.cols
+            renwidth = (width - (cols - 1) * xspacing - left_margin - right_margin) // cols
         if self.style.yfill:
-            renheight = (height - (self.rows - 1) * yspacing - top_margin - bottom_margin) // self.rows
+            renheight = (height - (rows - 1) * yspacing - top_margin - bottom_margin) // rows
 
         renders = [render(child, renwidth, renheight, st, at) for child in self.children]
         sizes = [r.get_size() for r in renders]
@@ -518,8 +523,8 @@ class Grid(Container):
         if self.style.yfill:
             cheight = renheight
 
-        width = cwidth * self.cols + xspacing * (self.cols - 1) + left_margin + right_margin
-        height = cheight * self.rows + yspacing * (self.rows - 1) + top_margin + bottom_margin
+        width = cwidth * cols + xspacing * (cols - 1) + left_margin + right_margin
+        height = cheight * rows + yspacing * (rows - 1) + top_margin + bottom_margin
 
         rv = renpy.display.render.Render(width, height)
 
@@ -568,11 +573,11 @@ class Grid(Container):
             self.add(null)
 
     def generate_gridmap(self):
-        row_order = list(range(self.rows))
+        row_order = range(self.rows)
         if self.bottom_to_top:
             row_order = row_order[::-1]
 
-        col_order = list(range(self.cols))
+        col_order = range(self.cols)
         if self.right_to_left:
             col_order = col_order[::-1]
 
@@ -580,8 +585,9 @@ class Grid(Container):
             intended_order = [(col, row) for col in col_order for row in row_order]
         else:
             intended_order = [(col, row) for row in row_order for col in col_order]
-        
+
         return intended_order
+
 
 class IgnoreLayers(Exception):
     """

--- a/renpy/sl2/sldisplayables.py
+++ b/renpy/sl2/sldisplayables.py
@@ -147,6 +147,8 @@ Positional("cols")
 Positional("rows")
 Keyword("transpose")
 Keyword("allow_underfull")
+Keyword("right_to_left")
+Keyword("bottom_to_top")
 add(grid_properties)
 
 DisplayableParser("side", renpy.display.layout.Side, "side", many)

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -688,12 +688,22 @@ It takes two parameters. The first is the number of columns in the
 grid, and the second is the number of rows in the grid. If the grid
 is not full, the remaining cells are filled with the ``null`` displayable.
 
-Grid takes one property:
+Grid takes several properties related to the way its children are placed:
 
 .. screen-property:: transpose
 
     If False (the default), rows are filled before columns. If True,
     then columns are filled before rows.
+
+.. screen-property:: right_to_left
+
+    If True, cells are filled from right to left, instead of the default
+    left to right.
+
+.. screen-property:: bottom_to_top
+
+    If True, cells are filled from bottom to top, instead of the default
+    top to bottom.
 
 It also takes:
 


### PR DESCRIPTION
These properties combined with transpose allow for 8 different ways to fill a grid. The way grid is rendered had to be changed slightly.  
  
Tested for all types of grid (square, more-rows rectangle, more-columns rectangle).  
  
Behind-the-scenes of the grid was changed. It now generates a gridmap (dict of {child : (col, row)}), and children are placed according to it, rather than always being filled in row-major order. Offsets are also sorted based on gridmap.  
This shouldn't break anything in existing code.   
  
Closes #6007