### PR TITLE
Add callback for when persistent file is loaded

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -71,6 +71,7 @@ EARLY_CONFIG = {
     "defer_tl_scripts",
     "munge_in_strings",
     "interface_layer",
+    "persistent_callback",
 }
 
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1528,6 +1528,9 @@ keep_screenshot_entering_menu = False
 # Should Ren'Py hash seen statements and tlids?
 hash_seen = True
 
+# A function that is called whenever persistent data is loaded.
+persistent_callback = None
+
 
 del os
 del collections

--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -143,6 +143,12 @@ class Persistent(object):
                 "_seen_translates" : 0,
             }
 
+        if self._version is None:
+            self._version = renpy.config.version
+
+        if cb := renpy.config.persistent_callback:
+            cb(self)
+
 
 renpy.game.Persistent = Persistent # type: ignore
 renpy.game.persistent = Persistent()

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -102,6 +102,8 @@ apply :ref:`text interpolation <text-interpolation>` to the result. Interpolatio
 that the function is called from. The triple underscore function also marks the string contained
 inside for translation.
 
+The :var:`config.persistent_callback` callback makes it possible to update persistent data when it is loaded.
+
 
 Other Changes
 -------------

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1185,6 +1185,15 @@ Saving and Loading
     True if the file is loadable, and False if not. This can be used with
     :var:`config.file_open_callback` or :var:`config.missing_image_callback`.
 
+.. var:: config.persistent_callback = None
+
+    When not None, a function that's called with a persistent store whenever
+    a persistent save file is loaded. It should make any alterations in-place.
+
+    This must be set with either the define statement, or inside a ``python
+    early`` block. It should only reference other things typically available
+    to ``python early`` blocks.
+
 .. var:: config.quicksave_slots = 10
 
     The number of slots used by quicksaves.


### PR DESCRIPTION
A callback is needed for this as a `persistent` file can be loaded at any time by the save-scanning thread. The most common example of when this would occur is immediate after using Ren'Py Sync to retrieve remote save files, but can also occur if a player drops a newer `persistent` file into one of the various save locations observed by the scan thread.

The callback should be set "early", and has been added to `renpy.ast.EARLY_CONFIG` and documented accordingly. This is so it is already in-place by the time `renpy.persistent.init()` is called in `renpy.main.main`.

In addition `persistent._version` is set to the current version of the game, if is not already set. This felt like a good addition which seeks to parallel the behaviour of `store._version` defined in normal save files, which can be useful for debugging and data migrations. Note that an explicit `is None` check is used as the default version string is `""`.