### PR TITLE
Type renpy.revertable module (v2)

### DIFF
--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -316,26 +316,23 @@ class RevertableDict[KT, VT](dict[KT, VT]):
         def has_key(self, key):
             return key in self
 
-    # https://peps.python.org/pep-0584 methods
-    def __or__(self, other):
+    def __or__[KT2, VT2](self, other: dict[KT2, VT2]) -> "RevertableDict[KT | KT2, VT | VT2]":
         if not isinstance(other, dict):
             return NotImplemented
-        rv = RevertableDict(self)
-        rv.update(other)
-        return rv
 
-    def __ror__(self, other):
+        return RevertableDict(super().__or__(other))
+
+    def __ror__[KT2, VT2](self, other: dict[KT2, VT2]) -> "RevertableDict[KT | KT2, VT | VT2]":
         if not isinstance(other, dict):
             return NotImplemented
-        rv = RevertableDict(other)
-        rv.update(self)
-        return rv
 
-    def __ior__(self, other):
+        return RevertableDict(super().__ror__(other))
+
+    def __ior__(self, other: dict[KT, VT] | Iterable[tuple[KT, VT]]) -> "RevertableDict[KT, VT]":
         self.update(other)
         return self
 
-    def copy(self):
+    def copy(self) -> "RevertableDict[KT, VT]":
         rv = RevertableDict()
         rv.update(self)
         return rv

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -643,7 +643,7 @@ class RollbackRandom(random.Random):
         seed = checkpointing(mutator(random.Random.seed))
         random = checkpointing(mutator(random.Random.random))
 
-    def Random(self, seed=None):
+    def Random(self, seed: int | float | str | bytes | bytearray | None = None):
         """
         Returns a new RNG object separate from the main one.
         """
@@ -663,7 +663,7 @@ class DetRandom(random.Random):
 
     def __init__(self):
         super(DetRandom, self).__init__()
