### PR TITLE
Restore `renpy.loadsave.dumps` removed in af9679f

### DIFF
--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -32,7 +32,7 @@ import time
 import renpy
 from json import dumps as json_dumps
 
-from renpy.compat.pickle import dump, loads, dump_paths, find_bad_reduction
+from renpy.compat.pickle import dump, dumps, loads, dump_paths, find_bad_reduction
 
 
 # This is used as a quick and dirty way of versioning savegame


### PR DESCRIPTION
The API `renpy.loadsave.dumps` was removed in af9679f, which is a breaking change introduced in 7.5.0 and 8.5.2.

https://github.com/renpy/renpy/commit/af9679f3ab3becd5516e949427505bd25279cb50#diff-9c341eebc74dbd209775af1ea6d4072346feb1bdbbe0af5a35ce9bf0a7238d4fL46-L76