### PR TITLE
Check for flatpak install when launching VSCode(System) on Linux

### DIFF
--- a/launcher/Visual Studio Code (System).edit.py
+++ b/launcher/Visual Studio Code (System).edit.py
@@ -75,6 +75,17 @@ class Editor(renpy.editor.Editor):
         if renpy.windows:
             CREATE_NO_WINDOW = 0x08000000
             subprocess.Popen(args, creationflags=CREATE_NO_WINDOW)
+        elif renpy.linux and self.system:
+            try:
+                subprocess.Popen(args)
+            except FileNotFoundError as missingvscode:
+                flatpak_code = [ "flatpak", "run", "com.visualstudio.code" ]
+                flatpak_args = flatpak_code + [ "-g" ] + self.args
+                flatpak_args = [ renpy.exports.fsencode(i) for i in flatpak_args ]
+                try:
+                    subprocess.Popen(flatpak_args)
+                except
+                    raise missingvscode
         else:
             subprocess.Popen(args)
 


### PR DESCRIPTION
Like many users my Visual Studio Code is installed using flatpak, I have added a check for visual studio installed via flatpak, it can get some improvements, but this version should allow flatpak users to enjoy Ren'py and save space and data.

The idea I have implemented is:
When the launcher cannot find ```code``` in the path, retry using flatpak, if flatpak is not found, raise the original exception.