### PR TITLE
Allow to load persistent if tokens dir does not exists, or security keys are empty.

### DIFF
--- a/renpy/savetoken.py
+++ b/renpy/savetoken.py
@@ -184,6 +184,16 @@ def check_persistent(data: object, signatures: str) -> bool:
     This checks a persistent file to see if the token is valid.
     """
 
+    if token_dir is None:
+        return True
+
+    if not signing_keys:
+        return True
+
+    # The web sandbox should be enough.
+    if renpy.emscripten:
+        return True
+
     if should_upgrade:
         return True
 

--- a/renpy/savetoken.py
+++ b/renpy/savetoken.py
@@ -326,7 +326,7 @@ def init_tokens():
     if os.path.exists(upgraded_txt):
         with open(upgraded_txt, "r") as f:
             for line in f:
-                if line == game_name:
+                if line.strip() == game_name:
                     return
 
     should_upgrade = True


### PR DESCRIPTION
After an hour of remote debuging, I figured out that somehow our users `security_keys.txt` was empty, which was making all persistent variables to reset to default values on each load.

In second commit I added the same checks that we use for regular saves for persistent file check, so this should not happen.

But I am not sure if we want that. Maybe it is better to create new tokens if for some reason user has keys file empty.