### PR TITLE
Move depth tracking to correct loop

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -956,12 +956,7 @@ class Layout(object):
 
         di = DrawInfo()
 
-        depth = len(self.outlines)
-        max_depth = depth - 1
-
         for o, color, xo, yo in self.outlines:
-            depth -= 1
-
             key = (o, color)
 
             if key in self.textures:
@@ -1025,8 +1020,13 @@ class Layout(object):
             self.textures[key] = tex
 
         if self.textshaders:
+            depth = len(self.outlines)
+            max_depth = depth - 1
+
             for o, color, xo, yo in self.outlines:
                 tex = self.textures[(o, color)]
+
+                depth -= 1
 
                 for ts in self.textshaders:
                     mr = self.create_mesh_displayable(o, tex, lines, xo, yo, depth, max_depth, ts)


### PR DESCRIPTION
Fixes #6287.

The `depth` value for outlines was being calculated in a separate loop to where it was being used, the result of which being that each outline was given the same final value of `depth` from the first loop instead of one relevant to the iteration.

<details><summary>Test case code</summary>

```rpy
label main_menu:
    $ _confirm_quit = False
    return

label start:
    scene bg
    show screen test()
    pause
    return

define config.default_textshader = "typewriter"

screen test():
    text '{shader=test}Hello World!{/shader}':
        at transform:
            align (0.5, 0.5)
            zoom 10

        outlines ((20, 'f77', 0, 0),
                  (15, 'f77', 0, 0),
                  (10, 'f77', 0, 0),
                  (5, 'f77', 0, 0))

init python:
    renpy.register_textshader(
        "test",
        variables="""
        uniform float u_text_depth;
        """,
        fragment_500="""
        gl_FragColor.rgb *= u_text_depth / 6.;
        """)
```
</details>

**Before**
![before](https://github.com/user-attachments/assets/0d106527-4b2d-4605-9291-4fd90543fd71)

**After**
![after](https://github.com/user-attachments/assets/f070928b-204f-4fb0-9bd6-bc03150fc11e)