### PR TITLE
Fixed typos in documentation and tutorial

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -315,7 +315,7 @@ def show_display_say(who, what, who_args={}, what_args={}, window_args={},
     @param who: The name of the character that is speaking, or None to
     not show this name to the user.
 
-    @param what: What that character is saying. Please not that this
+    @param what: What that character is saying. Please note that this
     may not be a string, as it can also be a list containing both text
     and displayables, suitable for use as the first argument of ui.text().
 
@@ -1641,7 +1641,7 @@ def Character(name=NotSet, kind=None, **properties):
          character.
 
     **Voice Tag.**
-    If a voice tag is assign to a Character, the voice files that are
+    If a voice tag is assigned to a Character, the voice files that are
     associated with it, can be muted or played in the preference
     screen.
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -141,7 +141,7 @@ sound_sample_rate = 48000
 # The default fadeout used when playing or stopping audio.
 fadeout_audio = 0.016
 
-# The old name of config.fadeout_audio. Kept for compatibility, and yused
+# The old name of config.fadeout_audio. Kept for compatibility, and used
 # in 00compat.rpy.
 fade_music = None
 
@@ -776,7 +776,7 @@ translate_files = [ ]
 # translated.
 translate_comments = [ ]
 
-# Should we trying detect user locale on first launch?
+# Should we try detect user locale on first launch?
 enable_language_autodetect = False
 
 # A function from (locale, region) -> existing language.
@@ -823,7 +823,7 @@ profile_screens = [ ]
 allow_sysfonts = False
 
 # Should Ren'Py tightly loop during fadeouts? (That is, not stop the fadeout
-# if it reaches the end of a trac.)
+# if it reaches the end of a track.)
 tight_loop_default = True
 
 # Should Ren'Py apply style_prefix to viewport scrollbar styles?
@@ -849,7 +849,7 @@ lint_stats_callbacks = [ ]
 # Should we apply position properties to the side of a viewport?
 position_viewport_side = True
 
-# Things that be given properties via Character.
+# Things that can be given properties via Character.
 character_id_prefixes = [ ]
 
 # Should {nw} wait for voice.
@@ -1053,7 +1053,7 @@ context_copy_remove_screens = [ "notify" ]
 # An exception handling callback.
 exception_handler = None
 
-# A label that is jumped to if return fails.
+# A label to jump to if return fails.
 return_not_found_label = None
 
 # A list of (regex, autoreload function) tuples.
@@ -1152,7 +1152,7 @@ allow_screensaver = True
 context_fadein_music = 0
 context_fadeout_music = 0
 
-# Shout it be possible to dismiss blocking transitions that are not part of
+# Should it be possible to dismiss blocking transitions that are not part of
 # a with statement?
 dismiss_blocking_transitions = True
 
@@ -1318,7 +1318,7 @@ physical_height = None
 # If true, lenticular brackets can be used to encode ruby text.
 lenticular_bracket_ruby = True
 
-# If true, the web implentation of renpy.input will be used.
+# If true, the web implementation of renpy.input will be used.
 web_input = True
 
 # Aliases for the keys on the numeric keypad, to make them easier to write as keysyms.
@@ -1375,7 +1375,7 @@ check_conflicting_properties = False
 # A list of extra save directories. Strings giving the full paths.
 extra_savedirs = [ ]
 
-# The text-to-speech dictionary. A list of [ (RegeEx|String, String) ] pairs.
+# The text-to-speech dictionary. A list of [ (RegEx|String, String) ] pairs.
 tts_substitutions = [ ]
 
 # The base URL where unpacked web videos can be found.

--- a/tutorial/game/tutorial_nvlmode.rpy
+++ b/tutorial/game/tutorial_nvlmode.rpy
@@ -19,7 +19,7 @@ label tutorial_nvlmode:
     nvl clear
     nvl show dissolve
 
-    nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
 
     show example nvl1 bottom
 

--- a/tutorial/game/tutorial_quickstart.rpy
+++ b/tutorial/game/tutorial_quickstart.rpy
@@ -113,7 +113,7 @@ label tutorial_dialogue:
     scene black
     with dissolve
 
-    "Wow, It's really really dark in here."
+    "Wow, it's really really dark in here."
 
     scene bg washington
     show eileen happy
@@ -148,7 +148,7 @@ label tutorial_dialogue:
 
     e "Using a string for a character's name is inconvenient, for two reasons."
 
-    e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
 
     e "The second is that it doesn't leave any place to put styling, which can change the look of a character."
 


### PR DESCRIPTION
This pull request addresses a few spelling errors or grammatical mistakes I noticed in the code comments and documentation. 
A few of the tutorial strings were also updated to fix grammatical errors that I had noticed.

## Ren'Py Character and Config Files:

    Fixed spelling errors in code comments and documentation for:
    character.py
    config.py
        

## Tutorial files
       Replaced “rather then” with “rather than” in tutorial_nvlmode.rpy
       Corrected the capitalization in dialogue in tutorial_quickstart.rpy
       Removed the double contraction "that's it's" in tutorial_quickstart.rpy

No functional code changes were made, only changes to improve text accuracy and readability.