### PR TITLE
Only try to resume audio context if interrupted (fix devtools crash)

### DIFF
--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -598,8 +598,8 @@ renpyAudio.queue_depth = (channel) => {
     let rv = 0;
     let c = get_channel(channel);
 
-    // Try to resume the audio context if it's not running.
-    if (context.state != "running") {
+    // Try to resume the audio context if it's been interrupted (iOS Safari feature)
+    if (context.state === "interrupted") {
         context.resume();
     }
 


### PR DESCRIPTION
When the game has just been loaded, the audio context is suspended by Web browsers until the user interacts with the game. Trying to resume the context before this interaction triggers a warning message in the console on Chrome (at least) for every single attempt. Because queue_depth() is called very frequently, this warning message appears a lot in the console which makes it crash on Chrome (it closes automatically). That's really annoying, especially when trying to debug something that happens soon after the game has loaded.

<img width="1450" height="751" alt="image" src="https://github.com/user-attachments/assets/85a84b3a-b333-4e70-a1c6-c1b3e0634ef3" />


The message from 5db965a7093333a5ae0ea4e434af908483a801c4 indicates the intent is to resume the context if it has been interrupted by Safari on iOS. In this case, the context state will be set to "interrupted", so better use that to check if it needs to be resumed and prevent the devtools crash.