### PR TITLE
Preserve some niceties of older traceback style

### DIFF
--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -233,6 +233,10 @@ init label _errorhandling:
         size gui._scale(26)
         kerning -1
 
+    style _trace:
+        left_margin gui._scale(10)
+        top_margin gui._scale(5)
+
     style _bar is _default:
         left_bar "#468"
         hover_left_bar "#24C"
@@ -508,17 +512,14 @@ init python:
 
             return s
 
-        def _big(self, text: str):
-            return f"{{size=+2}}{text}{{/size}}"
-
         def _color(self, text: str, color: str):
             return f"{{color={color}}}{text}{{/color}}"
 
         def location(self, filename, lineno, name):
             self._print(
-                f'File {{a=edit:{lineno}:{filename}}}"{filename}", '
-                f'line {lineno}{{/a}}, '
-                f'in {name}')
+                f'{{a=edit:{lineno}:{filename}}}'
+                f'File "{filename}", line {lineno}'
+                f'{{/a}}, in {name}')
 
         def source_carets(self, line, carets):
             if carets is None:
@@ -547,7 +548,6 @@ init python:
 
         def final_exception_line(self, exc_type: str, text: str | None):
             exc_type = self._escape_limit(exc_type)
-            exc_type = self._big(exc_type)
             if text is None:
                 self._print(exc_type)
             else:
@@ -806,10 +806,12 @@ screen _exception:
             has vbox
 
             text "[renpy.game.exception_info]" size gui._scale(22)
-            text fmt_short substitute False
+            frame style '_trace':
+                text fmt_short substitute False
 
             text "Full traceback:" size gui._scale(22)
-            text fmt_full substitute False
+            frame style '_trace':
+                text fmt_full substitute False
 
         hbox:
             vbox:

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -496,13 +496,14 @@ init python:
         BRIGHT_RED = "#e00000"
         RED = "#800000"
 
-        def __init__(self, *, filter_private: bool):
+        def __init__(self, *, filter_private: bool, context_line=None):
             import io
             super().__init__(
                 io.StringIO(),
                 filter_private=filter_private,
                 max_group_width=5,
                 max_group_depth=1,
+                context_line=context_line
             )
 
         def _escape_limit(self, s: str):
@@ -556,10 +557,12 @@ init python:
 
 
     def __simple_traceback(traceback_exception):
-        return traceback_exception.format(_ExceptionPrintContext(filter_private=True))
+        return traceback_exception.format(_ExceptionPrintContext(
+            filter_private=True, context_line=False))
 
     def __full_traceback(traceback_exception):
-        return traceback_exception.format(_ExceptionPrintContext(filter_private=False))
+        return traceback_exception.format(_ExceptionPrintContext(
+            filter_private=False, context_line=False))
 
     def __format_parse_errors(errors: list[str]):
         """

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -303,9 +303,9 @@ class ANSIColoredPrintContext(TextIOExceptionPrintContext):
             name_str = f', in {name}'
 
         self._print(
-            f'File {self.LOCATION_COLOR}"{filename}", '
-            f'line {lineno}{ANSIColors.RESET}'
-            f'{name_str}')
+            f'{self.LOCATION_COLOR}'
+            f'File "{filename}", line {lineno}'
+            f'{ANSIColors.RESET}{name_str}')
 
     def source_carets(self, line, carets):
         if carets is None:
@@ -1355,10 +1355,7 @@ class TracebackException:
 
             if exc.exceptions is None:
                 if not exc.stack.should_filter(ctx):
-                    ctx.string('Traceback (most recent call last):')
-
-                    with ctx.indent():
-                        exc.stack.format(ctx)
+                    exc.stack.format(ctx)
 
                 exc.format_exception_only(ctx)
 
@@ -1372,10 +1369,7 @@ class TracebackException:
                     ctx.exception_group_depth += 1
 
                 if not exc.stack.should_filter(ctx):
-                    ctx.string('Exception Group Traceback (most recent call last):')
-
-                    with ctx.indent():
-                        exc.stack.format(ctx)
+                    exc.stack.format(ctx)
 
                     exc.format_exception_only(ctx)
 

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -65,6 +65,7 @@ class ExceptionPrintContextKwargs(TypedDict):
     filter_private: NotRequired[bool]
     max_group_width: NotRequired[int]
     max_group_depth: NotRequired[int]
+    context_line: NotRequired[str|bool|None]
 
 
 class ExceptionPrintContext(abc.ABC):
@@ -76,6 +77,7 @@ class ExceptionPrintContext(abc.ABC):
         self.filter_private = kwargs.get("filter_private", False)
         self.max_group_width = kwargs.get("max_group_width", 15)
         self.max_group_depth = kwargs.get("max_group_depth", 10)
+        self.context_line = kwargs.get("context_line", None)
 
     def should_filter(self, filename: str) -> bool:
         """
