### PR TITLE
Only generate mipmap when blur is active

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -247,8 +247,6 @@ cdef class RenderTransform:
             mr.add_shader("-renpy.texture")
             mr.add_shader("renpy.blur")
             mr.add_uniform("u_renpy_blur_log2", math.log(blur, 2))
-
-        if (blur is not None):
             mr.add_property("mipmap", True)
 
         self.mr = mr


### PR DESCRIPTION
Wasn't sure if it's intentional, but on the surface it seems like all this belongs in the same condition block.