### PR TITLE
Avoid processing UserStatements with no init at init time

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -2201,7 +2201,7 @@ class UserStatement(Node):
     translation_relevant: bool = False # type: ignore
     rollback: RollbackType = "normal"
     subparses: list['renpy.lexer.SubParse'] = [ ]
-    init_priority: SignedInt = 0
+    init_priority: 'SignedInt | None' = 0
     atl: 'renpy.atl.RawBlock | None' = None
 
     def __init__(self, loc, line, block, parsed):

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -318,7 +318,11 @@ def register(
             rv.code_block = code_block
             rv.atl = atl
             rv.subparses = l.subparses
-            rv.init_priority = init_priority + l.init_offset
+
+            if init or execute_init:
+                rv.init_priority = init_priority + l.init_offset
+            else:
+                rv.init_priority = None
 
         finally:
             l.subparses = old_subparses


### PR DESCRIPTION
By returning `None` instead of `0` from initless `UserStatement.get_init` the statements are no longer included in `renpy.script.initcode`.
https://github.com/renpy/renpy/blob/0cdb3a576913f69c4706e59f01864129ecdd066f/renpy/script.py#L686-L687

This reduced the `initcode` list by around 80% in a test game (just under 4k down to 800 and change), I suspect mostly due to `pause` and various sound management statements.