### PR TITLE
Imrove Sentinel repr.

### DIFF
--- a/renpy/object.py
+++ b/renpy/object.py
@@ -91,3 +91,6 @@ class Sentinel(object):
 
     def __reduce__(self):
         return (Sentinel, (self.name,))
+
+    def __repr__(self):
+        return f"renpy.object.Sentinel({self.name!r})"


### PR DESCRIPTION
That way, when it is used as function parameters default, sphinx will produce reproducible signature, instead of `<Sentinel at 0x...>`.