### PR TITLE
Drop reload save if load fails

### DIFF
--- a/renpy/common/00keymap.rpy
+++ b/renpy/common/00keymap.rpy
@@ -544,6 +544,13 @@ label _load_reload_game:
     if not renpy.session.get("_reload_slot", None):
         return
 
+    if renpy.session.get("_did_load_reload", False):
+        python:
+            renpy.rename_save(renpy.session["_reload_slot"], "_reload-2")
+            del renpy.session["_reload_slot"]
+            del renpy.session["_did_load_reload"]
+        return
+
     if not renpy.can_load(renpy.session["_reload_slot"]):
         $ del renpy.session["_reload_slot"]
         return
@@ -562,12 +569,14 @@ label _load_reload_game:
             ui.pausebehavior(0)
             ui.interact(suppress_underlay=True, suppress_overlay=True)
 
+            renpy.session["_did_load_reload"] = True
             renpy.load(renpy.session["_reload_slot"])
 
         except (renpy.game.RestartTopContext, renpy.game.RestartContext):
 
             renpy.rename_save(renpy.session["_reload_slot"], "_reload-2")
             del renpy.session["_reload_slot"]
+            del renpy.session["_did_load_reload"]
             raise
 
 


### PR DESCRIPTION
If ignoring the error ends the context, Ren'Py would enter infinite loop of failing load of reload slot. With this change the game will proceed to start as if no save was made.