### PR TITLE
Initial implementation of PEP 657

### DIFF
--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -19,15 +19,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
-
-from typing import Optional
-
 import os
 import sys
 import subprocess
 import io
+import textwrap
 
 # Encoding and sys.stderr/stdout handling ######################################
 
@@ -191,6 +187,19 @@ def get_alternate_base(basedir, always=False):
     return altbase
 
 
+def excepthook(type, value, traceback):
+    # In rare cases, the exception value can be None,
+    # In which case, we create a new exception object.
+    # We can't just instantiate it, but because error handling
+    # code uses only BaseException fields, we can create an empty instance.
+    if value is None:
+        value = BaseException.__new__(type)
+        value.__traceback__ = traceback
+
+    te = renpy.error.TracebackException(value)
+    te.format(renpy.error.MaybeColoredExceptionPrintContext(sys.stderr))
+
+
 def bootstrap(renpy_base):
 
     global renpy
@@ -269,6 +278,9 @@ def bootstrap(renpy_base):
         if basedir.endswith("Contents/Resources/autorun"):
             renpy.macapp = True
 
+    # Set up Ren'Py specific exception handling.
+    sys.excepthook = excepthook
+
     # Check that we have installed pygame properly. This also deals with
     # weird cases on Windows and Linux where we can't import modules. (On
     # windows ";" is a directory separator in PATH, so if it's in a parent
@@ -278,15 +290,15 @@ def bootstrap(renpy_base):
         import pygame_sdl2
         if not ("pygame" in sys.modules):
             pygame_sdl2.import_as_pygame()
-    except Exception:
-        print("""\
-Could not import pygame_sdl2. Please ensure that this program has been built
-and unpacked properly. Also, make sure that the directories containing
-this program do not contain : or ; in their names.
+    except Exception as e:
+        e.add_note(textwrap.dedent(f"""\
+        Could not import pygame_sdl2. Please ensure that this program has been built
+        and unpacked properly. Also, make sure that the directories containing
+        this program do not contain : or ; in their names.
 
-You may be using a system install of python. Please run {0}.sh,
-{0}.exe, or {0}.app instead.
-""".format(name), file=sys.stderr)
+        You may be using a system install of python. Please run {name}.sh,
+        {name}.exe, or {name}.app instead.
+        """))
 
         raise
 
@@ -299,15 +311,15 @@ You may be using a system install of python. Please run {0}.sh,
 
     # Ditto for the Ren'Py module.
     try:
-        import _renpy
-    except Exception:
-        print("""\
-Could not import _renpy. Please ensure that this program has been built
-and unpacked properly.
+        import _renpy  # type: ignore
+    except Exception as e:
+        e.add_note(textwrap.dedent(f"""\
+        Could not import _renpy. Please ensure that this program has been built
+        and unpacked properly.
 
-You may be using a system install of python. Please run {0}.sh,
-{0}.exe, or {0}.app instead.
-""".format(name), file=sys.stderr)
+        You may be using a system install of python. Please run {name}.sh,
+        {name}.exe, or {name}.app instead.
+        """))
         raise
 
     # Load the rest of Ren'Py.
@@ -408,6 +420,7 @@ You may be using a system install of python. Please run {0}.sh,
             import android
             android.activity.finishAndRemoveTask()
 
-            # Avoid running Python shutdown, which can cause more harm than good. (#5280)
+            # Avoid running Python shutdown, which can cause more harm than good.
+            # For more details, see https://github.com/renpy/renpy/issues/5280.
             System = autoclass("java.lang.System")
             System.exit(0)

--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -354,9 +354,6 @@ You may be using a system install of python. Please run {0}.sh,
 
                 exit_status = 0
 
-            except KeyboardInterrupt:
-                raise
-
             except renpy.game.UtterRestartException:
 
                 # On an UtterRestart, reload Ren'Py.
@@ -377,7 +374,9 @@ You may be using a system install of python. Please run {0}.sh,
                 pass
 
             except Exception as e:
-                renpy.error.report_exception(e)
+                # If exception was raised outside of Ren'Py execution context,
+                # or context was unable to handle it, report it here.
+                renpy.error.report_exception(e, editor=True)
 
         sys.exit(exit_status)
 

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -488,19 +488,18 @@ init python:
         return s
 
 
-    class __RenPyExceptionPrintContext(renpy.renpy.error.ExceptionPrintContext):
+    class __RenPyExceptionPrintContext(renpy.renpy.error.TextIOExceptionPrintContext):
+        BOLD_RED = "#DE382B"
+        RED = "#FF0000"
+
         def __init__(self, *, filter_private: bool):
+            import io
             super().__init__(
+                io.StringIO(),
                 filter_private=filter_private,
                 max_group_width=5,
                 max_group_depth=1,
             )
-
-            from io import StringIO
-            self.file = StringIO()
-
-        def getvalue(self):
-            return self.file.getvalue()
 
         def _escape_limit(self, s: str):
             s = s.replace("{", "{{")
@@ -508,12 +507,6 @@ init python:
                 s = s[:200] + " ... " + s[-200:]
 
             return s
-
-        def _print(self, text: str = ""):
-            if text:
-                text = f"{'  ' * self.indent_depth}{text}"
-
-            print(text, file=self.file)
 
         def _bold(self, text: str):
             return f"{{b}}{text}{{/b}}"
@@ -541,10 +534,10 @@ init python:
                 line_part = "".join(char for char, _ in caret_group)
                 line_part = self._escape_limit(line_part)
                 if color == "^":
-                    line_part = self._color(line_part, "#DE382B")
+                    line_part = self._color(line_part, self.BOLD_RED)
                     line_part = self._bold(line_part)
                 elif color == "~":
-                    line_part = self._color(line_part, "#FF0000")
+                    line_part = self._color(line_part, self.RED)
 
                 colorized_line_parts.append(line_part)
 
@@ -555,34 +548,14 @@ init python:
 
         def final_exception_line(self, exc_type: str, text: str | None):
             exc_type = self._escape_limit(exc_type)
-            exc_type = self._color(exc_type, "#DE382B")
+            exc_type = self._color(exc_type, self.BOLD_RED)
             exc_type = self._bold(exc_type)
             if text is None:
                 self._print(exc_type)
             else:
                 text = self._escape_limit(text)
-                text = self._color(text, "#FF0000")
+                text = self._color(text, self.RED)
                 self._print(f"{exc_type}: {text}")
-
-        def chain_cause(self):
-            self._print()
-            self._print(renpy.renpy.error.CAUSE_MESSAGE)
-            self._print()
-
-        def chain_context(self):
-            self._print()
-            self._print(renpy.renpy.error.CONTEXT_MESSAGE)
-            self._print()
-
-        def exceptions_separator(self, index: int, total: int):
-            truncated = (index >= self.max_group_width)
-            title = f'{index + 1}' if not truncated else '...'
-            self._print(
-                ('+-' if index == 0 else '  ') +
-                f'+---------------- {title} ----------------')
-
-        def exceptions_close(self):
-            self._print("+------------------------------------")
 
 
     def __simple_traceback(traceback_exception):
@@ -823,7 +796,8 @@ screen _exception:
         side "c r":
             xfill True
             label _("An exception has occurred.") text_size gui._scale(40)
-            text "{size=-3}[config.version!q]\n[renpy.version_only!q]\n[renpy.platform!q]{/size}" textalign 1.0 yalign 0.5
+            text "{size=-3}[config.version!q]\n[renpy.version_only!q]\n[renpy.platform!q]{/size}":
+                textalign 1.0 yalign 0.5
 
         viewport:
             id "viewport"
@@ -834,7 +808,10 @@ screen _exception:
 
             has vbox
 
+            text "[renpy.game.exception_info]" size gui._scale(22)
             text fmt_short substitute False
+
+            text "Full traceback:" size gui._scale(22)
             text fmt_full substitute False
 
         hbox:

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -487,33 +487,73 @@ init python:
     def _(s):
         return s
 
-    def __limit_lines(lines):
-        """
-        Limit the number of lines shown.
-        """
 
-        if len(lines) < 401:
-            return lines
+    class __RenPyExceptionPrintContext(renpy.renpy.error.ExceptionPrintContext):
+        BOLD_RED = "#DE382B"
+        RED = "#FF0000"
 
-        return lines[:200] + [ "..." ] + lines[-200:]
+        def __init__(self, *, filter_private: bool):
+            super().__init__(filter_private=filter_private)
 
-    # This function is responsible for taking a traceback, and converting
-    # it to a string that can be shown with text.
-    def __format_traceback(s):
-        import re
+            from io import StringIO
+            self.file = StringIO()
 
-        lines = [ i.replace("{", "{{") for i in s.split("\n") ]
-        lines = __limit_lines(lines)
+        def getvalue(self):
+            return self.file.getvalue()
 