-        self.stack = []
+        self.stack: list[float] = []
 
     def choices[T](
         self,
@@ -699,13 +699,13 @@ class DetRandom(random.Random):
 
         return rv
 
-    def pushback(self, l):
+    def pushback(self, lst: list[float]):
         """
-        Pushes the random numbers in l onto the stack so they will be generated
+        Pushes the random numbers in lst onto the stack so they will be generated
         in the order given.
         """
 
-        ll = l[:]
+        ll = lst[:]
         ll.reverse()
 
         self.stack.extend(ll)
@@ -717,7 +717,7 @@ class DetRandom(random.Random):
 
         del self.stack[:]
 
-    def Random(self, seed=None):
+    def Random(self, seed: int | float | str | bytes | bytearray | None = None):
         """
         Returns a new RNG object separate from the main one.
         """

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -320,6 +320,8 @@ class RevertableDict[KT, VT](dict[KT, VT]):
 
         super().__init__(iterable, **kwargs)
 
+    # FIXME: Missing dict.fromkeys
+
     __delitem__ = mutator(dict.__delitem__)
     __setitem__ = mutator(dict.__setitem__)
     clear = mutator(dict.clear)

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -365,11 +365,32 @@ class RevertableDefaultDict[KT, VT](RevertableDict[KT, VT]):
     participate in rollback, and so should not be changed.
     """
 
+    default_factory: Callable[[], VT] | None
+
+    # Typeshed actually have more correct overloads, but for our case, we only
+    # care about str: VT when kwargs are present, and KT: VT if not.
+    @overload
+    def __init__(
+        self: "RevertableDefaultDict[str, VT]",  # pyright: ignore[reportInvalidTypeVarUse]
+        default_factory: Callable[[], VT] | None = None,
+        iterable: dict[str, VT] | Iterable[tuple[str, VT]] = (),
+        /,
+        **kwargs: VT,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        default_factory: Callable[[], VT] | None = None,
+        iterable: dict[KT, VT] | Iterable[tuple[KT, VT]] = (),
+        /,
+    ): ...
+
     def __init__(self, default_factory=None, *args, **kwargs):
         self.default_factory = default_factory
         super(RevertableDefaultDict, self).__init__(*args, **kwargs)
 
-    def __missing__(self, key):
+    def __missing__(self, key) -> VT:
         if self.default_factory is None:
             raise KeyError(key)
 

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -23,7 +23,7 @@
 # contained within the script file. It also handles rolling back the
 # game state to some time in the past.
 
-from typing import Any, TYPE_CHECKING, SupportsIndex, overload
+from typing import Any, TYPE_CHECKING, Callable, Iterable, Protocol, SupportsIndex, overload
 
 import __future__
 
@@ -244,6 +244,42 @@ class RevertableList[T](list[T]):
             self[:] = compressed.decompress(self)
         else:
             self[:] = compressed
+
+
+if TYPE_CHECKING:
+
+    @overload
+    def revertable_range(start: SupportsIndex, /) -> RevertableList[int]: ...
+
+    @overload
+    def revertable_range(
+        start: SupportsIndex, stop: SupportsIndex, step: SupportsIndex = ..., /
+    ) -> RevertableList[int]: ...
+
+    class SupportsDunderLT(Protocol):
+        def __lt__(self, other: Any, /) -> bool: ...
+
+    class SupportsDunderGT(Protocol):
+        def __gt__(self, other: Any, /) -> bool: ...
+
+    type SupportsRichComparison = SupportsDunderLT | SupportsDunderGT
+
+    @overload
+    def revertable_sorted[T: SupportsRichComparison](
+        iterable: Iterable[T],
+        /,
+        *,
+        key: None = None,
+        reverse: bool = False,
+    ) -> RevertableList[T]: ...
+    @overload
+    def revertable_sorted[T](
+        iterable: Iterable[T],
+        /,
+        *,
+        key: Callable[[T], SupportsRichComparison],
+        reverse: bool = False,
+    ) -> RevertableList[T]: ...
 
 
 def revertable_range(*args):

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -23,7 +23,7 @@
 # contained within the script file. It also handles rolling back the
 # game state to some time in the past.
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import __future__
 
@@ -155,25 +155,27 @@ class CompressedList:
 
 
 class RevertableList[T](list[T]):
-    def __init__(self, *args):
-        log = renpy.game.log
+    if not TYPE_CHECKING:
 
-        if log is not None:
-            log.mutated[id(self)] = None
+        def __init__(self, *args):
+            log = renpy.game.log
 
-        list.__init__(self, *args)
+            if log is not None:
+                log.mutated[id(self)] = None
 
-    __delitem__ = mutator(list.__delitem__)
-    __setitem__ = mutator(list.__setitem__)
-    __iadd__ = mutator(list.__iadd__)
-    __imul__ = mutator(list.__imul__)
-    append = mutator(list.append)
-    extend = mutator(list.extend)
-    insert = mutator(list.insert)
-    pop = mutator(list.pop)
-    remove = mutator(list.remove)
-    reverse = mutator(list.reverse)
-    sort = mutator(list.sort)
+            list.__init__(self, *args)
+
+        __delitem__ = mutator(list.__delitem__)
+        __setitem__ = mutator(list.__setitem__)
+        __iadd__ = mutator(list.__iadd__)
+        __imul__ = mutator(list.__imul__)
+        append = mutator(list.append)
+        extend = mutator(list.extend)
+        insert = mutator(list.insert)
+        pop = mutator(list.pop)
+        remove = mutator(list.remove)
+        reverse = mutator(list.reverse)
+        sort = mutator(list.sort)
 
     @staticmethod
     def wrapper(method):
@@ -253,28 +255,30 @@ def revertable_sorted(*args, **kwargs):
 
 
 class RevertableDict[KT, VT](dict[KT, VT]):
-    def __init__(self, *args, **kwargs):
-        log = renpy.game.log
+    if not TYPE_CHECKING:
 
-        if log is not None:
-            log.mutated[id(self)] = None
+        def __init__(self, *args, **kwargs):
+            log = renpy.game.log
 
-        dict.__init__(self, *args, **kwargs)
+            if log is not None:
+                log.mutated[id(self)] = None
 
-    __delitem__ = mutator(dict.__delitem__)
-    __setitem__ = mutator(dict.__setitem__)
-    clear = mutator(dict.clear)
-    pop = mutator(dict.pop)
-    popitem = mutator(dict.popitem)
-    setdefault = mutator(dict.setdefault)
-    update = mutator(dict.update)
+            dict.__init__(self, *args, **kwargs)
 
-    itervalues = dict.values
-    iterkeys = dict.keys
-    iteritems = dict.items
+        __delitem__ = mutator(dict.__delitem__)
+        __setitem__ = mutator(dict.__setitem__)
+        clear = mutator(dict.clear)
+        pop = mutator(dict.pop)
+        popitem = mutator(dict.popitem)
+        setdefault = mutator(dict.setdefault)
+        update = mutator(dict.update)
 
-    def has_key(self, key):
-        return key in self
+        itervalues = dict.values
+        iterkeys = dict.keys
+        iteritems = dict.items
+
+        def has_key(self, key):
+            return key in self
 
     # https://peps.python.org/pep-0584 methods
     def __or__(self, other):
@@ -356,28 +360,30 @@ class RevertableSet[T](set[T]):
     __reduce__ = object.__reduce__
     __reduce_ex__ = object.__reduce_ex__
 
-    def __init__(self, *args):
-        log = renpy.game.log
+    if not TYPE_CHECKING:
 
-        if log is not None:
-            log.mutated[id(self)] = None
+        def __init__(self, *args):
+            log = renpy.game.log
 
-        set.__init__(self, *args)
+            if log is not None:
+                log.mutated[id(self)] = None
 
-    __iand__ = mutator(set.__iand__)
-    __ior__ = mutator(set.__ior__)
-    __isub__ = mutator(set.__isub__)
-    __ixor__ = mutator(set.__ixor__)
-    add = mutator(set.add)
-    clear = mutator(set.clear)
-    difference_update = mutator(set.difference_update)
-    discard = mutator(set.discard)
-    intersection_update = mutator(set.intersection_update)
-    pop = mutator(set.pop)
-    remove = mutator(set.remove)
-    symmetric_difference_update = mutator(set.symmetric_difference_update)
-    union_update = mutator(set.update)
-    update = mutator(set.update)
+            set.__init__(self, *args)
+
+        __iand__ = mutator(set.__iand__)
+        __ior__ = mutator(set.__ior__)
+        __isub__ = mutator(set.__isub__)
+        __ixor__ = mutator(set.__ixor__)
+        add = mutator(set.add)
+        clear = mutator(set.clear)
+        difference_update = mutator(set.difference_update)
+        discard = mutator(set.discard)
+        intersection_update = mutator(set.intersection_update)
+        pop = mutator(set.pop)
+        remove = mutator(set.remove)
+        symmetric_difference_update = mutator(set.symmetric_difference_update)
+        union_update = mutator(set.update)
+        update = mutator(set.update)
 
     @staticmethod
     def wrapper(method):
@@ -422,18 +428,20 @@ class RevertableObject:
     # For more details, see https://github.com/renpy/renpy/pull/3282
     # __slots__ = ("__weakref__", "__dict__")
 
-    def __new__(cls, *args, **kwargs):
-        self = super(RevertableObject, cls).__new__(cls)
+    if not TYPE_CHECKING:
 
-        log = renpy.game.log
-        if log is not None:
-            log.mutated[id(self)] = None
+        def __new__(cls, *args, **kwargs):
+            self = super(RevertableObject, cls).__new__(cls)
 
-        return self
+            log = renpy.game.log
+            if log is not None:
+                log.mutated[id(self)] = None
 
-    def __init__(self, *args, **kwargs):
-        if (args or kwargs) and renpy.config.developer:
-            raise TypeError("object() takes no parameters.")
+            return self
+
+        def __init__(self, *args, **kwargs):
+            if (args or kwargs) and renpy.config.developer:
+                raise TypeError("object() takes no parameters.")
 
     def __init_subclass__(cls):
         if renpy.config.developer and "__slots__" in cls.__dict__:
@@ -444,8 +452,9 @@ class RevertableObject:
 
         super().__init_subclass__()
 
-    __setattr__ = mutator(object.__setattr__)
-    __delattr__ = mutator(object.__delattr__)
+    if not TYPE_CHECKING:
+        __setattr__ = mutator(object.__setattr__)
+        __delattr__ = mutator(object.__delattr__)
 
     def _clean(self):
         return self.__dict__.copy()
@@ -540,14 +549,16 @@ class RollbackRandom(random.Random):
     def _rollback(self, compressed):
         super(RollbackRandom, self).setstate(compressed)
 
-    setstate = checkpointing(mutator(random.Random.setstate))
+    if not TYPE_CHECKING:
+        setstate = checkpointing(mutator(random.Random.setstate))
 
     choices = list_wrapper(random.Random.choices)
     sample = list_wrapper(random.Random.sample)
 
-    getrandbits = checkpointing(mutator(random.Random.getrandbits))
-    seed = checkpointing(mutator(random.Random.seed))
-    random = checkpointing(mutator(random.Random.random))
+    if not TYPE_CHECKING:
+        getrandbits = checkpointing(mutator(random.Random.getrandbits))
+        seed = checkpointing(mutator(random.Random.seed))
+        random = checkpointing(mutator(random.Random.random))
 
     def Random(self, seed=None):
         """

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -23,7 +23,19 @@
 # contained within the script file. It also handles rolling back the
 # game state to some time in the past.
 
-from typing import AbstractSet, Any, Callable, Iterable, Mapping, Never, Protocol, Sequence, SupportsIndex, overload
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Iterable,
+    Mapping,
+    Never,
+    Protocol,
+    Self,
+    Sequence,
+    SupportsIndex,
+    overload,
+)
 
 import __future__
 
