### PR TITLE
fix: Restore widget support in transition

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -1553,7 +1553,7 @@ class Interface:
             return None
 
         start = self.transition_time.get(layer, self.frame_time) or self.frame_time
-        delay = getattr(transition, "delay", 0)
+        delay = getattr(transition, "delay", 0) or 0
 
         if (self.frame_time - start) < delay:
             return rv


### PR DESCRIPTION
Until 8.3.1 at least, it was possible to create custom transitions that simply returned the new widget to e.g. conditionally disable an effect:

```python
init python:
    def vpunch(new_widget, **kwargs):
        # Override native vpunch
        if persistent.is_vibration_enabled:
            return Move((0, 10), (0, -10), .10, bounce=True, repeat=True, delay=.275)(new_widget = new_widget, **kwargs)
        else:
            return new_widget
```

This does not appear to work anymore. as the `delay` attribute may be `None`, which raises an exception when testing the condition `(self.frame_time - start) < delay`. This ensures that the value of delay is a numeral instead of `None`.

