### PR TITLE
Add support for the Inochi2D SDK

### DIFF
--- a/renpy/gl2/inochi2d.pxi
+++ b/renpy/gl2/inochi2d.pxi
@@ -1,0 +1,232 @@
+
+from libc.stdint cimport uint8_t, uint32_t
+
+# Basic Functions
+ctypedef void* (__cdecl *in_retain_t)()
+cdef in_retain_t in_retain
+ctypedef void* (__cdecl *in_release_t)(void*)
+cdef in_release_t in_release
+ctypedef const char *(__cdecl *in_get_last_error_t)()
+cdef in_get_last_error_t in_get_last_error
+
+# Puppet
+ctypedef in_puppet_t* (__cdecl *in_puppet_load_t)(const char *file)
+cdef in_puppet_load_t in_puppet_load
+ctypedef in_puppet_t* (__cdecl *in_puppet_load_from_memory_t)(const uint8_t* data, uint32_t length)
+cdef in_puppet_load_from_memory_t in_puppet_load_from_memory
+ctypedef void (__cdecl *in_puppet_free_t)(in_puppet_t* obj)
+cdef in_puppet_free_t in_puppet_free
+ctypedef const char* (__cdecl *in_puppet_get_name_t)(in_puppet_t* obj)
+cdef in_puppet_get_name_t in_puppet_get_name
+ctypedef bint (__cdecl *in_puppet_get_physics_enabled_t)(in_puppet_t* obj)
+cdef in_puppet_get_physics_enabled_t in_puppet_get_physics_enabled
+ctypedef void (__cdecl *in_puppet_set_physics_enabled_t)(in_puppet_t* obj, bint value)
+cdef in_puppet_set_physics_enabled_t in_puppet_set_physics_enabled
+ctypedef float (__cdecl *in_puppet_get_pixels_per_meter_t)(in_puppet_t* obj)
+cdef in_puppet_get_pixels_per_meter_t in_puppet_get_pixels_per_meter
+ctypedef void (__cdecl *in_puppet_set_pixels_per_meter_t)(in_puppet_t* obj, float value)
+cdef in_puppet_set_pixels_per_meter_t in_puppet_set_pixels_per_meter
+ctypedef float (__cdecl *in_puppet_get_gravity_t)(in_puppet_t* obj)
+cdef in_puppet_get_gravity_t in_puppet_get_gravity
+ctypedef void (__cdecl *in_puppet_set_gravity_t)(in_puppet_t* obj, float value)
+cdef in_puppet_set_gravity_t in_puppet_set_gravity
+ctypedef void (__cdecl *in_puppet_update_t)(in_puppet_t* obj, float delta)
+cdef in_puppet_update_t in_puppet_update
+ctypedef void (__cdecl *in_puppet_draw_t)(in_puppet_t* obj, float delta)
+cdef in_puppet_draw_t in_puppet_draw
+ctypedef void (__cdecl *in_puppet_reset_drivers_t)(in_puppet_t* obj)
+cdef in_puppet_reset_drivers_t in_puppet_reset_drivers
+ctypedef in_texture_cache_t* (__cdecl *in_puppet_get_texture_cache_t)(in_puppet_t* obj)
+cdef in_puppet_get_texture_cache_t in_puppet_get_texture_cache
+ctypedef in_parameter_t** (__cdecl *in_puppet_get_parameters_t)(in_puppet_t* obj, uint32_t* count)
+cdef in_puppet_get_parameters_t in_puppet_get_parameters
+ctypedef in_drawlist_t* (__cdecl *in_puppet_get_drawlist_t)(in_puppet_t* obj)
+cdef in_puppet_get_drawlist_t in_puppet_get_drawlist
+
+# Parameter
+ctypedef const char* (__cdecl *in_parameter_get_name_t)(in_parameter_t* obj)
+cdef in_parameter_get_name_t in_parameter_get_name
+ctypedef bint (__cdecl *in_parameter_get_active_t)(in_parameter_t* obj)
+cdef in_parameter_get_active_t in_parameter_get_active
+ctypedef uint32_t (__cdecl *in_parameter_get_dimensions_t)(in_parameter_t* obj)
+cdef in_parameter_get_dimensions_t in_parameter_get_dimensions
+ctypedef in_vec2_t (__cdecl *in_parameter_get_min_value_t)(in_parameter_t* obj)
+cdef in_parameter_get_min_value_t in_parameter_get_min_value
+ctypedef in_vec2_t (__cdecl *in_parameter_get_max_value_t)(in_parameter_t* obj)
+cdef in_parameter_get_max_value_t in_parameter_get_max_value
+ctypedef in_vec2_t (__cdecl *in_parameter_get_value_t)(in_parameter_t* obj)
+cdef in_parameter_get_value_t in_parameter_get_value
+ctypedef void (__cdecl *in_parameter_set_value_t)(in_parameter_t* obj, in_vec2_t value)
+cdef in_parameter_set_value_t in_parameter_set_value
+ctypedef in_vec2_t (__cdecl *in_parameter_get_normalized_value_t)(in_parameter_t* obj)
+cdef in_parameter_get_normalized_value_t in_parameter_get_normalized_value
+ctypedef void (__cdecl *in_parameter_set_normalized_value_t)(in_parameter_t* obj, in_vec2_t value)
+cdef in_parameter_set_normalized_value_t in_parameter_set_normalized_value
+
+# Texture Cache
+ctypedef uint32_t (__cdecl *in_texture_cache_get_size_t)(in_texture_cache_t* obj)
+cdef in_texture_cache_get_size_t in_texture_cache_get_size
+ctypedef in_texture_t* (__cdecl *in_texture_cache_get_texture_t)(in_texture_cache_t* obj, uint32_t slot)
+cdef in_texture_cache_get_texture_t in_texture_cache_get_texture
+ctypedef in_texture_t** (__cdecl *in_texture_cache_get_textures_t)(in_texture_cache_t* obj, uint32_t* count)
+cdef in_texture_cache_get_textures_t in_texture_cache_get_textures
+ctypedef void (__cdecl *in_texture_cache_prune_t)(in_texture_cache_t* obj)
+cdef in_texture_cache_prune_t in_texture_cache_prune
+
+# Resources
+ctypedef uint32_t (__cdecl *in_resource_get_length_t)(in_resource_t* obj)
+cdef in_resource_get_length_t in_resource_get_length
+ctypedef void* (__cdecl *in_resource_get_id_t)(in_resource_t* obj)
+cdef in_resource_get_id_t in_resource_get_id
+ctypedef void (__cdecl *in_resource_set_id_t)(in_resource_t* obj, void* value)
+cdef in_resource_set_id_t in_resource_set_id
+
+# Textures
+ctypedef in_texture_t* (__cdecl *in_texture_from_resource_t)(in_resource_t* obj)
+cdef in_texture_from_resource_t in_texture_from_resource
+ctypedef uint32_t (__cdecl *in_texture_get_width_t)(in_texture_t* obj)
+cdef in_texture_get_width_t in_texture_get_width
+ctypedef uint32_t (__cdecl *in_texture_get_height_t)(in_texture_t* obj)
+cdef in_texture_get_height_t in_texture_get_height
+ctypedef uint32_t (__cdecl *in_texture_get_channels_t)(in_texture_t* obj)
+cdef in_texture_get_channels_t in_texture_get_channels
+ctypedef void (__cdecl *in_texture_flip_vertically_t)(in_texture_t* obj)
+cdef in_texture_flip_vertically_t in_texture_flip_vertically
+ctypedef void (__cdecl *in_texture_premultiply_t)(in_texture_t* obj)
+cdef in_texture_premultiply_t in_texture_premultiply
+ctypedef void (__cdecl *in_texture_unpremultiply_t)(in_texture_t* obj)
+cdef in_texture_unpremultiply_t in_texture_unpremultiply
+ctypedef void (__cdecl *in_texture_pad_t)(in_texture_t* obj, uint32_t thickness)
+cdef in_texture_pad_t in_texture_pad
+ctypedef void* (__cdecl *in_texture_get_pixels_t)(in_texture_t* obj)
+cdef in_texture_get_pixels_t in_texture_get_pixels
+
+# DrawList
+ctypedef bint (__cdecl *in_drawlist_get_use_base_vertex_t)(in_drawlist_t* obj)
+cdef in_drawlist_get_use_base_vertex_t in_drawlist_get_use_base_vertex
+ctypedef void (__cdecl *in_drawlist_set_use_base_vertex_t)(in_drawlist_t* obj, bint value)
+cdef in_drawlist_set_use_base_vertex_t in_drawlist_set_use_base_vertex
+ctypedef in_drawcmd_t* (__cdecl *in_drawlist_get_commands_t)(in_drawlist_t* obj, uint32_t* count)
+cdef in_drawlist_get_commands_t in_drawlist_get_commands
+ctypedef in_vtxdata_t* (__cdecl *in_drawlist_get_vertex_data_t)(in_drawlist_t* obj, uint32_t* bytes)
+cdef in_drawlist_get_vertex_data_t in_drawlist_get_vertex_data
+ctypedef void* (__cdecl *in_drawlist_get_index_data_t)(in_drawlist_t* obj, uint32_t* bytes)
+cdef in_drawlist_get_index_data_t in_drawlist_get_index_data
+ctypedef in_drawalloc_t* (__cdecl *in_drawlist_get_allocations_t)(in_drawlist_t* obj, uint32_t* count)
+cdef in_drawlist_get_allocations_t in_drawlist_get_allocations
+
+cdef bint did_load = False
+def load(dll):
+    global did_load
+    if did_load:
+        return True
+    
+    did_load = True
+    
+    cdef void* object = NULL
+    if dll:
+        object = load_inochi2d_object(dll)
+
+        if not object:
+            return False
+    
+    global in_retain
+    in_retain = <in_retain_t> load_inochi2d_function(object, "in_retain")
+    global in_release
+    in_release = <in_release_t> load_inochi2d_function(object, "in_release")
+    global in_get_last_error
+    in_get_last_error = <in_get_last_error_t> load_inochi2d_function(object, "in_get_last_error")
+    global in_puppet_load
+    in_puppet_load = <in_puppet_load_t> load_inochi2d_function(object, "in_puppet_load")
+    global in_puppet_load_from_memory
+    in_puppet_load_from_memory = <in_puppet_load_from_memory_t> load_inochi2d_function(object, "in_puppet_load_from_memory")
+    global in_puppet_free
+    in_puppet_free = <in_puppet_free_t> load_inochi2d_function(object, "in_puppet_free")
+    global in_puppet_get_name
+    in_puppet_get_name = <in_puppet_get_name_t> load_inochi2d_function(object, "in_puppet_get_name")
+    global in_puppet_get_physics_enabled
+    in_puppet_get_physics_enabled = <in_puppet_get_physics_enabled_t> load_inochi2d_function(object, "in_puppet_get_physics_enabled")
+    global in_puppet_set_physics_enabled
+    in_puppet_set_physics_enabled = <in_puppet_set_physics_enabled_t> load_inochi2d_function(object, "in_puppet_set_physics_enabled")
+    global in_puppet_get_pixels_per_meter
+    in_puppet_get_pixels_per_meter = <in_puppet_get_pixels_per_meter_t> load_inochi2d_function(object, "in_puppet_get_pixels_per_meter")
+    global in_puppet_set_pixels_per_meter
+    in_puppet_set_pixels_per_meter = <in_puppet_set_pixels_per_meter_t> load_inochi2d_function(object, "in_puppet_set_pixels_per_meter")
+    global in_puppet_get_gravity
+    in_puppet_get_gravity = <in_puppet_get_gravity_t> load_inochi2d_function(object, "in_puppet_get_gravity")
+    global in_puppet_set_gravity
+    in_puppet_set_gravity = <in_puppet_set_gravity_t> load_inochi2d_function(object, "in_puppet_set_gravity")
+    global in_puppet_update
+    in_puppet_update = <in_puppet_update_t> load_inochi2d_function(object, "in_puppet_update")
+    global in_puppet_draw
+    in_puppet_draw = <in_puppet_draw_t> load_inochi2d_function(object, "in_puppet_draw")
+    global in_puppet_reset_drivers
+    in_puppet_reset_drivers = <in_puppet_reset_drivers_t> load_inochi2d_function(object, "in_puppet_reset_drivers")
+    global in_puppet_get_texture_cache
+    in_puppet_get_texture_cache = <in_puppet_get_texture_cache_t> load_inochi2d_function(object, "in_puppet_get_texture_cache")
+    global in_puppet_get_parameters
+    in_puppet_get_parameters = <in_puppet_get_parameters_t> load_inochi2d_function(object, "in_puppet_get_parameters")
+    global in_puppet_get_drawlist
+    in_puppet_get_drawlist = <in_puppet_get_drawlist_t> load_inochi2d_function(object, "in_puppet_get_drawlist")
+    global in_parameter_get_name
+    in_parameter_get_name = <in_parameter_get_name_t> load_inochi2d_function(object, "in_parameter_get_name")
+    global in_parameter_get_active
+    in_parameter_get_active = <in_parameter_get_active_t> load_inochi2d_function(object, "in_parameter_get_active")
+    global in_parameter_get_dimensions
+    in_parameter_get_dimensions = <in_parameter_get_dimensions_t> load_inochi2d_function(object, "in_parameter_get_dimensions")
+    global in_parameter_get_min_value
+    in_parameter_get_min_value = <in_parameter_get_min_value_t> load_inochi2d_function(object, "in_parameter_get_min_value")
+    global in_parameter_get_max_value
+    in_parameter_get_max_value = <in_parameter_get_max_value_t> load_inochi2d_function(object, "in_parameter_get_max_value")
+    global in_parameter_get_value
+    in_parameter_get_value = <in_parameter_get_value_t> load_inochi2d_function(object, "in_parameter_get_value")
+    global in_parameter_set_value 
+    in_parameter_set_value = <in_parameter_set_value_t> load_inochi2d_function(object, "in_parameter_set_value")
+    global in_parameter_get_normalized_value
+    in_parameter_get_normalized_value = <in_parameter_get_normalized_value_t> load_inochi2d_function(object, "in_parameter_get_normalized_value")
+    global in_parameter_set_normalized_value
+    in_parameter_set_normalized_value = <in_parameter_set_normalized_value_t> load_inochi2d_function(object, "in_parameter_set_normalized_value")
+    global in_texture_cache_get_size
+    in_texture_cache_get_size = <in_texture_cache_get_size_t> load_inochi2d_function(object, "in_texture_cache_get_size")
+    global in_texture_cache_get_texture
+    in_texture_cache_get_texture = <in_texture_cache_get_texture_t> load_inochi2d_function(object, "in_texture_cache_get_texture")
+    global in_texture_cache_get_textures
+    in_texture_cache_get_textures = <in_texture_cache_get_textures_t> load_inochi2d_function(object, "in_texture_cache_get_textures")
+    global in_texture_cache_prune
+    in_texture_cache_prune = <in_texture_cache_prune_t> load_inochi2d_function(object, "in_texture_cache_prune")
+    global in_resource_get_length
+    in_resource_get_length = <in_resource_get_length_t> load_inochi2d_function(object, "in_resource_get_length")
+    global in_resource_get_id
+    in_resource_get_id = <in_resource_get_id_t> load_inochi2d_function(object, "in_resource_get_id")
+    global in_resource_set_id
+    in_resource_set_id = <in_resource_set_id_t> load_inochi2d_function(object, "in_resource_set_id")
+    global in_texture_from_resource
+    in_texture_from_resource = <in_texture_from_resource_t> load_inochi2d_function(object, "in_texture_from_resource")
+    global in_texture_get_width
+    in_texture_get_width = <in_texture_get_width_t> load_inochi2d_function(object, "in_texture_get_width")
+    global in_texture_get_height
+    in_texture_get_height = <in_texture_get_height_t> load_inochi2d_function(object, "in_texture_get_height")
+    global in_texture_get_channels
+    in_texture_get_channels = <in_texture_get_channels_t> load_inochi2d_function(object, "in_texture_get_channels")
+    global in_texture_flip_vertically
+    in_texture_flip_vertically = <in_texture_flip_vertically_t> load_inochi2d_function(object, "in_texture_flip_vertically")
+    global in_texture_premultiply
+    in_texture_premultiply = <in_texture_premultiply_t> load_inochi2d_function(object, "in_texture_premultiply")
+    global in_texture_unpremultiply
+    in_texture_unpremultiply = <in_texture_unpremultiply_t> load_inochi2d_function(object, "in_texture_unpremultiply")
+    global in_texture_pad
+    in_texture_pad = <in_texture_pad_t> load_inochi2d_function(object, "in_texture_pad")
+    global in_texture_get_pixels
+    in_texture_get_pixels = <in_texture_get_pixels_t> load_inochi2d_function(object, "in_texture_get_pixels")
+    global in_drawlist_get_use_base_vertex
+    in_drawlist_get_use_base_vertex = <in_drawlist_get_use_base_vertex_t> load_inochi2d_function(object, "in_drawlist_get_use_base_vertex")
+    global in_drawlist_set_use_base_vertex
+    in_drawlist_set_use_base_vertex = <in_drawlist_set_use_base_vertex_t> load_inochi2d_function(object, "in_drawlist_set_use_base_vertex")
+    global in_drawlist_get_commands
+    in_drawlist_get_commands = <in_drawlist_get_commands_t> load_inochi2d_function(object, "in_drawlist_get_commands")
+    global in_drawlist_get_vertex_data
+    in_drawlist_get_vertex_data = <in_drawlist_get_vertex_data_t> load_inochi2d_function(object, "in_drawlist_get_vertex_data")
+    global in_drawlist_get_index_data
+    in_drawlist_get_index_data = <in_drawlist_get_index_data_t> load_inochi2d_function(object, "in_drawlist_get_index_data")
+    global in_drawlist_get_allocations
+    in_drawlist_get_allocations = <in_drawlist_get_allocations_t> load_inochi2d_function(object, "in_drawlist_get_allocations")

