### PR TITLE
Update loader.py

### DIFF
--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -246,14 +246,14 @@ def index_files():
     game_files.clear()
     lower_map.clear()
 
+    if renpy.android:
+        find_apks()
+
     for _dir, fn in listdirfiles():
         lower_map[unicodedata.normalize("NFC", fn.lower())] = fn
 
     for fn in remote_files:
         lower_map[unicodedata.normalize("NFC", fn.lower())] = fn
-
-    if renpy.android:
-        find_apks()
 
 
 def index_archives():


### PR DESCRIPTION
`find_apks()` at the original spot won't work with local files in mobile search paths.
basically any empty file there already breaks loading of modules and scripts.