### PR TITLE
Add NULL guard for media_close in RPS_periodic

### DIFF
--- a/src/renpysound_core.c
+++ b/src/renpysound_core.c
@@ -1441,7 +1441,10 @@ void RPS_periodic() {
     UNLOCK_NAME();
 
     while (d) {
-        media_close(d->stream);
+		if (d->stream) {
+        	media_close(d->stream);
+		}
+		
         struct Dying *next_d = d->next;
 
         if (d->audio_filter) {


### PR DESCRIPTION
RPS_periodic can crash with a NULL pointer dereference when d->stream is NULL in the dying queue.

A race condition can cause c->playing to be NULL at capture time, resulting in a Dying entry with a NULL stream. When RPS_periodic processes the dying queue, it calls media_close(d->stream) unconditionally, which dereferences the NULL pointer.