--- a/renpy/gl2/inochi2d.py
+++ b/renpy/gl2/inochi2d.py
@@ -1,0 +1,79 @@
+import renpy
+from renpy.gl2.gl2shadercache import register_shader
+from renpy.display.core import absolute
+
+try:
+    import renpy.gl2.inochi2dmodel as inochi2dmodel
+except ImportError:
+    inochi2dmodel = None
+
+import sys
+import os
+import json
+import collections
+import re
+import time
+
+did_onetime_init = False
+def onetime_init():
+    global did_onetime_init
+    if did_onetime_init:
+        return
+
+    if renpy.emscripten:
+        raise Exception("Inochi2D is not WASM compatible at current time.")
+    elif renpy.windows:
+        dll = "inochi2d.dll"
+    elif renpy.macintosh:
+        dll = "libinochi2d.dylib"
+    elif renpy.ios:
+        dll = sys.executable
+    else:
+        dll = "libinochi2d.so"
+    
+    if dll != "builtin":
+        fn = os.path.join(os.path.dirname(sys.executable), dll)
+        if os.path.exists(fn):
+            dll = fn
+    
+    dll = dll.encode("utf-8")
+    if not renpy.gl2.inochi2dmodel.load(dll):  # type: ignore
+        raise Exception("Could not load Inochi2D. {} was not found.".format(dll))
+    
+    did_onetime_init = True
+
+did_init = False
+def init():
+    """
+    Called to initialize Inochi2D, if needed.
+    """
+
+    global did_init
+    if did_init:
+        return
+
+    if inochi2dmodel is None:
+        raise Exception("Inochi2D has not been built.")
+    
+    onetime_init()
+
+# Caches the result of has_inochi2d.
+_has_inochi2d = None
+def has_inochi2d():
+    """
+    :doc: inochi2d
+
+    Returns True if Inochi2D is supported on the current platform, and
+    False otherwise.
+    """
+
+    global _has_inochi2d
+
+    if _has_inochi2d is None:
+        try:
+            init()
+            _has_inochi2d = True
+        except Exception:
+            _has_inochi2d = False
+
+    return _has_inochi2d

