### PR TITLE
Add reference to renpy.substitute to section on text interpolation.

### DIFF
--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -150,6 +150,7 @@ The transformations are done in the following order:
 #. ``l`` (lowercase)
 #. ``c`` (capitalize)
 
+If you want to get the resulting string, with the arguments replaced with actual data, you can pass it to :ref:`renpy.substitute <renpy.substitute>`.
 
 Styling and Text Tags
 =====================


### PR DESCRIPTION
Useful info for when someone wants to evaluate the resulting string from code (or use it to bake the data in for situations where the source data it isn't available anymore or changed).