### PR TITLE
Centralize python cache code

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -653,7 +653,8 @@ def reload_all():
         renpy.display.draw.quit()  # type: ignore
         renpy.display.draw = None
 
-    py_compile_cache = renpy.python.py_compile_cache
+    renpy.python.compile_cache.reload()
+
     reload_modules = renpy.config.reload_modules
 
     # Delete the store modules.
@@ -671,8 +672,6 @@ def reload_all():
 
     # Restore the state of all modules from backup.
     backup.restore()
-
-    renpy.python.old_py_compile_cache = py_compile_cache
 
     renpy.display.im.reset_module()
 


### PR DESCRIPTION
This PR decouples `renpy.script` and `renpy.python` referencing each other to cache result of `py_compile` storing it all in one dedicated class. This is related to #6328 and removes one of responsibilities of `Script` class.