### PR TITLE
Resolve regex library warnings

### DIFF
--- a/scripts/setuplib.py
+++ b/scripts/setuplib.py
@@ -290,9 +290,9 @@ def generate_cython(name, language, mod_coverage, split_name, fn, c_fn):
         if len(split_name) > 1:
             ccode = re.sub(r'Py_InitModule4\("([^"]+)"', 'Py_InitModule4("' + parent_module + '.\\1"', ccode) # Py2
             ccode = re.sub(r'(__pyx_moduledef.*?"){}"'.format(re.escape(split_name[-1])), '\\1' + '.'.join(split_name) + '"', ccode, count=1, flags=re.DOTALL) # Py3
-            ccode = re.sub(r'^__Pyx_PyMODINIT_FUNC init', '__Pyx_PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, 0, re.MULTILINE) # Py2 Cython 0.28+
-            ccode = re.sub(r'^__Pyx_PyMODINIT_FUNC PyInit_', '__Pyx_PyMODINIT_FUNC PyInit_' + parent_module_identifier + '_', ccode, 0, re.MULTILINE) # Py3 Cython 0.28+
-            ccode = re.sub(r'^PyMODINIT_FUNC init', 'PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, 0, re.MULTILINE) # Py2 Cython 0.25.2
+            ccode = re.sub(r'^__Pyx_PyMODINIT_FUNC init', '__Pyx_PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, count=0, flags=re.MULTILINE) # Py2 Cython 0.28+
+            ccode = re.sub(r'^__Pyx_PyMODINIT_FUNC PyInit_', '__Pyx_PyMODINIT_FUNC PyInit_' + parent_module_identifier + '_', ccode, count=0, flags=re.MULTILINE) # Py3 Cython 0.28+
+            ccode = re.sub(r'^PyMODINIT_FUNC init', 'PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, count=0, flags=re.MULTILINE) # Py2 Cython 0.25.2
 
         with open(c_fn, 'w') as f:
             f.write(ccode)


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying regex library warnings showing starting Python3.11:
```python
/tmp/renpy/scripts/setuplib.py:293: DeprecationWarning: 'count' is passed as positional argument
```