### PR TITLE
Add config variable to determine if controller input hides the mouse

### DIFF
--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -77,6 +77,8 @@ _autosave = True
 # Should live2d fading happen?
 _live2d_fade = True
 
+# Should the mouse be hidden when a controller event happens?
+_controller_hides_mouse = True
 
 class _Config(object):
     def __getstate__(self):

--- a/renpy/display/controller.py
+++ b/renpy/display/controller.py
@@ -19,10 +19,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
-
-
 import os
 
 import renpy.pygame as pygame
@@ -192,7 +188,7 @@ class PadEvent(object):
 
         post_event(self.control, self.state, False)
 
-        if renpy.display.interface is not None:
+        if renpy.display.interface is not None and renpy.store._controller_hides_mouse:
             renpy.display.interface.hide_mouse()
 
     def repeat(self):


### PR DESCRIPTION
Currently, controller input will hide the mouse. I'm using a controller to move the mouse so having controller input hide the mouse is not ideal. This PR makes this functionality configurable, with the default being the current behaviour.