### PR TITLE
Fixed typo in menuexports.py

### DIFF
--- a/renpy/exports/menuexports.py
+++ b/renpy/exports/menuexports.py
@@ -263,8 +263,8 @@ def display_menu(
     If you need to supply per-item arguments, use :class:`renpy.Choice` objects as the values. For example::
 
         renpy.display_menu([
-            ("East", renpy.Choice("east", icon="right_arrow"),
-            ("West", renpy.Choice("west", icon="left_arrow"),
+            ("East", renpy.Choice("east", icon="right_arrow")),
+            ("West", renpy.Choice("west", icon="left_arrow"))
             ])
     """
 


### PR DESCRIPTION
It's probably for the best that the code snippets in the docs run, ha. Fixed a simple typo.