### PR TITLE
Several fixes for CDS init logic.

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2273,14 +2273,27 @@ class UserStatement(Node):
     def execute_init(self):
         self.call("execute_init")
 
-        if renpy.statements.get("init", self.parsed):
-            self.init_priority = 1
-
         if renpy.statements.get("execute_default", self.parsed):
             default_statements.append(self)
 
     def get_init(self):
-        return self.init_priority
+        is_init = renpy.statements.get("init", self.parsed)
+        # Statement has no init logic, skip it.
+        if not (
+            is_init or
+            renpy.statements.get("execute_init", self.parsed) or
+            renpy.statements.get("execute_default", self.parsed)
+        ):
+            return None
+
+        init_priority = renpy.statements.get("init_priority", self.parsed)
+
+        # In older versions without init_priority, init-time statements had priority 1.
+        if not init_priority and is_init:
+            init_priority = 1
+
+        # Statement init priority and init offset.
+        return init_priority + self.init_priority
 
     def execute(self):
         next_node(self.get_next())

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2201,7 +2201,7 @@ class UserStatement(Node):
     translation_relevant: bool = False # type: ignore
     rollback: RollbackType = "normal"
     subparses: list['renpy.lexer.SubParse'] = [ ]
-    init_priority: SignedInt = 0
+    init_priority: SignedInt | None = 0
     atl: 'renpy.atl.RawBlock | None' = None
 
     def __init__(self, loc, line, block, parsed):
@@ -2277,19 +2277,14 @@ class UserStatement(Node):
             default_statements.append(self)
 
     def get_init(self):
-        is_init = renpy.statements.get("init", self.parsed)
-        # Statement has no init logic, skip it.
-        if not (
-            is_init or
-            renpy.statements.get("execute_init", self.parsed) or
-            renpy.statements.get("execute_default", self.parsed)
-        ):
+        if self.init_priority is None:
             return None
 
+        is_init = renpy.statements.get("init", self.parsed)
         init_priority = renpy.statements.get("init_priority", self.parsed)
 
         # In older versions without init_priority, init-time statements had priority 1.
-        if not init_priority and is_init:
+        if is_init and not init_priority:
             init_priority = 1
 
         # Statement init priority and init offset.

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -265,6 +265,7 @@ def register(
         predict_next=predict_next,
         execute_default=execute_default,
         reachable=reachable,
+        init_priority=init_priority,
     )
 
     if block not in [True, False, "script", "script-possible", "atl", "atl-possible", "possible" ]:
@@ -318,7 +319,7 @@ def register(
             rv.code_block = code_block
             rv.atl = atl
             rv.subparses = l.subparses
-            rv.init_priority = init_priority + l.init_offset
+            rv.init_priority = l.init_offset
 
         finally:
             l.subparses = old_subparses
@@ -327,9 +328,6 @@ def register(
         if (post_execute is not None) or (post_label is not None):
             post = renpy.ast.PostUserStatement(loc, rv)
             rv = [ rv, post ]
-
-        if init and not l.init:
-            rv = renpy.ast.Init(loc, [rv], init_priority + l.init_offset)
 
         return rv
 

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -329,6 +329,12 @@ def register(
             post = renpy.ast.PostUserStatement(loc, rv)
             rv = [ rv, post ]
 
+        if init and not l.init:
+            if not isinstance(rv, list):
+                rv = [rv]
+
+            rv = renpy.ast.Init(loc, rv, init_priority + l.init_offset)
+
         return rv
 
     renpy.parser.statements.add(name, parse_user_statement)

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -319,7 +319,11 @@ def register(
             rv.code_block = code_block
             rv.atl = atl
             rv.subparses = l.subparses
-            rv.init_priority = l.init_offset
+
+            if init or execute_init or execute_default:
+                rv.init_priority = l.init_offset
+            else:
+                rv.init_priority = None
 
         finally:
             l.subparses = old_subparses


### PR DESCRIPTION
1. Store `init_priority` of the statement in registry instead of node itself, so changing it does not require recompilation.
2. If statement does not need to run its `execute_init`, do not include it into initlist.