### PR TITLE
Update Reserved Names Docs

### DIFF
--- a/sphinx/source/reserved.rst
+++ b/sphinx/source/reserved.rst
@@ -11,6 +11,12 @@ Ren'Py reserves all names beginning with a single underscore (\_). Do not
 use names beginning with an underscore, as that may cause your game to break
 in future versions of Ren'Py.
 
+In addition, Python has rules for what names are valid variables:
+
+* A variable name must start with a letter
+* A variable name cannot start with a number
+* A variable name can only contain alpha-numeric characters and underscores (A-z, 0-9, and _ )
+
 The following is a list of names that are used by Python. Re-using these
 names can lead to obscure problems.
 

--- a/sphinx/source/reserved.rst
+++ b/sphinx/source/reserved.rst
@@ -11,11 +11,11 @@ Ren'Py reserves all names beginning with a single underscore (\_). Do not
 use names beginning with an underscore, as that may cause your game to break
 in future versions of Ren'Py.
 
-In addition, Python has rules for what names are valid variables:
+In addition, Python has rules for what names are valid:
 
-* A variable name must start with a letter
-* A variable name cannot start with a number
-* A variable name can only contain alpha-numeric characters and underscores (A-z, 0-9, and _ )
+* A name must start with a letter
+* A name cannot start with a number
+* A name can only contain alpha-numeric characters and underscores (A-z, 0-9, and _ )
 
 The following is a list of names that are used by Python. Re-using these
 names can lead to obscure problems.

--- a/sphinx/source/reserved.rst
+++ b/sphinx/source/reserved.rst
@@ -15,7 +15,7 @@ In addition, Python has rules for what names are valid:
 
 * A name must start with a letter
 * A name cannot start with a number
-* A name can only contain alpha-numeric characters and underscores (A-z, 0-9, and _ )
+* A name can only contain alpha-numeric characters and underscores (A-z, 0-9, and \_ )
 
 The following is a list of names that are used by Python. Re-using these
 names can lead to obscure problems.


### PR DESCRIPTION
This minor update adds Python naming restrictions to the Reserved Names page to assist newer coders with what is and isn't allowed.  The page already lists other Python specific exceptions/rules; these should be here as well.