### PR TITLE
Remove unused import

### DIFF
--- a/renpy/display/particle.py
+++ b/renpy/display/particle.py
@@ -26,7 +26,7 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 
 
 
-from renpy.display.render import render, BLIT
+from renpy.display.render import render
 
 import renpy
 import random


### PR DESCRIPTION
This PR removes the import of renpy.display.render.BLIT from renpy/display/particle.py. A previous commit removed the use of BLIT.