### PR TITLE
Update presplash progress after load order changes

### DIFF
--- a/renpy/display/presplash.py
+++ b/renpy/display/presplash.py
@@ -152,11 +152,13 @@ last_pump_time = 0
 
 # The number of times the progress was pumped.
 pump_count = 0
+pump_clock = 23
+pump_total = 0
 
 def pump_window():
 
     global last_pump_time
-    global pump_count
+    global pump_count, pump_total
 
     pump_count += 1
 
@@ -171,13 +173,23 @@ def pump_window():
 
     last_pump_time = time.time()
 
-    if progress_bar and renpy.game.script:
-        progress_bar.draw(window.get_surface(), pump_count / (len(renpy.game.script.script_files) + 23))
-        window.update()
-
     for ev in pygame_sdl2.event.get():
         if ev.type == pygame_sdl2.QUIT:
             raise renpy.game.QuitException(relaunch=False, status=0)
+
+    if not progress_bar:
+        return
+
+    if not pump_total:
+        if not renpy.game.script:
+            return
+
+        pump_total = (len(renpy.game.script.common_script_files) +
+                      len(renpy.game.script.script_files)) + pump_clock
+
+    progress_bar.draw(window.get_surface(), pump_count / pump_total)
+    window.update()
+
 
 # Becomes true when the presplash is done.
 done = False


### PR DESCRIPTION
Fixes #6271.

Core of the change is that the presplash will now include common script files when calculating how many pumps it is expecting. Additionally the calculation of the expected total is now only done once (allowing some short-circuit checks to be simplified), and the magical `23` number representing the static number of expected `log_clock` calls during boot has been moved to a variable hinting at its purpose.