### PR TITLE
Support embeded RTL when using harfbuzz as shaper

### DIFF
--- a/renpy/text/ftfont.pyx
+++ b/renpy/text/ftfont.pyx
@@ -544,7 +544,7 @@ cdef class FTFont:
         return rv
 
 
-    def glyphs(self, unicode s):
+    def glyphs(self, unicode s, int level):
         """
         Sizes s, returning a list of Glyph objects.
         """

--- a/renpy/text/hbfont.pyx
+++ b/renpy/text/hbfont.pyx
@@ -901,7 +901,7 @@ cdef class HBFont:
 
         return rv
 
-    def glyphs(self, unicode s):
+    def glyphs(self, unicode s, int level):
         """
         Sizes s, returning a list of Glyph objects.
         """
@@ -941,9 +941,15 @@ cdef class HBFont:
         hb_buffer_add_utf32(hb, <const uint32_t *> ((<const char *> utf32_s) + 4), len(s), 0, len(s));
 
         if self.vertical:
-            hb_buffer_set_direction(hb, HB_DIRECTION_TTB)
+            if level & 0x1:
+                hb_buffer_set_direction(hb, HB_DIRECTION_BTT)
+            else:
+                hb_buffer_set_direction(hb, HB_DIRECTION_TTB)
         else:
-            hb_buffer_set_direction(hb, HB_DIRECTION_LTR)
+            if level & 0x1:
+                hb_buffer_set_direction(hb, HB_DIRECTION_RTL)
+            else:
+                hb_buffer_set_direction(hb, HB_DIRECTION_LTR)
 
         hb_buffer_guess_segment_properties(hb)
         hb_buffer_set_cluster_level(hb, HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS)

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -340,7 +340,7 @@ class TextSegment(object):
 
     # From here down is the public glyph API.
 
-    def glyphs(self, s, layout):
+    def glyphs(self, s, layout, level=0):
         """
         Return the list of glyphs corresponding to unicode string s.
         """
@@ -349,7 +349,7 @@ class TextSegment(object):
             return [ ]
 
         fo = font.get_font(self.font, self.size, self.bold, self.italic, 0, self.antialias, self.vertical, self.hinting, layout.oversample, self.shaper, self.instance, self.axis, self.features)
-        rv = fo.glyphs(s)
+        rv = fo.glyphs(s, level)
 
         # Apply kerning to the glyphs.
         kerning = self.kerning + self.size / 30 * renpy.game.preferences.font_kerning

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -39,7 +39,7 @@ from renpy.text.emoji_trie import emoji, UNQUALIFIED
 
 from renpy.gl2.gl2polygon import Polygon
 
-from _renpybidi import log2vis, WRTL, RTL, ON # @UnresolvedImport
+from _renpybidi import ON, RTL, WRTL, get_embedding_levels, log2vis # @UnresolvedImport
 
 BASELINE = -65536
 
@@ -760,34 +760,20 @@ class Layout(object):
                 # segment.
                 p = self.thaic90_paragraph(p)
 
-            # RTL - apply RTL to the text of each segment, then
-            # reverse the order of the segments in each paragraph.
-            if renpy.config.rtl:
-                p, rtl = self.rtl_paragraph(p)
-            else:
-                rtl = False
-
             # 3. Convert each paragraph into a Segment, glyph list. (Store this
             # to use when we draw things.)
+            seg_glyphs, rtl = self.glyphs_paragraph(p)
 
             # A list of glyphs in the paragraph.
             par_glyphs = [ ]
 
-            # A list of (segment, list of glyph) pairs.
-            seg_glyphs = [ ]
-
-
-            for ts, s in p:
-                glyphs = ts.glyphs(s, self)
-
-                t = (ts, glyphs)
-                seg_glyphs.append(t)
+            for t in seg_glyphs:
                 par_seg_glyphs.append(t)
-                par_glyphs.extend(glyphs)
-                all_glyphs.extend(glyphs)
+                par_glyphs.extend(t[1])
+                all_glyphs.extend(t[1])
 
             # RTL - Reverse each line, segment, so that we can use LTR
