### PR TITLE
Avoid storing persistent data replicas in memory

### DIFF
--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -432,7 +432,7 @@ def update(force_save=False):
 
     # A list of (mtime, other) pairs, where other is a persistent file
     # we might want to merge in.
-    pairs = renpy.loadsave.location.load_persistent()
+    pairs = renpy.loadsave.location.load_persistent(consume=True)
     pairs.sort(key=lambda a : a[0])
 
     # Deals with the case where we don't have any persistent data for

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -394,17 +394,22 @@ class FileLocation(object):
             self.sync()
             self.scan()
 
-    def load_persistent(self):
+    def load_persistent(self, *, consume=False):
         """
         Returns a list of (mtime, persistent) tuples loaded from the
         persistent file. This should return quickly, with the actual
         load occurring in the scan thread.
         """
 
-        if self.persistent_data:
-            return [ (self.persistent_mtime, self.persistent_data) ]
-        else:
+        if not self.persistent_data:
             return [ ]
+
+        rv = [ (self.persistent_mtime, self.persistent_data) ]
+
+        if consume:
+            self.persistent_data = None
+
+        return rv
 
     def save_persistent(self, data):
         """
@@ -608,11 +613,11 @@ class MultiLocation(object):
             for l in self.active_locations():
                 l.copy(old, new)
 
-    def load_persistent(self):
+    def load_persistent(self, *, consume=False):
         rv = [ ]
 
         for l in self.active_locations():
-            rv.extend(l.load_persistent())
+            rv.extend(l.load_persistent(consume=consume))
 
         return rv
 


### PR DESCRIPTION
Ren'Py currently holds on to loaded data long past necessary (in `FileLocation` objects), and for larger games especially this can result in a non-trivial amount of memory being consumed, especially as there are typically at least three copies of persistent: game, user, and sync.

This patch frees the persistent object in `FileLocation` when it is pulled for merging into the main persistent object, while leaving the mtime value, used to determine when to reload it, untouched.

A happy side effect of this is that the amount of operations done when evaluating whether a merge is needed is reduced significantly.