### PR TITLE
split `Parser.copy_properties` into `copy_positionals` and `copy_keywords`

### DIFF
--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -618,6 +618,14 @@ def register_sl_displayable(*args, **kwargs):
         These correspond to groups of :doc:`style_properties`. Group can
         also be "ui", in which case it adds the :ref:`common ui properties <common-properties>`.
 
+    .. method:: copy_positionals(name)
+    
+        Adds positional arguments that can be passed to the `name` screen statement.
+        
+    .. method:: copy_keywords(name)
+    
+        Adds all styles and keyword arguments that can be passed to the `name` screen statement.
+
     .. method:: copy_properties(name)
 
         Adds all styles and positional/keyword arguments that can be passed to the `name` screen statement.


### PR DESCRIPTION
allows for more flexibility on what you want to copy

use case: i'm making a custom isometric grid and want to copy everything but the positionals from the `grid` sl displayable