@@ -341,15 +353,19 @@ class RevertableDict[KT, VT](dict[KT, VT]):
         if not isinstance(other, dict):
             return NotImplemented
 
-        return RevertableDict(super().__or__(other))
+        rv: RevertableDict[Any, Any] = RevertableDict(self)
+        rv.update(other)
+        return rv
 
     def __ror__[KT2, VT2](self, other: dict[KT2, VT2]) -> "RevertableDict[KT | KT2, VT | VT2]":
         if not isinstance(other, dict):
             return NotImplemented
 
-        return RevertableDict(super().__ror__(other))
+        rv: RevertableDict[Any, Any] = RevertableDict(other)
+        rv.update(self)
+        return rv
 
-    def __ior__(self, other: dict[KT, VT] | Iterable[tuple[KT, VT]]) -> "RevertableDict[KT, VT]":
+    def __ior__(self, other: dict[KT, VT] | Iterable[tuple[KT, VT]]) -> Self:
         self.update(other)
         return self
 

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -66,18 +66,19 @@ this to check to see if store has changed after save started.
 """
 
 
-def mutator(method):
+def mutator[**P, R](method: Callable[P, R]) -> Callable[P, R]:
     @functools.wraps(method)
-    def do_mutation(self, *args, **kwargs):
+    def do_mutation(*args: P.args, **kwargs: P.kwargs) -> R:
         global mutate_flag
 
+        self = args[0]
         mutated = renpy.game.log.mutated
 
         if id(self) not in mutated:
-            mutated[id(self)] = (weakref.ref(self), self._clean())
+            mutated[id(self)] = (weakref.ref(self), self._clean())  # type: ignore
             mutate_flag = True
 
-        return method(self, *args, **kwargs)
+        return method(*args, **kwargs)
 
     return do_mutation
 
@@ -578,12 +579,12 @@ class MultiRevertable:
             i._rollback(self, c)
 
 
-def checkpointing(method):
+def checkpointing[**P, R](method: Callable[P, R]) -> Callable[P, R]:
     @functools.wraps(method)
-    def do_checkpoint(self, *args, **kwargs):
+    def do_checkpoint(*args: P.args, **kwargs: P.kwargs) -> R:
         renpy.game.context().force_checkpoint = True
 
-        return method(self, *args, **kwargs)
+        return method(*args, **kwargs)
 
     return do_checkpoint
 

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -23,14 +23,12 @@
 # contained within the script file. It also handles rolling back the
 # game state to some time in the past.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
+from typing import Any
 
 import __future__
 
 import random
 import weakref
-import sys
 import copyreg
 import functools
 
@@ -61,10 +59,11 @@ def _reconstructor(cls, base, state):
 
 copyreg._reconstructor = _reconstructor  # type: ignore
 
-
-# This is set to True whenever a mutation occurs. The save code uses
-# this to check to see if a background-save is valid.
-mutate_flag = True
+mutate_flag: bool = True
+"""
+This is set to True whenever a mutation occurs. The background save code uses
+this to check to see if store has changed after save started.
+"""
 
 
 def mutator(method):
@@ -83,7 +82,7 @@ def mutator(method):
     return do_mutation
 
 
-class CompressedList(object):
+class CompressedList:
     """
     Compresses the changes in a queue-like list. What this does is to try
     to find a central sub-list for which has objects in both lists. It
