### PR TITLE
Update live2d.rst for 8.5

### DIFF
--- a/sphinx/source/live2d.rst
+++ b/sphinx/source/live2d.rst
@@ -26,8 +26,6 @@ It supports the playback of expressions and motions.
 
 .. warning::
 
-    Live2D is not supported on the web platform.
-
     Installing Live2D on iOS requires copying the static libraries into your
     iOS project by hand.
 


### PR DESCRIPTION
As of 8.5, Live2D is now supported on the Web Platform.