-        rv = [ ("{size=%d}" % gui._scale(22)) + lines[0] + "{/size}" ]
+        def _escape_limit(self, s: str):
+            s = s.replace("{", "{{")
+            if len(s) > 400:
+                s = s[:200] + " ... " + s[-200:]
 
-        for i in lines[1:]:
-            i = re.sub(r'(File "(.*)", line (\d+))', r'{a=edit:\3:\2}\1{/a}', i)
-            rv.append("  " + i)
+            return s
 
-        rv[1] = "{vspace=5}" + rv[1]
+        def _print(self, text: str):
+            print(f"{'  ' * self.indent_depth}{text}", file=self.file)
 
-        return "\n".join(rv)
+        def emit_location(self, filename, lineno, name):
+            self._print(
+                f'File {{a=edit:{lineno}:{filename}}}"{filename}", '
+                f'line {lineno}{{/a}}, '
+                f'in {name}')
+
+        def emit_source_carets(self, line, carets):
+            if carets is None:
+                self._print(self._escape_limit(line))
+                return
+
+            zipped = zip(line, carets, strict=True)
+            colorized_line_parts: list[str] = []
+            for color, group in itertools.groupby(zipped, key=lambda x: x[1]):
+                caret_group = list(group)
+                line_part = "".join(char for char, _ in caret_group)
+                line_part = self._escape_limit(line_part)
+                if color == "^":
+                    line_part = f"{{color={self.BOLD_RED}}}{line_part}{{/color}}"
+                elif color == "~":
+                    line_part = f"{{color={self.RED}}}{line_part}{{/color}}"
+
+                colorized_line_parts.append(line_part)
+
+            self._print("".join(colorized_line_parts))
+
+        def emit_string(self, text: str):
+            self._print(self._escape_limit(text))
+
+        def emit_iterable(self, text_gen: Iterable[str]):
+            for text in text_gen:
+                self._print(self._escape_limit(text))
+
+
+    def __simple_traceback(traceback_exception):
+        ctx = __RenPyExceptionPrintContext(filter_private=True)
+        traceback_exception.format(ctx)
+        return ctx.getvalue()
+
+    def __full_traceback(traceback_exception):
+        ctx = __RenPyExceptionPrintContext(filter_private=False)
+        traceback_exception.format(ctx)
+        return ctx.getvalue()
 
     def __format_parse_errors(errors: list[str]):
         """
@@ -735,8 +775,8 @@ screen _exception:
     zorder 1090
 
     default tt = __Tooltip("")
-    default fmt_short = __format_traceback(short)
-    default fmt_full = __format_traceback(full)
+    default fmt_short = __simple_traceback(traceback_exception)
+    default fmt_full = __full_traceback(traceback_exception)
 
     frame:
         style_group ""
@@ -793,7 +833,7 @@ screen _exception:
                                 action __EnterConsole()
                                 hovered tt.action(_("Opens a console to allow debugging the problem."))
 
-                    use _exception_actions(traceback_fn, tt)
+                    use _exception_actions(traceback_exception.traceback_fn, tt)
 
                 # Tooltip.
                 text tt.value

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -522,9 +522,11 @@ init python:
                 self._print(self._escape_limit(line))
                 return
 
+            from itertools import groupby
+
             zipped = zip(line, carets, strict=True)
             colorized_line_parts: list[str] = []
-            for color, group in itertools.groupby(zipped, key=lambda x: x[1]):
+            for color, group in groupby(zipped, key=lambda x: x[1]):
                 caret_group = list(group)
                 line_part = "".join(char for char, _ in caret_group)
                 line_part = self._escape_limit(line_part)
@@ -539,6 +541,8 @@ init python:
 
         def emit_string(self, text: str):
             self._print(self._escape_limit(text))
+
+        from typing import Iterable
 
         def emit_iterable(self, text_gen: Iterable[str]):
             for text in text_gen:

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -489,11 +489,12 @@ init python:
 
 
     class __RenPyExceptionPrintContext(renpy.renpy.error.ExceptionPrintContext):
-        BOLD_RED = "#DE382B"
-        RED = "#FF0000"
-
         def __init__(self, *, filter_private: bool):
-            super().__init__(filter_private=filter_private)
+            super().__init__(
+                filter_private=filter_private,
+                max_group_width=5,
+                max_group_depth=1,
+            )
 
             from io import StringIO
             self.file = StringIO()
@@ -508,16 +509,25 @@ init python:
 
             return s
 
-        def _print(self, text: str):
-            print(f"{'  ' * self.indent_depth}{text}", file=self.file)
+        def _print(self, text: str = ""):
+            if text:
+                text = f"{'  ' * self.indent_depth}{text}"
 
-        def emit_location(self, filename, lineno, name):
+            print(text, file=self.file)
+
+        def _bold(self, text: str):
+            return f"{{b}}{text}{{/b}}"
+
+        def _color(self, text: str, color: str):
+            return f"{{color={color}}}{text}{{/color}}"
+
+        def location(self, filename, lineno, name):
             self._print(
                 f'File {{a=edit:{lineno}:{filename}}}"{filename}", '
                 f'line {lineno}{{/a}}, '
                 f'in {name}')
 
-        def emit_source_carets(self, line, carets):
+        def source_carets(self, line, carets):
             if carets is None:
                 self._print(self._escape_limit(line))
                 return
@@ -531,33 +541,53 @@ init python:
                 line_part = "".join(char for char, _ in caret_group)
                 line_part = self._escape_limit(line_part)
                 if color == "^":
-                    line_part = f"{{color={self.BOLD_RED}}}{line_part}{{/color}}"
+                    line_part = self._color(line_part, "#DE382B")
+                    line_part = self._bold(line_part)
                 elif color == "~":
-                    line_part = f"{{color={self.RED}}}{line_part}{{/color}}"
+                    line_part = self._color(line_part, "#FF0000")
 
                 colorized_line_parts.append(line_part)
 
             self._print("".join(colorized_line_parts))
 
-        def emit_string(self, text: str):
+        def string(self, text: str):
             self._print(self._escape_limit(text))
 
-        from typing import Iterable
+        def final_exception_line(self, exc_type: str, text: str | None):
+            exc_type = self._escape_limit(exc_type)
+            exc_type = self._color(exc_type, "#DE382B")
+            exc_type = self._bold(exc_type)
+            if text is None:
+                self._print(exc_type)
+            else:
+                text = self._escape_limit(text)
+                text = self._color(text, "#FF0000")
+                self._print(f"{exc_type}: {text}")
 
-        def emit_iterable(self, text_gen: Iterable[str]):
-            for text in text_gen:
-                self._print(self._escape_limit(text))
+        def chain_cause(self):
+            self._print()
+            self._print(renpy.renpy.error.CAUSE_MESSAGE)
+
+        def chain_context(self):
+            self._print()
+            self._print(renpy.renpy.error.CONTEXT_MESSAGE)
+
+        def exceptions_separator(self, index: int, total: int):
+            truncated = (index >= self.max_group_width)
+            title = f'{index + 1}' if not truncated else '...'
+            self._print(
+                ('+-' if index == 0 else '  ') +
+                f'+---------------- {title} ----------------')
+
+        def exceptions_close(self):
+            self._print("+------------------------------------")
 
 
     def __simple_traceback(traceback_exception):
-        ctx = __RenPyExceptionPrintContext(filter_private=True)
-        traceback_exception.format(ctx)
-        return ctx.getvalue()
+        return traceback_exception.format(__RenPyExceptionPrintContext(filter_private=True))
 
     def __full_traceback(traceback_exception):
-        ctx = __RenPyExceptionPrintContext(filter_private=False)
-        traceback_exception.format(ctx)
-        return ctx.getvalue()
+        return traceback_exception.format(__RenPyExceptionPrintContext(filter_private=False))
 
     def __format_parse_errors(errors: list[str]):
         """

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -567,10 +567,12 @@ init python:
         def chain_cause(self):
             self._print()
             self._print(renpy.renpy.error.CAUSE_MESSAGE)
+            self._print()
 
         def chain_context(self):
             self._print()
             self._print(renpy.renpy.error.CONTEXT_MESSAGE)
+            self._print()
 
         def exceptions_separator(self, index: int, total: int):
             truncated = (index >= self.max_group_width)

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1051,7 +1051,7 @@ depth_size = 24
 context_copy_remove_screens = [ "notify" ]
 
 # An exception handling callback.
-exception_handler = None
+exception_handler: Callable[[renpy.error.TracebackException], bool] | None = None
 
 # A label to jump to if return fails.
 return_not_found_label = None