@@ -94,7 +93,12 @@ class CompressedList(object):
     results are efficient even if this doesn't work.
     """
 
-    def __init__(self, old, new):
+    pre: list[Any]
+    start: int
+    end: int
+    post: list[Any]
+
+    def __init__(self, old: list[Any], new: list[Any]):
         # Pick out a pivot element near the center of the list.
         new_center = (len(new) - 1) // 2
         new_pivot = new[new_center]
@@ -143,14 +147,14 @@ class CompressedList(object):
         self.end = new_end
         self.post = list.__getitem__(old, slice(old_end, len_old))
 
-    def decompress(self, new):
+    def decompress(self, new: list[Any]) -> list[Any]:
         return self.pre + new[self.start : self.end] + self.post
 
     def __repr__(self):
-        return "<CompressedList {} [{}:{}] {}>".format(self.pre, self.start, self.end, self.post)
+        return f"<CompressedList {self.pre} [{self.start}:{self.end}] {self.post}>"
 
 
-class RevertableList(list):
+class RevertableList[T](list[T]):
     def __init__(self, *args):
         log = renpy.game.log
 
@@ -171,19 +175,20 @@ class RevertableList(list):
     reverse = mutator(list.reverse)
     sort = mutator(list.sort)
 
-    def wrapper(method):  # type: ignore
+    @staticmethod
+    def wrapper(method):
         @functools.wraps(method)
         def newmethod(*args, **kwargs):
-            l = method(*args, **kwargs)  # type: ignore
+            l = method(*args, **kwargs)
             if l is NotImplemented:
                 return l
             return RevertableList(l)
 
         return newmethod
 
-    __add__ = wrapper(list.__add__)  # type: ignore
-    __mul__ = wrapper(list.__mul__)  # type: ignore
-    __rmul__ = wrapper(list.__rmul__)  # type: ignore
+    __add__ = wrapper(list.__add__)
+    __mul__ = wrapper(list.__mul__)
+    __rmul__ = wrapper(list.__rmul__)
 
     del wrapper
 
@@ -247,7 +252,7 @@ def revertable_sorted(*args, **kwargs):
     return RevertableList(sorted(*args, **kwargs))
 
 
-class RevertableDict(dict):
+class RevertableDict[KT, VT](dict[KT, VT]):
     def __init__(self, *args, **kwargs):
         log = renpy.game.log
 
@@ -308,7 +313,7 @@ class RevertableDict(dict):
             self[k] = v
 
 
-class RevertableDefaultDict(RevertableDict):
+class RevertableDefaultDict[KT, VT](RevertableDict[KT, VT]):
     """
     :doc: rollbackclasses
     :name: defaultdict
