### PR TITLE
Only consider top and bottom in AlphaBlend compat

### DIFF
--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -685,8 +685,8 @@ class AlphaDissolve(Transition):
         top = render(self.new_widget, width, height, st, at)
 
         if renpy.config.dissolve_shrinks:
-            width = min(bottom.width, top.width, image.width)
-            height = min(bottom.height, top.height, image.height)
+            width = min(bottom.width, top.width)
+            height = min(bottom.height, top.height)
         else:
             width = max(bottom.width, top.width)
             height = max(bottom.height, top.height)


### PR DESCRIPTION
Resolves issue found during investigation of #6508.

Previously it would crash as `image` was not defined, now it correctly mirrors the other side of the conditional, only considering `top` and `bottom`.