### PR TITLE
Fix issue with `config.always_shown_screens`

### DIFF
--- a/renpy/display/screen.py
+++ b/renpy/display/screen.py
@@ -1652,7 +1652,7 @@ def show_overlay_screens(suppress_overlay):
                 hide_screen(i)
 
     for i in renpy.config.always_shown_screens:
-        if get_screen(i) is None:
+        if get_screen(i) is None and has_screen(i):
             show_screen(i)
 
 


### PR DESCRIPTION
## Case
1. have a syntax error in renpy code
2. define a screen somewhere **after** the syntax error triggers
3. add the screen to `renpy.config.always_shown_screens` **before** the syntax error
4. attempt to launch the project, get `renpy.display.screen.ScreenNotFound: Screen 'example' is not known.` instead of the syntax error

This happens because renpy is trying to show the screen while showing the traceback, but since script parsing stopped at the syntax error, the screen was never defined.

## Fix
Check the screen exists before attempting to show it

NOTE: I didn't added a similar check to other places because I didn't have any problems there, I decided to leave it as is to avoid unnecessary performance hit.