### PR TITLE
Drop some dead code

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -216,8 +216,6 @@ type_blacklist = (types.ModuleType,)
 
 name_blacklist = {
     "renpy.loadsave.autosave_not_running",
-    "renpy.python.unicode_re",
-    "renpy.python.string_re",
     "renpy.python.store_dicts",
     "renpy.python.store_modules",
     "renpy.text.text.VERT_FORWARD",

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -1252,7 +1252,7 @@ def translate_strings(init_loc, language, l):
         s = s.strip()
 
         try:
-            bc = compile(s, "<string>", "eval", renpy.python.new_compile_flags, True)
+            bc = compile(s, "<string>", "eval", dont_inherit=True)
             return eval(bc, renpy.store.__dict__)
         except Exception:
             ll.error("could not parse string")

--- a/renpy/python.py
+++ b/renpy/python.py
@@ -23,10 +23,7 @@
 # contained within the script file. It also handles rolling back the
 # game state to some time in the past.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
-
-from typing import Optional, Any
+from typing import Any
 import contextlib
 
 # Import the python ast module, not ours.
@@ -37,45 +34,41 @@ import __future__
 
 import collections
 import marshal
-import random
 import weakref
-import re
 import sys
-import time
-import io
 import types
 import copyreg
-import functools
 import warnings
 
 import renpy
 
 from renpy.astsupport import hash32
+from renpy.pydict import DictItems, find_changes
 
 # Import these for pickle-compatibility.
 from renpy.revertable import (
-    CompressedList,
-    DetRandom,
-    RevertableDict,
-    RevertableList,
-    RevertableObject,
-    RevertableSet,
-    RollbackRandom,
-    revertable_range,
-    revertable_sorted,
+    CompressedList as CompressedList,
+    DetRandom as DetRandom,
+    RevertableDict as RevertableDict,
+    RevertableList as RevertableList,
+    RevertableObject as RevertableObject,
+    RevertableSet as RevertableSet,
+    RollbackRandom as RollbackRandom,
+    revertable_range as revertable_range,
+    revertable_sorted as revertable_sorted,
 )
 
 from renpy.rollback import (
-    deleted,
-    StoreDeleted,
-    AlwaysRollback,
-    NoRollback,
-    SlottedNoRollback,
-    rng,
-    reached,
-    reached_vars,
-    Rollback,
-    RollbackLog,
+    deleted as deleted,
+    StoreDeleted as StoreDeleted,
+    AlwaysRollback as AlwaysRollback,
+    NoRollback as NoRollback,
+    SlottedNoRollback as SlottedNoRollback,
+    rng as rng,
+    reached as reached,
+    reached_vars as reached_vars,
+    Rollback as Rollback,
+    RollbackLog as RollbackLog,
 )
 
 
@@ -109,9 +102,6 @@ class StoreModule(object):
 
 def get_store_module(name):
     return sys.modules[name]
-
-
-from renpy.pydict import DictItems, find_changes
 
 
 class StoreDict(dict):
@@ -241,10 +231,8 @@ def create_store(name):
     d = store_dicts.setdefault(name, StoreDict())
     d.reset()
 
-    pyname = pystr(name)
-
     # Set the name.
-    d.update(__name__=pyname, __package__=pyname)
+    d.update(__name__=name, __package__=name)
 
     # Set up the default contents of the store.
     eval("1", d)
@@ -260,12 +248,12 @@ def create_store(name):
 
     # Create or reuse the corresponding module.
     if name in store_modules:
-        sys.modules[pyname] = store_modules[name]
+        sys.modules[name] = store_modules[name]
     else:
-        store_modules[name] = sys.modules[pyname] = StoreModule(d)  # type: ignore
+        store_modules[name] = sys.modules[name] = StoreModule(d)  # type: ignore
 
     if parent:
-        store_dicts[parent][var] = sys.modules[pyname]
+        store_dicts[parent][var] = sys.modules[name]
 
 
 class StoreBackup:
@@ -311,7 +299,7 @@ class StoreBackup:
             self.restore_one(k)
 
 
-clean_store_backup = None  # type: Optional[StoreBackup]
+clean_store_backup: StoreBackup | None = None
 
 
 def make_clean_stores():
@@ -333,7 +321,7 @@ def clean_stores():
     Revert the store to the clean copy.
     """
 
-    clean_store_backup.restore()  # type: ignore
+    clean_store_backup.restore()
 
 
 def clean_store(name):
@@ -344,7 +332,7 @@ def clean_store(name):
     if not name.startswith("store."):
         name = "store." + name
 
-    clean_store_backup.restore_one(name)  # type: ignore
+    clean_store_backup.restore_one(name)
 
 
 def reset_store_changes(name):
@@ -782,42 +770,6 @@ _execute_python_hide()
     tree.body = hide.body
 
 
-unicode_re = re.compile(r"[\u0080-\uffff]")
-
-
-def unicode_sub(m):
-    """
-    If the string s contains a unicode character, make it into a
-    unicode string.
-    """
-
-    s = m.group(0)
-
-    if not unicode_re.search(s):
-        return s
-
-    prefix = m.group(1)
-    sep = m.group(2)
-    body = m.group(3)
-
-    if "u" not in prefix and "U" not in prefix:
-        prefix = "u" + prefix
-
-    rv = prefix + sep + body + sep
-
-    return rv
-
-
-string_re = re.compile(r'([uU]?[rR]?)("""|"|\'\'\'|\')((\\.|.)*?)\2')
-
-
-def escape_unicode(s):
-    if unicode_re.search(s):
-        s = string_re.sub(unicode_sub, s)
-
-    return s
-
-
 # A list of warnings that were issued during compilation.
 compile_warnings = []
 
@@ -845,16 +797,6 @@ def save_warnings():
     finally:
         warnings.showwarning = old
 
-
-# Flags used by py_compile.
-old_compile_flags = __future__.nested_scopes.compiler_flag | __future__.with_statement.compiler_flag
-
-new_compile_flags = (
-    old_compile_flags
-    | __future__.absolute_import.compiler_flag
-    | __future__.print_function.compiler_flag
-    | __future__.unicode_literals.compiler_flag
-)
 
 # A set of __future__ flag overrides for each file.
 file_compiler_flags = collections.defaultdict(int)

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -80,7 +80,7 @@ def compile_expr(loc, node):
     """
 
     filename = loc[0]
-    flags = renpy.python.new_compile_flags | renpy.python.file_compiler_flags.get(filename, 0)
+    flags = renpy.python.file_compiler_flags.get(filename, 0)
 
     expr = ast.Expression(body=node)
     renpy.python.LocationFixer(node)


### PR DESCRIPTION
1. Remove use of `pystr` which is always `str` now.
2. Remove `escape_unicode` which was used to wrap unicode strings in Python 2.
3. Remove `old_compile_flags` and `new_compile_flags` which are always enabled in Python 3.12, and its uses.