-            # linebreaking algorithms.
+            # linebreaking algorithms. Also necessary for timings.
             if rtl:
                 par_glyphs.reverse()
                 seg_glyphs.reverse()
@@ -1592,29 +1578,53 @@ class Layout(object):
         return rv
 
 
-    def rtl_paragraph(self, p):
+    def glyphs_paragraph(self, p):
         """
-        Given a paragraph (a list of segment, text tuples) handles
-        RTL, and if the shaper is set to freetype, ligaturization.
-        This returns the reversed RTL paragraph, which differs
-        from the LTR one. It also returns a flag that is
-        True if this is an rtl paragraph.
+        Takes a paragraph (a list of segment, text tuples) and return a list
+        segment, glyph tuples as well as a boolen indicating if this is an RTL
+        paragraph.
         """
+
+        if not renpy.config.rtl:
+            return [(ts, ts.glyphs(s, self)) for ts, s in p], False
 
         direction = ON
-
-        l = [ ]
+        rv = []
 
         for ts, s in p:
-            ft_enabled = (getattr(ts, "shaper", "") != "harfbuzz")
+            if not isinstance(ts, TextSegment):
+                rv.append((ts, ts.glyphs(s, self)))
 
-            s, direction = log2vis(str(s), ft_enabled, direction)
+            elif ts.shaper == "harfbuzz":
+                l, direction = get_embedding_levels(str(s), direction)
+                offset = 0
 
-            l.append((ts, s))
+                if l:
+                    current = l[0]
 
-        rtl = (direction == RTL or direction == WRTL)
+                    for i, l in enumerate(l):
+                        if l == current:
+                            continue
 
