### PR TITLE
focus: Fix default focus when no input events received

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -434,7 +434,9 @@ def before_interact(roots):
         max_default_focus_name = None
 
     # Should we do the max_default logic?
-    should_max_default = renpy.display.interface.input_event_time > renpy.display.interface.mouse_event_time + .1
+    input_event_time = renpy.display.interface.input_event_time
+    mouse_event_time = renpy.display.interface.mouse_event_time
+    should_max_default = input_event_time == 0 or input_event_time > mouse_event_time + .1
 
     # Is this an explicit change, using the override operation?
     explicit = False


### PR DESCRIPTION
Right now, when launching a game and not pressing any keys, not moving the mouse at all, and not pressing any buttons on any controllers, the player might see nothing highlighted on the main menu (at least in the scenarios I've been working on).

`mouse_event_time` is set on interface init (seems to be a 15 year old remnant?), while `input_event_time` is only ever set when receiving an input event. Even if `mouse_event_time` were to default to 0, the current check would result in `should_max_default = 0 > .1` thus false.

This commit changes the default behavior to treat no input as keyboard input for `should_max_default`, which makes the default focus highlighted when no input is provided at all, improving the user experience. Coincidentally, this is also how older versions of RenPy behaved.

As an aside: `old_max_default_focus_name` is currently never being assigned to and thus always `None` - presumably unintentionally, hence pointing it out here.