### PR TITLE
Fix "play movie" for Web

### DIFF
--- a/renpy/common/000statements.rpy
+++ b/renpy/common/000statements.rpy
@@ -131,6 +131,12 @@ python early hide:
 
     def predict_play_music(p):
         if renpy.emscripten or os.environ.get('RENPY_SIMULATE_DOWNLOAD', False):
+            if p["channel"] is not None:
+                channel = eval(p["channel"])
+                if channel == 'movie':
+                    # Movies cannot be preloaded
+                    return [ ]
+
             fn = _audio_eval(p["file"])
             try:
                 with renpy.loader.load(fn, directory="audio") as f:


### PR DESCRIPTION
Using the syntax `play movie "video.webm"` does not work on Web because `predict_play_music()` will download the movie file so that it will be present in the FS when `renpy.audio.audio.load()` will be called, so no `DownloadNeeded` exception will be raised and the FS path will be given to the `renpyAudio.queue()` instead of the 'url:' path, which is not supported for movies.

I'm not sure if that syntax is still valid to play a movie (it is only referenced in [the old wiki](https://www.renpy.org/wiki/renpy/doc/reference/Movies)), but it seems to be supported by other platforms at least, so better have Web support it too?