### PR TITLE
gl2: Expose GPU max texture size

### DIFF
--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -774,7 +774,7 @@ cdef class GL2Draw:
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size)
         glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &max_renderbuffer_size)
 
-        max_texture_size = max(max_texture_size, 1024)
+        max_texture_size = self.info["max_texture_size"] = max(max_texture_size, 1024)
         max_renderbuffer_size = max(max_renderbuffer_size, 1024)
 
         # The number of pixels of additional border, so we can load textures with


### PR DESCRIPTION
Fixes #6694.

Typically indicative of overall GPU strength, making it a potentially useful metric for scaling more intensive shaders and VFX in order to avoid overloading weaker hardware found in older phones, and budget tablets and laptops.

Intentionally very low-level exposure/code impact for now while we consider its reliability/usefulness. Can always pick some thresholds and add it to the existing variant system down the line if it turns out to be super useful for that.