### PR TITLE
Refactor change language into a linear sequence

### DIFF
--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -131,19 +131,7 @@ init -1150 python in gui:
         for i in config.translate_clean_stores:
             renpy.python.clean_store_backup.backup_one("store." + i)
 
-        # Similar process to that used in renpy.change_language, devoid
-        # of any specific language-change related activities.
-
-        renpy.style.restore(renpy.translation.style_backup)
-        renpy.style.rebuild(False)
-
-        for i in renpy.translation.deferred_styles:
-            i.apply()
-
-        renpy.config.init_system_styles()
-
         renpy.style.rebuild()
-
         renpy.exports.restart_interaction()
 
     not_set = object()

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -133,7 +133,7 @@ init -1150 python in gui:
 
         # Do the same sort of reset we'd do when changing language, without
         # actually changing the language.
-        renpy.change_language(_preferences.language, force=True)
+        renpy.change_language(_preferences.language, force='style')
 
     not_set = object()
 

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -131,8 +131,9 @@ init -1150 python in gui:
         for i in config.translate_clean_stores:
             renpy.python.clean_store_backup.backup_one("store." + i)
 
-        renpy.style.rebuild()
-        renpy.exports.restart_interaction()
+        # Do the same sort of reset we'd do when changing language, without
+        # actually changing the language.
+        renpy.change_language(_preferences.language, force=True)
 
     not_set = object()
 

--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -108,10 +108,13 @@ init -1150 python in gui:
 
         return f
 
-    def _apply_rebuild():
+    def rebuild():
         """
-        Called by renpy.translation.change_language to rebuild the gui
-        when the language changes.
+        :doc: gui
+
+        Rebuilds the GUI.
+
+        Note: This is a very slow function.
         """
 
         global variant_functions
@@ -125,16 +128,22 @@ init -1150 python in gui:
             if renpy.variant(variant):
                 f()
 
-    def rebuild():
-        """
-        :doc: gui
+        for i in config.translate_clean_stores:
+            renpy.python.clean_store_backup.backup_one("store." + i)
 
-        Rebuilds the GUI.
+        # Similar process to that used in renpy.change_language, devoid
+        # of any specific language-change related activities.
 
-        Note: This is a very slow function.
-        """
+        renpy.style.restore(renpy.translation.style_backup)
+        renpy.style.rebuild(False)
 
-        renpy.translation.change_language(_preferences.language, force=True, rebuild=True)
+        for i in renpy.translation.deferred_styles:
+            i.apply()
+
+        renpy.config.init_system_styles()
+
+        renpy.style.rebuild()
+
         renpy.exports.restart_interaction()
 
     not_set = object()

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -21,7 +21,7 @@
 
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
-from typing import Callable
+
 
 import renpy
 
@@ -429,7 +429,6 @@ class Restructurer(object):
         for i in children:
             if isinstance(i, renpy.ast.Label):
                 if not i.hide:
-                    assert isinstance(i.name, str)
                     if i.name.startswith("_"):
                         self.alternate = i.name
                     else:
@@ -761,19 +760,12 @@ def clean_data():
     renpy.game.log.forward = []
 
 
-def change_language(language, force: bool = False, rebuild: bool = False):
+def change_language(language, force=False):
     """
     :doc: translation_functions
 
     Changes the current language to `language`, which can be a string or
     None to use the default language.
-
-    `force`
-        If true, ensure the Python code is re-executed even if the language
-        hasn't changed.
-
-    `rebuild`
-        This forces the styles to be rebuild in all cases.
     """
 
     global old_language
@@ -782,9 +774,6 @@ def change_language(language, force: bool = False, rebuild: bool = False):
 
     renpy.game.preferences.language = language
     changed = language != old_language
-
-    if rebuild:
-        changed = True
 
     if not changed and not force:
         return
@@ -821,8 +810,6 @@ def change_language(language, force: bool = False, rebuild: bool = False):
     for i in renpy.config.translate_clean_stores:
         renpy.python.clean_store(i)
 
-    renpy.store.gui._apply_rebuild()
-
     if renpy.config.new_translate_order:
         new_change_language(tl, language, changed)
     else:
@@ -848,6 +835,7 @@ def change_language(language, force: bool = False, rebuild: bool = False):
         renpy.exports.block_rollback()
 
     old_language = language
+
 
 
 def check_language():


### PR DESCRIPTION
Seeks to resolve #6504.

Currently a first pass at getting us back to a stable base for `change_language`. Good chance this is not it's "final form" but this presentation should make it easier to view and reason about the code path as a whole, along with the various subpaths it needs to support. The hope is that it sets us in good stead for continuing this refactor now or in future should we decide it needs further clean up or optimisation.

Currently the old and new change language order code has been rolled into the main function, this seemed worth doing while seeking to understand and review the whole pipeline, but may make sense to factor out again later.

I've done some cursory testing already involving reloads, end-of-game rollover (back to main menu), save/load cycles, language changes, gui preference changes, and various combinations of these together. So far everything appears to function as it should, but with there being so many edge cases it's possible there are still some out there so I'll be continuing to test.