### PR TITLE
Fix bidirectional paragraphs

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -1585,13 +1585,26 @@ class Layout(object):
         direction = ON
 
         l = [ ]
+        levels = [ ]
+        seg_dir = [ ]
+        seg_str = [ ]
+        curr_seg = 0
 
         for ts, s in p:
             ft_enabled = (getattr(ts, "shaper", "") != "harfbuzz")
 
-            s, direction = log2vis(str(s), ft_enabled, direction)
-            
-            l.append((ts, s))
+            s, direction, levels = log2vis(str(s), levels, ft_enabled, direction)
+            seg_dir.append(levels[0]%2)
+            seg_str.append(s[0])
+            for i in range(1, len(s)):
+                if seg_dir[curr_seg] != levels[i]%2:
+                    seg_dir.append(levels[i]%2)
+                    seg_str.append(s[i])
+                    curr_seg += 1
+                else:
+                    seg_str[curr_seg] += s[i]
+            for ss in seg_str:
+                l.append((ts, ss))
 
         rtl = (direction == RTL or direction == WRTL)
         

--- a/src/_renpybidi.pyx
+++ b/src/_renpybidi.pyx
@@ -30,7 +30,7 @@ cdef extern from "fribidi/fribidi.h":
 
 cdef extern from "renpybidicore.h":
     object renpybidi_log2vis(object, int *)
-    object renpybidi_reorder(object, int *)
+    object renpybidi_get_embedding_levels(object, int *, object)
 
 WLTR = FRIBIDI_TYPE_WL
 LTR = FRIBIDI_TYPE_LTR
@@ -39,10 +39,10 @@ RTL = FRIBIDI_TYPE_RTL
 WRTL = FRIBIDI_TYPE_WR
 
 
-def log2vis(s, shapetext=True, int direction=FRIBIDI_TYPE_ON):
+def log2vis(s, levels=[], shapetext=True, int direction=FRIBIDI_TYPE_ON):
 
     if shapetext:
         s = renpybidi_log2vis(s, &direction)
     else:
-        s = renpybidi_reorder(s, &direction)
-    return s, direction
+        s = renpybidi_get_embedding_levels(s, &direction, levels)
+    return s, direction, levels

--- a/src/renpybidicore.c
+++ b/src/renpybidicore.c
@@ -35,52 +35,36 @@ PyObject *renpybidi_log2vis(PyObject *s, int *direction) {
     return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, dstuni, size);
 }
 
-PyObject *renpybidi_reorder(PyObject *s, int *direction) {
+PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction, PyObject *seg_levels) {
     Py_ssize_t size;
     FriBidiChar *srcuni;
-    FriBidiLevel *levels;
     FriBidiCharType *types;
-    FriBidiLevel ret;
+    FriBidiLevel *levels;
 
     PyUnicode_READY(s);
     size = PyUnicode_GET_LENGTH(s);
 
     srcuni = (FriBidiChar *) alloca(size * 4);
-    levels = (FriBidiLevel *) alloca(size * 4);
     types = (FriBidiCharType *) alloca(size * 4);
+    levels = (FriBidiLevel *) alloca(size * 4);
 
     PyUnicode_AsUCS4(s, (Py_UCS4 *) srcuni, size, 0);
-
+    
     fribidi_get_bidi_types(
         srcuni,
         size,
         types);
-
-    ret = fribidi_get_par_embedding_levels_ex(
+    
+    fribidi_get_par_embedding_levels_ex(
         types,
         NULL,
         size,
         (FriBidiParType *) direction,
         levels);
-
-    if (ret == 0) {
-        return s;
-    }
-
-    ret = fribidi_reorder_line(
-        FRIBIDI_FLAG_REORDER_NSM,
-        types,
-        size,
-        0,
-        (FriBidiParType) *direction,
-        levels,
-        srcuni,
-        NULL);
-
-    if (ret == 0) {
-        return s;
-    }
-
+    
+    for (int i=0; i<size; i++)
+        PyList_Append(seg_levels, Py_BuildValue("i", (int) levels[i]));
+    
     return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, srcuni, size);
 }
 
@@ -124,53 +108,39 @@ PyObject *renpybidi_log2vis(PyObject *s, int *direction) {
     return rv;
 }
 
-PyObject *renpybidi_reorder(PyObject *s, int *direction) {
+PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction, PyObject *seg_levels) {
     Py_ssize_t size;
     FriBidiChar *srcuni;
-    FriBidiLevel *levels;
     FriBidiCharType *types;
-    PyObject *rv = s;
-    FriBidiLevel ret;
+    FriBidiLevel *levels;
+    PyObject *rv;
+
 
     Py_UNICODE *p = PyUnicode_AS_UNICODE((PyUnicodeObject *) s);
     size = PyUnicode_GET_SIZE((PyUnicodeObject *) s);
 
     srcuni = (FriBidiChar *) alloca(size * 4);
-    levels = (FriBidiLevel *) alloca(size * 4);
     types = (FriBidiCharType *) alloca(size * 4);
+    levels = (FriBidiLevel *) alloca(size * 4);
 
     for (Py_ssize_t i = 0; i < size; i++) {
         srcuni[i] = p[i];
     }
-
+    
     fribidi_get_bidi_types(
         srcuni,
         size,
         types);
-
-    ret = fribidi_get_par_embedding_levels_ex(
+    
+    fribidi_get_par_embedding_levels_ex(
         types,
         NULL,
         size,
         (FriBidiParType *) direction,
         levels);
-
-    if (ret == 0) {
-        goto done;
-    }
-
-    ret = fribidi_reorder_line(
-        FRIBIDI_FLAG_REORDER_NSM,
-        types,
-        size,
-        0,
-        (FriBidiParType) *direction,
-        levels,
-        srcuni,
-        NULL);
-
-    if (ret == 0) {
-        goto done;
+    
+    for (int i=0; i<size; i++)
+        PyList_Append(seg_levels, Py_BuildValue("i", (int) levels[i]));
 
     p = (Py_UNICODE *) alloca(size * sizeof(Py_UNICODE));
 
@@ -180,7 +150,6 @@ PyObject *renpybidi_reorder(PyObject *s, int *direction) {
 
     rv = PyUnicode_FromUnicode(p, size);
 
-done:
     return rv;
 }
 

--- a/src/renpybidicore.h
+++ b/src/renpybidicore.h
@@ -3,5 +3,5 @@
 #include <Python.h>
 
 PyObject *renpybidi_log2vis(PyObject *s, int *direction);
-PyObject *renpybidi_reorder(PyObject *s, int *direction);
+PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction, PyObject *levels);
 #endif


### PR DESCRIPTION
Addresses the issues mentioned in (https://github.com/renpy/renpy/issues/6284).
This pull request will eventually contain the following changes:
- Split paragraphs into segments based on the direction.
- Shape each segment (using harfbuzz) according to its direction
- Adjust any position advancement/offset issues that might occur

**After this pull request is finished, a full clean-up of the written code will be needed**