### PR TITLE
Fix critical error in Live2D render.

### DIFF
--- a/renpy/gl2/live2dmodel.pyx
+++ b/renpy/gl2/live2dmodel.pyx
@@ -527,6 +527,10 @@ cdef class Live2DModel:
 
             r = raw_renders[i]
 
+            # Layer is not visible.
+            if r is None:
+                continue
+
             if self.drawable_mask_counts[i] == 1:
                 m = mask_renders[self.drawable_masks[i][0]]
 


### PR DESCRIPTION
Error was
```
  File "renpy/gl2/live2dmodel.pyx", line 559, in renpy.gl2.live2dmodel.Live2DModel.render
AttributeError: 'NoneType' object has no attribute 'add_shader'
```