--- a/renpy/gl2/inochi2dmodel.pyx
+++ b/renpy/gl2/inochi2dmodel.pyx
@@ -1,0 +1,258 @@
+# Copyright (c) 2025, Kitsunebi Games EMV.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from libc.stdint cimport intptr_t, uint32_t
+from libc.stdlib cimport malloc, free
+from libc.string cimport memcpy
+from libc.stdio cimport printf
+
+from renpy.gl2.gl2mesh import TEXTURE_LAYOUT
+from renpy.gl2.gl2mesh2 cimport Mesh2
+
+from renpy.display.matrix cimport Matrix
+from renpy.display.render cimport Render
+
+from renpy.uguu.gl cimport GL_ZERO, GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_FUNC_ADD, GL_DST_COLOR, GL_DST_ALPHA
+
+import renpy
+
+cdef extern from "inochi2d_ldr.h" nogil:
+    void* load_inochi2d_object(const char* sofile)
+    void* load_inochi2d_function(void* handle, const char* name)
+
+cdef extern from "inochi2d.h":
+
+    # Opaque types.
+    ctypedef struct in_puppet_t
+    ctypedef struct in_texture_cache_t
+    ctypedef struct in_parameter_t
+    ctypedef struct in_resource_t
+    ctypedef struct in_texture_t
+    ctypedef struct in_drawlist_t
+
+    # Enumerations.
+    enum in_drawstate_t:
+        IN_DRAW_STATE_NORMAL            = 0
+        IN_DRAW_STATE_DEFINE_MASK       = 1
+        IN_DRAW_STATE_MASKED_DRAW       = 2
+        IN_DRAW_STATE_COMPOSITE_BEGIN   = 3
+        IN_DRAW_STATE_COMPOSITE_END     = 4
+        IN_DRAW_STATE_COMPOSITE_BLIT    = 5
+    
+    enum in_mask_mode_t:
+        IN_MASK_MODE_MASK   = 0
+        IN_MASK_MODE_DODGE  = 1
+
+    enum in_blend_mode_t:
+        IN_BLEND_MODE_NORMAL            = 0x00
+        IN_BLEND_MODE_MULTIPLY          = 0x01
+        IN_BLEND_MODE_SCREEN            = 0x02
+        IN_BLEND_MODE_OVERLAY           = 0x03
+        IN_BLEND_MODE_DARKEN            = 0x04
+        IN_BLEND_MODE_LIGHTEN           = 0x05
+        IN_BLEND_MODE_COLOR_DODGE       = 0x06
+        IN_BLEND_MODE_LINEAR_DODGE      = 0x07
+        IN_BLEND_MODE_ADD_GLOW          = 0x08
+        IN_BLEND_MODE_COLOR_BURN        = 0x09
+        IN_BLEND_MODE_HARD_LIGHT        = 0x0A
+        IN_BLEND_MODE_SOFT_LIGHT        = 0x0B
+        IN_BLEND_MODE_DIFFERENCE        = 0x0C
+        IN_BLEND_MODE_EXCLUSION         = 0x0D
+        IN_BLEND_MODE_SUBTRACT          = 0x0E
+        IN_BLEND_MODE_INVERSE           = 0x0F
+        IN_BLEND_MODE_DESTINATION_IN    = 0x10
+        IN_BLEND_MODE_SOURCE_IN         = 0x11
+        IN_BLEND_MODE_SOURCE_OUT        = 0x12
+
+    ctypedef struct in_vec2_t:
+        float x
+        float y
+    
+    ctypedef struct in_vtx_t:
+        float x
+        float y
+    
+    ctypedef struct in_vtxdata_t:
+        in_vtx_t vtx
+        in_vec2_t uv
+    
+    ctypedef struct in_drawcmd_t:
+        (in_texture_t *)[8] sources
+        in_drawstate_t      state
+        in_blend_mode_t     blendMode
+        in_mask_mode_t      maskMode
+        uint32_t            allocId
+        uint32_t            vtxOffset
+        uint32_t            idxOffset
+        uint32_t            elemCount
+        uint32_t            type_
+        unsigned char[64]   vars_
+
+    ctypedef struct in_drawalloc_t:
+        uint32_t vtxOffset
+        uint32_t idxOffset
+        uint32_t idxCount
+        uint32_t vtxCount
+        uint32_t allocId
+
+include "inochi2d.pxi"
+
+cdef class Parameter:
+    """
+    Represents an Inochi2D Parameter, modifying the parameter
+    animates it.
+    """
+    cdef str name
+    cdef in_parameter_t *handle
+
+    def get_name(self):
+        """
+        Gets the name of a parameter.
+        """
+        return self.name
+
+    def get_active(self):
+        """
+        Gets whether the parameter is active.
+        """
+        return in_parameter_get_active(self.handle)
+
+    def get_dimensions(self):
+        """
+        Gets the number of dimensions the parameter has.
+        """
+        return in_parameter_get_dimensions(self.handle)
+
+    def get_min_value(self):
+        """
+        Gets the minimum values of the parameter.
+        """
+        return in_parameter_get_min_value(self.handle)
+
+    def get_max_value(self):
+        """
+        Gets the maximum values of the parameter.
+        """
+        return in_parameter_get_max_value(self.handle)
+
+    def get_value(self):
+        """
+        Gets the current values of the parameter.
+        """
+        return in_parameter_get_value(self.handle)
+
+    def get_value_norm(self):
+        """
+        Gets the current normalized values of the parameter.
+        """
+        return in_parameter_get_normalized_value(self.handle)
+
+    def set_value(self, in_vec2_t value):
+        """
+        Sets the current values of the parameter.
+        """
+        return in_parameter_set_value(self.handle, value)
+
+    def set_value_norm(self, in_vec2_t value):
+        """
+        Sets the current normalized values of the parameter.
+        """
+        return in_parameter_set_normalized_value(self.handle, value)
+
+    @staticmethod
+    cdef Parameter from_ptr(in_parameter_t* handle):
+        """
+        Creates a new Inochi2D Parameter from its handle
+        """
+        cdef Parameter __self = Parameter.__new__(Parameter)
+        __self.handle = handle
+        __self.name = in_parameter_get_name(__self.handle).decode("utf-8")
+        return __self
+
+
+cdef class DrawList:
+    """
+    Represents an Inochi2D Draw List
+    """
+    cdef in_drawlist_t *handle
+    
+    @staticmethod
+    cdef DrawList from_ptr(in_drawlist_t* handle):
+        """
+        Creates Inochi2D DrawList from its handle.
+        """
+        cdef DrawList __self = DrawList.__new__(DrawList)
+        __self.handle = handle
+        return __self
+
+cdef class Inochi2DModel:
+    cdef in_puppet_t *handle
+    cdef public list parameters
+    cdef public object drawlist
+
+    cdef str name
+    cdef object filename
+
+    """
+    Represents an Inochi2D Model
+    """
+    def __dealloc__(self):
+        in_puppet_free(self.handle)
+
+    def __init__(self, path):
+        """
+        Loads an Inochi2D Model from file.
+        """
+        self.filename = path
+        with renpy.loader.load(path, directory="images") as f:
+            data = f.read()
+        
+        self.handle = in_puppet_load_from_memory(<const uint8_t *>data, len(data))
+        if self.handle is NULL:
+            raise Exception(in_get_last_error())
+
+        # Get Parameters
+        cdef int i
+        cdef in_parameter_t** params
+        cdef uint32_t param_count
+        params = in_puppet_get_parameters(self.handle, &param_count)
+        for i in range(param_count):
+            self.parameters.append(Parameter.from_ptr(params[i]))
+        
+        # Get DrawList
+        self.drawlist = DrawList.from_ptr(in_puppet_get_drawlist(self.handle))
+        self.name = in_puppet_get_name(self.handle).decode("utf-8")
+        
+    def get_name(self) -> str:
+        """
+        Gets the name of the puppet
+        """
+        return self.name
+    
+    def update(self, float delta):
+        """
+        Updates the model and refills its drawlist.
+        """
+        in_puppet_update(self.handle, delta)
+        in_puppet_draw(self.handle, delta)

