### PR TITLE
Ensure can_rollback does not mutate values

### DIFF
--- a/renpy/rollback.py
+++ b/renpy/rollback.py
@@ -878,8 +878,8 @@ class RollbackLog(renpy.object.Object):
         it returns False.
         """
 
-        if checkpoints and (self.rollback_limit <= 0) and not force:
-            return False
+        if not force:
+            return checkpoints <= self.rollback_limit
 
         # Find the place to roll back to.
         for rb in reversed(self.log):


### PR DESCRIPTION
- Removes mutation of `self.rollback_block` during the read-only `can_rollback` check.
- Removes double decrement of local `checkpoints` (see the if statement immediately following removed block).

This is mostly a speculative fix, I've done some cursory testing and believe it to be correct but I've not used it in anger.

---

Second commit addresses the short circuit check that wasn't accounting for `checkpoints` being a numeric value.