--- a/renpy/display/error.py
+++ b/renpy/display/error.py
@@ -113,6 +113,8 @@ def report_exception(traceback_exception: renpy.error.TracebackException) -> boo
     rollback_action = None
     reload_action = None
 
+    renpy.store.te = traceback_exception
+
     try:
         if not renpy.game.context().init_phase:
 

--- a/renpy/display/error.py
+++ b/renpy/display/error.py
@@ -21,10 +21,6 @@
 
 # This file contains code to handle GUI-based error reporting.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
-
-
 import os
 
 import renpy
@@ -84,7 +80,7 @@ def error_dump():
     renpy.dump.dump(True)
 
 
-def report_exception(traceback_exception: renpy.error.TracebackException):
+def report_exception(traceback_exception: renpy.error.TracebackException) -> bool:
     """
     Reports an exception to the user. Returns True if the exception should
     be raised by the normal reporting mechanisms. Otherwise, should raise
@@ -128,38 +124,32 @@ def report_exception(traceback_exception: renpy.error.TracebackException):
         else:
             reload_action = renpy.exports.utter_restart
 
-        if renpy.game.context(-1).next_node is not None:
+        # If next node is known, allow to advance to it.
+        if renpy.game.context().next_node is not None:
             ignore_action = renpy.ui.returns(False)
+
     except Exception:
         pass
 
-    try:
+    renpy.game.invoke_in_new_context(
+        call_exception_screen,
+        "_exception",
+        traceback_exception=traceback_exception,
+        rollback_action=rollback_action,
+        reload_action=reload_action,
+        ignore_action=ignore_action,
+    )
 
-        renpy.game.invoke_in_new_context(
-            call_exception_screen,
-            "_exception",
-            traceback_exception=traceback_exception,
-            rollback_action=rollback_action,
-            reload_action=reload_action,
-            ignore_action=ignore_action,
-        )
+    # Don't report images that failed to load.
+    renpy.display.im.ignored_images |= renpy.display.im.images_to_ignore
+    renpy.config.raise_image_exceptions = False
+    renpy.config.raise_image_load_exceptions = False
 
-        renpy.display.im.ignored_images |= renpy.display.im.images_to_ignore
+    # If creator overrides ignore action, run it.
+    if renpy.store._ignore_action is not None:
+        renpy.display.behavior.run(renpy.store._ignore_action)
 
-        if renpy.store._ignore_action is not None:
-            renpy.display.behavior.run(renpy.store._ignore_action)
-
-        renpy.config.raise_image_exceptions = False
-        renpy.config.raise_image_load_exceptions = False
-
-    except renpy.game.CONTROL_EXCEPTIONS:
-        raise
-
-    except Exception:
-        renpy.display.log.write("While handling exception:")
-        renpy.display.log.exception()
-        raise
-
+    return False
 
 def report_parse_errors(errors: list[str], error_fn: str) -> bool:
     """

--- a/renpy/display/error.py
+++ b/renpy/display/error.py
@@ -84,7 +84,7 @@ def error_dump():
     renpy.dump.dump(True)
 
 
-def report_exception(short, full, traceback_fn):
+def report_exception(traceback_exception: renpy.error.TracebackException):
     """
     Reports an exception to the user. Returns True if the exception should
     be raised by the normal reporting mechanisms. Otherwise, should raise
@@ -138,11 +138,10 @@ def report_exception(short, full, traceback_fn):
         renpy.game.invoke_in_new_context(
             call_exception_screen,
             "_exception",
-            short=short, full=full,
+            traceback_exception=traceback_exception,
             rollback_action=rollback_action,
             reload_action=reload_action,
             ignore_action=ignore_action,
-            traceback_fn=traceback_fn,
         )
 
         renpy.display.im.ignored_images |= renpy.display.im.images_to_ignore

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -21,112 +21,1043 @@
 
 # This file contains code for formatting tracebacks.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
+from typing import IO, TYPE_CHECKING, Iterable, Iterator, Callable, Any
 
+if TYPE_CHECKING:
+    from types import TracebackType
 
-
-import traceback
-import sys
 import io
+import os
+import abc
+import sys
+import itertools
+import textwrap
+import dataclasses
 import platform
 import linecache
 import time
-import os
+import contextlib
+import collections.abc
 
 import renpy
 
-FSENCODING = sys.getfilesystemencoding() or "utf-8"
 
-
-def write_traceback_list(out, l):
+# Reimplement parts of Python 3.14 traceback module, so we can add Ren'Py-specific behavior.
+def _display_width(line: str) -> Iterator[int]:
     """
-    Given the traceback list, writes it to out as unicode.
-    """
-
-    ul = [ ]
-
-    for filename, line, what, text in l:
-
-        # Filename is either unicode or fsecoded bytes.
-        if isinstance(filename, bytes):
-            filename = filename.decode(FSENCODING)
-
-        # Line is a number.
-
-        # Assume what is in a unicode encoding, since it is either python,
-        # or comes from inside Ren'Py.
-
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
-
-        ul.append((filename, line, what, text))
-
-    for t in traceback.format_list(ul):
-        out.write(t)
-
-
-def traceback_list(tb):
-    """
-    Given `tb`, returns a list of (filename, line_number, function, line_text)
-    tuples.
+    Calculate the extra amount of width space the given source
+    code segment might take if it were to be displayed on a fixed
+    width output device. Supports wide unicode characters and emojis.
     """
 
-    l = [ ]
+    # Fast track for ASCII-only strings
+    if line.isascii():
+        return itertools.repeat(1, len(line))
 
-    while tb:
-        frame = tb.tb_frame
-        line_number = tb.tb_lineno
-        code = frame.f_code
-        filename = code.co_filename
-        name = code.co_name
+    from unicodedata import east_asian_width
 
-        tb = tb.tb_next
+    return (2 if east_asian_width(char) in "WF" else 1 for char in line)
 
-        if ('self' in frame.f_locals) and (not renpy.config.raw_tracebacks):
-            obj = frame.f_locals['self']
 
-            last = (tb is None)
+def _calculate_anchors(frame_summary: 'FrameSummary'):
+    """
+    For given frame summary, return None if there is no column information or
+    other error happens, or list of 4 (lineno, colno) tuples that represent:
+        - position where secondary character starts
+        - position where primary character starts
+        - position where secondary character starts again
+        - position where secondary character ends
 
