### PR TITLE
Error suggestions

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -26,7 +26,7 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
-from typing import Optional, List, Callable
+from typing import Any, Optional, List, Callable
 
 
 import collections
@@ -1537,6 +1537,13 @@ lint_show_names = False
 # Should label callbacks be called for creator-defined statements?
 cds_label_callbacks = True
 
+error_suggestion_handlers: dict[type[BaseException], Callable[[Any], str | None]] = { }
+"""
+Dictonary from exception type to a function that takes an exception that
+occurred and returns a string with suggestion to add to the exception message
+or None if no suggestion is available.
+"""
+
 
 del os
 del collections
@@ -1571,6 +1578,13 @@ def init():
     gl_blend_func["multiply"] = (GL_FUNC_ADD, GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_FUNC_ADD, GL_ZERO, GL_ONE)
     gl_blend_func["min"] = (GL_MIN, GL_ONE, GL_ONE, GL_MIN, GL_ONE, GL_ONE)
     gl_blend_func["max"] = (GL_MAX, GL_ONE, GL_ONE, GL_MAX, GL_ONE, GL_ONE)
+
+    error_suggestion_handlers[AttributeError] = renpy.error.handle_attribute_error
+    error_suggestion_handlers[NameError] = renpy.error.handle_name_error
+    error_suggestion_handlers[ImportError] = renpy.error.handle_import_error
+    error_suggestion_handlers[renpy.script.LabelNotFound] = renpy.script.LabelNotFound.get_suggestion
+    error_suggestion_handlers[renpy.display.screen.ScreenNotFound] = renpy.display.screen.ScreenNotFound.get_suggestion
+    error_suggestion_handlers[renpy.display.image.ImageNotFound] = renpy.display.image.ImageNotFound.get_suggestion
 
 
 def post_init():

--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -192,7 +192,25 @@ def cache_get(screen, args, kwargs):
 
     return sc.cache
 
+
 # Screens #####################################################################
+class ScreenNotFound(LookupError):
+    """
+    Exception that is raised when a screen with given name does not exists.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(f"Screen {name!r} is not known.")
+        self.name = name
+
+    def get_suggestion(self):
+        d = list(renpy.display.screen.screens_by_name)
+
+        if self.name[:1] != '_':
+            d = [x for x in d if x[:1] != '_']
+
+        if suggestion := renpy.error.compute_closest_value(self.name, d):
+            return f" Did you mean: '{suggestion}'?"
 
 
 class Screen(renpy.object.Object):
@@ -1293,7 +1311,7 @@ def get_screen_roll_forward(screen_name):
     screen = get_screen_variant(name[0])
 
     if screen is None:
-        raise Exception("Screen %s is not known.\n" % (name[0],))
+        raise ScreenNotFound(name[0])
 
     return screen.roll_forward
 
@@ -1349,7 +1367,7 @@ def show_screen(_screen_name, *_args, **kwargs):
     screen = get_screen_variant(name[0])
 
     if screen is None:
-        raise Exception("Screen %s is not known.\n" % (name[0],))
+        raise ScreenNotFound(name[0])
 
     if _layer is None:
         _layer = get_screen_layer(name)
@@ -1496,7 +1514,7 @@ def use_screen(_screen_name, *_args, **kwargs):
     screen = get_screen_variant(name[0])
 
     if screen is None:
-        raise Exception("Screen %r is not known." % (name,))
+        raise ScreenNotFound(name[0])
 
     old_transfers = _current_screen.old_transfers
     _current_screen.old_transfers = True

--- a/renpy/error.py
+++ b/renpy/error.py
@@ -1358,10 +1358,10 @@ class TracebackException:
             self.msg = exception.msg
             self._is_syntax_error = True
 
-        else:
+        elif handlers := renpy.config.error_suggestion_handlers:
             suggestion = None
             # Reversed so that the most specific handler is called first.
-            for typ, handler in reversed(renpy.config.error_suggestion_handlers.items()):
+            for typ, handler in reversed(handlers.items()):
                 if isinstance(exception, typ):
                     if suggestion := handler(exception):
                         break

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -23,6 +23,7 @@
 # Ren'Py script.
 
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
+from typing import Any
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
 
 import renpy
@@ -77,11 +78,14 @@ class LabelNotFound(ScriptError, LookupError):
     Exception that is raised when a named node is not found.
     """
 
-    def __init__(self, label: str):
-        super().__init__(f"Label {label!r} not found.")
+    def __init__(self, label: str | tuple[Any, ...]):
+        super().__init__(f"could not find label '{label}'.")
         self.name = label
 
     def get_suggestion(self):
+        if not isinstance(self.name, str):
+            return None
+
         d = [node.name for node in renpy.game.script.namemap.values()
                         if isinstance(node.name, str)]
 
@@ -1120,7 +1124,7 @@ class Script(object):
     def lookup(self, label):
         """
         Looks up the given label in the game. If the label is not found,
-        raises a ScriptError.
+        raises a LabelNotFound.
         """
 
         if isinstance(label, renpy.parser.SubParse):
@@ -1136,10 +1140,7 @@ class Script(object):
             rv = self.namemap.get(label, None)
 
         if rv is None:
-            if isinstance(original, str):
-                raise LabelNotFound(original)
-            else:
-                raise ScriptError(f"could not find label '{original}'.")
+            raise LabelNotFound(original)
 
         return self.namemap[label]
 

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -2040,7 +2040,7 @@ class SLUse(SLNode):
                 self.constant = NOT_CONST
 
                 if renpy.config.developer:
-                    raise Exception("A screen named {} does not exist.".format(self.target))
+                    raise renpy.display.screen.ScreenNotFound(self.target)
                 else:
                     return
 
@@ -2083,7 +2083,7 @@ class SLUse(SLNode):
             target = renpy.display.screen.get_screen_variant(target_name)
 
             if target is None:
-                raise Exception("A screen named {} does not exist.".format(target_name))
+                raise renpy.display.screen.ScreenNotFound(target_name)
 
             ast = target.ast.not_const_ast
 


### PR DESCRIPTION
This PR adds error suggestions to Ren'Py error handling. This works by adding `config.error_suggestion_handlers` (is hook a better term here?) dictionary from exception type to function that takes raised exception and returns suggestion text.
Also it adds handlers for AttributeError, NameError and ImportError from Python, and Ren'Py specific handlers for unknown label names, screen names and image tags (but not attributes).