### PR TITLE
gl2: Set correct type requirement for u_viewport

### DIFF
--- a/renpy/gl2/gl2uniform.pyx
+++ b/renpy/gl2/gl2uniform.pyx
@@ -631,7 +631,7 @@ UNIFORM_GETTER_CLASSES = {
     "u_lod_bias": (LODBiasGetter, "float"),
     "u_time": (TimeGetter, "float"),
     "u_random": (RandomGetter, "vec4"),
-    "u_viewport": (ViewportGetter, "vec2"),
+    "u_viewport": (ViewportGetter, "vec4"),
     "u_drawable_size": (DrawableSizeGetter, "vec2"),
     "u_virtual_size": (VirtualSizeGetter, "vec2"),
     "tex0" : (Tex0Getter, "sampler2D"),


### PR DESCRIPTION
Fixes #6566

Haven't done a recompile check, but the fix seems obvious enough, appears to be a copy-paste oversight from uniform handling changes in 8.4. The `ViewportGetter` already appears to produce the expected `vec4`.