+    The invariant is that for split lines of frame code, carets can be rendered as
+    nothing until first tuple, secondary char until second tuple, primary char
+    until third tuple, secondary char until fourth tuple, and nothing after fourth
+    tuple.
+    """
+
+    if frame_summary.colno is None or frame_summary.end_colno is None:
+        return None
+
+    all_lines = list(frame_summary.lines)
+    end_lineno = frame_summary.end_lineno - frame_summary.lineno
+    first_line = all_lines[0]
+    # assume all_lines has enough lines (since we constructed it)
+    last_line = all_lines[end_lineno]
+
+    # character index of the start/end of the instruction
+    start_offset = frame_summary.colno
+    end_offset = frame_summary.end_colno
+
+    # Correct extra offset from _ren.py transformation.
+    if frame_summary.filename.endswith("_ren.py"):
+        from renpy.lexer import ren_py_to_rpy_offsets
+        try:
+            with open(frame_summary.filename, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+
+            offsets = list(ren_py_to_rpy_offsets(lines, frame_summary.filename))
+        except Exception:
+            return None
+
+        for i, offset in enumerate(offsets, start=1):
+            if offset is not None:
+                if i == frame_summary.lineno:
+                    start_offset -= offset
+
+                elif i == frame_summary.end_lineno:
+                    end_offset -= offset
+
+    # Correct extra offset from munged names.
+    from renpy.lexer import munge_filename, get_string_munger
+    munge_prefix = munge_filename(frame_summary.filename)
+    munge_string = get_string_munger(munge_prefix)
+    len_prefix = len(munge_prefix) - 2
+
+    idx = 0
+    munged_first_line = munge_string(first_line)
+    while (idx := munged_first_line.find(munge_prefix, idx, start_offset + len_prefix)) != -1:
+        start_offset -= len_prefix
+        idx += len_prefix
+
+    idx = 0
+    munged_last_line = munge_string(last_line)
+    while (idx := munged_last_line.find(munge_prefix, idx, end_offset + len_prefix)) != -1:
+        end_offset -= len_prefix
+        idx += len_prefix
+
+    default_anchors = [
+        (0, start_offset), (0, start_offset),
+        (end_lineno, end_offset), (end_lineno, end_offset)]
+
+    # get exact code segment corresponding to the instruction
+    segment = "\n".join(all_lines)
+    segment = segment[start_offset:len(segment) - (len(last_line) - end_offset)]
+
+    from ast import parse, expr, BinOp, Expr, Subscript, Call
+    # Without parentheses, `segment` is parsed as a statement.
+    # Binary ops, subscripts, and calls are expressions, so
+    # we can wrap them with parentheses to parse them as
+    # (possibly multi-line) expressions.
+    # e.g. if we try to highlight the addition in
+    # x = (
+    #     a +
+    #     b
+    # )
+    # then we would ast.parse
+    #     a +
+    #     b
+    # which is not a valid statement because of the newline.
+    # Adding brackets makes it a valid expression.
+    # (
+    #     a +
+    #     b
+    # )
+    # Line locations will be different than the original,
+    # which is taken into account later on.
+    tree = parse(f"(\n{segment}\n)")
+
+    if len(tree.body) != 1:
+        return default_anchors
+
+    lines = segment.splitlines()
+
+    def normalize(lineno: int, offset: int):
+        """Get character index given byte offset"""
+        return offset
+
+    def next_valid_char(lineno: int, col: int):
+        """Gets the next valid character index in `lines`, if
+        the current location is not valid. Handles empty lines.
+        """
+        while lineno < len(lines) and col >= len(lines[lineno]):
+            col = 0
+            lineno += 1
+        assert lineno < len(lines) and col < len(lines[lineno])
+        return lineno, col
+
+    def increment(lineno: int, col: int):
+        """Get the next valid character index in `lines`."""
+        col += 1
+        lineno, col = next_valid_char(lineno, col)
+        return lineno, col
+
+    def next_line(lineno: int, col: int):
+        """Get the next valid character at least on the next line"""
+        col = 0
+        lineno += 1
+        lineno, col = next_valid_char(lineno, col)
+        return lineno, col
+
+    def increment_until(lineno: int, col: int, stop: Callable[[str], bool]):
+        """Get the next valid non-"\\#" character that satisfies the `stop` predicate"""
+        while True:
+            ch = lines[lineno][col]
+            if ch in "\\#":
+                lineno, col = next_line(lineno, col)
+            elif not stop(ch):
+                lineno, col = increment(lineno, col)
+            else:
+                break
+        return lineno, col
+
+    def setup_positions(expr: expr, force_valid=True):
+        """Get the lineno/col position of the end of `expr`. If `force_valid` is True,
+        forces the position to be a valid character (e.g. if the position is beyond the
+        end of the line, move to the next line)
+        """
+        # -2 since end_lineno is 1-indexed and because we added an extra
+        # bracket + newline to `segment` when calling ast.parse
+        if expr.end_lineno is None or expr.end_col_offset is None:
+            raise Exception("Precise positions are not available.")
+
+        lineno = expr.end_lineno - 2
+        col = normalize(lineno, expr.end_col_offset)
+        return next_valid_char(lineno, col) if force_valid else (lineno, col)
+
+    match tree.body[0]:
+        case Expr(value=expression):
+            pass
+        case _:
+            return default_anchors
+
+    match expression:
+        case BinOp(left=left, right=right):
+            # ast gives these locations for BinOp subexpressions
+            # ( left_expr ) + ( right_expr )
+            #   left^^^^^       right^^^^^
+            left_lineno, left_col = setup_positions(left)
+
+            # First operator character is the first non-space/')' character
+            left_lineno, left_col = increment_until(
+                left_lineno, left_col, lambda x: not x.isspace() and x != ')')
+
+            # binary op is 1 or 2 characters long, on the same line,
+            # before the right subexpression
+            right_lineno = left_lineno
+            right_col = left_col + 1
+            if (
+                right_col < len(lines[right_lineno])
+                and (
+                    # operator char should not be in the right subexpression
+                    right.lineno - 2 > right_lineno or
+                    right_col < normalize(right.lineno - 2, right.col_offset)
+                )
+                and not (ch := lines[right_lineno][right_col]).isspace()
+                and ch not in "\\#"
+            ):
+                right_col += 1
+
+            if left_lineno == 0:
+                left_col += start_offset
+            if right_lineno == 0:
+                right_col += start_offset
+
+            return [
+                (0, start_offset),  # start of left_expr
+                (left_lineno, left_col),  # end of left_expr
+                (right_lineno, right_col),  # start of right_expr
+                (end_lineno, end_offset),  # end of right_expr
+            ]
+
+        case Subscript(value=value):
+            # ast gives these locations for value and slice subexpressions
+            # ( value_expr ) [ slice_expr ]
+            #   value^^^^^     slice^^^^^
+            # subscript^^^^^^^^^^^^^^^^^^^^
+
+            # find left bracket
+            left_lineno, left_col = setup_positions(value)
+            left_lineno, left_col = increment_until(left_lineno, left_col, lambda x: x == '[')
+            # find right bracket (final character of expression)
+            right_lineno, right_col = setup_positions(expression, force_valid=False)
+
+            if left_lineno == 0:
+                left_col += start_offset
+            if right_lineno == 0:
+                right_col += start_offset
+
+            return [
+                (0, start_offset),
+                (left_lineno, left_col),
+                (right_lineno, right_col),
+                (end_lineno, end_offset),
+            ]
+
+        case Call(func=func):
+            # ast gives these locations for function call expressions
+            # ( func_expr ) (args, kwargs)
+            #   func^^^^^
+            # call^^^^^^^^^^^^^^^^^^^^^^^^
+
+            # find left bracket
+            left_lineno, left_col = setup_positions(func)
+            left_lineno, left_col = increment_until(left_lineno, left_col, lambda x: x == '(')
+            # find right bracket (final character of expression)
+            right_lineno, right_col = setup_positions(expression, force_valid=False)
+
+            if left_lineno == 0:
+                left_col += start_offset
+            if right_lineno == 0:
+                right_col += start_offset
+
+            return [
+                (0, start_offset),
+                (left_lineno, left_col),
+                (right_lineno, right_col),
+                (end_lineno, end_offset),
+            ]
+
+        case _:
+            return default_anchors
+
+
+class ExceptionPrintContext(abc.ABC):
+    def __init__(self, *, filter_private: bool):
+        self.seen = set()
+        self.indent_depth = 0
+        self.exception_group_depth = 0
+        self.need_close = False
+        self.filter_private = filter_private
+
+    def should_filter(self, filename: str) -> bool:
+        """
+        Returns true if the FrameSummary with the given filename should be
+        skipped when printing the stack.
+
+        By default filters Ren'Py common code, Ren'Py libraries, and all pure
+        Python code.
+        """
+
+        if not self.filter_private:
+            return False
+
+        if filename.endswith((".rpy", ".rpym", "_ren.py")):
+            return filename.startswith(("renpy/common/", "libs/"))
+        elif filename.endswith(".py"):
+            return True
+        else:
+            return False
+
+    @contextlib.contextmanager
+    def indent(self):
+        self.indent_depth += 1
+        try:
+            yield
+        finally:
+            self.indent_depth -= 1
+
+    @abc.abstractmethod
+    def emit_location(self, filename: str, lineno: int, name: str):
+        """
+        Emits a line that shows the location of the frame in the source code.
+
+        `filename`
+            The filename of the source code.
+
+        `lineno`
+            The line number of the source code.
+
+        `name`
+            The name of the code that was running when the exception occurred.
+
+        Subclasses should override this method to emit the location information
+        in a way that makes sense for their particular application.
+        """
+
+    @abc.abstractmethod
+    def emit_source_carets(self, line: str, carets: str | None):
+        """
+        Emits a line(s) that shows the source code that was running in the
+        frame when the exception occurred.
+
+        `line`
+            The source code that was running when the exception occurred.
+
+        `carets`
+            The carets that point to the location of the exception in the
+            source code. If carets for that line are not available, this
+            is None. Otherwise this is a string that contains spaces, ~, and ^
+            characters.
+
+        """
+
+    @abc.abstractmethod
+    def emit_string(self, text: str):
+        """
+        Emits a string.
+        """
+
+    @abc.abstractmethod
+    def emit_iterable(self, text_gen: Iterable[str]):
+        """
+        Emits an iterable of strings.
+        """
+
+
+class ANSIColoredPrintContext(ExceptionPrintContext):
+    RESET = "\x1b[0m"
+    MAGENTA = "\x1b[35m"
+    BOLD_RED = "\x1b[1;31m"
+    RED = "\x1b[31m"
+
+    def __init__(self, file: IO[str], *, filter_private: bool):
+        super().__init__(filter_private=filter_private)
+        self.file = file
+
+    def _print(self, text: str):
+        print(f"{'  ' * self.indent_depth}{text}", file=self.file)
+
+    def emit_location(self, filename, lineno, name):
+        self._print(
+            f'File {self.MAGENTA}"{filename}"{self.RESET}, '
+            f'line {self.MAGENTA}{lineno}{self.RESET}, '
+            f'in {self.MAGENTA}{name}{self.RESET}')
+
+    def emit_source_carets(self, line, carets):
+        if carets is None:
+            self._print(line)
+            return
+
+        zipped = zip(line, carets, strict=True)
+        colorized_line_parts: list[str] = []
+        colorized_carets_parts: list[str] = []
+        for color, group in itertools.groupby(zipped, key=lambda x: x[1]):
+            caret_group = list(group)
+            line_part = "".join(char for char, _ in caret_group)
+            caret_part = "".join(caret for _, caret in caret_group)
+            if color == "^":
+                line_part = f"{self.BOLD_RED}{line_part}{self.RESET}"
+                caret_part = f"{self.BOLD_RED}{caret_part}{self.RESET}"
+            elif color == "~":
+                line_part = f"{self.RED}{line_part}{self.RESET}"
+                caret_part = f"{self.RED}{caret_part}{self.RESET}"
+
+            colorized_line_parts.append(line_part)
+            colorized_carets_parts.append(caret_part)
+
+        self._print("".join(colorized_line_parts))
+        self._print("".join(colorized_carets_parts))
+
+    def emit_string(self, text: str):
+        self._print(text)
+
+    def emit_iterable(self, text_gen: Iterable[str]):
+        for text in text_gen:
+            self._print(text)
+
+
+class NonColoredExceptionPrintContext(ExceptionPrintContext):
+    def __init__(self, file: IO[str], *, filter_private: bool):
+        super().__init__(filter_private=filter_private)
+        self.file = file
+
+    def _print(self, text: str):
+        print(f"{'  ' * self.indent_depth}{text}", file=self.file)
+
+    def emit_location(self, filename: str, lineno: int, name: str):
+        self._print(f'    File "{filename}", line {lineno}, in {name}\n')
+
+    def emit_source_carets(self, line: str, carets: str | None):
+        self._print(line)
+        if carets is not None:
+            self._print(carets)
+
+    def emit_string(self, text: str):
+        self._print(text)
+
+    def emit_iterable(self, text_gen: Iterable[str]):
+        for text in text_gen:
+            self._print(text)
+
+
+@dataclasses.dataclass(repr=False, slots=True)
+class FrameSummary:
+    """Information about a single frame from a traceback."""
+
+    filename: str
+    """The filename of the source code."""
+
+    lineno: int
+    """The line number of the source code."""
+
+    colno: int | None
+    """The column number of the source code."""
+
+    end_lineno: int
+    """The line number of the end of the source code."""
+
+    end_colno: int | None
+    """The column number of the end of the source code."""
+
+    name: str
+    """The name of the function or method that was executing when the frame was captured."""
+
+    _lines: list[str] | None = dataclasses.field(init=False, default=None, compare=False)
+    _carets: list[str] | None = dataclasses.field(init=False, default=None, compare=False)
+    _anchors_value: list[tuple[int, int]] | None = dataclasses.field(init=False, default=None, compare=False)
+
+    locals: dict[str, Any] | None = dataclasses.field(default=None, compare=False)
+    """Either None if locals were not supplied, or a dict mapping the name to the repr() of the variable."""
+
+    def __post_init__(self):
+        if self.lineno is None:
+            raise ValueError("FrameSummary.lineno must not be None")
+
+        if self.end_lineno is None:
+            self.end_lineno = self.lineno
+
+        from renpy.lexer import elide_filename
+        self.filename = elide_filename(self.filename)
+
+    def __repr__(self):
+        return f"<FrameSummary file {self.filename}, line {self.lineno} in {self.name}>"
+
+    @property
+    def lines(self) -> Iterator[str]:
+        """
+        Yields the lines of the frame source code as-is.
+        """
+
+        if self._lines is None:
+            lines = []
+            for lineno in range(self.lineno, self.end_lineno + 1):
+                # treat errors (empty string) and empty lines (newline) as the same
+                lines.append(linecache.getline(self.filename, lineno).rstrip())
+
+            self._lines = lines
+        else:
+            lines = self._lines
+
+        yield from lines
+
+    @property
+    def _anchors(self) -> list[tuple[int, int]] | None:
+        if self._anchors_value is None:
             try:
-                report = obj.report_traceback(name, last)
-
-                if report is not None:
-                    l.extend(report)
-                    continue
+                anchors = _calculate_anchors(self)
             except Exception:
-                pass
+                anchors = None
 
-        l.append((filename, line_number, name, None))
+            if anchors is None:
+                anchors = []
+            self._anchors_value = anchors
 
-    rv = [ ]
+        return self._anchors_value or None
 
-    for filename, line_number, name, line in l:
-        if line is None:
-            try:
-                line = linecache.getline(filename, line_number)
-            except Exception:
-                line = ''
+    @property
+    def carets(self) -> Iterator[str]:
+        """
+        Yields the carets line for each line in the frame source code.
+        """
 
-        rv.append((filename, line_number, name, line))
+        if self._carets is not None:
+            yield from self._carets
 
-    return rv
+        if (anchors := self._anchors) is None:
+            self._carets = []
+            return
+
+        result = []
+        for lineno, line in enumerate(self.lines):
+            carets: list[str] = []
+            whitespace = True
+            for colno, char in enumerate(line):
+                pos = (lineno, colno)
+                if not char.isspace():
+                    whitespace = False
+
+                if whitespace:
+                    carets.append(" ")
+                elif pos >= anchors[3]:
+                    carets.append(" ")
+                elif pos >= anchors[2]:
+                    carets.append("~")
+                elif pos >= anchors[1]:
+                    carets.append("^")
+                elif pos >= anchors[0]:
+                    carets.append("~")
+                else:
+                    carets.append(" ")
+
+            result.append("".join(carets))
+            yield result[-1]
+
+        self._carets = result
+
+    @property
+    def significant_lines(self):
+        """
+        Yields line numbers that are significant to render during format.
+        """
+
+        yield 0
+
+        len_lines = len(list(self.lines))
+        seen = {-1, 0, len_lines}
+        if (anchors := self._anchors) is not None:
+            if anchors[0] != anchors[1] or anchors[2] != anchors[3]:
+                for lineno, _ in anchors:
+                    for i in range(lineno - 1, lineno + 2):
+                        if i in seen:
+                            continue
+
+                        seen.add(i)
+                        yield i
+
+        if len_lines - 1 not in seen:
+            yield len_lines - 1
+
+    def format(self, ctx: ExceptionPrintContext, /):
+        """
+        Returns a string representing one frame involved in the stack. This
+        gets called for every frame to be printed in the stack summary.
+        """
+
+        ctx.emit_location(self.filename, self.lineno, self.name)
+
+        original_lines = list(self.lines)
+        dedent_lines = textwrap.dedent("\n".join(original_lines)).split("\n")
+        dedent_amount = len(original_lines[0]) - len(dedent_lines[0])
+        carets = [c[dedent_amount:] for c in self.carets]
+        if not carets:
+            carets = [None] * len(dedent_lines)
+
+        sig_lines_list = list(self.significant_lines)
+        with ctx.indent():
+            for i, lineno in enumerate(self.significant_lines):
+                if i:
+                    line_diff = lineno - sig_lines_list[i - 1]
+                    if line_diff == 2:
+                        # 1 line in between - just output it
+                        ctx.emit_source_carets(dedent_lines[lineno - 1], carets[lineno - 1])
+                    elif line_diff > 2:
+                        # > 1 line in between - abbreviate
+                        ctx.emit_string(f"...<{line_diff - 1} lines>...")
+
+                ctx.emit_source_carets(dedent_lines[lineno], carets[lineno])
 
 
-def filter_traceback_list(tl):
+class StackSummary(list[FrameSummary]):
     """
