### PR TITLE
Fix fade-in for first audio clip on Web

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -53,7 +53,7 @@ let get_channel = (channel) => {
         playing : null,
         queued : null,
         stereo_pan : context.createStereoPanner(),
-        fade_volume : context.createGain(),
+        fade_volume: new GainNode(context, {gain: 0.0}),
         primary_volume : context.createGain(),
         secondary_volume : context.createGain(),
         relative_volume : context.createGain(),


### PR DESCRIPTION
Initializing the gain to 0 for new channels makes sure the fade-in starts from 0 for the first audio clip played on the channels. If no fadein is given for it, the gain will be set to max by start_playing() and there is no reason for the first audio clip to have the fadeout property set in start_playing().

Fixes #6291