### PR TITLE
Fix blurry effect with nearest sampling

### DIFF
--- a/renpy/gl2/gl2uniform.pyx
+++ b/renpy/gl2/gl2uniform.pyx
@@ -355,6 +355,12 @@ cdef class Sampler2DSetter(Setter):
             if "texture_scaling" in context.properties:
                 mag_filter, min_filter = TEXTURE_SCALING[context.properties["texture_scaling"]]
 
+        if renpy.display.draw.gles and mag_filter == GL_NEAREST and min_filter == GL_NEAREST:
+            # If anisotropy is not set to 1.0, linear filtering will be used by ANGLE.
+            # This is a Windows only issue affecting "gles" and "angle2", but also any
+            # Web browsers running on Windows.
+            anisotropy = 1.0
+
         if wrap_s != texture.wrap_s:
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_s)
             texture.wrap_s = wrap_s


### PR DESCRIPTION
See renpy/renpy#6929 for the initial issue.

The problem is caused by ANGLE interpretation of the anisotropy parameter: if it is set to something other than 1.0, linear sampling will be used for the mag/min filters, even when they are configured as GL_NEAREST. The solution is to force it to 1.0 when these filters are configured to GL_NEAREST. I don't know if other configuration should be considered too (GL_NEAREST_MIPMAP_NEAREST maybe?).

I'm not sure there is a point in enabling anisotropy when using GL_NEAREST anyway, but just to be safe, the changes only force the value when using gles2 (which includes ANGLE and emscripten). Ideally, this should be limited to Windows only, but detecting Windows from emscripten is probably not reliable.

TBH, I don't really see a difference with and without anisotropy, so I can't tell if these changes break anything with linear sampling.

Fix renpy/renpy#6929
Fix renpy/renpyweb#11