### PR TITLE
Update dragdrop.py docstring

### DIFF
--- a/renpy/display/dragdrop.py
+++ b/renpy/display/dragdrop.py
@@ -103,7 +103,7 @@ class Drag(renpy.display.displayable.Displayable, renpy.revertable.RevertableObj
 
     `drag_name`
         If not None, the name of this draggable. This is available
-        as the `name` property of draggable objects. If a Drag
+        as the `drag_name` property of draggable objects. If a Drag
         with the same name is or was in the DragGroup, the starting
         position of this Drag is taken from that Draggable.
 


### PR DESCRIPTION
It says about "drag_name": "available as the `name` property of draggable objects". In fact, using `Drag.name` causes an exception. The correct property name is `drag_name`, so I believe this should be corrected.