### PR TITLE
user defined confirm screen

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -639,6 +639,9 @@ init -1500 python:
             is already selected. If false (the default), the prompt
             will not be displayed if the `yes` action is selected.
 
+        `screen`
+            If provided, this screen will be used instead of the default screen.
+
         Additional keyword arguments not beginning with _ are passed to
         the screen.
 
@@ -651,18 +654,19 @@ init -1500 python:
 
         kwargs = { }
 
-        def __init__(self, prompt, yes, no=None, confirm_selected=False, **kwargs):
+        def __init__(self, prompt, yes, no=None, confirm_selected=False, screen=None, **kwargs):
             self.prompt = prompt
             self.yes = yes
             self.no = no
             self.confirm_selected = confirm_selected
+            self.screen = screen
             self.kwargs = kwargs
 
         def __call__(self):
             if self.get_selected() and not self.confirm_selected:
                 return renpy.run(self.yes)
 
-            return layout.yesno_screen(self.prompt, self.yes, self.no, **self.kwargs)
+            return layout.yesno_screen(self.prompt, self.yes, self.no, self.screen, **self.kwargs)
 
         def get_sensitive(self):
             if self.yes is None:

--- a/renpy/common/00layout.rpy
+++ b/renpy/common/00layout.rpy
@@ -477,7 +477,7 @@ init -1400 python hide:
         return rv
 
     @layout
-    def yesno_screen(message, yes=None, no=None, **kwargs):
+    def yesno_screen(message, yes=None, no=None, _screen=None, **kwargs):
         """
         :undocumented:
 
@@ -485,7 +485,9 @@ init -1400 python hide:
         or the Confirm action in a screen context.
         """
 
-        if config.confirm_screen and renpy.has_screen('confirm'):
+        if _screen and renpy.has_screen(_screen):
+            screen = _screen
+        elif config.confirm_screen and renpy.has_screen('confirm'):
             screen = "confirm"
         elif renpy.has_screen("yesno_prompt"):
             screen = "yesno_prompt"

--- a/renpy/exports/actionexports.py
+++ b/renpy/exports/actionexports.py
@@ -72,10 +72,14 @@ def confirm(message, **kwargs):
     `message`
         The message that will be displayed.
 
+    `screen`
+        If provided, this screen will be used instead of the default screen.
+
     Additional keyword arguments not beginning with _ are passed to the screen.
 
     See :func:`Confirm` for a similar Action.
     """
     Return = renpy.store.Return
-    renpy.store.layout.yesno_screen(message, yes=Return(True), no=Return(False), **kwargs)
+    screen = kwargs.pop("screen", None)
+    renpy.store.layout.yesno_screen(message, yes=Return(True), no=Return(False), _screen=screen, **kwargs)
     return renpy.ui.interact()


### PR DESCRIPTION
it adds the option to specify a screen that should be used in `renpy.confirm() `and `Confirm()` rather than the default screen `confirm`. it might be more convenient to have separate screens for confirmation / information purposes rather than having only the default one and modify its layout based on the message to be shown.