### PR TITLE
Add support for custom actions in the launcher via project.json

### DIFF
--- a/launcher/game/front_page.rpy
+++ b/launcher/game/front_page.rpy
@@ -206,6 +206,9 @@ screen front_page_project:
             frame style "l_indent":
                 has vbox
 
+                for button_name, path in p.get_renpy_launcher()["actions"].items():
+                    textbutton button_name action RunScript(os.path.join(p.path, path))
+
                 textbutton _("Navigate Script") action Jump("navigation")
                 textbutton _("Check Script (Lint)") action Call("lint")
                 textbutton _("Launch tests") action Jump("launch_tests")

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -191,6 +191,8 @@ init python in project:
                     "options.rpy": "game/options.rpy",
                     "gui.rpy": "game/gui.rpy",
                     "screens.rpy": "game/screens.rpy"
+                },
+                "actions": {
                 }
             }
 


### PR DESCRIPTION
Hi, I noticed that while the launcher supports adding options through `project.json`, there’s currently no way to customize the **Actions** tab.

This pull request introduces the ability to define custom actions directly in `project.json`. Example:

```json
"open_directory": {
  ...
},
"edit_file": {
  ...
},
"actions": {
  "Install dependencies": "./install.ps1"
}
```

These custom entries will appear in the **Actions** tab of the launcher.

<img width="526" height="331" alt="image" src="https://github.com/user-attachments/assets/5c540f93-4f89-4d18-b9a7-457359743b8e" />

---

**Notes:**

* Marked as draft because testing was done on version **8.4.1**, and the changes were then ported to the **master** branch.
* Currently tested only on **Windows**.