@@ -107,6 +109,16 @@ class ExceptionPrintContext(abc.ABC):
             yield
         finally:
             self.indent_depth -= 1
+
+    def context(self, text: str):
+        if self.context_line is None:
+            self.string(text)
+        else:
+            if self.context_line:
+                self.string(self.context_line)
+
+            # Reset so as not to affect chained exceptions.
+            self.context_line = None
 
     @abc.abstractmethod
     def getvalue(self) -> Any:
@@ -1355,6 +1367,7 @@ class TracebackException:
 
             if exc.exceptions is None:
                 if not exc.stack.should_filter(ctx):
+                    ctx.context('Traceback (most recent call last):')
                     exc.stack.format(ctx)
 
                 exc.format_exception_only(ctx)
@@ -1369,8 +1382,8 @@ class TracebackException:
                     ctx.exception_group_depth += 1
 
                 if not exc.stack.should_filter(ctx):
+                    ctx.context('Exception Group Traceback (most recent call last):')
                     exc.stack.format(ctx)
-
                     exc.format_exception_only(ctx)
 
                 num_exceptions = len(exc.exceptions)
@@ -1472,21 +1485,21 @@ def report_exception(e: Exception, editor=True) -> TracebackException:
     simple = io.StringIO()
     full = io.StringIO()
 
-    print(str(renpy.game.exception_info), file=simple)
-    te.format(NonColoredExceptionPrintContext(simple, filter_private=True))
+    te.format(NonColoredExceptionPrintContext(
+        simple, filter_private=True, context_line=renpy.game.exception_info))
 
-    print("Full traceback:", file=full)
-    te.format(NonColoredExceptionPrintContext(full, filter_private=False))
+    te.format(NonColoredExceptionPrintContext(
+        full, filter_private=False, context_line="Full traceback:"))
 
     # Write to stdout/stderr.
     try:
         print(file=sys.stdout)
-        print("Full traceback:", file=sys.stdout)
-        te.format(MaybeColoredExceptionPrintContext(sys.stdout, filter_private=False))
+        te.format(MaybeColoredExceptionPrintContext(
+            sys.stdout, filter_private=False, context_line="Full traceback:"))
 
         print(file=sys.stdout)
-        print(str(renpy.game.exception_info), file=sys.stdout)
-        te.format(MaybeColoredExceptionPrintContext(sys.stdout, filter_private=True))
+        te.format(MaybeColoredExceptionPrintContext(
+            sys.stdout, filter_private=True, context_line=renpy.game.exception_info))
     except Exception:
         pass
 


### PR DESCRIPTION
- Drop "Traceback (most recent call last):" lines.
   We provide our own more specific context to traces already, no need for two.
- Prevent double indentation of stack frames in text file output.
  Fewer characters is nice in some scenarios (such as pasting traces into Discord).
  Also makes each increase in indentation level consistent, and matches how it appeared in 8,3 and previous.
- Restore breathing room around tracebacks on exception screen.
- Include the initial "File " of frames in the location hyperlink.
  I noticed this when scanning the left side of traces, having each line start the same colour was distracting in a way that I hadn't previously remembered, and I believe this was why.
  Also matches how we dynamically highlight parse errors:
  https://github.com/renpy/renpy/blob/a9dd010dc87ff065987639cb1231f9225066c54b/renpy/common/_errorhandling.rpym#L579-L582
- Fixes sizing on strangely oversized final line.

**Comparisons**

<details><summary>GUI</summary>

<table><tr><th>8.3</th><th>8.4-nightly</th><th>8.4-this-patch</th></tr><tr><td>

