### PR TITLE
Optimise language initialisation

### DIFF
--- a/renpy/display/presplash.py
+++ b/renpy/display/presplash.py
@@ -152,7 +152,7 @@ last_pump_time = 0
 
 # The number of times the progress was pumped.
 pump_count = 0
-pump_clock = 23
+pump_clock = 21
 pump_total = 0
 
 def pump_window():

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -71,10 +71,6 @@ def run(restart):
     renpy.python.clean_stores()
     log_clock("Cleaning stores")
 
-    # Init translation.
-    renpy.translation.init_translation()
-    log_clock("Init translation")
-
     # Rebuild the various style caches.
     renpy.style.build_styles() # @UndefinedVariable
     log_clock("Build styles")
@@ -605,6 +601,10 @@ def main():
         if not game.interface:
             renpy.display.core.Interface()
             log_clock("Creating interface object")
+
+        # Init translation.
+        renpy.translation.init_translation()
+        log_clock("Init translation")
 
         # Start things running.
         restart = None

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -71,10 +71,6 @@ def run(restart):
     renpy.python.clean_stores()
     log_clock("Cleaning stores")
 
-    # Rebuild the various style caches.
-    renpy.style.build_styles() # @UndefinedVariable
-    log_clock("Build styles")
-
     renpy.sl2.slast.load_cache()
     log_clock("Load screen analysis")
 
@@ -86,12 +82,6 @@ def run(restart):
         renpy.sl2.slast.save_cache()
         log_clock("Save screen analysis")
 
-    # Prepare the screens.
-    renpy.display.screen.prepare_screens()
-
-    log_clock("Prepare screens")
-
-    if not restart:
         renpy.pyanalysis.save_cache()
         log_clock("Save pyanalysis")
 

--- a/renpy/style.pyx
+++ b/renpy/style.pyx
@@ -804,7 +804,7 @@ def rebuild(prepare_screens=True):
 
     renpy.display.screen.prepared = False
 
-    if not renpy.game.context().init_phase:
+    if prepare_screens and not renpy.game.context().init_phase:
         renpy.display.screen.prepare_screens()
 
     renpy.exports.restart_interaction()

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -704,10 +704,11 @@ old_language = "language never set"
 deferred_styles = [ ]
 
 
-def old_change_language(tl, language):
+def old_change_language(tl, language, changed):
 
-    for i in deferred_styles:
-        i.apply()
+    if changed:
+        for i in deferred_styles:
+            i.apply()
 
     def run_blocks():
         for i in tl.early_block[language]:
@@ -725,7 +726,7 @@ def old_change_language(tl, language):
         i()
 
 
-def new_change_language(tl, language):
+def new_change_language(tl, language, changed):
 
     for i in tl.python[language]:
         renpy.python.py_exec_bytecode(i.code.bytecode)
@@ -739,8 +740,9 @@ def new_change_language(tl, language):
     for i in renpy.config.language_callbacks[language]:
         i()
 
-    for i in deferred_styles:
-        i.apply()
+    if changed:
+        for i in deferred_styles:
+            i.apply()
 
     def run_blocks():
         for i in tl.block[language]:
@@ -748,7 +750,9 @@ def new_change_language(tl, language):
 
     renpy.game.invoke_in_new_context(run_blocks)
 