@@ -336,7 +341,7 @@ class RevertableDefaultDict(RevertableDict):
         return rv
 
 
-class RevertableSet(set):
+class RevertableSet[T](set[T]):
     def __setstate__(self, state):
         if isinstance(state, tuple):
             self.update(state[0].keys())
@@ -374,10 +379,11 @@ class RevertableSet(set):
     union_update = mutator(set.update)
     update = mutator(set.update)
 
-    def wrapper(method):  # type: ignore
+    @staticmethod
+    def wrapper(method):
         @functools.wraps(method)
         def newmethod(*args, **kwargs):
-            rv = method(*args, **kwargs)  # type: ignore
+            rv = method(*args, **kwargs)
             if isinstance(rv, set):
                 return RevertableSet(rv)
             else:
@@ -385,15 +391,15 @@ class RevertableSet(set):
 
         return newmethod
 
-    __and__ = wrapper(set.__and__)  # type: ignore
-    __sub__ = wrapper(set.__sub__)  # type: ignore
-    __xor__ = wrapper(set.__xor__)  # type: ignore
-    __or__ = wrapper(set.__or__)  # type: ignore
-    copy = wrapper(set.copy)  # type: ignore
-    difference = wrapper(set.difference)  # type: ignore
-    intersection = wrapper(set.intersection)  # type: ignore
-    symmetric_difference = wrapper(set.symmetric_difference)  # type: ignore
-    union = wrapper(set.union)  # type: ignore
+    __and__ = wrapper(set.__and__)
+    __sub__ = wrapper(set.__sub__)
+    __xor__ = wrapper(set.__xor__)
+    __or__ = wrapper(set.__or__)
+    copy = wrapper(set.copy)
+    difference = wrapper(set.difference)
+    intersection = wrapper(set.intersection)
+    symmetric_difference = wrapper(set.symmetric_difference)
+    union = wrapper(set.union)
 
     del wrapper
 
