### PR TITLE
Ensure styles are rebuilt in gui.SetPreference

### DIFF
--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -131,9 +131,8 @@ init -1150 python in gui:
         for i in config.translate_clean_stores:
             renpy.python.clean_store_backup.backup_one("store." + i)
 
-        # Do the same sort of reset we'd do when changing language, without
-        # actually changing the language.
-        renpy.change_language(_preferences.language, force=True)
+        renpy.style.rebuild()
+        renpy.exports.restart_interaction()
 
     not_set = object()
 


### PR DESCRIPTION
Fixes #6491

Previously used a no-op `change_language` to rebuild styles. This is no longer reliable as rebuilds are now only done when the language changes. Resolve this by using the style rebuild function directly.