### PR TITLE
Support for direct style access in screens

### DIFF
--- a/renpy/style.pyx
+++ b/renpy/style.pyx
@@ -804,7 +804,7 @@ def rebuild(prepare_screens=True):
 
     renpy.display.screen.prepared = False
 
-    if not renpy.game.context().init_phase:
+    if prepare_screens and not renpy.game.context().init_phase:
         renpy.display.screen.prepare_screens()
 
     renpy.exports.restart_interaction()

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -696,6 +696,8 @@ def init_translation():
 
     load_all_rpts()
 
+    renpy.store._init_language()
+
 
 old_language = "language never set"
 
@@ -779,7 +781,7 @@ def change_language(language, force=False):
     tl = renpy.game.script.translator
 
     renpy.style.restore(style_backup) # @UndefinedVariable
-    renpy.style.rebuild() # @UndefinedVariable
+    renpy.style.rebuild(False) # @UndefinedVariable
 
     for i in renpy.config.translate_clean_stores:
         renpy.python.clean_store(i)


### PR DESCRIPTION
Fixes #6265.

The primary change is that it skips screen preparation during the first call to `renpy.style.rebuild` in `renpy.translation.change_language`. This is done because otherwise, having just reset styles, they're not available for direct access in screens, causing the exception seen in the motivating issue. The justification for this is that later in `change_language` we `rebuild` styles again, this time after having installed all `deferred_styles`, and this call we allow to prepare screens. Even without the broader change to behaviour, only preparing screens in the later call feels like it could be a nice change.

The second change needed is to undo a small part of https://github.com/renpy/renpy/commit/45352847ab94b8e41592740aac9ba6913d4f7eef, restoring the call to `store._init_language` in `renpy.translation.init_translation`. This ensures styles are fully initialised when screens a prepared a little later in `renpy.main.run`.

~~Finally, in order to avoid doing the same work twice on boot, adding the `force` argument to `change_language` in `store._init_language` has been reverted. This has a side benefit of eliminating the click lag seen in games with many screens and/or styles when starting a new game, loading a save, or launching a replay. That lag was introduced by the commit referenced in the paragraph above.~~

While testing this I went back to the issue that motivated 45352847ab94b8e41592740aac9ba6913d4f7eef, https://github.com/renpy/renpy/issues/6192, and used that report to help inform the test game I created below. Best I can determine, the result of this change adds the support for direct style access in screens without introducing a regression related to that issue, and ~~clears up the click lag explained in the paragraph above~~.

Here is the test game for this feature, it covers both traditional and direct style use, as well as the use of `gui` variables and language specific overrides to define them. In the default (`None`) language, you see a red shape followed by a yellow shape, while in the other (`foo`) language you see a blue shape followed by magenta.

Scenarios tested:
Test | Expect | `None` | `"foo"`
:-|:-|-:|-:
Finish game, start new | retain language | ✔️ | ✔️
Save game, start new, switch, load | use new language | ✔️ | ✔️

<details><summary>Test Game</summary>

```rpy
define gui.abc = "#f775"
define gui.xyz = "#ff75"

translate foo python:
    gui.abc = "#7ff5"
    gui.xyz = "#f7f5"

screen test1():
    window:
        align (.5, .4) xysize (300, 200)
        style 's1'
        text 'Test1' align (.5, .5) size 40
        text 'Red' align (.1, .9)
        text 'Blue' align (.9, .9)

    dismiss action Return()

    textbutton 'Default' action Language(None) align (.25, .6)
    textbutton 'Other' action Language('foo') align (.75, .6)

screen test2():
    window:
        align (.5, .4) xysize (300, 200)
        background style.s2.background
        text 'Test2' align (.5, .5) size 40
        text 'Yellow' align (.1, .9)
        text 'Magenta' align (.9, .9)

    dismiss action Return()

    textbutton 'Default' action Language(None) align (.25, .6)
    textbutton 'Other' action Language('foo') align (.75, .6)

style s1:
    background gui.abc

style s2:
    background gui.xyz

label start:
    call screen test1()
    pause 0
    call screen test2()
    return
```
</details>