-        return l, rtl
+                        rv.append((ts, ts.glyphs(s[offset:i], self, current)))
+
+                        offset = i
+                        current = l
+
+                else:
+                    l = 0
+
+                rv.append((ts, ts.glyphs(s[offset:], self, l)))
+
+            else:
+                s, direction = log2vis(str(s), direction)
+                rv.append((ts, ts.glyphs(s, self)))
+
+        if rtl := direction == RTL or direction == WRTL:
+            rv.reverse()
+
+        return rv, rtl
+
 
     def figure_outlines(self, style):
         """

--- a/src/_renpybidi.pyx
+++ b/src/_renpybidi.pyx
@@ -30,7 +30,7 @@ cdef extern from "fribidi/fribidi.h":
 
 cdef extern from "renpybidicore.h":
     object renpybidi_log2vis(object, int *)
-    object renpybidi_get_embedding_levels(object, int *, object)
+    object renpybidi_get_embedding_levels(object, int *)
 
 WLTR = FRIBIDI_TYPE_WL
 LTR = FRIBIDI_TYPE_LTR
@@ -39,10 +39,13 @@ RTL = FRIBIDI_TYPE_RTL
 WRTL = FRIBIDI_TYPE_WR
 
 
-def log2vis(s, levels=[], shapetext=True, int direction=FRIBIDI_TYPE_ON):
+def log2vis(s, int direction=FRIBIDI_TYPE_ON):
+    s = renpybidi_log2vis(s, &direction)
 
-    if shapetext:
-        s = renpybidi_log2vis(s, &direction)
-    else:
-        s = renpybidi_get_embedding_levels(s, &direction, levels)
-    return s, direction, levels
+    return s, direction
+
+
+def get_embedding_levels(s, int direction=FRIBIDI_TYPE_ON):
+    l = renpybidi_get_embedding_levels(s, &direction)
+
+    return l, direction

--- a/src/_renpybidi.pyx
+++ b/src/_renpybidi.pyx
@@ -30,7 +30,7 @@ cdef extern from "fribidi/fribidi.h":
 
 cdef extern from "renpybidicore.h":
     object renpybidi_log2vis(object, int *)
-    object renpybidi_reorder(object, int *)
+    object renpybidi_get_embedding_levels(object, int *, object)
 
 WLTR = FRIBIDI_TYPE_WL
 LTR = FRIBIDI_TYPE_LTR
@@ -39,10 +39,10 @@ RTL = FRIBIDI_TYPE_RTL
 WRTL = FRIBIDI_TYPE_WR
 
 
-def log2vis(s, shapetext=True, int direction=FRIBIDI_TYPE_ON):
+def log2vis(s, levels=[], shapetext=True, int direction=FRIBIDI_TYPE_ON):
 
     if shapetext:
         s = renpybidi_log2vis(s, &direction)
     else:
-        s = renpybidi_reorder(s, &direction)
-    return s, direction
+        s = renpybidi_get_embedding_levels(s, &direction, levels)
+    return s, direction, levels

--- a/src/renpybidicore.h
+++ b/src/renpybidicore.h
@@ -3,5 +3,5 @@
 #include <Python.h>
 
 PyObject *renpybidi_log2vis(PyObject *s, int *direction);
-PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction, PyObject *levels);
+PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction);
 #endif

--- a/src/renpybidicore.h
+++ b/src/renpybidicore.h
@@ -3,5 +3,5 @@
 #include <Python.h>
 
 PyObject *renpybidi_log2vis(PyObject *s, int *direction);
-PyObject *renpybidi_reorder(PyObject *s, int *direction);
+PyObject *renpybidi_get_embedding_levels(PyObject *s, int *direction, PyObject *levels);
 #endif


### PR DESCRIPTION
Builds on and supersedes #6313, fixes #6284.

Credit for figuring out the problem, and how to solve it goes to @TDCMC, I mostly just wrapped it in a bit of Python.

Main goals were to:
- Have RTL text in the middle of a LTR paragraph display correctly when using `harfbuzz`.
- Avoid needing to create duplicate/copy `TextSegment` objects.
- Avoid holding directionality as part of a font's state.
- Slice `str`s rather than rebuild them using per-character concatenation (`+=`).

<details><summary>Finally, here's the script I've been using to test it.</summary>

```rpy
define config.rtl = True

label start:
    "This is a \u0646\u0648\u0634\u062A\u0647 in rtl."
    "This is a \u0646\u0648\u0634\u062A\u0647 in rtl." (show_shaper='freetype')
    "\u0633\u0644\u0627\u0645 player \u0686\u0637\u0648\u0631\u06CC\u061F"
    "\u0633\u0644\u0627\u0645 player \u0686\u0637\u0648\u0631\u06CC\u061F" (show_shaper='freetype')
    "\u0645\u0646 \u0627\u0645\u0631\u0648\u0632 25 \u062A\u0627 apple \u062E\u0631\u06CC\u062F\u0645."
    "\u0645\u0646 \u0627\u0645\u0631\u0648\u0632 25 \u062A\u0627 apple \u062E\u0631\u06CC\u062F\u0645." (show_shaper='freetype')
    "I put \u06F2\u06F5 apples in my bag." 
    "I put \u06F2\u06F5 apples in my bag." (show_shaper='freetype')
    "When I type \u0644\u0627\u064B, a mark should be on the first glyph, and when I type \u0644\u064B\u0627\u064B, a mark should be on both."
    "When I type \u0644\u0627\u064B, a mark should be on the first glyph, and when I type \u0644\u064B\u0627\u064B  a mark should be on both." (show_shaper='freetype')
    return

screen say(who, what, shaper='harfbuzz'):
    style_prefix "say"

    window:
        id "window"

        window:
            id "namebox"
            style "namebox"
            text "using: [shaper]"

        text what id "what" shaper shaper
```

Examples of what some of the various lines should look like. Again, credit to @TDCMC:

![441867139-24e53398-a99c-4f24-b512-d31440b07045](https://github.com/user-attachments/assets/3b9f8e67-7561-4236-9f82-7bc782457082)
![441867765-e30459c6-3d53-4f9d-ba6c-f11b3d0553d4](https://github.com/user-attachments/assets/c88798c3-d129-47f1-8ee4-723c7b9c51bc)
![441871420-d07312d2-3e47-4dce-bdb2-f316a91fdbb4](https://github.com/user-attachments/assets/8a089d0f-f6ed-47fe-8dd5-c75dd0f015f7)
![441871534-37a3946b-07f8-4418-ba32-0da572cc3e41](https://github.com/user-attachments/assets/94183946-5dae-4e5f-a9d8-0b5f99311dd3)




</details>