### PR TITLE
Update add_from.py

### DIFF
--- a/renpy/add_from.py
+++ b/renpy/add_from.py
@@ -82,8 +82,8 @@ def process_file(fn):
     edits = missing[fn]
     edits.sort()
 
-    with open(fn, "r", encoding="utf-8") as f:
-        data = f.read()
+    with open(fn, "rb") as f:
+        data = f.read().decode("utf-8")
 
     # How much of the input has been consumed.
     consumed = 0
@@ -104,8 +104,8 @@ def process_file(fn):
 
     output += data[consumed:]
 
-    with open(fn + ".new", "w", encoding="utf-8") as f:
-        f.write(output)
+    with open(fn + ".new", "wb") as f:
+        f.write(output.encode("utf-8"))
 
     try:
         os.unlink(fn + ".bak")


### PR DESCRIPTION
commit 4738dac won't work as expected.
when you open a file in text mode on a Windows system, you get \r\n line separators that offset the injected from clauses.
with the currently used code
```renpy
label foo:
    return

label start:

    call foo from _call_foo

    # ===== blah =====

    call foo from _call_foo_1

    # ===== blah =====

    call foo from _call_foo_2

    # ===== blah =====

    call foo from _call_foo_3

    # ===== blah =====

    call foo from _call_foo_4

    # ===== blah =====

    return
```
result in
```renpy
label foo:
    return

label start:

    call foo

    from _call_foo # ===== blah =====

    call foo

    # = from _call_foo_1==== blah =====

    call foo

    # ===== from _call_foo_2 blah =====

    call foo

    # ===== bla from _call_foo_3h =====

    call foo

    # ===== blah == from _call_foo_4===

    return
```