### PR TITLE
Ensure sane clock times in log after reload

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -676,6 +676,9 @@ def reload_all():
     # Re-initialize the importer.
     renpy.loader.init_importer()
 
+    # Reset main log clock.
+    renpy.main.reset_clock()
+
 
 # renpy.store and sub-modules can have names of any type inside.
 store: Any = None


### PR DESCRIPTION
Previously the `Early init took` log line would include all the time since the last boot/reload, which was frustrating when working in that area of the codebase.