### PR TITLE
focus: Fix focus being stolen by same old "new" max default focus

### DIFF
--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -371,6 +371,7 @@ def before_interact(roots):
     global grab
     global modal_generation
     global old_max_default
+    global old_max_default_focus_name
 
     modal_generation = 0
 
@@ -498,6 +499,8 @@ def before_interact(roots):
         explicit = True
         current = max_default_focus
         set_focused(max_default_focus, None, max_default_screen)
+
+    old_max_default_focus_name = max_default_focus_name
 
     if current is None:
         set_focused(None, None, None)


### PR DESCRIPTION
As hinted at by #6441, `old_max_default_focus_name` was never updated, causing spontaneous questionable focus switches and even blocking navigation in some scenarios. This has been effectively broken since 8.2.1 (cf3163d37be3e77ebd5e639cfaced27d78f5e7ed, the very change which introduced this).

This commit sets `old_max_default_focus_name` the same way `old_max_default` is being set.

A member of my team (thank you, Liwia!) has prepared a repro by changing The Question to match our broken scenario:
- Enable self-voicing,
- start a new game,
- and using the keyboard only, proceed to the first list of choices.
- Then try to navigate to the quick menu by pressing left / up.

With 8.2.0 or older, the player can navigate just fine.  
With cf3163d37be3e77ebd5e639cfaced27d78f5e7ed (8.2.1), the player cannot navigate to the quick menu that way.
With this fix, that works once again.

[the_question_focus_repro.zip](https://github.com/user-attachments/files/20978558/the_question_focus_repro.zip)
