### PR TITLE
Update distribute.rpy

### DIFF
--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -639,7 +639,8 @@ fix_dlc("renios", "renios")
             # The destination directory.
             if destination is None:
                 destination = build["destination"]
-                parent = os.path.dirname(project.path)
+                path, sep, package = project.path.rpartition(project.name)
+                parent = path or package
                 self.destination = os.path.join(parent, destination)
             else:
                 self.destination = destination


### PR DESCRIPTION
this should fix #6689.
first i was using `parent = os.path.dirname(project.path.partition(project.name)[0])`, but this results in the wrong parent folder when the sub folder uses the package name.