### PR TITLE
Rewrite RenpyImporter to be more align with new import strategies.

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -927,6 +927,9 @@ class RenpyImporter(importlib.abc.MetaPathFinder, importlib.abc.InspectLoader):
                 is_package=module_info.is_package,
             )
 
+            if module_info.absolute_path is not None:
+                spec.has_location = True
+
             if module_info.is_namespace:
                 spec.submodule_search_locations = [filename]
 


### PR DESCRIPTION
Per #4644
This rewrities RenpyImporter to modern standarts with following changes:
1. Create only one instance of the class, and add prefixes by a method.
2. Cache modules discovery, so scanning happens only once, and during import it is cache lookups.
3. Add support for [namespace packages](https://peps.python.org/pep-0420/) even inside archives.
4. Correctly set `mod.__file__` and `mod.__spec__.origin` to absolute path when it is avaliable, but sets to relative path when actual file is in archive or apk.