### PR TITLE
Remove duplicated header in launcher

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -108,7 +108,6 @@ screen front_page_project_list:
     vbox:
 
         if projects:
-            text "Projects"
             for p in projects:
 
                 textbutton ("[p.display_name]" if p.display_name else "[p.name!q]"):


### PR DESCRIPTION
Removes the superfluous secondary "Projects" header, and as a side effects gives more space to the projects list.

`                     before                      ` | `                       after                     `
-|-


<img width="676" height="370" alt="Screenshot from 2025-07-14 16-37-25" src="https://github.com/user-attachments/assets/493d06e7-5f97-4863-8653-63aa731c7b1e" /><br/>


Had a quick look to make sure it doesn't end up weird when folders are used, and it looks fine since top-level projects are always listed first.