### PR TITLE
Introduce a version attribute to UserStatement

### DIFF
--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -319,9 +319,9 @@ def register(
             rv.subparses = l.subparses
 
             if execute_init or execute_default:
-                rv.init_offset = l.init_offset
+                rv.init_priority = l.init_offset
             else:
-                rv.init_offset = None
+                rv.init_priority = None
 
         finally:
             l.subparses = old_subparses


### PR DESCRIPTION
A new approach to managing changes in the UserStatement object, seeking to provide a more understandable approach to compat management both now, and for any future iterations.

- Repurpose `UserStatement.init_priority` to hold `init_offset` to avoid a new attribute or rendering this one dead weight.
- Add a `UserStatement.version` attribute to manage this and any future alterations to the object.
- Support redefinition of the default of `UserStatement.init_priority`, via the new `version` attribute.