### PR TITLE
Raise an error when playing a video stored in game.zip

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -464,6 +464,8 @@ renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, en
 
         video_start(c);
         return;
+    } else if (c.video) {
+        throw new Error('Videos must not be stored in game.zip.');
     }
 
     const q = {


### PR DESCRIPTION
Only the "url:" scheme is supported for video playback (i.e., video files stored on a web server).

Supporting video playback from game.zip entries is probably possible by:
1. reading the whole file in memory using FS.readFile()
2. wrapping the result in a Blob
3. create an URL for it using URL.createObjectURL()
4. using that url as if we extracted it from a "url:" scheme.

But storing videos in game.zip is probably a bad practice because of the files size and the need to read the whole file in memory before being able to play it, so do we really want to support that anyway?