### PR TITLE
Document use of the None key in dict transitions

### DIFF
--- a/sphinx/source/transitions.rst
+++ b/sphinx/source/transitions.rst
@@ -197,6 +197,10 @@ dialogue is being shown on the screen. For example::
 
 The dissolve will take place while the text is displayed on the screen.
 
+The exception to this is when a dict transition has a `None` key. If a dict
+transition maps the `None` layer to a transition, this transition will run with
+the standard pause. This can be used with `NoTransition` to create a pause.
+
 Dict layer transitions can't be used every place a transition can be used, only
 in places where applying transitions to a layer is possible. It can be used with
 the :ref:`with-statement` and ``with`` cause of the


### PR DESCRIPTION
I've been trying to use dict transitions on one layer while keeping the standard pause, which the documentation claims it doesn't support. After a day of searching I found that the with statement *does* fully support this behavior, but it's gone undocumented. 

The main point is the documentation of this behavior:

https://github.com/renpy/renpy/blob/0bd3393be41f9f1b2fd89e3ff3dcfa96789bddf8/sphinx/source/transitions.rst?plain=1#L200-L202

The `with_statement` currently behaves as described, although not even the docstring for the function mentions this:

https://github.com/renpy/renpy/blob/6794fcd3983aa0e5a8eabdced0e4a2ad2c02ff3b/renpy/exports/statementexports.py#L248-L260

Both of these are very tentative as I don't fully understand the intent here. Several questions remain which could influence this:

- Is the `None` key intended to be completely hidden or reserved for internal use even though it's part of a publicly exposed export? (i.e. https://github.com/renpy/renpy/pull/5751#issuecomment-2323332875; this seems external enough to me but maybe it's not?)
- Should this situation be handled better, like adding a parameter to the with statement to automatically pause other layers?
  - This appears nontrivial as it would involve predicting the duration of multiple uninstantiated transitions without knowing their displayables
  - ~~Also, `NoTransition` is not directly exported yet, so in order to get the pause behavior I describe in the documentation you have to curry `renpy.display.transition.NoTransition` yourself~~
    - This is exported as `Pause`, oops