### PR TITLE
Fix "Show all unreachable blocks and orphaned translations" option is inverted 

### DIFF
--- a/renpy/lint.py
+++ b/renpy/lint.py
@@ -109,15 +109,15 @@ def problem_listing(header, problems):
         print("{}:".format(filename))
 
         if args.all_problems:
+            for line, message in file_problems:
+                print("    * line {:>5d} {}".format(line, message))
+
+        else:
             for line, message in file_problems[:4]:
                 print("    * line {:>5d} {}".format(line, message))
 
             if len(file_problems) > 4:
                 print("    * and {} more.".format(len(file_problems) - 4))
-
-        else:
-            for line, message in file_problems:
-                print("    * line {:>5d} {}".format(line, message))
 
     global error_reported
     error_reported = True


### PR DESCRIPTION
In lint.py at lines 111-120, I swapped the conditional logic to correct the behaviour so that the toggle works as intended.

```
        if args.all_problems:
            for line, message in file_problems:
                print("    * line {:>5d} {}".format(line, message))

        else:
            for line, message in file_problems[:4]:
                print("    * line {:>5d} {}".format(line, message))

            if len(file_problems) > 4:
                print("    * and {} more.".format(len(file_problems) - 4))
```
                
 
Corrected Behaviour:
https://github.com/user-attachments/assets/7be836b6-cde1-41a4-8dc8-d065a9b3995c


