### PR TITLE
Create mesh render using post-padding size

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -207,9 +207,6 @@ cdef class RenderTransform:
         Handles the mesh, mesh_pad, and blur properties.
         """
 
-        # The render we're going to return.
-        mr = Render(cr.width, cr.height)
-
         mesh = self.state.mesh
         blur = self.state.blur
         mesh_pad = self.state.mesh_pad
@@ -227,6 +224,9 @@ cdef class RenderTransform:
             padded.blit(cr, (pad_left, pad_top))
 
             cr = padded
+
+        # The render we're going to return.
+        mr = Render(cr.width, cr.height)
 
         mr.blit(cr, (0, 0))
 


### PR DESCRIPTION
Attempts to fix #6223.

This may be incomplete as I'm uncertain if the change in size needs to be pushed into `self.width`, `self.height`, `transform.child_size` and/or `transform.render_size` as this seems to occur only if not using `perspective`.

See
https://github.com/renpy/renpy/blob/1e0b44a1721377bd4b4b3059ce2eb50142a5c254/renpy/display/accelerator.pyx#L1007-L1014
vs
https://github.com/renpy/renpy/blob/1e0b44a1721377bd4b4b3059ce2eb50142a5c254/renpy/display/accelerator.pyx#L1068-L1078

Filed against `master` as it's untested, potentially incomplete, and pre-releases are already rolling, but can rebase if appropriate.