### PR TITLE
compat: Flip value for zoom_zaxis prior to 8.4

### DIFF
--- a/renpy/common/00compat.rpy
+++ b/renpy/common/00compat.rpy
@@ -53,7 +53,7 @@ init -1100 python:
             config.old_show_expression = True
             config.cds_label_callbacks = False
             config.mesh_pad_compat = True
-            config.zoom_zaxis = True
+            config.zoom_zaxis = False
 
         if _compat_versions(version, (7, 7, 99), (8, 2, 99)):
             config.character_callback_compat = True


### PR DESCRIPTION
The flag was added in 8.4.2, and the [documentation](https://www.renpy.org/doc/html/incompatible.html#incompatible-8-4-2) states that the value to revert behaviour is `False`, which I believe should be the value set by automatic compat based on script version, which currently sets it to `True` which is already the default.