![8 3](https://github.com/user-attachments/assets/0431d846-ff99-47b3-82e8-4a90b539c194)

</td><td>

![8 4](https://github.com/user-attachments/assets/5f84f451-11e6-453f-8fea-8d81656116d0)

</td><td>

![new](https://github.com/user-attachments/assets/ad6a0d78-122b-4d6f-8c97-d51370947dbb)

</td></tr></table>

</details>
<details><summary>Console</summary>

<table><tr><th>8.3</th></tr><tr><td>

```
I'm sorry, but an uncaught exception occurred.

While running game code:
  File "game/script.rpy", line 1, in script
    init python:
  File "game/script.rpy", line 2, in <module>
    import problem3
ZeroDivisionError: division by zero

-- Full Traceback ------------------------------------------------------------

Full traceback:
  File "game/script.rpy", line 1, in script
    init python:
  File "renpy/ast.py", line 827, in execute
    renpy.python.py_exec_bytecode(self.code.bytecode, self.hide, store=self.store)
  File "renpy/python.py", line 1178, in py_exec_bytecode
    exec(bytecode, globals, locals)
  File "game/script.rpy", line 2, in <module>
    import problem3
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
  File "renpy/loader.py", line 864, in load_module
    exec(code, mod.__dict__)
  File "problem3.py", line 1, in <module>
ZeroDivisionError: division by zero

Linux-6.11.0-21-generic-x86_64-with-glibc2.39 x86_64
Ren'Py 8.3.4.24120703
```

</td></tr><tr><th>8.4-nightly</th></tr><tr><td>

```
I'm sorry, but an uncaught exception occurred.

While running game code:
Traceback (most recent call last):
    File "game/script.rpy", line 1, in script
      init python:
    File "game/script.rpy", line 2, in <module>
      import problem3
ZeroDivisionError: division by zero

-- Full Traceback ------------------------------------------------------------

Full traceback:
Traceback (most recent call last):
    File "game/script.rpy", line 1, in script
      init python:
    File "renpy/ast.py", line 1223, in execute
      renpy.python.py_exec_bytecode(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
          self.code.bytecode,
          ^^^^^^^^^^^^^^^^^^^
          self.hide,
          ^^^^^^^^^^
          store=self.store)
          ^^^^^^^^^^^^^^^^^
    File "renpy/python.py", line 1277, in py_exec_bytecode
      exec(bytecode, globals, locals)
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "game/script.rpy", line 2, in <module>
      import problem3
    File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 919, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 879, in _load_backward_compatible
    File "renpy/loader.py", line 858, in load_module
      exec(code, mod.__dict__)
      ~~~~^^^^^^^^^^^^^^^^^^^^
    File "problem3.py", line 1, in <module>
ZeroDivisionError: division by zero

Linux-6.11.0-21-generic-x86_64-with-glibc2.39 x86_64
Ren'Py 8.4.0.25042802+nightly
```

</td></tr><tr><th>8.4-this-patch</th></tr><tr><td>

```
I'm sorry, but an uncaught exception occurred.

While running game code:
  File "game/script.rpy", line 1, in script
    init python:
  File "game/script.rpy", line 2, in <module>
    import problem3
ZeroDivisionError: division by zero

-- Full Traceback ------------------------------------------------------------

Full traceback:
  File "game/script.rpy", line 1, in script
    init python:
  File "renpy/ast.py", line 1223, in execute
    renpy.python.py_exec_bytecode(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.code.bytecode,
        ^^^^^^^^^^^^^^^^^^^
        self.hide,
        ^^^^^^^^^^
        store=self.store)
        ^^^^^^^^^^^^^^^^^
  File "renpy/python.py", line 1277, in py_exec_bytecode
    exec(bytecode, globals, locals)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "game/script.rpy", line 2, in <module>
    import problem3
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 919, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 879, in _load_backward_compatible
  File "renpy/loader.py", line 858, in load_module
    exec(code, mod.__dict__)
    ~~~~^^^^^^^^^^^^^^^^^^^^
  File "problem3.py", line 1, in <module>
ZeroDivisionError: division by zero

Linux-6.11.0-21-generic-x86_64-with-glibc2.39 x86_64
Ren'Py 8.4.0.25042802+nightly
```

</td></tr></table>