### PR TITLE
Use LOD bias uniform when provided

### DIFF
--- a/renpy/gl2/gl2uniform.pyx
+++ b/renpy/gl2/gl2uniform.pyx
@@ -442,7 +442,7 @@ cdef class ModelSizeGetter(Getter):
 
 cdef class LODBiasGetter(Getter):
     cdef object get(self, GL2DrawingContext context, GL2Model model):
-        return float(renpy.config.gl_lod_bias)
+        return context.uniforms.get(self.uniform_name, float(renpy.config.gl_lod_bias))
 
 
 cdef class TimeGetter(Getter):


### PR DESCRIPTION
Fixes #6501.

Assumes that `u_lod_bias` is intended to be creator manageable (based on its absence from [`standard_uniforms`](https://github.com/renpy/renpy/blob/ec00ca208f8c2d7915ddcc2da91b3c235e10dde3/renpy/gl2/gl2draw.pyx#L1790-L1791)). If that assumption is invalid then a custom shader for use solely with the `pixelate` transition could be created using a differently named uniform to ameliorate 6501, as that transition is the only use in Ren'Py proper which requires this uniform be overridden.

This change prefers a `u_lod_bias` value set by `add_uniform`, but will fall back to the global default if none is provided.