### PR TITLE
Always wrap child render when making mesh

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -202,7 +202,6 @@ cdef class RenderTransform:
         # The reverse transform.
         self.reverse = None # type: renpy.display.render.Matrix|None
 
-
     cdef make_mesh(self, cr):
         """
         Creates a mesh from the given render.
@@ -210,13 +209,10 @@ cdef class RenderTransform:
         Handles the mesh, mesh_pad, and blur properties.
         """
 
-
         mesh = self.state.mesh
         blur = self.state.blur
-        mesh_pad = self.state.mesh_pad
 
-        if self.state.mesh_pad:
-
+        if mesh_pad := self.state.mesh_pad:
             if len(mesh_pad) == 4:
                 pad_left, pad_top, pad_right, pad_bottom = mesh_pad
             else:
@@ -224,16 +220,15 @@ cdef class RenderTransform:
                 pad_left = 0
                 pad_top = 0
 
-            padded = Render(cr.width + pad_left + pad_right, cr.height + pad_top + pad_bottom)
-            padded.blit(cr, (pad_left, pad_top))
+            pr = Render(cr.width + pad_left + pad_right, cr.height + pad_top + pad_bottom)
+            pr.blit(cr, (pad_left, pad_top))
 
         else:
             pad_left = pad_top = pad_right = pad_bottom = 0
-            padded = cr
+            pr = cr
 
-        mr = Render(cr.width + pad_left + pad_right, cr.height + pad_top + pad_bottom)
-        mr.blit(padded, (pad_left, pad_top))
-
+        mr = Render(pr.width, pr.height)
+        mr.blit(pr, (pad_left, pad_top))
 
         mr.operation = renpy.display.render.FLATTEN
         mr.add_shader("renpy.texture")
@@ -256,11 +251,11 @@ cdef class RenderTransform:
         if (blur is not None):
             mr.add_property("mipmap", True)
 
-        self.mr = mr
-        rv = self.mr
+        rv = self.mr = mr
 
         if pad_left or pad_top or pad_right or pad_bottom:
             rv = Render(mr.width - pad_left - pad_right, mr.height - pad_top - pad_bottom)
+
             if renpy.config.mesh_pad_compat:
                 rv.blit(mr, (0, 0))
             else:

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -231,7 +231,6 @@ cdef class RenderTransform:
         mr.blit(pr, (0, 0))
 
         mr.operation = renpy.display.render.FLATTEN
-        mr.add_shader("renpy.texture")
 
         if isinstance(mesh, tuple):
             mesh_width, mesh_height = mesh
@@ -244,9 +243,10 @@ cdef class RenderTransform:
             mr.mesh = True
 
         if (blur is not None) and (blur > 0):
-            mr.add_shader("-renpy.texture")
             mr.add_shader("renpy.blur")
             mr.add_uniform("u_renpy_blur_log2", math.log(blur, 2))
+        else:
+            mr.add_shader("renpy.texture")
 
         if (blur is not None):
             mr.add_property("mipmap", True)

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -237,7 +237,7 @@ cdef class RenderTransform:
 
             mr.mesh = renpy.gl2.gl2mesh2.Mesh2.texture_grid_mesh(
                 mesh_width, mesh_height,
-                0.0, 0.0, cr.width, cr.height,
+                0.0, 0.0, mr.width, mr.height,
                 0.0, 0.0, 1.0, 1.0)
         else:
             mr.mesh = True

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -228,7 +228,7 @@ cdef class RenderTransform:
             pr = cr
 
         mr = Render(pr.width, pr.height)
-        mr.blit(pr, (pad_left, pad_top))
+        mr.blit(pr, (0, 0))
 
         mr.operation = renpy.display.render.FLATTEN
         mr.add_shader("renpy.texture")

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -219,13 +219,11 @@ cdef class RenderTransform:
                 pad_right, pad_bottom = mesh_pad
                 pad_left = 0
                 pad_top = 0
-
-            pr = Render(cr.width + pad_left + pad_right, cr.height + pad_top + pad_bottom)
-            pr.blit(cr, (pad_left, pad_top))
-
         else:
             pad_left = pad_top = pad_right = pad_bottom = 0
-            pr = cr
+
+        pr = Render(cr.width + pad_left + pad_right, cr.height + pad_top + pad_bottom)
+        pr.blit(cr, (pad_left, pad_top))
 
         mr = Render(pr.width, pr.height)
         mr.blit(pr, (0, 0))


### PR DESCRIPTION
Fixes #6426, and covers a few other things I noticed while investigating.

Recommend reviewing each commit individually as it may make sense to take only some (mostly unsure about 4).

1. Tidy - Mostly just whitespace and condensed syntax.
2. Readability - Found the double offset during mesh_pad very confusing until realising the second was effectively discarded.
3. Shaders - Seemed better to simply add the necessary shaders, rather then opt-in, then out of texture shader.
4. Mesh size - Not 100% sure on this one, but if I understand correctly this ought to be the pixel size of the incoming texture.
5. Fix - Resolves the issue outlined in 6426 by always wrapping the child render in another, see notes below.

---

Putting this in draft initially as, while the fix works, I can't reconcile _why_ the additional `Render` instance makes it work.

**Observations**
1. It does appear to be mipmap related, as the following works in the prerelease:
   ```rpy
       add Transform("gui/window_icon.png", gl_mipmap=True) blur 32
   ```
2. Using `mesh_pad` (which has the side effect of forcing an additional render) also works in the prerelease:
   ```rpy
       add "gui/window_icon.png" blur 32 mesh_pad (0, 0)
   ```

The latter lead me to the fix presented, but as I say, not sure why this is the case.