### PR TITLE
Add Gain filter to audio_filter doc category

### DIFF
--- a/renpy/audio/filter.pyx
+++ b/renpy/audio/filter.pyx
@@ -755,6 +755,8 @@ cdef class Multiply(AudioFilter):
 
 def Gain(db):
     """
+    :doc: audio_filter
+
     An audio filter that adjusts the gain of the input by `db` decibels.
     """
 


### PR DESCRIPTION
This PR adds the useful `Gain` audio filter to the `audio_filter` docs category so it appears in the appropriate documentation.