### PR TITLE
Added extra information because of dubious use of "filename" instead of "save slot"

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -796,7 +796,7 @@ def can_load(filename, test=False):
     """
     :doc: loadsave
 
-    Returns true if `filename` exists as a save slot, and False otherwise.
+    Returns true if `filename` (e.g. '3-2' for page 3, slot 2) exists as a save slot, and False otherwise.
     """
 
     accessed_slots.add(filename)


### PR DESCRIPTION
For https://www.renpy.org/doc/html/save_load_rollback.html#renpy.can_load
- Returns true if `filename` exists as a save slot, and False otherwise.
+ Returns true if `filename` (e.g. '3-2' for page 3, slot 2) exists as a save slot, and False otherwise.