-    Returns the subset of `tl` that originates in creator-written files, as
-    opposed to those portions that come from Ren'Py itself.
+    A list of FrameSummary objects, representing a stack of frames.
     """
 
-    rv = [ ]
+    def __init__(self, traceback: 'TracebackType', /):
+        tb = traceback
+        filenames = set()
 
-    for t in tl:
-        filename = t[0]
-        if filename.endswith(".rpy") and not filename.replace("\\", "/").startswith("common/"):
-            rv.append(t)
+        while tb:
+            frame = tb.tb_frame
+            code = frame.f_code
+            filename = code.co_filename
+            if tb.tb_lasti < 0:
+                lineno = colno = end_lineno = end_colno = None
+            else:
+                lineno, end_lineno, colno, end_colno = \
+                    next(itertools.islice(code.co_positions(), tb.tb_lasti // 2, None))
 
-    return rv
+            if lineno is None:
+                lineno = tb.tb_lineno
+
+            tb = tb.tb_next
+
+            filenames.add(filename)
+            linecache.lazycache(filename, frame.f_globals)
+            self.append(FrameSummary(
+                filename,
+                lineno,
+                colno,
+                end_lineno or lineno,
+                end_colno,
+                code.co_name,
+                # frame.f_locals,
+            ))
+
+        for filename in filenames:
+            linecache.checkcache(filename)
+
+    def should_filter(self, ctx: ExceptionPrintContext, /) -> bool:
+        """
+        Returns true if the stack is empty or all frames should be skipped
+        when printing the stack.
+        """
+
+        for frame_summary in self:
+            if not ctx.should_filter(frame_summary.filename):
+                return False
+
+        return True
+
+    def format(self, ctx: ExceptionPrintContext, /):
+        """Format the stack ready for printing.
+
+        Returns a list of strings ready for printing.  Each string in the
+        resulting list corresponds to a single frame from the stack.
+        Each string ends in a newline; the strings may contain internal
+        newlines as well, for those items with source text lines.
+
+        For long sequences of the same frame and line, the first few
+        repetitions are shown, followed by a summary line stating the exact
+        number of further repetitions.
+        """
+
+        RECURSIVE_CUTOFF = 3  # Hardcoded in traceback.c.
+
+        last_file = None
+        last_line = None
+        last_name = None
+        count = 0
+        for frame_summary in self:
+            if ctx.should_filter(frame_summary.filename):
+                continue
+
+            if (
+                last_file is None or last_file != frame_summary.filename or
+                last_line is None or last_line != frame_summary.lineno or
+                last_name is None or last_name != frame_summary.name
+            ):
+                if count > RECURSIVE_CUTOFF:
+                    count -= RECURSIVE_CUTOFF
+                    ctx.emit_string(
+                        f'[Previous line repeated {count} more '
+                        f'time{"s" if count > 1 else ""}]')
+
+                last_file = frame_summary.filename
+                last_line = frame_summary.lineno
+                last_name = frame_summary.name
+                count = 0
+            count += 1
+            if count > RECURSIVE_CUTOFF:
+                continue
+
+            with ctx.indent():
+                frame_summary.format(ctx)
+
+        if count > RECURSIVE_CUTOFF:
+            count -= RECURSIVE_CUTOFF
+            ctx.emit_string(
+                f'[Previous line repeated {count} more '
+                f'time{"s" if count > 1 else ""}]')
+
+
+def _safe_string(value, what, func: Callable[..., str] = str):
+    try:
+        return func(value)
+    except:
+        return f'<{what} {func.__name__}() failed>'
+
+
+class TracebackException:
+    """An exception ready for rendering.
+
+    The traceback module captures enough attributes from the original exception
+    to this intermediary form to ensure that no references are held, while
+    still being able to fully print or format it.
+
+    max_group_width and max_group_depth control the formatting of exception
+    groups. The depth refers to the nesting level of the group, and the width
+    refers to the size of a single exception group's exceptions array. The
+    formatted output is truncated when either limit is exceeded.
+
+    Use `from_exception` to create TracebackException instances from exception
+    objects, or the constructor to create TracebackException instances from
+    individual components.
+
+    - :attr:`__cause__` A TracebackException of the original *__cause__*.
+    - :attr:`__context__` A TracebackException of the original *__context__*.
+    - :attr:`exceptions` For exception groups - a list of TracebackException
+      instances for the nested *exceptions*.  ``None`` for other exceptions.
+    - :attr:`__suppress_context__` The *__suppress_context__* value from the
+      original exception.
+    - :attr:`stack` A `StackSummary` representing the traceback.
+    - :attr:`exc_type_str` String display of exc_type
+    - :attr:`filename` For syntax errors - the filename where the error
+      occurred.
+    - :attr:`lineno` For syntax errors - the linenumber where the error
+      occurred.
+    - :attr:`end_lineno` For syntax errors - the end linenumber where the error
+      occurred. Can be `None` if not present.
+    - :attr:`text` For syntax errors - the text where the error
+      occurred.
+    - :attr:`offset` For syntax errors - the offset into the text where the
+      error occurred.
+    - :attr:`end_offset` For syntax errors - the end offset into the text where
+      the error occurred. Can be `None` if not present.
+    - :attr:`msg` For syntax errors - the compiler error message.
+    """
+
+    def __init__(
+        self,
+        exception: BaseException, *,
+        max_group_width=15,
+        max_group_depth=10,
+        _seen=None,
+    ):
+        # Handle loops in __cause__ or __context__.
+        is_recursive_call = _seen is not None
+        if _seen is None:
+            _seen = set()
+        _seen.add(id(exception))
+
+        self.max_group_width = max_group_width
+        self.max_group_depth = max_group_depth
+
+        assert exception.__traceback__ is not None
+        self.stack = StackSummary(exception.__traceback__)
+
+        # Capture now to permit freeing resources
+        self._str = _safe_string(exception, 'exception')
+        try:
+            self.__notes__ = getattr(exception, '__notes__', None)
+        except Exception as e:
+            self.__notes__ = [
+                f'Ignored error getting __notes__: {_safe_string(e, '__notes__', repr)}']
+
+        self._is_syntax_error = False
+        self._exc_type = type(exception)
+        self.exc_type_qualname = type(exception).__qualname__
+        self.exc_type_module = type(exception).__module__
+
+        if isinstance(exception, SyntaxError):
+            # Handle SyntaxError's specially
+            self.filename = exception.filename
+            lno = exception.lineno
+            self.lineno = str(lno) if lno is not None else None
+            end_lno = exception.end_lineno
+            self.end_lineno = str(end_lno) if end_lno is not None else None
+            self.text = exception.text
+            self.offset = exception.offset
+            self.end_offset = exception.end_offset
+            self.msg = exception.msg
+            self._is_syntax_error = True
+
+        self.__suppress_context__ = exception.__suppress_context__
+
+        self.__cause__: TracebackException | None = None
+        self.__context__: TracebackException | None = None
+        self.exceptions: list[TracebackException] | None = None
+
+        # Convert __cause__ and __context__ to `TracebackExceptions`s, use a
+        # queue to avoid recursion (only the top-level call gets _seen == None)
+        if not is_recursive_call:
+            queue: list[tuple[TracebackException, BaseException | None]] = [(self, exception)]
+            while queue:
+                te, e = queue.pop()
+                if (e and e.__cause__ is not None and id(e.__cause__) not in _seen):
+                    cause = TracebackException(
+                        e.__cause__,
+                        max_group_width=max_group_width,
+                        max_group_depth=max_group_depth,
+                        _seen=_seen)
+
+                    te.__cause__ = cause
+                    queue.append((te.__cause__, e.__cause__))
+
+                if (e and e.__context__ is not None and id(e.__context__) not in _seen):
+                    context = TracebackException(
+                        e.__context__,
+                        max_group_width=max_group_width,
+                        max_group_depth=max_group_depth,
+                        _seen=_seen)
+
+                    te.__context__ = context
+                    queue.append((te.__context__, e.__context__))
+
+                if e and isinstance(e, BaseExceptionGroup):
+                    exceptions = []
+                    for exc in e.exceptions:
+                        te = TracebackException(
+                            exc,
+                            max_group_width=max_group_width,
+                            max_group_depth=max_group_depth,
+                            _seen=_seen)
+                        exceptions.append(te)
+                        queue.append((te, exc))
+
+                    te.exceptions = exceptions
+
+        self.simple: str | None = None
+        self.full: str | None = None
+        self.traceback_fn: str | None = None
+
+    @property
+    def exc_type_str(self):
+        s_type = self.exc_type_qualname
+        s_mod = self.exc_type_module
+        if s_mod not in ("__main__", "builtins"):
+            if not isinstance(s_mod, str):
+                s_mod = "<unknown>"
+            s_type = s_mod + '.' + s_type
+        return s_type
+
+    def __eq__(self, other):
+        if isinstance(other, TracebackException):
+            return self.__dict__ == other.__dict__
+
+        return NotImplemented
+
+    def __str__(self):
+        return self._str
+
+    def _format_final_exc_line(self):
+        if self._str:
+            return f"{self.exc_type_str}: {self._str}"
+        else:
+            return f"{self.exc_type_str}"
+
+    def format_exception_only(self, ctx: ExceptionPrintContext, /, *, show_group=False):
+        """Format the exception part of the traceback.
+
+        The return value is a generator of strings, each ending in a newline.
+
+        Generator yields the exception message.
+        For :exc:`SyntaxError` exceptions, it
+        also yields (before the exception message)
+        several lines that (when printed)
+        display detailed information about where the syntax error occurred.
+        Following the message, generator also yields
+        all the exception's ``__notes__``.
+
+        When *show_group* is ``True``, and the exception is an instance of
+        :exc:`BaseExceptionGroup`, the nested exceptions are included as
+        well, recursively, with indentation relative to their nesting depth.
+        """
+
+        if self._is_syntax_error:
+            raise NotImplementedError
+
+        ctx.emit_string(self._format_final_exc_line())
+
+        if (
+            isinstance(self.__notes__, collections.abc.Sequence)
+            and not isinstance(self.__notes__, (str, bytes))
+        ):
+            for note in self.__notes__:
+                ctx.emit_iterable(_safe_string(note, 'note').split('\n'))
+
+        elif self.__notes__ is not None:
+            ctx.emit_string(_safe_string(self.__notes__, '__notes__', func=repr))
+
+        if show_group and self.exceptions:
+            with ctx.indent():
+                for ex in self.exceptions:
+                    ex.format_exception_only(ctx, show_group=show_group)
+
+    def format(self, ctx: ExceptionPrintContext, /, *, chain=True, show_group=False):
+        """Format the exception.
+
+        If chain is not *True*, *__cause__* and *__context__* will not be formatted.
+
+        The return value is a generator of strings, each ending in a newline and
+        some containing internal newlines. `print_exception` is a wrapper around
+        this method which just prints the lines to a file.
+
+        The message indicating which exception occurred is always the last
+        string in the output.
+        """
+
+        output: list[tuple[str | None, TracebackException]] = []
+        exc = self
+
+        if chain:
+            while exc:
+                if exc.__cause__ is not None:
+                    chained_msg = (
+                        "\nThe above exception was the direct cause "
+                        "of the following exception:\n\n")
+                    chained_exc = exc.__cause__
+                elif (exc.__context__ is not None and
+                      not exc.__suppress_context__):
+                    chained_msg = (
+                        "\nDuring handling of the above exception, "
+                        "another exception occurred:\n\n")
+                    chained_exc = exc.__context__
+                else:
+                    chained_msg = None
+                    chained_exc = None
+
+                output.append((chained_msg, exc))
+                exc = chained_exc
+        else:
+            output.append((None, exc))
+
+        for msg, exc in reversed(output):
+            if exc.stack.should_filter(ctx):
+                ctx.emit_string("Traceback is suppressed.")
+                continue
+
+            if msg is not None:
+                ctx.emit_string(msg)
+
+            if exc.exceptions is None:
+                ctx.emit_string('Traceback (most recent call last):')
+
+                with ctx.indent():
+                    exc.stack.format(ctx)
+
+                exc.format_exception_only(ctx)
+
+            elif ctx.exception_group_depth > self.max_group_depth:
+                # exception group, but depth exceeds limit
+                ctx.emit_string(f"... (max_group_depth is {self.max_group_depth})")
+            else:
+                # format exception group
+                is_toplevel = (ctx.exception_group_depth == 0)
+                if is_toplevel:
+                    ctx.exception_group_depth += 1
+
+                ctx.emit_string('Exception Group Traceback (most recent call last):')
+
+                with ctx.indent():
+                    exc.stack.format(ctx)
+
+                exc.format_exception_only(ctx)
+
+                num_exceptions = len(exc.exceptions)
+                if num_exceptions <= self.max_group_width:
+                    n = num_exceptions
+                else:
+                    n = self.max_group_width + 1
+                ctx.need_close = False
+                for i in range(n):
+                    last_exc = (i == n-1)
+                    if last_exc:
+                        # The closing frame may be added by a recursive call
+                        ctx.need_close = True
+
+                    truncated = (i >= self.max_group_width)
+                    title = f'{i+1}' if not truncated else '...'
+                    with ctx.indent():
+                        ctx.emit_string(
+                            ('+-' if i == 0 else '  ') +
+                            f'+---------------- {title} ----------------')
+
+                        ctx.exception_group_depth += 1
+                        if not truncated:
+                            exc.exceptions[i].format(ctx, chain=chain)
+                        else:
+                            remaining = num_exceptions - self.max_group_width
+                            plural = 's' if remaining > 1 else ''
+                            ctx.emit_string(f"and {remaining} more exception{plural}")
+
+                        if last_exc and ctx.need_close:
+                            ctx.emit_string("+------------------------------------")
+                            ctx.need_close = False
+
+                    ctx.exception_group_depth -= 1
+
+                if is_toplevel:
+                    assert ctx.exception_group_depth == 1
+                    ctx.exception_group_depth = 0
+
+    # Mimic old report_exception return value.
+    def __getitem__(self, pos):
+        return (self.simple, self.full, self.traceback_fn)[pos]
+
+    def __iter__(self):
+        return iter([self.simple, self.full, self.traceback_fn])
+
+    def __len__(self):
+        return 3
 
 
 def open_error_file(fn, mode):
@@ -136,7 +1067,7 @@ def open_error_file(fn, mode):
     """
 
     try:
