### PR TITLE
tts: Allow disabling queueing via config + compat

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -323,6 +323,7 @@ init -1100 python:
 
         if _compat_versions(version, (7, 7, 1), (8, 2, 1)):
             config.fill_shrinks_frame = True
+            config.tts_queue = False
 
         if ((7, 4, 0) <= version) and _compat_versions(version, (7, 7, 99), (8, 2, 99)):
             config.window_functions_set_auto = True

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1228,6 +1228,9 @@ relative_transform_size = True
 # Should tts of layers be from front to back?
 tts_front_to_back = True
 
+# Should tts invocations be queued (default) or cancel each other out (legacy)?
+tts_queue = True
+
 # Should live2d loading be logged to log.txt
 log_live2d_loading = False
 

--- a/renpy/display/tts.py
+++ b/renpy/display/tts.py
@@ -292,6 +292,9 @@ def tts(s):
     if not renpy.game.preferences.self_voicing:
         return
 
+    if not renpy.config.tts_queue:
+        tts_queue[:] = [ ]
+
     tts_queue.append(s)
 
 
@@ -314,6 +317,10 @@ def speak(s, translate=True, force=False):
         s = renpy.translation.translate_string(s)
 
     s = apply_substitutions(s)
+
+    if not renpy.config.tts_queue:
+        tts_queue[:] = [ ]
+
     tts_queue.append(s)
 
 


### PR DESCRIPTION
ab09cd29f0797d20c3b286974888039357223e48 (8.2.2) introduced a queue for TTS texts. While this is the ideal way to handle TTS text going forward, some older games (8.0.x) have layouts which cause problems with how TTS texts get queued - f.e. texts which get queued before a screen transition and are no longer displayed but still read.

This PR adds a config flag that gets disabled for games <= 8.2.1 to fix this, and to allow developers to use the old TTS behavior if they so desire for whatever reason - f.e. because fixing their layouts shortly before release while staying on a newer RenPy version isn't as feasible.