@@ -408,7 +414,7 @@ class RevertableSet(set):
         set.update(self, compressed)
 
 
-class RevertableObject(object):
+class RevertableObject:
     # All RenPy's objects have  __dict__, so _rollback is fast, i.e
     # one update, not iterating over all attributes.
     # __weakref__ should exist, so mutator can work.
@@ -452,7 +458,7 @@ class RevertableObject(object):
         self.__dict__.update(compressed)
 
 
-class MultiRevertable(object):
+class MultiRevertable:
     """
     :doc: rollbackclasses
     :name: MultiRevertable

--- a/renpy/revertable.py
+++ b/renpy/revertable.py
@@ -255,6 +255,10 @@ def revertable_range(
 ) -> RevertableList[int]: ...
 
 
+def revertable_range(*args):
+    return RevertableList(range(*args))
+
+
 class SupportsDunderLT(Protocol):
     def __lt__(self, other: Any, /) -> bool: ...
 
@@ -266,18 +270,14 @@ class SupportsDunderGT(Protocol):
 type SupportsRichComparison = SupportsDunderLT | SupportsDunderGT
 
 
-def revertable_range(*args):
-    return RevertableList(range(*args))
-
-
 @overload
-def revertable_sorted[T: SupportsRichComparison](
-    iterable: Iterable[T],
+def revertable_sorted[SupportsRichComparisonT: SupportsRichComparison](
+    iterable: Iterable[SupportsRichComparisonT],
     /,
     *,
     key: None = None,
     reverse: bool = False,
-) -> RevertableList[T]: ...
+) -> RevertableList[SupportsRichComparisonT]: ...
 @overload
 def revertable_sorted[T](
     iterable: Iterable[T],


### PR DESCRIPTION
This PR hides mutator functions from type checker, so the wrapper does not erase signatures, replaces over revertable wrappers with hand-written signatures, and adds type hints for the rest of the module.
You could look at commit history for more readable diff.