### PR TITLE
Add control action corresponding to renpy.call_in_new_context

### DIFF
--- a/renpy/common/00action_control.rpy
+++ b/renpy/common/00action_control.rpy
@@ -105,7 +105,10 @@ init -1500 python:
 
         Calls `label`, given as a string, in a new context. This is useful
         when calling a label from a screen which is itself being
-        called via `call screen`.
+        called via `call screen`. Note that, while in a new context,
+        the player will be unable to save the game, and
+        the scene and audio state will be reset upon returning
+        to the outer context. See :ref:`Contexts <context>` for more info.
         Arguments and keyword arguments are passed to
         :func:`renpy.call_in_new_context`.
         """

--- a/renpy/common/00action_control.rpy
+++ b/renpy/common/00action_control.rpy
@@ -99,6 +99,29 @@ init -1500 python:
             renpy.call(self.label, *self.args, **self.kwargs)
 
     @renpy.pure
+    class CallInNewContext(Action, DictEquality):
+        """
+        :doc: control_action
+
+        Calls `label`, given as a string, in a new context. This is useful
+        when calling a label from a screen which is itself being
+        called via `call screen`.
+        Arguments and keyword arguments are passed to
+        :func:`renpy.call_in_new_context`.
+        """
+
+        args = tuple()
+        kwargs = dict()
+
+        def __init__(self, label, *args, **kwargs):
+            self.label = label
+            self.args = args
+            self.kwargs = kwargs
+
+        def __call__(self):
+            renpy.call_in_new_context(self.label, *self.args, **self.kwargs)
+
+    @renpy.pure
     class Show(Action, DictEquality):
         """
         :doc: control_action


### PR DESCRIPTION
This PR creates an `Action` called `CallInNewContext`, categorized as a control action, that corresponds to `renpy.call_in_new_context`. Its API is exactly the same as the `Call` action.

The justification for this action being included by default is that calling a label in a new context is necessary when calling a label from a screen which is itself being called, if that label would trigger an interaction. The most notable case for this is calling a label that runs a transition as part of its execution. Examples of what I mean:

```
# calling this label with the Call action is fine, no problems here
label call_me_from_the_map_screen_1:
  flowerpot "Dang, this sure is the map screen!"
  return

label call_me_from_the_map_screen_2:
  show flowerpot at center
  with Dissolve(0.3) # this will crash if we don't enter a new context!!
  flowerpot "Dang, this sure is the map screen!"
  return
```

It's possible to correctly call labels like `call_me_from_the_map_screen_2` by using `Function(renpy.call_in_new_context, "call_me_from_the_map_screen_2")`, but there's no reason for this to be so much more cumbersome.

I propose the inclusion of this action directly into the engine rather than as an add-on because calling labels from a called screen is a very common design pattern, especially in detective and mystery games, which use this pattern for exploration and investigation segments. Since calling in a new context is necessary if you want to call a label with transitions or some other kind of interaction in it, the engine should provide the proper tool for this task.