### PR TITLE
Document renpy object

### DIFF
--- a/renpy/object.py
+++ b/renpy/object.py
@@ -88,11 +88,11 @@ class Object:
             self.after_setstate()
 
     def __init_subclass__(cls):
-        # This also prevents the class from removing __dict__ slot, which is
-        # necessary for fast pickle/unpickle of Object.
         if getattr(cls, "__slots__", None):
             raise TypeError("nonempty __slots__ not supported for subtype of 'renpy.object.Object'")
 
+        if cls.__version__ and cls.after_upgrade is Object.after_upgrade:
+            raise TypeError(f"class {cls.__name__} does not override 'after_upgrade' method")
 
 
 sentinels = {}


### PR DESCRIPTION
This PR adds documentation for `renpy.object.Object` and following behavior changes:
1. Raises exception at class creation time when subclass defines `__slots__` instead exception in `__getstate__`.
2. Raises `TypeError` when subclasses does not define `after_upgrade` instead of `AttributeError` in `__setstate__`.