### PR TITLE
Reduce number of times persistent files are loaded during boot

### DIFF
--- a/renpy/persistent.py
+++ b/renpy/persistent.py
@@ -260,6 +260,8 @@ def init():
     disk, so that we can configure the savelocation system.
     """
 
+    global persistent_mtime
+
     if renpy.config.early_developer:
         init_debug_pickler()
 
@@ -272,6 +274,8 @@ def init():
 
     if persistent is None:
         persistent = Persistent()
+    else:
+        persistent_mtime = os.path.getmtime(filename)
 
     # Create the backup of the persistent data.
     for k, v in persistent.__dict__.items():

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -694,17 +694,26 @@ def init():
 
     location = MultiLocation()
 
+    # Reuse locations when possible.
+    if current := renpy.loadsave.location:
+        reusable = {fl.directory: fl for fl in current.locations}
+    else:
+        reusable = {}
+
+    def location_add(d):
+        location.add(reusable.get(d, None) or FileLocation(d))
+
     # 1. User savedir.
-    location.add(FileLocation(renpy.config.savedir))
+    location_add(renpy.config.savedir)
 
     # 2. Game-local savedir.
     if (not renpy.mobile) and (not renpy.macapp):
         path = os.path.join(renpy.config.gamedir, "saves")
-        location.add(FileLocation(path))
+        location_add(path)
 
     # 3. Extra savedirs.
     for i in renpy.config.extra_savedirs:
-        location.add(FileLocation(i))
+        location_add(i)
 
     # Scan the location once.
     location.scan()

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -623,7 +623,7 @@ class MultiLocation(object):
 
     def save_persistent(self, data):
         with SyncfsLock():
-            for l in self.active_locations():
+            for l in reversed(self.active_locations()):
                 l.save_persistent(data)
 
     def unlink_persistent(self):

--- a/renpy/savelocation.py
+++ b/renpy/savelocation.py
@@ -132,8 +132,8 @@ class FileLocation(object):
         # The persistent file.
         self.persistent = os.path.join(self.directory, "persistent")
 
-        # The mtime of the persistent file.
-        self.persistent_mtime = 0
+        # The minumum mtime at which it makes sense to load the persistent file.
+        self.persistent_mtime = renpy.persistent.persistent_mtime
 
         # The data loaded from the persistent file.
         self.persistent_data = None
@@ -193,7 +193,7 @@ class FileLocation(object):
                 if os.path.exists(pfn):
                     mtime = os.path.getmtime(pfn)
 
-                    if mtime != self.persistent_mtime:
+                    if mtime > self.persistent_mtime:
                         data = renpy.persistent.load(pfn)
                         if data is not None:
                             self.persistent_mtime = mtime


### PR DESCRIPTION
More detailed rationale in the respective commits, but here's the headlines:

- Right now a typical boot performs six persistent data load operations (user x3, game x2, sync x1), even though most of this data is ignored due to `mtime` checks.
- The first commit reuses `FileLocation` objects to reduce this to four (user x2, game x1, sync x1).
- Second commit uses the established `mtime` behaviour to cut this down to between one and three (user x1, game x1, sync x1), by skipping game and sync loads if they don't have a newer `mtime`. Anecdotally two was most common, then three, then one. This was due to the write order of files (and thus mtime), and prompted the next commit.
- Finally the third commit reverses the order of `FileLocation`s when saving persistent data. This ensures the user location will always have the newest `mtime` (short of outside interference). The end result is that a typical boot will only need to load a single persistent file (the one from the user location), but will still do the correct thing with other locations when needed.