### PR TITLE
Fix testfocus position finder

### DIFF
--- a/renpy/test/testfocus.py
+++ b/renpy/test/testfocus.py
@@ -136,8 +136,8 @@ def find_position(f, position):
             if (nf.widget == f.widget) and (nf.arg == f.arg):
                 return x, y
 
-        x = random.randrange(f.x, f.x + f.w)
-        y = random.randrange(f.y, f.y + f.h)
+        x = random.randrange(f.x, int(f.x + f.w))
+        y = random.randrange(f.y, int(f.y + f.h))
 
     else:
         print()


### PR DESCRIPTION
When rotating images, the resulting widget's size might not be an integer. In such cases, the call to `random.randrange` will fail and raise an exception that will stop Ren'Py with an error code.