### PR TITLE
Support returning an error code when a problem is encountered during linting

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -125,6 +125,8 @@ def problem_listing(header, problems):
             for line, message in file_problems:
                 print("    * line {:>5d} {}".format(line, message))
 
+    global error_reported
+    error_reported = True
 
 # Tries to evaluate an expression, announcing an error if it fails.
 def try_eval(where, expr, additional=None):


### PR DESCRIPTION
Hi,

Just noticed that our CI had been logging linting problems for a while without failing, thus not prompting us to fix/investigate further.
This PR allows to keep the current differentiation between errors and problems but allows to opt in to more strict linting rules by returning an error code even if only problems occured.

This is quite important for us as Ren'Py's linting output is quite verbose even if no error occurs (a huge amount of game characters makes it so that problem logs are not even visible on the screen), is not very parseable, and the amount of deprecated stuff that is only reported as a problem and not an error will end up biting us hard if not taken care of as it gets deprecated.

Thanks in advance,