-        new_fn = os.path.join(renpy.config.logdir, fn) # type: ignore
+        new_fn = os.path.join(renpy.config.logdir, fn)  # type: ignore
         f = open(new_fn, mode)
         return f, new_fn
     except Exception:
@@ -154,19 +1085,19 @@ def open_error_file(fn, mode):
     return open(new_fn, mode), new_fn
 
 
-def report_exception(e, editor=True):
-    """
-    Reports an exception by writing it to standard error and
-    traceback.txt. If `editor` is True, opens the traceback
-    up in a text editor.
-
-    Returns a three-item tuple, with the first item being
-    a simplified traceback, the second being a full traceback,
-    and the third being the traceback filename.
-    """
-
+def report_exception(e: Exception, editor=True) -> TracebackException:
     # Note: Doki Doki Literature club calls this as ("Words...", False).
     # For what it's worth.
+    if not isinstance(e, Exception):  # type: ignore
+        e = Exception(e)
+
+    # Still, if we were called directly with exception without traceback
+    # we need to populate it.
+    if e.__traceback__ is None:
+        from types import TracebackType
+        f = sys._getframe().f_back  # type: ignore
+        assert f is not None
+        e.__traceback__ = TracebackType(None, f, f.f_lasti, f.f_lineno)
 
     if not int(os.environ.get("RENPY_REPORT_EXCEPTIONS", "1")):
         raise