-    renpy.config.init_system_styles()
+    if changed:
+        renpy.config.init_system_styles()
+
 
 def clean_data():
     """
@@ -773,45 +777,54 @@ def change_language(language, force=False):
     renpy.exports.load_language(language)
 
     renpy.game.preferences.language = language
-    if old_language == language and not force:
+    changed = language != old_language
+
+    if not changed and not force:
         return
+
+    if changed:
+        renpy.style.restore(style_backup) # @UndefinedVariable
+        renpy.style.rebuild(False) # @UndefinedVariable
+
+        for i in renpy.config.translate_clean_stores:
+            renpy.python.clean_store(i)
+    else:
+        # Prevent memory leak by ignoring any style changes from translate
+        # blocks when language hasn't changed.
+        current_styles = renpy.style.backup()
 
     tl = renpy.game.script.translator
 
-    renpy.style.restore(style_backup) # @UndefinedVariable
-    renpy.style.rebuild(False) # @UndefinedVariable
-
-    for i in renpy.config.translate_clean_stores:
-        renpy.python.clean_store(i)
-
     if renpy.config.new_translate_order:
-        new_change_language(tl, language)
+        new_change_language(tl, language, changed)
     else:
-        old_change_language(tl, language)
+        old_change_language(tl, language, changed)
 
-    for i in renpy.config.change_language_callbacks:
-        i()
+    if changed:
+        for i in renpy.config.change_language_callbacks:
+            i()
 
-    # Reset various parts of the system. Most notably, this clears the image
-    # cache, letting us load translated images.
-    renpy.exports.free_memory()
+        # Reset various parts of the system. Most notably, this clears the image
+        # cache, letting us load translated images.
+        renpy.exports.free_memory()
 
-    # Rebuild the styles.
-    renpy.style.rebuild() # @UndefinedVariable
+        # Rebuild the styles.
+        renpy.style.rebuild() # @UndefinedVariable
 
-    # Re-init tts.
-    renpy.display.tts.init()
+        # Re-init tts.
+        renpy.display.tts.init()
 
-    for i in renpy.config.translate_clean_stores:
-        renpy.python.reset_store_changes(i)
+        for i in renpy.config.translate_clean_stores:
+            renpy.python.reset_store_changes(i)
 
-    # Restart the interaction.
-    renpy.exports.restart_interaction()
-
-    if language != old_language:
         renpy.exports.block_rollback()
 
         old_language = language
+    else:
+        renpy.style.restore(current_styles)
+
+    # Restart the interaction.
+    renpy.exports.restart_interaction()
 
 
 

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -779,7 +779,7 @@ def change_language(language, force=False):
     tl = renpy.game.script.translator
 
     renpy.style.restore(style_backup) # @UndefinedVariable
-    renpy.style.rebuild() # @UndefinedVariable
+    renpy.style.rebuild(False) # @UndefinedVariable
 
     for i in renpy.config.translate_clean_stores:
         renpy.python.clean_store(i)


### PR DESCRIPTION
**Problem**
The change in https://github.com/renpy/renpy/commit/45352847ab94b8e41592740aac9ba6913d4f7eef resulted in styles being regenerated and screens being reprepared each time a new context was begun — typically when starting a new game, loading a earlier save, or launching a replay. This introduced click lag when performing these actions, most noticeably in games with a high screen count.

**Solution**
Per-discussion on Discord, this PR takes a broader approach to tackle the problem with the aim to reduce the impact of language initialisation and related tasks more generally. This is achieved by only doing them when necessary and eliminating repeated work both during boot, and when starting contexts.

Rough commit-by-commit synopsis. More details in commit messages.
1. Move translation module init to avoid accidentally corrupting style backups.
2. When changing language, only prepare screens once; after style changes are complete.
3. Remove style building and screen prep from `main.run` since they're going to be done again anyway.
4. When calling change language with `force` and the language in use has not changed, only execute the translate blocks to set up the context, skip global work such as style regeneration and screen prep.
5. If a language doesn't have any init work to do, short-circuit to reduce the overhead.

_Toggling whitespace in the diff might be helpful to reduce noise from indentation changes._

**Testing**
<details><summary>Simple game script used during testing.</summary>

It covers both using translate python block to alter a `gui` variable and a translate style block. In the default (`None`) language, you'll see a red shape followed by a yellow shape, while in the other (`foo`) language you'll see a blue shape followed by magenta.

Scenarios tested originate from https://github.com/renpy/renpy/issues/6192 to ensure no regressions against that fix.
Test | Expect | `None` | `"foo"`
:-|:-|-:|-:
Finish game, start new | retain language | ✔️ | ✔️
Save game, start new, switch, load | use new language | ✔️ | ✔️

```rpy
define gui.abc = "#f775"
define gui.xyz = "#ff75"

translate foo python:
    gui.abc = "#7ff5"
    gui.xyz = "#f7f5"

screen test1():
    window:
        align (.5, .4) xysize (300, 200)
        style 's1'
        text 'Test1' align (.5, .5) size 40
        text 'Red' align (.1, .9)
        text 'Blue' align (.9, .9)

    dismiss action Return()

    textbutton 'Default' action Language(None) align (.25, .6)
    textbutton 'Other' action Language('foo') align (.75, .6)

screen test2():
    window:
        align (.5, .4) xysize (300, 200)
        style 's2'
        text 'Test2' align (.5, .5) size 40
        text 'Yellow' align (.1, .9)
        text 'Magenta' align (.9, .9)

    dismiss action Return()

    textbutton 'Default' action Language(None) align (.25, .6)
    textbutton 'Other' action Language('foo') align (.75, .6)

style s1:
    background gui.abc

style s2:
    background gui.xyz

label start:
    call screen test1()
    pause 0 # allow for saves on each test screen
    call screen test2()
    return

translate foo style s1:
    offset (300, 0)
```
</details>