### PR TITLE
Improve linter logs on im.ImageMatrix usage

### DIFF
--- a/renpy/display/im.py
+++ b/renpy/display/im.py
@@ -692,8 +692,9 @@ class ImageBase(renpy.display.displayable.Displayable):
         self.identity = (type(self).__name__,) + args + flat_properties
 
         if self.obsolete and renpy.game.context().init_phase:
-            frame = sys._getframe(2)
-            while frame.f_code.co_filename == __file__ and frame.f_back:
+            frame = sys._getframe()
+            current_filename = frame.f_code.co_filename
+            while frame.f_code.co_filename == current_filename and frame.f_back:
                 frame = frame.f_back
             filename = frame.f_code.co_filename
             line = frame.f_lineno


### PR DESCRIPTION
Consider the following code in a `game/images.rpy` file:

```py
define img1 = im.Grayscale("gui/namebox.png")
define img2 = im.MatrixColor("gui/namebox.png", [0]*20)
```

Currently, if an `im.ImageMatrix` proxy function is used (e.g.: `im.GrayScale` above), the linter logs an issue within Ren'Py's code, which makes the original issue way harder to identify for non-technical users:

```
Obsolete Image Manipulators:

/home/ayowel/data/development/sdk/renpy/renpy-8.5.2-sdk/renpy/display/im.py:
    * line  2137 im.MatrixColor

game/images.rpy:
    * line    2 im.MatrixColor
```

This improves linting by ensuring that the logged frame is out of im.py, which will usually more closely match user's expectations as a step toward permanently deleting this deprecated usage:

```
Obsolete Image Manipulators:

game/images.rpy:
    * line    1 im.MatrixColor
    * line    2 im.MatrixColor
```
