### PR TITLE
Remove implicit override of texture_scaling

### DIFF
--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -295,7 +295,9 @@ cdef class GLTexture(GL2Model):
         self.wrap_s = GL_CLAMP_TO_EDGE
         self.wrap_t = GL_CLAMP_TO_EDGE
         self.anisotropy = loader.max_anisotropy
-        self.texture_scaling = None
+        self.mag_filter = GL_LINEAR
+        self.min_filter = None
+        self.scaling = None
 
         if renpy.emscripten and generate:
             # Generate a texture name to access video frames for web
@@ -602,9 +604,12 @@ cdef class GLTexture(GL2Model):
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
 
         if max_level:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST)
+            self.min_filter = GL_LINEAR_MIPMAP_NEAREST
         else:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+            self.min_filter = GL_LINEAR
+
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.min_filter)
+        self.scaling = (GL_LINEAR, self.min_filter)
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)

--- a/renpy/gl2/gl2uniform.pyx
+++ b/renpy/gl2/gl2uniform.pyx
@@ -299,8 +299,6 @@ TEXTURE_SCALING = {
     "linear_mipmap_linear" : (GL_LINEAR, GL_LINEAR_MIPMAP_LINEAR),
 }
 
-default_texture_scaling = TEXTURE_SCALING["linear_mipmap_nearest"]
-
 
 cdef class Sampler2DSetter(Setter):
 
@@ -337,7 +335,8 @@ cdef class Sampler2DSetter(Setter):
         cdef GLint wrap_s = GL_CLAMP_TO_EDGE
         cdef GLint wrap_t = GL_CLAMP_TO_EDGE
         cdef GLfloat anisotropy = texture.loader.max_anisotropy
-        cdef texture_scaling = default_texture_scaling
+        cdef GLint mag_filter = texture.scaling[0]
+        cdef GLint min_filter = texture.scaling[1]
 
         if context.properties:
             if self.texture_wrap_key in context.properties:
@@ -349,7 +348,7 @@ cdef class Sampler2DSetter(Setter):
                 anisotropy = 1.0
 
             if "texture_scaling" in context.properties:
-                texture_scaling = TEXTURE_SCALING[context.properties["texture_scaling"]]
+                mag_filter, min_filter = TEXTURE_SCALING[context.properties["texture_scaling"]]
 
         if wrap_s != texture.wrap_s:
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_s)
@@ -363,10 +362,13 @@ cdef class Sampler2DSetter(Setter):
             glTexParameterf(GL_TEXTURE_2D, TEXTURE_MAX_ANISOTROPY_EXT, anisotropy)
             texture.anisotropy = anisotropy
 
-        if texture_scaling != texture.texture_scaling:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texture_scaling[0])
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, texture_scaling[1])
-            texture.texture_scaling = texture_scaling
+        if mag_filter != texture.mag_filter:
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, mag_filter)
+            texture.mag_filter = mag_filter
+
+        if min_filter != texture.min_filter:
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, min_filter)
+            texture.min_filter = min_filter
 
 
 cdef class Getter:


### PR DESCRIPTION
Potential fix for https://github.com/renpy/renpy/issues/6261.

The scaling filters of a texture are now left for the texture itself to determine, unless explicitly overridden. This allows the MIN filter to be based on whether mipmaps are available.

You can see the existing code for setting the scaling filters per texture here:
https://github.com/renpy/renpy/blob/f0cb787964544a08c5fd665631047a991b9397e2/renpy/gl2/gl2texture.pyx#L604-L607

Previously, even if a texture had realised that it should use `GL_LINEAR` rather than `GL_LINEAR_MIPMAP_NEAREST` due a lack of mipmaps, the default would override that in the `Sampler2DSetter`.