### PR TITLE
Fix glyph offsets in HarfBuzz.

### DIFF
--- a/renpy/text/hbfont.pyx
+++ b/renpy/text/hbfont.pyx
@@ -919,7 +919,7 @@ cdef class HBFont:
                 gl.advance = -glyph_pos[i].y_advance / 64.0
             else:
                 gl.x_offset = glyph_pos[i].x_offset / 64.0
-                gl.y_offset = glyph_pos[i].y_offset / 64.0
+                gl.y_offset = -glyph_pos[i].y_offset / 64.0
                 gl.advance = glyph_pos[i].x_advance / 64.0
 
             gl.width = gl.advance


### PR DESCRIPTION
Fixes the issue described in (https://github.com/renpy/renpy/issues/6202). May or may not also fix (https://github.com/renpy/renpy/issues/2268) (Untested). I don't think freetype adjusts offsets of glyphs, so there isn't a reasonable way of fixing this for that.