### PR TITLE
Fix `@pure` decorator logic to support class methods via `__qualname__`

### DIFF
--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -240,7 +240,7 @@ def pure(fn):
     name = fn
 
     if not isinstance(name, str):
-        name = fn.__name__
+        name = fn.__qualname__
 
         module = fn.__module__
         name = module + "." + name


### PR DESCRIPTION
Previously, using `fn.__name__` caused class methods to be registered incorrectly as top-level functions (e.g., `'module.method'` instead of `'module.Class.method'`).

Swapping to `__qualname__` ensures the fully qualified name is used, allowing the analyzer to correctly track pure methods nested inside classes.

**Technical Note**: This change relies on Python 3.10+ behavior where `staticmethod` and `classmethod` wrappers directly expose `__name__`, `__qualname__`, and `__module__`, removing the need to manually unwrap the underlying function.

Closes #6871