### PR TITLE
Remove branch names from official builds

### DIFF
--- a/renpy/versions.py
+++ b/renpy/versions.py
@@ -94,7 +94,7 @@ def _make_version_string(
     if dirty:
         suffixes.append("dirty")
 
-    if branch != "main" or dirty:
+    if not official and branch != "main" or dirty:
         suffixes.append(branch)
 
     return f"{major}.{minor}.{patch}.{commit:08d}+{'.'.join(suffixes)}"


### PR DESCRIPTION
Official builds already have a well managed versioning system, adding `.master` and `.fix` to the end of them doesn't seem necessary.