### PR TITLE
Use `find_bad_reduction` in more places.

### DIFF
--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -23,7 +23,6 @@ from typing import Any, BinaryIO
 
 import types
 import pickle
-import pickletools
 import io
 import functools
 import datetime
@@ -236,6 +235,7 @@ def find_bad_reduction(**roots: object) -> str | None:
 
     return None
 
+
 def make_datetime(cls, *args, **kwargs):
     """
     Makes a datetime.date, datetime.time, or datetime.datetime object
@@ -248,6 +248,7 @@ def make_datetime(cls, *args, **kwargs):
         return cls.__new__(cls, data.decode("latin-1"))
 
     return cls.__new__(cls, *args, **kwargs)
+
 
 class Unpickler(pickle.Unpickler):
     date = functools.partial(make_datetime, datetime.date)
@@ -268,6 +269,7 @@ class Unpickler(pickle.Unpickler):
 
         return super().find_class(module, name)
 
+
 def load(f) -> Any:
     """
     Read and return an object from the pickle data stored in a file.
@@ -275,12 +277,14 @@ def load(f) -> Any:
 
     return Unpickler(f, fix_imports=True, encoding="utf-8", errors="surrogateescape").load()
 
+
 def loads(s) -> Any:
     """
     Read and return an object from the given pickle data.
     """
 
     return load(io.BytesIO(s))
+
 
 def dump(o: object, f: BinaryIO, highest=False):
     """
@@ -293,7 +297,8 @@ def dump(o: object, f: BinaryIO, highest=False):
 
     pickle.dump(o, f, pickle.HIGHEST_PROTOCOL if highest else PROTOCOL)
 
-def dumps(o: object, highest=False, optimize=False, bad_reduction_name: str | None = None) -> bytes:
+
+def dumps(o: object, highest=False, bad_reduction_name: str | None = None) -> bytes:
     """
     Return the pickled representation of the object as a bytes object.
 
@@ -301,16 +306,13 @@ def dumps(o: object, highest=False, optimize=False, bad_reduction_name: str | No
         If true, use the highest protocol version available.
         Otherwise, use the default protocol version.
 
-    `optimize`
-        If true, optimize pickle data by `pickletools.optimize()`.
-
     `report_bad_reduction`
         If true, and errors are encountered during pickle, add an exception note with
         the path to the offending object.
     """
 
     try:
-        data = pickle.dumps(o, pickle.HIGHEST_PROTOCOL if highest else PROTOCOL)
+        return pickle.dumps(o, pickle.HIGHEST_PROTOCOL if highest else PROTOCOL)
     except Exception as e:
         if bad_reduction_name is not None:
             try:
@@ -321,10 +323,6 @@ def dumps(o: object, highest=False, optimize=False, bad_reduction_name: str | No
 
         raise
 
-    if optimize:
-        data = pickletools.optimize(data)
-
-    return data
 
 # The python AST module changed significantly between python 2 and 3. Old-style
 # screenlang support records raw python ast nodes into the rpyc data, making these

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -845,9 +845,6 @@ class Script(object):
 
                 self.assign_names(stmts, renpy.lexer.elide_filename(fullfn))
 
-                # import code
-                # code.interact(local=locals())
-
                 pickle_data_before_static_transforms = pickletools.optimize(dumps(
                     (data, stmts), bad_reduction_name=f"<{fn} rpyc data>"))
 

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -22,27 +22,24 @@
 # This file contains code that is responsible for storing and executing a
 # Ren'Py script.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from typing import Any
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode # *
-
-import renpy
 
 import __future__
 import collections
+import pickletools
 import hashlib
 import os
 import difflib
 import time
-import marshal
 import struct
 import zlib
 import sys
-import pathlib
+import shutil
+
+import renpy
 
 from renpy.compat.pickle import loads, dumps
 
-import shutil
 
 # The version of the dumped script.
 script_version = renpy.script_version
@@ -108,7 +105,6 @@ def collapse_stmts(stmts):
         i.get_children(rv.append)
 
     return rv
-
 
 class Script(object):
     """
@@ -849,11 +845,16 @@ class Script(object):
 
                 self.assign_names(stmts, renpy.lexer.elide_filename(fullfn))
 
-                pickle_data_before_static_transforms = dumps((data, stmts))
+                # import code
+                # code.interact(local=locals())
+
+                pickle_data_before_static_transforms = pickletools.optimize(dumps(
+                    (data, stmts), bad_reduction_name=f"<{fn} rpyc data>"))
 
                 self.static_transforms(stmts)
 
-                pickle_data_after_static_transforms = dumps((data, stmts))
+                pickle_data_after_static_transforms = pickletools.optimize(dumps(
+                    (data, stmts), bad_reduction_name=f"<{fn} transformed rpyc data>"))
 
                 if not renpy.macapp:
                     try:


### PR DESCRIPTION
This PR makes following changes:
1. Fixes the issue with `find_bad_reduce` reporting modules as being source of error when actual source is something unpickable at different path.
2. Adds checks for keys of mappings.
3. Adds check for `(slots, state)` case in `__reduce__`.
5. Adds error message as exception note instead of mutating args.
6. Adds bad reduction check for persistent and multipersistent pickle and deepcopy.
7. Adds bad reduction check for script AST pickle.
8. Applies [pickletools.optimize](https://docs.python.org/3/library/pickletools.html#pickletools.optimize) for rpyc data, saving ~15000 bytes to write and marginally speeds up reading of rpyc.