### PR TITLE
Fix scriptedit line metadata

### DIFF
--- a/renpy/add_from.py
+++ b/renpy/add_from.py
@@ -81,8 +81,8 @@ def process_file(fn):
     edits = missing[fn]
     edits.sort()
 
-    with open(fn, "rb") as f:
-        data = f.read().decode("utf-8")
+    with open(fn, "r", encoding="utf-8") as f:
+        data = f.read()
 
     # How much of the input has been consumed.
     consumed = 0
@@ -103,8 +103,8 @@ def process_file(fn):
 
     output += data[consumed:]
 
-    with open(fn + ".new", "wb") as f:
-        f.write(output.encode("utf-8"))
+    with open(fn + ".new", "w", encoding="utf-8") as f:
+        f.write(output)
 
     try:
         os.unlink(fn + ".bak")

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -583,45 +583,11 @@ def list_logical_lines(
 
     # Add scriptedit lines if requested.
     if add_lines:
-        offsets = []
-
-        if filedata is None:
-            # Calculate positional offsets for CR characters that Python
-            # has ignored during the code read, but that we need to know
-            # about for editing purposes.
-
-            with open(original_filename, "r", encoding="utf-8", newline="") as f:
-                raw_data = f.read()
-
-            if filename.endswith("_ren.py"):
-                raw_data = ren_py_to_rpy(raw_data, filename)
-
-            raw_data += "\n\n"
-
-            # No need to do this unless we notice missing characters.
-            if len_data < len(raw_data):
-                data = raw_data
-
-                count = 0
-
-                for c in data:
-                    if c == "\r":
-                        count += 1
-                    else:
-                        offsets.append(count)
-
         lines = renpy.scriptedit.lines
         for _, number, start, end in rv:
-            if offsets:
-                start += offsets[start]
-                end += offsets[end]
-
             l = renpy.scriptedit.Line(original_filename, number, start)
 
             l.end_delim = end + 1
-
-            if data[end - 1] == "\r":
-                end -= 1
 
             while data[end - 1] == " ":
                 end -= 1


### PR DESCRIPTION
Reverts the original solution to #6364 (#6399, which caused #6503) in favour of a much simpler solution now that the issue is better understood.

Problem:
- The `add_from` feature was accessing script files in binary mode and manually decoding, allowing it to see `\r` characters.
- The original fix was to adjust offsets for `\r` characters when creating data for use with `scriptedit`, data `add_from` needed.
- That in turn caused 6503, as `scriptedit` proper expects to operate with `\r` characters abstracted away.
- The mismatch between `scriptedit` and `add_from` meant that fixing one always broke the other.

Solution:
- Pull out the original fix which mangled character offsets, leave it `\r`-agnostic.
- This fixes 6503, allowing `scriptedit` to once again function normally.
- Change `add_from` to access script files in `\r`-agnostic mode, so the `scriptedit` offset match what it operates on.

---

**tl;dr**: Use Python's default line-end agnostic text file access everywhere for script files.

```diff
-    # bad - not line-end agnostic
-    with open(fn, "rb") as f:
-        data = f.read().decode("utf-8")

+    # good - line-end agnostic
+    with open(fn, "r", encoding="utf-8") as f:
+        data = f.read()
```