### PR TITLE
Fix internal image font API

### DIFF
--- a/renpy/text/font.py
+++ b/renpy/text/font.py
@@ -99,7 +99,7 @@ class ImageFont(object):
     # chars - A map from a character to the surface containing that character.
     chars = {}  # type: dict[str, pygame.surface.Surface]
 
-    def glyphs(self, s):
+    def glyphs(self, s, level):
         rv = []
 
         if not s:


### PR DESCRIPTION
Fixes #5830.

Signature of the glyphs function changed in May but was missed in the ImageFont implementation.