### PR TITLE
Ensure _in_current_store call in transformed layer

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -675,10 +675,7 @@ class MultiBox(Container):
         self.scene_list = None
 
     def _in_current_store(self):
-        if self.layer_name is not None:
-            if self.scene_list is None:
-                return self
-
+        if self.scene_list is not None:
             scene_list = []
 
             changed = False
@@ -729,7 +726,7 @@ class MultiBox(Container):
                 return self
 
         else:
-            return super(MultiBox, self)._in_current_store()
+            return super()._in_current_store()
 
         if self.offsets:
             rv.offsets = list(self.offsets)


### PR DESCRIPTION
Fixes #6534.

This is a very basic fix. I don't know it this path would benefit from either of the following:
- ~~A short circuit to return `self` if `not self.children`.~~
- Combining
   https://github.com/renpy/renpy/blob/99456f2f26e89799e86eaf93796bf9403e7e5562/renpy/display/layout.py#L678-L679
   into
   ```py
       if self.layer_name is not None and self.scene_list is not None:
   ```
   such that it can fallback to the else clause (passing `elif self.layers`) which already does the right thing:
   https://github.com/renpy/renpy/blob/99456f2f26e89799e86eaf93796bf9403e7e5562/renpy/display/layout.py#L731-L732
   <br/>Also checked other instances of `return self` and all appear to correctly check for changes beforehand.