@@ -174,33 +1105,24 @@ def report_exception(e, editor=True):
     # The sound system may not be ready during exception handling.
     renpy.config.debug_sound = False
 
-    import codecs
-
-    type, _value, tb = sys.exc_info() # @ReservedAssignment
+    te = TracebackException(e)
 
     # Return values - which can be displayed to the user.
     simple = io.StringIO()
     full = io.StringIO()
 
-    full_tl = traceback_list(tb)
-    simple_tl = filter_traceback_list(full_tl)
-
     print(str(renpy.game.exception_info), file=simple)
-    write_traceback_list(simple, simple_tl)
-    print(type.__name__ + ":", end=' ', file=simple)
-    print(str(e), file=simple)
+    te.format(NonColoredExceptionPrintContext(simple, filter_private=True))
 
     print("Full traceback:", file=full)
-    write_traceback_list(full, full_tl)
-    print(type.__name__ + ":", end=' ', file=full)
-    print(str(e), file=full)
+    te.format(NonColoredExceptionPrintContext(full, filter_private=False))
 
     # Write to stdout/stderr.
     try:
         sys.stdout.write("\n")
-        sys.stdout.write(full.getvalue())
+        te.format(ANSIColoredPrintContext(sys.stdout, filter_private=False))
         sys.stdout.write("\n")
-        sys.stdout.write(simple.getvalue())
+        te.format(ANSIColoredPrintContext(sys.stdout, filter_private=True))
     except Exception:
         pass
 
@@ -214,40 +1136,40 @@ def report_exception(e, editor=True):
     except Exception:
         pass
 
-    simple = simple.getvalue()
-    full = full.getvalue()
+    te.simple = simple.getvalue()
+    te.full = full.getvalue()
 
     # Inside of the file, which may not be openable.
     try:
 
-        f, traceback_fn = open_error_file("traceback.txt", "w")
+        f, te.traceback_fn = open_error_file("traceback.txt", "w")
 
         with f:
-            f.write("\ufeff") # BOM
+            f.write("\ufeff")  # BOM
 
             print("I'm sorry, but an uncaught exception occurred.", file=f)
             print('', file=f)
 
-            f.write(simple)
+            f.write(te.simple)
 
             print('', file=f)
             print("-- Full Traceback ------------------------------------------------------------", file=f)
             print('', file=f)
 
-            f.write(full)
+            f.write(te.full)
 
         try:
-            renpy.util.expose_file(traceback_fn)
+            renpy.util.expose_file(te.traceback_fn)
         except Exception:
             pass
 
         try:
-            if editor and ((renpy.game.args.command == "run") or (renpy.game.args.errors_in_editor)): # type: ignore
-                renpy.exports.launch_editor([ traceback_fn ], 1, transient=True)
+            if editor and ((renpy.game.args.command == "run") or (renpy.game.args.errors_in_editor)):
+                renpy.editor.launch_editor([te.traceback_fn], 1, transient=True)
         except Exception:
             pass
 
     except Exception:
-        traceback_fn = os.path.join(renpy.config.basedir, "traceback.txt") # type: ignore
+        te.traceback_fn = os.path.join(renpy.config.basedir, "traceback.txt")
 
-    return simple, full, traceback_fn
+    return te

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -404,10 +404,6 @@ def normalize_renpy_line_offset(filename: str, linenumber: int, offset: int, lin
     discard extra offset from munged names.
     """
 
-    if not line.isascii():
-        as_utf8 = line.encode('utf-8')
-        offset = len(as_utf8[:offset].decode("utf-8", errors="replace"))
-
     # Correct extra offset from _ren.py transformation.
     if filename.endswith("_ren.py"):
         from renpy.lexer import ren_py_to_rpy_offsets
@@ -420,6 +416,10 @@ def normalize_renpy_line_offset(filename: str, linenumber: int, offset: int, lin
                 if i == linenumber:
                     offset -= base_offset
                     break
+
+    if not line.isascii():
+        as_utf8 = line.encode('utf-8')
+        offset = len(as_utf8[:offset].decode("utf-8", errors="replace"))
 
     from renpy.lexer import munge_filename, get_string_munger
     munge_prefix = munge_filename(filename)

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -611,28 +611,24 @@ class Context(renpy.object.Object):
                 except Exception as e:
                     self.translate_interaction = None
 
-                    short, full, traceback_fn = renpy.error.report_exception(e, editor=False)
+                    te = renpy.error.report_exception(e, editor=False)
 
                     reraise = True
                     try:
                         # Local exception handler, if any.
                         if self.exception_handler is not None:
-                            self.exception_handler(short, full, traceback_fn)
+                            self.exception_handler(*te)
                             reraise = False
 
                         # Creator-defined exception handler. Returns True
                         # if exception handled.
                         elif renpy.config.exception_handler is not None:
-                            reraise = not renpy.config.exception_handler(short, full, traceback_fn)
+                            reraise = not renpy.config.exception_handler(*te)
 
                         # RenPy default exception handler. Returns True
                         # if exception NOT handled.
                         if reraise:
-                            reraise = renpy.display.error.report_exception(
-                                short,
-                                full,
-                                traceback_fn
-                            )
+                            reraise = renpy.display.error.report_exception(te)
 
                     except renpy.game.CONTROL_EXCEPTIONS:
                         raise

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -22,7 +22,11 @@
 # This file contains code responsible for managing the execution of a
 # renpy object, as well as the context object.
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
+
+# FrameType can't be pickled!
+if TYPE_CHECKING:
+    from types import FrameType
 
 import sys
 import time
@@ -489,18 +493,20 @@ class Context(renpy.object.Object):
                 # Before 8.4 it was a function that takes 3 strings.
                 import inspect
                 inspect.signature(renpy.config.exception_handler).bind(te)
-                if not renpy.config.exception_handler(te):
-                    return
 
             except TypeError:
                 if not renpy.config.exception_handler(*te): # type: ignore
+                    return
+
+            else:
+                if not renpy.config.exception_handler(te):
                     return
 
         # RenPy default exception handler. Returns True
         # if exception NOT handled.
         renpy.display.error.report_exception(te)
 
-    def report_traceback(self, name, last):
+    def report_traceback(self, name: str, last: bool):
 
         if last:
             return

--- a/renpy/game.py
+++ b/renpy/game.py
@@ -102,7 +102,7 @@ preferences = None # type: Any
 initcode_ast_id = 0
 
 # The build_info.
-build_info = { "info" : { } }
+build_info: dict[str, Any] = { "info" : { } }
 
 
 class ExceptionInfo(object):

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -69,10 +69,12 @@ class ParseError(SyntaxError):
     def message(self) -> str:
         """
         Fully formatted message of the error close to the result of
-        `traceback.print_exception_only`.
+        `traceback.format_exception_only`.
         """
         if self._message is None:
-            message = f'File "{self.filename}", line {self.lineno}: {self.msg}'
+            filename = self.filename or "<string>"
+            lineno = self.lineno or 1
+            message = f'File "{filename}", line {lineno}: {self.msg}'
             if self.text is not None:
                 # Neither Python nor this class does not support multiline syntax error code.
                 # Just strip the first line of provided code.
@@ -85,20 +87,29 @@ class ParseError(SyntaxError):
                 message += f'\n    {text.lstrip()}'
 
                 if self.offset is not None:
-                    offset = self.offset
+                    from renpy.error import normalize_renpy_line_offset
+                    offset = normalize_renpy_line_offset(
+                        filename,
+                        lineno,
+                        self.offset,
+                        self.text)
 
                     # Fallback to single caret for cases end_offset is before offset.
                     if self.end_offset is None or self.end_offset <= offset:
                         end_offset = offset + 1
                     else:
-                        end_offset = self.end_offset
+                        end_offset = normalize_renpy_line_offset(
+                            filename,
+                            self.end_lineno or lineno,
+                            self.end_offset,
+                            self.text)
 
                     left_spaces = len(text) - len(text.lstrip())
                     offset -= left_spaces
                     end_offset -= left_spaces
 
                     if offset >= 0:
-                        caret_space = ' ' * offset
+                        caret_space = ' ' * (offset - 1)
                         carets = '^' * (end_offset - offset)
                         message += f"\n    {caret_space}{carets}"
 
@@ -363,7 +374,7 @@ def list_logical_lines(
                 # This can happen only if we have unclosed parens.
                 c, lineno, column = open_parens[-1]
                 raise ParseError(f"'{c}' was never closed",
-                                 filename, lineno, column,
+                                 filename, lineno, column + 1,
                                  linecache.getline(filename, lineno))
 
             # Name and runs of spaces are the most common cases, so it's first.
@@ -473,7 +484,7 @@ def list_logical_lines(
             elif c in '}])':
                 if not open_parens:
                     raise ParseError(f"unmatched '{c}'",
-                                     filename, number, pos - line_startpos,
+                                     filename, number, pos - line_startpos + 1,
                                      linecache.getline(filename, number))
 
                 open_c, _, _ = open_parens.pop()
@@ -484,7 +495,7 @@ def list_logical_lines(
                     c == "}" and open_c == "{"
                 ):
                     raise ParseError(f"closing parenthesis '{c}' does not match opening parenthesis '{open_c}'",
-                                     filename, number, pos - line_startpos,
+                                     filename, number, pos - line_startpos + 1,
                                      linecache.getline(filename, number))
 
                 line.append(c)
@@ -854,7 +865,7 @@ class Lexer(object):
             msg,
             self.filename,
             self.number,
-            self.pos,
+            self.pos + 1,
             self.text)
 
     def deferred_error(self, queue, msg):
@@ -1631,6 +1642,10 @@ def ren_py_to_rpy_offsets(lines: list[str], filename: str):
     state = IGNORE
 
     open_linenumber = 0
+
+    # Remove BOM.
+    if lines and lines[0] and lines[0][0] == '\ufeff':
+        lines[0] = lines[0][1:]
 
     for linenumber, l in enumerate(lines, start=1):
         if state != RENPY:

--- a/renpy/log.py
+++ b/renpy/log.py
@@ -278,6 +278,12 @@ class StdioRedirector(object):
 
         self.buffer = lines[-1]
 
+    def fileno(self):
+        return self.real_file.fileno()
+
+    def isatty(self):
+        return self.real_file.isatty()
+
     def writelines(self, lines):
         for i in lines:
             self.write(i)


### PR DESCRIPTION
This PR adds support for [Fine Grained Error Locations](https://peps.python.org/pep-0657/) in Ren'Py error handling.
That allow to render different color in exception screen and precice carets in traceback file.
In this PR I adopted some code from Python 3.14 traceback module, adding handling of Ren'Py `_ren.py` extra indent and munged names, and also added ExceptionPrintContext abstract class that actually emits output to abstract printer and implemented it for console attached to the process, traceback.txt file and exception screen.
![file](https://github.com/user-attachments/assets/4cd43e38-8438-4ec8-9f3c-5fbe386f1a90)
![console](https://github.com/user-attachments/assets/f09d5310-62f1-4142-bdbe-a045cb4c2cd6)
![screen](https://github.com/user-attachments/assets/ce56f1bc-780d-4247-813c-0e34cb379131)

Things to fix before it can be merged:
1. Handle non-ASCII text in lines.
2. Handle wide chars in console and text file.
3. Handle SyntaxErrors in new system.
4. Update Ren'Py console to use new system.
5. Test it thoroughly.