### PR TITLE
Fix typo in documentation and tutorial

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -315,7 +315,7 @@ def show_display_say(who, what, who_args={}, what_args={}, window_args={},
     @param who: The name of the character that is speaking, or None to
     not show this name to the user.
 
-    @param what: What that character is saying. Please not that this
+    @param what: What that character is saying. Please note that this
     may not be a string, as it can also be a list containing both text
     and displayables, suitable for use as the first argument of ui.text().
 
@@ -1641,7 +1641,7 @@ def Character(name=NotSet, kind=None, **properties):
          character.
 
     **Voice Tag.**
-    If a voice tag is assign to a Character, the voice files that are
+    If a voice tag is assigned to a Character, the voice files that are
     associated with it, can be muted or played in the preference
     screen.
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -141,7 +141,7 @@ sound_sample_rate = 48000
 # The default fadeout used when playing or stopping audio.
 fadeout_audio = 0.016
 
-# The old name of config.fadeout_audio. Kept for compatibility, and yused
+# The old name of config.fadeout_audio. Kept for compatibility, and used
 # in 00compat.rpy.
 fade_music = None
 
@@ -776,7 +776,7 @@ translate_files = [ ]
 # translated.
 translate_comments = [ ]
 
-# Should we trying detect user locale on first launch?
+# Should we try detect user locale on first launch?
 enable_language_autodetect = False
 
 # A function from (locale, region) -> existing language.
@@ -823,7 +823,7 @@ profile_screens = [ ]
 allow_sysfonts = False
 
 # Should Ren'Py tightly loop during fadeouts? (That is, not stop the fadeout
-# if it reaches the end of a trac.)
+# if it reaches the end of a track.)
 tight_loop_default = True
 
 # Should Ren'Py apply style_prefix to viewport scrollbar styles?
@@ -849,7 +849,7 @@ lint_stats_callbacks = [ ]
 # Should we apply position properties to the side of a viewport?
 position_viewport_side = True
 
-# Things that be given properties via Character.
+# Things that can be given properties via Character.
 character_id_prefixes = [ ]
 
 # Should {nw} wait for voice.
@@ -1053,7 +1053,7 @@ context_copy_remove_screens = [ "notify" ]
 # An exception handling callback.
 exception_handler = None
 
-# A label that is jumped to if return fails.
+# A label to jump to if return fails.
 return_not_found_label = None
 
 # A list of (regex, autoreload function) tuples.
@@ -1152,7 +1152,7 @@ allow_screensaver = True
 context_fadein_music = 0
 context_fadeout_music = 0
 
-# Shout it be possible to dismiss blocking transitions that are not part of
+# Should it be possible to dismiss blocking transitions that are not part of
 # a with statement?
 dismiss_blocking_transitions = True
 
@@ -1318,7 +1318,7 @@ physical_height = None
 # If true, lenticular brackets can be used to encode ruby text.
 lenticular_bracket_ruby = True
 
-# If true, the web implentation of renpy.input will be used.
+# If true, the web implementation of renpy.input will be used.
 web_input = True
 
 # Aliases for the keys on the numeric keypad, to make them easier to write as keysyms.
@@ -1375,7 +1375,7 @@ check_conflicting_properties = False
 # A list of extra save directories. Strings giving the full paths.
 extra_savedirs = [ ]
 
-# The text-to-speech dictionary. A list of [ (RegeEx|String, String) ] pairs.
+# The text-to-speech dictionary. A list of [ (RegEx|String, String) ] pairs.
 tts_substitutions = [ ]
 
 # The base URL where unpacked web videos can be found.

--- a/tutorial/game/tl/french/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/french/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate french tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate french tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "Les jeux de style NVL sont des jeux dont les dialogues couvrent l’écran en entier, plutôt que d’être placés dans une fenêtre en bas de l’écran. Comme ceci."
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/french/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/french/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate french tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate french tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Ouah, c’est vraiment sombre ici."
 
 # game/tutorial_quickstart.rpy:91
@@ -200,7 +200,7 @@ translate french tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate french tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "La première, c’est que c’est une solution un peu verbeuse. Même si écrire \"Lucy\" n’est pas faux, imaginez ce que cela va être si vous devez taper \"Eileen Richardson\" un millier de fois !"
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/japanese/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/japanese/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate japanese tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate japanese tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "NVLスタイルゲームは、テキストが画面下部に位置するのではなく、このように画面全体を覆うゲームです。"
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/japanese/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/japanese/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate japanese tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate japanese tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "わっ！ここって、とても暗いわね。"
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate japanese tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate japanese tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "わっ！ここって、とても暗いわね。"
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate japanese tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate japanese tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "まず、少し冗長だからです。\"ルーシー\" と入力する時は問題ないですが、\"エイリーン・リチャードソン\" を数千回入力しなければならない場合はどうでしょうか。"
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/korean/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/korean/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate korean tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate korean tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "NVL 스타일 게임은 화면 아래쪽에 창을 표시하지 않고 전체 화면을 글자로 채우는 게임이야. 이렇게 말야."
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/korean/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/korean/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate korean tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate korean tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "와우, 여긴 정말 정말 어두워."
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate korean tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate korean tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "와우, 여기는 정말 정말 어두워."
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate korean tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate korean tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "첫 번째는 다소 장황하다는 거야. \"루시\"를 타이핑하는 것이 그렇게 나쁘지는 않지만, \"아일린 리차드슨\"을 수천 번 입력해야 한다고 상상해봐."
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/piglatin/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/piglatin/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate piglatin tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:22
 translate piglatin tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "Vlnay-ylestay amesgay areay amesgay hattay overcay hetay ullfay creensay ithway exttay, atherray hentay acingplay itay inay aay indowway atay hetay ottombay ofay hetay creensay. Ikelay histay."
 
 # game/tutorial_nvlmode.rpy:26

--- a/tutorial/game/tl/piglatin/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/piglatin/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate piglatin tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate piglatin tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Owway, Tiay'say eallyray eallyray arkday inay erehay."
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate piglatin tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate piglatin tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Owway, Tiay'say eallyray eallyray arkday inay erehay."
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate piglatin tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate piglatin tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "Hetay irstfay isay hattay'say itay'say aay itbay erbosevay. Hileway ypingtay \"Ucylay\" isnay'tay osay adbay, imagineay ifay ouyay adhay otay ypetay \"Ileeneay Ichardsonray\" housandstay ofay imestay."
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/russian/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/russian/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate russian tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate russian tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "Игры стиля NVL покрывают текстом весь экран, а не размещают весь текст в небольшом окне внизу экрана. Например, так."
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/russian/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/russian/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate russian tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate russian tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Ого, здесь очень темно."
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate russian tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate russian tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Ого, здесь очень темно."
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate russian tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate russian tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "Первая состоит в том, что это долго печатать. Нет, конечно, напечатать \"Люси\" не так сложно, но представьте, что вам нужно набрать \"Эйлин Ричардсон\" несколько тысяч раз."
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/schinese/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/schinese/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate schinese tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate schinese tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "NVL风格的游戏用文本覆盖整个界面，而不是将其放在界面底部的窗口中。像这样。"
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/schinese/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/schinese/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate schinese tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate schinese tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "哇，这里真的很黑。"
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate schinese tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate schinese tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "哇，这里真的很黑。"
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate schinese tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate schinese tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "首先是有点冗长。虽然输入“露西”不是很糟糕，但是想象一下，如果你不得不输入数千次“艾琳·理查森”。"
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/spanish/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/spanish/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate spanish tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:20
 translate spanish tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "Los juegos estilo NVL son juegos que cubren la pantalla completa con texto, en lugar de colocarlos en una ventana en la parte inferior de la pantalla. Como esto."
 
 # game/tutorial_nvlmode.rpy:24

--- a/tutorial/game/tl/spanish/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/spanish/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate spanish tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate spanish tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Guau, realmente está muy oscuro aquí."
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate spanish tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate spanish tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Guau, realmente está muy oscuro aquí."
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate spanish tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate spanish tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "La primera es que es un poco verbosa. Mientras que escribir \"Lucy\" no es tan malo, imagínate si tuvieras que escribir \"Eileen Richardson\" miles de veces."
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tl/ukrainian/tutorial_nvlmode.rpy
+++ b/tutorial/game/tl/ukrainian/tutorial_nvlmode.rpy
@@ -8,7 +8,7 @@ translate ukrainian tutorial_nvlmode_76b2fe88:
 # game/tutorial_nvlmode.rpy:22
 translate ukrainian tutorial_nvlmode_ac125210:
 
-    # nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    # nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
     nvle "Ігри у стилі NVL — це ігри, які покривають текст на весь екран, а не розміщують його у вікні внизу екрана. Подобається це."
 
 # game/tutorial_nvlmode.rpy:26

--- a/tutorial/game/tl/ukrainian/tutorial_quickstart.rpy
+++ b/tutorial/game/tl/ukrainian/tutorial_quickstart.rpy
@@ -104,7 +104,7 @@ translate ukrainian tutorial_dialogue_f0d66410:
 # game/tutorial_quickstart.rpy:89
 translate ukrainian tutorial_dialogue_3e6b0068:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Вау, тут справді дуже темно."
 
 # game/tutorial_quickstart.rpy:91
@@ -152,7 +152,7 @@ translate ukrainian tutorial_dialogue_628c9e4c:
 # game/tutorial_quickstart.rpy:116
 translate ukrainian tutorial_dialogue_3e6b0068_1:
 
-    # "Wow, It's really really dark in here."
+    # "Wow, it's really really dark in here."
     "Вау, тут справді дуже темно."
 
 # game/tutorial_quickstart.rpy:125
@@ -200,7 +200,7 @@ translate ukrainian tutorial_dialogue_90719f73:
 # game/tutorial_quickstart.rpy:151
 translate ukrainian tutorial_dialogue_910f286a:
 
-    # e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    # e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
     e "По-перше, це трохи багатослівно. Хоча введення \"Люсі\" не таке вже й погане, уявіть, якби вам довелося вводити \"Ейлін Річардсон\" тисячі разів."
 
 # game/tutorial_quickstart.rpy:153

--- a/tutorial/game/tutorial_nvlmode.rpy
+++ b/tutorial/game/tutorial_nvlmode.rpy
@@ -19,7 +19,7 @@ label tutorial_nvlmode:
     nvl clear
     nvl show dissolve
 
-    nvle "NVL-style games are games that cover the full screen with text, rather then placing it in a window at the bottom of the screen. Like this."
+    nvle "NVL-style games are games that cover the full screen with text, rather than placing it in a window at the bottom of the screen. Like this."
 
     show example nvl1 bottom
 

--- a/tutorial/game/tutorial_quickstart.rpy
+++ b/tutorial/game/tutorial_quickstart.rpy
@@ -113,7 +113,7 @@ label tutorial_dialogue:
     scene black
     with dissolve
 
-    "Wow, It's really really dark in here."
+    "Wow, it's really really dark in here."
 
     scene bg washington
     show eileen happy
@@ -148,7 +148,7 @@ label tutorial_dialogue:
 
     e "Using a string for a character's name is inconvenient, for two reasons."
 
-    e "The first is that's it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
+    e "The first is that it's a bit verbose. While typing \"Lucy\" isn't so bad, imagine if you had to type \"Eileen Richardson\" thousands of times."
 
     e "The second is that it doesn't leave any place to put styling, which can change the look of a character."
 

--- a/tutorial/game/tutorial_quickstart.rpy
+++ b/tutorial/game/tutorial_quickstart.rpy
@@ -86,7 +86,7 @@ label tutorial_dialogue:
 
     example dialogue1 hide:
 
-        "Wow, It's really really dark in here."
+        "Wow, it's really really dark in here."
 
         "Lucy" "Better watch out. You don't want to be eaten by a Grue."
 


### PR DESCRIPTION
This pull request addresses a few spelling errors or grammatical mistakes I noticed in the code comments and documentation. 
A few of the tutorial strings were also updated to fix grammatical errors that I had noticed.

## Ren'Py Character and Config Files:

    Fixed spelling errors in code comments and documentation for:
    character.py
    config.py
        
## Tutorial files
       Replaced “rather then” with “rather than” in tutorial_nvlmode.rpy
       Corrected the capitalization in dialogue in tutorial_quickstart.rpy
       Removed the double contraction "that's it's" in tutorial_quickstart.rpy

No functional code changes were made, only changes to improve text accuracy and readability.