### PR TITLE
Extract colorspace from the video instead of assuming default

### DIFF
--- a/src/ffmedia.c
+++ b/src/ffmedia.c
@@ -881,8 +881,15 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 			return NULL;
 		}
 
+		int colorspace = ms->video_decode_frame->colorspace;
+		if (colorspace == AVCOL_SPC_UNSPECIFIED) {
+			colorspace = SWS_CS_DEFAULT;
+		}
+
+		int src_range = (ms->video_decode_frame->color_range == AVCOL_RANGE_JPEG) ? 1 : 0;
+
 		sws_setColorspaceDetails(ms->sws,
-			sws_getCoefficients(SWS_CS_DEFAULT), 0,
+			sws_getCoefficients(colorspace), src_range,
 			sws_getCoefficients(SWS_CS_DEFAULT), 0,
 			0, 1 << 16, 1 << 16);
 	}


### PR DESCRIPTION
Currently renpy assumes that all videos use the mpeg (limited) color range and the (very outdated) bt601 color-space for what appears to be no good reason, this made it so that videos looked different outside of renpy and made seamless transitions from starting frame to video file impossible unless you encoded your video to these standards.
This PR makes it so that both color range and color space are extracted from the metadata of the file, with the color-space falling back to the default if not specified.