--- a/sphinx/source/inochi2d.rst
+++ b/sphinx/source/inochi2d.rst
@@ -1,0 +1,24 @@
+.. _inochi2d:
+
+Inochi2D
+========
+
+`Inochi2D <https://inochi2d.com>`_ is an open source alternative to Live2D
+which allows you to animate 2D characters in real-time.
+
+.. warning::
+    Inochi2D is not yet supported on the web, there is plans to do so
+    in the future.
+
+    Installing Inochi2D on iOS requires copying static libraries into
+    your iOS project by hand.
+
+Installing Inochi2D
+-------------------
+
+Before you can use Inochi2D you must install the SDK into your project,
+you can find prebuilt libraries `on GitHub <https://github.com/Inochi2D/inochi2d/releases>`_.
+
+Inochi2D is provided under the BSD 2-clause license, with ren'py support
+provided by Kitsunebi Games EMV. As such if you distribute the source code
+for your game you must include the LICENSE file provided in the Inochi2D

--- a/src/inochi2d_ldr.c
+++ b/src/inochi2d_ldr.c
@@ -1,0 +1,18 @@
+#include "inochi2d.h"
+#include <SDL2/SDL.h>
+#include <stdio.h>
+#include <string.h>
+
+// NOTE:    Inochi2D does not support web yet until it becomes fully nogc.
+//          This will change in later releases and this file will be updated
+//          accordingly.
+
+void *load_inochi2d_object(const char *sofile) {
+    void *handle = SDL_LoadObject(sofile);
+    return handle;
+}
+
+void *load_inochi2d_function(void *obj, const char *name) {
+    void *func = SDL_LoadFunction(obj, name);
+    return func;
+}

--- a/src/inochi2d_ldr.h
+++ b/src/inochi2d_ldr.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void *load_inochi2d_object(const char *sofile);
+void *load_inochi2d_function(void *obj, const char *name);


### PR DESCRIPTION
This code is not finished yet and since I have not worked on the ren'py codebase before, feel free to point out if I'm doing something wrong somewhere.

This PR adds support for the open source Inochi2D format, which allows animated characters and CGs to be displayed in-game with more complex post processing (if desired by the developer). Inochi2D itself is a "bring your own renderer" library, which I plan to implement a renderer for inside of the ren'py codebase, including writing custom shaders for ren'py that are included directly in the source as requested by @renpytom. 