### PR TITLE
Add UnoptimizedTexture._repr_info

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -2067,6 +2067,9 @@ class UnoptimizedTexture(ImageBase):
         self.image = im
 
         self.const_size = im.const_size
+        
+    def _repr_info(self):
+        return repr(self.image)
 
     def get_hash(self):
         return self.image.get_hash()


### PR DESCRIPTION
Mostly to get a better output while debugging image cache.