### PR TITLE
Adjustment in config.bottom_layers docs

### DIFF
--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -562,7 +562,7 @@ Layers
 
 .. var:: config.bottom_layers = [ "bottom", ... ]
 
-    This is a list of names of layers that are displayed above all
+    This is a list of names of layers that are displayed beneath all
     other layers, and do not participate in a transition that is
     applied to all layers. If a layer name is listed here, it should
     not be listed in :var:`config.layers`` or :var:`config.top_layers`.


### PR DESCRIPTION
The explanation for the following config variables is identical, motivating this adjustment.
- https://www.renpy.org/doc/html/config.html#var-config.bottom_layers
- https://www.renpy.org/doc/html/config.html#var-config.top_layers

This adjustment is a guess on my part, since I'm not intimately familiar with the source code and have no idea how to look it up.