### PR TITLE
Ensure mipmap property gets set for videos on web

### DIFF
--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -310,7 +310,9 @@ cdef class GLTexture(GL2Model):
                 0.0, 0.0, width, height,
                 0.0, 0.0, 1.0, 1.0,
                 )
-            self.properties = { }
+            self.properties = {
+                "mipmap" : self.should_have_mipmaps({}),
+                }
 
     def should_have_mipmaps(GLTexture self, properties):
         """


### PR DESCRIPTION
Untested, speculative fix for #6499.

Reasoning is that this appears to be the only path whereby `self.properties` will not have the `mipmap` key set explicitly, and the code path conditional and comment (shown below) lines up with the report stating that it occurred while attempting to play movies in the web build:

https://github.com/renpy/renpy/blob/54485f25271b321093370db2c8d55234c9dfb050/renpy/gl2/gl2texture.pyx#L303-L304

<br/>I don't love the empty literal dict pass and resulting no-op lookup, but it seemed like the lesser evil given that `should_have_mipmaps` has the centralised logic to not only pull the `config` but also resolve `"auto"`.