### PR TITLE
Check constness in `*` imports

### DIFF
--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -206,6 +206,19 @@ def import_from(from_module_name, in_module_name, *names):
                 else:
                     const(imported_subname)
 
+def import_all_from(from_module_name, in_module_name):
+    """
+    Called after each `from from_module import *` statement.
+    """
+    from_store = renpy.python.store_modules[from_module_name]
+
+    try:
+        names = from_store.__all__
+    except AttributeError:
+        return
+        
+    import_from(from_module_name, in_module_name, *names)
+
 class Control(object):
     """
     Represents control flow.

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -765,8 +765,6 @@ class WrapNode(ast.NodeTransformer):
             return node
 
         namespace = node.module
-        if namespace.startswith("store"):
-            namespace = namespace[6:]
 
         names = [alias.asname or alias.name for alias in node.names]
         
@@ -790,32 +788,55 @@ class WrapNode(ast.NodeTransformer):
             )
         )
 
-        # what we are importing
-        args.extend([
-            ast.Constant(name)
-            for name in names
-        ])
-
-        renpy_pyanalysis_import_from = \
-        ast.Attribute(
-            value=ast.Attribute(
-                value=ast.Name(id="renpy", ctx=ast.Load()),
-                attr="pyanalysis",
+        if names == ["*"]:
+            renpy_pyanalysis_import_all_from = \
+            ast.Attribute(
+                value=ast.Attribute(
+                    value=ast.Name(id="renpy", ctx=ast.Load()),
+                    attr="pyanalysis",
+                    ctx=ast.Load()
+                ),
+                attr="import_all_from",
                 ctx=ast.Load()
-            ),
-            attr="import_from",
-            ctx=ast.Load()
-        )
-        
-        rv.append(
-            ast.Expr(
-                value=ast.Call(
-                    func=renpy_pyanalysis_import_from,
-                    args=args,
-                    keywords=[]
+            )
+
+            rv.append(
+                ast.Expr(
+                    value=ast.Call(
+                        func=renpy_pyanalysis_import_all_from,
+                        args=args,
+                        keywords=[]
+                    )
                 )
             )
-        )
+        
+        else:
+            # what we are importing
+            args.extend([
+                ast.Constant(name)
+                for name in names
+            ])
+
+            renpy_pyanalysis_import_from = \
+            ast.Attribute(
+                value=ast.Attribute(
+                    value=ast.Name(id="renpy", ctx=ast.Load()),
+                    attr="pyanalysis",
+                    ctx=ast.Load()
+                ),
+                attr="import_from",
+                ctx=ast.Load()
+            )
+            
+            rv.append(
+                ast.Expr(
+                    value=ast.Call(
+                        func=renpy_pyanalysis_import_from,
+                        args=args,
+                        keywords=[]
+                    )
+                )
+            )
             
         return rv
 


### PR DESCRIPTION
this was discussed in #6111 as being a bad idea, but i'd argue that it's worth it for modules / frameworks that have a lot of exportable stuff

i've also made it work only for modules that define `__all__`.