### PR TITLE
Catch errors when writing steam_appid.txt

### DIFF
--- a/renpy/common/00steam.rpy
+++ b/renpy/common/00steam.rpy
@@ -972,8 +972,11 @@ init -1499 python in achievement:
         steam_appid_fn = os.path.join(os.path.dirname(sys.executable), "steam_appid.txt")
 
         if config.steam_appid is not None:
-            with open(steam_appid_fn, "w") as f:
-                f.write(str(config.steam_appid) + "\n")
+            try:
+                with open(steam_appid_fn, "w") as f:
+                    f.write(str(config.steam_appid) + "\n")
+            except Exception as e:
+                renpy.write_log("Failed to write steam_appid.txt: %r", e)
         else:
             try:
                 os.unlink(steam_appid_fn)


### PR DESCRIPTION
This patch fixes some crashing when the Python executable is not in a writable dir (such as when it is in `/usr/bin`).

Actually to my understanding, the file `steam_appid.txt` should only be created when the executable is from `$ROOT/lib`, but I think the current patch is good enough.

By the way, from the official [documentation](https://partner.steamgames.com/doc/sdk/api) of Steamworks API, the file `steam_appid.txt` should be in the working directory instead of next to the executable:

> If you're running your application from the executable or debugger directly then you must have a `steam_appid.txt` in your game directory next to the executable, with your app ID in it and nothing else. Steam will look for this file in the current working directory. If you are running your executable from a different directory you may need to relocate the `steam_appid.txt` file.

So maybe we should just use `steam_appid_fn = "steam_appid.txt"` instead of the current `os.path.join` call? I may be mistaken.