### PR TITLE
C++ Optimized RPA Archive Reading Module

### DIFF
--- a/launcher/game/archiver.rpy
+++ b/launcher/game/archiver.rpy
@@ -32,13 +32,31 @@ init python in archiver:
 
     from pickle import dumps, HIGHEST_PROTOCOL
 
+    try:
+        from renpy.archiver.packer import RPAPacker, derive_key, RPA_ENCRYPTION_KEY_SIZE
+        _HAS_CXX_PACKER = True
+    except ImportError:
+        _HAS_CXX_PACKER = False
+
 
     class Archive(object):
         """
         Adds files from disk to a rpa archive.
         """
 
-        def __init__(self, filename):
+        def __init__(self, filename, encryption_password=None):
+
+            # Use C++ packer if available
+            if _HAS_CXX_PACKER:
+                encryption_key = None
+                if encryption_password:
+                    encryption_key = derive_key(encryption_password)
+                self.cxx_packer = RPAPacker(filename, encryption_key=encryption_key)
+                self.use_cxx = True
+                return
+
+            # Fall back to Python implementation
+            self.use_cxx = False
 
             # The archive file.
             self.f = open(filename, "wb")
@@ -57,6 +75,10 @@ init python in archiver:
             Adds a file to the archive.
             """
 
+            if self.use_cxx:
+                self.cxx_packer.add_file(name, path)
+                return
+
             self.index[name] = _list()
 
             with open(path, "rb") as df:
@@ -74,6 +96,10 @@ init python in archiver:
             self.index[name].append((offset ^ self.key, dlen ^ self.key, b""))
 
         def close(self):
+
+            if self.use_cxx:
+                self.cxx_packer.close()
+                return
 
             indexoff = self.f.tell()
 

--- a/renpy/archiver/__init__.py
+++ b/renpy/archiver/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/renpy/archiver/packer.pyx
+++ b/renpy/archiver/packer.pyx
@@ -1,0 +1,183 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import print_function
+
+cdef extern from "rpa_packer.h":
+    ctypedef struct RPAPacker:
+        pass
+
+    ctypedef struct RPAOptions:
+        int version
+        uint64_t key
+        bint compress_index
+        int compression_level
+
+    ctypedef enum RPAPackerError:
+        RPA_PACKER_OK = 0
+        RPA_PACKER_ERROR_FILE_NOT_FOUND = -1
+        RPA_PACKER_ERROR_FILE_WRITE = -2
+        RPA_PACKER_ERROR_OUT_OF_MEMORY = -3
+        RPA_PACKER_ERROR_ZLIB_ERROR = -4
+        RPA_PACKER_ERROR_INVALID_PATH = -5
+        RPA_PACKER_ERROR_ENTRY_EXISTS = -6
+
+    int rpa_packer_create(const char* output_path, RPAOptions* options, RPAPacker** out_packer)
+    int rpa_packer_add_file(RPAPacker* packer, const char* name, const char* path)
+    int rpa_packer_add_data(RPAPacker* packer, const char* name, const uint8_t* data, size_t len)
+    int rpa_packer_close(RPAPacker* packer)
+    const char* rpa_packer_error_string(int error)
+
+cdef extern from "rpa_encryption.h":
+    cdef int RPA_ENCRYPTION_KEY_SIZE
+    int rpa_encryption_init()
+    int rpa_encryption_encrypt(const uint8_t* data, size_t len, const uint8_t* key, uint8_t** out_encrypted, size_t* out_len)
+    int rpa_encryption_decrypt(const uint8_t* encrypted, size_t len, const uint8_t* key, uint8_t** out_decrypted, size_t* out_len)
+    int rpa_encryption_derive_key(const char* password, uint8_t* out_key)
+
+cdef class RPAPacker:
+    cdef RPAPacker* packer
+    cdef bytes _output_path
+
+    def __init__(self, output_path, key=0x42424242, encryption_key=None):
+        cdef RPAOptions options
+        cdef int result
+
+        self._output_path = output_path.encode('utf-8') if isinstance(output_path, str) else output_path
+
+        options.version = 3
+        options.key = key
+        options.compress_index = True
+        options.compression_level = 9
+        options.encrypt_index = (encryption_key is not None)
+        
+        if encryption_key:
+            if len(encryption_key) != RPA_ENCRYPTION_KEY_SIZE:
+                raise ValueError("Encryption key must be %d bytes" % RPA_ENCRYPTION_KEY_SIZE)
+            memcpy(options.encryption_key, <const uint8_t*>encryption_key, RPA_ENCRYPTION_KEY_SIZE)
+        else:
+            memset(options.encryption_key, 0, RPA_ENCRYPTION_KEY_SIZE)
+
+        result = rpa_packer_create(<const char*>self._output_path, &options, &self.packer)
+        if result != RPA_PACKER_OK:
+            raise Exception("Failed to create RPA packer: %s" % rpa_packer_error_string(result).decode('utf-8'))
+
+    def add_file(self, name, path):
+        cdef int result
+        cdef bytes py_name
+        cdef bytes py_path
+
+        if not self.packer:
+            raise Exception("Packer not initialized")
+
+        py_name = name.encode('utf-8') if isinstance(name, str) else name
+        py_path = path.encode('utf-8') if isinstance(path, str) else path
+
+        result = rpa_packer_add_file(self.packer, <const char*>py_name, <const char*>py_path)
+        if result != RPA_PACKER_OK:
+            raise Exception("Failed to add file: %s" % rpa_packer_error_string(result).decode('utf-8'))
+
+    def add_data(self, name, data):
+        cdef int result
+        cdef bytes py_name
+
+        if not self.packer:
+            raise Exception("Packer not initialized")
+
+        py_name = name.encode('utf-8') if isinstance(name, str) else name
+
+        result = rpa_packer_add_data(self.packer, <const char*>py_name, <const uint8_t*>data, len(data))
+        if result != RPA_PACKER_OK:
+            raise Exception("Failed to add data: %s" % rpa_packer_error_string(result).decode('utf-8'))
+
+    def close(self):
+        cdef int result
+
+        if self.packer:
+            result = rpa_packer_close(self.packer)
+            self.packer = NULL
+            if result != RPA_PACKER_OK:
+                raise Exception("Failed to close packer: %s" % rpa_packer_error_string(result).decode('utf-8'))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+def create_rpa_packer(output_path, key=0x42424242, encryption_key=None):
+    return RPAPacker(output_path, key, encryption_key)
+
+def secretbox_encrypt(bytes message, bytes key):
+    """
+    Encrypts the given message using the RPA encryption system.
+    """
+    cdef int result
+    cdef uint8_t* encrypted
+    cdef size_t encrypted_len
+    
+    if len(key) != RPA_ENCRYPTION_KEY_SIZE:
+        raise ValueError("Key must be %d bytes" % RPA_ENCRYPTION_KEY_SIZE)
+    
+    result = rpa_encryption_encrypt(<const uint8_t*>message, len(message), <const uint8_t*>key, &encrypted, &encrypted_len)
+    if result != 0:
+        raise ValueError("Encryption failed")
+    
+    try:
+        return bytes(encrypted[:encrypted_len])
+    finally:
+        free(encrypted)
+
+def secretbox_decrypt(bytes cyphertext, bytes key):
+    """
+    Decrypts the given cyphertext using the RPA encryption system.
+    """
+    cdef int result
+    cdef uint8_t* decrypted
+    cdef size_t decrypted_len
+    
+    if len(key) != RPA_ENCRYPTION_KEY_SIZE:
+        raise ValueError("Key must be %d bytes" % RPA_ENCRYPTION_KEY_SIZE)
+    
+    result = rpa_encryption_decrypt(<const uint8_t*>cyphertext, len(cyphertext), <const uint8_t*>key, &decrypted, &decrypted_len)
+    if result != 0:
+        raise ValueError("Decryption failed")
+    
+    try:
+        return bytes(decrypted[:decrypted_len])
+    finally:
+        free(decrypted)
+
+def derive_key(str password):
+    """
+    Derives a encryption key from a password.
+    """
+    cdef int result
+    cdef uint8_t key[RPA_ENCRYPTION_KEY_SIZE]
+    
+    result = rpa_encryption_derive_key(password.encode('utf-8'), key)
+    if result != 0:
+        raise ValueError("Key derivation failed")
+    
+    return bytes(key)
+
+RPA_ENCRYPTION_KEY_SIZE = RPA_ENCRYPTION_KEY_SIZE
+

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -38,6 +38,21 @@ from renpy.pygame.rwobject import RWopsIO
 from renpy.compat.pickle import loads
 from renpy.webloader import DownloadNeeded
 
+try:
+    from renpy.loader.rpa_cxx import (
+        get_rpa_reader,
+        read_from_rpa,
+        has_in_rpa,
+        preload_rpa_index,
+        _HAS_CXX_READER,
+    )
+except ImportError:
+    _HAS_CXX_READER = False
+    get_rpa_reader = None
+    read_from_rpa = None
+    has_in_rpa = None
+    preload_rpa_index = None
+
 # Ensure the utf-8 codec is loaded, to prevent recursion when we use it
 # to look up filenames.
 "".encode("utf-8")
@@ -579,9 +594,13 @@ def load_from_archive(name):
         if not name in index:
             continue
 
+        if _HAS_CXX_READER and get_rpa_reader is not None:
+            data = read_from_rpa(afn, name)
+            if data is not None:
+                return io.BytesIO(data)
+
         data = []
 
-        # Direct path.
         if len(index[name]) == 1:
             t = index[name][0]
             if len(t) == 2:
@@ -599,7 +618,6 @@ def load_from_archive(name):
                 rv = RWopsIO.from_split(a, b, name=name)
                 rv = io.BufferedReader(rv)
 
-        # Compatibility path.
         else:
             with open(afn, "rb") as f:
                 for offset, dlen in index[name]:

--- a/renpy/loader/__init__.py
+++ b/renpy/loader/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/renpy/loader/rpa_archive.pyx
+++ b/renpy/loader/rpa_archive.pyx
@@ -1,0 +1,137 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import print_function
+
+cdef extern from "rpa_archive.h":
+    ctypedef struct RPAArchive:
+        pass
+
+    ctypedef enum RPAError:
+        RPA_OK = 0
+        RPA_ERROR_FILE_NOT_FOUND = -1
+        RPA_ERROR_INVALID_HEADER = -2
+        RPA_ERROR_INDEX_CORRUPT = -3
+        RPA_ERROR_ENTRY_NOT_FOUND = -4
+        RPA_ERROR_READ_ERROR = -5
+        RPA_ERROR_ZLIB_ERROR = -6
+        RPA_ERROR_OUT_OF_MEMORY = -7
+
+    int rpa_archive_open(const char* path, RPAArchive** out_archive)
+    void rpa_archive_close(RPAArchive* archive)
+    int rpa_archive_read_entry(RPAArchive* archive, const char* name, uint8_t** out_data, size_t* out_len)
+    int rpa_archive_has_entry(RPAArchive* archive, const char* name)
+    int rpa_archive_get_entry_count(RPAArchive* archive)
+    const char* rpa_archive_get_entry_name(RPAArchive* archive, int index)
+    const char* rpa_archive_error_string(int error)
+
+cdef class RPAFile:
+    cdef RPAArchive* archive
+    cdef bytes _name
+
+    def __init__(self, name):
+        self._name = name.encode('utf-8') if isinstance(name, str) else name
+
+    def __enter__(self):
+        cdef RPAArchive* archive
+        cdef int result
+
+        result = rpa_archive_open(<const char*>self._name, &archive)
+        if result != RPA_OK:
+            raise Exception("Failed to open RPA archive: %s" % rpa_archive_error_string(result).decode('utf-8'))
+
+        self.archive = archive
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.archive != NULL:
+            rpa_archive_close(self.archive)
+            self.archive = NULL
+
+    def read_entry(self, name):
+        cdef uint8_t* data
+        cdef size_t length
+        cdef int result
+        cdef bytes py_name
+
+        if self.archive == NULL:
+            raise Exception("Archive not opened")
+
+        py_name = name.encode('utf-8') if isinstance(name, str) else name
+
+        result = rpa_archive_read_entry(self.archive, <const char*>py_name, &data, &length)
+        if result != RPA_OK:
+            return None
+
+        try:
+            return bytes(data[:length])
+        finally:
+            free(data)
+
+    def has_entry(self, name):
+        cdef int result
+        cdef bytes py_name
+
+        if self.archive == NULL:
+            raise Exception("Archive not opened")
+
+        py_name = name.encode('utf-8') if isinstance(name, str) else name
+
+        result = rpa_archive_has_entry(self.archive, <const char*>py_name)
+        return result != 0
+
+    def get_entry_count(self):
+        if self.archive == NULL:
+            raise Exception("Archive not opened")
+        return rpa_archive_get_entry_count(self.archive)
+
+    def get_entry_name(self, int index):
+        cdef const char* name
+
+        if self.archive == NULL:
+            raise Exception("Archive not opened")
+
+        name = rpa_archive_get_entry_name(self.archive, index)
+        if name == NULL:
+            return None
+
+        return name.decode('utf-8')
+
+    def get_all_entries(self):
+        cdef int count
+        cdef const char* name
+        cdef bytes py_name
+
+        if self.archive == NULL:
+            raise Exception("Archive not opened")
+
+        count = rpa_archive_get_entry_count(self.archive)
+        entries = []
+
+        for i in range(count):
+            name = rpa_archive_get_entry_name(self.archive, i)
+            if name != NULL:
+                entries.append(name.decode('utf-8'))
+
+        return entries
+
+def open_rpa_archive(name):
+    return RPAFile(name)

--- a/renpy/loader/rpa_cxx.py
+++ b/renpy/loader/rpa_cxx.py
@@ -1,0 +1,125 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+C++ optimized RPA archive reader.
+"""
+
+import io
+from renpy.pygame.rwobject import RWopsIO
+
+try:
+    from renpy.loader.rpa_archive import RPAFile
+    _HAS_CXX_READER = True
+except ImportError:
+    _HAS_CXX_READER = False
+
+
+class CachedRPAFile:
+    """
+    A cached RPA file reader that provides fast random access to entries.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.archive = None
+        self._entries = None
+
+    def open(self):
+        if self.archive is None:
+            self.archive = RPAFile(self.path)
+            self.archive.__enter__()
+        return self
+
+    def close(self):
+        if self.archive is not None:
+            self.archive.__exit__(None, None, None)
+            self.archive = None
+
+    def read_entry(self, name):
+        if self.archive is None:
+            self.open()
+        return self.archive.read_entry(name)
+
+    def has_entry(self, name):
+        if self.archive is None:
+            self.open()
+        return self.archive.has_entry(name)
+
+    def entries(self):
+        if self._entries is None and self.archive is not None:
+            self._entries = self.archive.get_all_entries()
+        return self._entries
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+_rpa_cache = {}
+
+
+def get_rpa_reader(path):
+    """
+    Get a cached RPA file reader for the given path.
+    """
+    if path not in _rpa_cache:
+        _rpa_cache[path] = CachedRPAFile(path)
+    return _rpa_cache[path]
+
+
+def read_from_rpa(archive_path, entry_name):
+    """
+    Read a single entry from an RPA archive using the C++ reader.
+
+    Returns bytes or None if the entry doesn't exist.
+    """
+    if not _HAS_CXX_READER:
+        return None
+
+    reader = get_rpa_reader(archive_path)
+    return reader.read_entry(entry_name)
+
+
+def has_in_rpa(archive_path, entry_name):
+    """
+    Check if an entry exists in an RPA archive using the C++ reader.
+    """
+    if not _HAS_CXX_READER:
+        return False
+
+    reader = get_rpa_reader(archive_path)
+    return reader.has_entry(entry_name)
+
+
+def preload_rpa_index(archive_path):
+    """
+    Preload the index of an RPA archive for faster later access.
+    """
+    if not _HAS_CXX_READER:
+        return False
+
+    reader = get_rpa_reader(archive_path)
+    reader.open()
+    return True

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ def main():
     # renpy.loader
     cython("renpy.loader.rpa_archive", [ "src/rpa_archive.c" ], packages="sdl2 zlib")
 
+    # renpy.archiver
+    cython("renpy.archiver.packer", [ "src/rpa_packer.c", "src/rpa_encryption.c" ], packages="zlib")
+
     # renpy.audio
     cython(
         "renpy.audio.renpysound",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ def main():
     cython("renpy.tfd", [ "src/tinyfiledialogs/tinyfiledialogs.c" ])
     cython("renpy.ecsign", [ "src/ec_sign_core.c" ], packages="openssl")
 
+    # renpy.loader
+    cython("renpy.loader.rpa_archive", [ "src/rpa_archive.c" ], packages="sdl2 zlib")
+
     # renpy.audio
     cython(
         "renpy.audio.renpysound",

--- a/src/rpa_archive.c
+++ b/src/rpa_archive.c
@@ -1,4 +1,5 @@
 #include "rpa_archive.h"
+#include "rpa_encryption.h"
 #include <zlib.h>
 #include <string.h>
 #include <stdlib.h>
@@ -450,6 +451,11 @@ int rpa_archive_open(const char* path, RPAArchive** out_archive) {
         return RPA_ERROR_FILE_NOT_FOUND;
     }
 
+    // Initialize encryption system
+    if (rpa_encryption_init() != RPA_ENCRYPTION_OK) {
+        return RPA_ERROR_ZLIB_ERROR;
+    }
+
     SDL_RWops* file = SDL_RWFromFile(path, "rb");
     if (!file) {
         return RPA_ERROR_FILE_NOT_FOUND;
@@ -500,6 +506,8 @@ int rpa_archive_open_v3(const char* path, RPAArchive** out_archive) {
     archive->file = file;
     archive->version = RPA_VERSION_3;
     archive->is_open = true;
+    archive->is_encrypted = false;
+    memset(archive->encryption_key, 0, RPA_ENCRYPTION_KEY_SIZE);
 
     int result = read_v3_index(archive);
     if (result != RPA_OK) {

--- a/src/rpa_archive.c
+++ b/src/rpa_archive.c
@@ -1,0 +1,690 @@
+#include "rpa_archive.h"
+#include <zlib.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define RPA_HEADER_V3 "RPA-3.0 "
+#define RPA_HEADER_V2 "RPA-2.0 "
+#define RPA_HEADER_V1 "\x78\x9c"
+
+#define ZLIB_CHUNK 16384
+
+static const char* error_strings[] = {
+    "Success",
+    "File not found",
+    "Invalid archive header",
+    "Index data corrupted",
+    "Entry not found in archive",
+    "Read error while accessing archive",
+    "Zlib decompression error",
+    "Out of memory"
+};
+
+const char* rpa_archive_error_string(int error) {
+    if (error >= RPA_OK && error <= RPA_ERROR_OUT_OF_MEMORY) {
+        return error_strings[-error];
+    }
+    return "Unknown error";
+}
+
+static uint64_t parse_hex_uint64(const char* str, int len) {
+    uint64_t result = 0;
+    for (int i = 0; i < len; i++) {
+        result <<= 4;
+        char c = str[i];
+        if (c >= '0' && c <= '9') {
+            result |= (c - '0');
+        } else if (c >= 'a' && c <= 'f') {
+            result |= (c - 'a' + 10);
+        } else if (c >= 'A' && c <= 'F') {
+            result |= (c - 'A' + 10);
+        }
+    }
+    return result;
+}
+
+static int read_file_header(SDL_RWops* file, char* header, int max_len) {
+    if (SDL_RWread(file, header, 1, max_len) != (size_t)max_len) {
+        return 0;
+    }
+    return 1;
+}
+
+static uint8_t* decompress_zlib_data(const uint8_t* compressed, size_t compressed_len, size_t* out_decompressed_len) {
+    if (compressed_len == 0) {
+        *out_decompressed_len = 0;
+        return NULL;
+    }
+
+    z_stream strm;
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    strm.avail_in = compressed_len;
+    strm.next_in = (Bytef*)compressed;
+
+    if (inflateInit(&strm) != Z_OK) {
+        return NULL;
+    }
+
+    uint8_t* decompressed = (uint8_t*)malloc(ZLIB_CHUNK);
+    if (!decompressed) {
+        inflateEnd(&strm);
+        return NULL;
+    }
+
+    size_t total_decompressed = 0;
+    int ret;
+
+    do {
+        strm.avail_out = ZLIB_CHUNK;
+        strm.next_out = decompressed + total_decompressed;
+
+        ret = inflate(&strm, Z_FINISH);
+
+        if (ret != Z_STREAM_END && ret != Z_OK) {
+            free(decompressed);
+            inflateEnd(&strm);
+            return NULL;
+        }
+
+        size_t just_decompressed = ZLIB_CHUNK - strm.avail_out;
+        total_decompressed += just_decompressed;
+
+        if (ret == Z_STREAM_END) {
+            break;
+        }
+
+        if (strm.avail_out == 0) {
+            uint8_t* new_buffer = (uint8_t*)realloc(decompressed, total_decompressed + ZLIB_CHUNK);
+            if (!new_buffer) {
+                free(decompressed);
+                inflateEnd(&strm);
+                return NULL;
+            }
+            decompressed = new_buffer;
+        }
+
+    } while (ret != Z_STREAM_END);
+
+    inflateEnd(&strm);
+    *out_decompressed_len = total_decompressed;
+
+    uint8_t* final_buffer = (uint8_t*)realloc(decompressed, total_decompressed);
+    if (!final_buffer && total_decompressed > 0) {
+        free(decompressed);
+        return NULL;
+    }
+
+    return final_buffer ? final_buffer : decompressed;
+}
+
+static int read_v3_index(RPAArchive* archive) {
+    char header[40];
+    if (SDL_RWread(archive->file, header, 1, 40) != 40) {
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    archive->index_offset = parse_hex_uint64(header + 8, 16);
+    archive->key = parse_hex_uint64(header + 25, 8);
+
+    if (SDL_RWseek(archive->file, (Sint64)archive->index_offset, RW_SEEK_SET) < 0) {
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    Sint64 remaining = SDL_RWsize(archive->file) - SDL_RWtell(archive->file);
+    if (remaining <= 0) {
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    size_t compressed_len = (size_t)remaining;
+    uint8_t* compressed = (uint8_t*)malloc(compressed_len);
+    if (!compressed) {
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    size_t read_len = SDL_RWread(archive->file, compressed, 1, compressed_len);
+    if (read_len != compressed_len) {
+        free(compressed);
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    size_t decompressed_len;
+    uint8_t* decompressed = decompress_zlib_data(compressed, compressed_len, &decompressed_len);
+    free(compressed);
+
+    if (!decompressed) {
+        return RPA_ERROR_ZLIB_ERROR;
+    }
+
+    size_t pos = 0;
+    int entry_count = 0;
+
+    while (pos + 4 <= decompressed_len) {
+        uint32_t num_entries = *(uint32_t*)(decompressed + pos);
+        entry_count = num_entries ^ (uint32_t)archive->key;
+        pos += 4;
+
+        if (entry_count < 0 || entry_count > 100000) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+        break;
+    }
+
+    archive->entries = (RPAEntry*)malloc(sizeof(RPAEntry) * entry_count);
+    archive->entry_names = (char**)malloc(sizeof(char*) * entry_count);
+
+    if (!archive->entries || !archive->entry_names) {
+        free(decompressed);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    for (int i = 0; i < entry_count; i++) {
+        if (pos + 12 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint32_t name_len;
+        memcpy(&name_len, decompressed + pos, 4);
+        name_len ^= (uint32_t)archive->key;
+        pos += 4;
+
+        if (name_len >= RPA_MAX_PATH || pos + name_len > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        archive->entry_names[i] = (char*)malloc(name_len + 1);
+        if (!archive->entry_names[i]) {
+            free(decompressed);
+            return RPA_ERROR_OUT_OF_MEMORY;
+        }
+
+        memcpy(archive->entry_names[i], decompressed + pos, name_len);
+        archive->entry_names[i][name_len] = '\0';
+        pos += name_len;
+
+        if (pos + 8 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint64_t offset, length;
+        memcpy(&offset, decompressed + pos, 8);
+        offset ^= archive->key;
+        pos += 8;
+
+        memcpy(&length, decompressed + pos, 8);
+        length ^= archive->key;
+        pos += 8;
+
+        archive->entries[i].offset = offset;
+        archive->entries[i].length = length;
+        archive->entries[i].start = NULL;
+
+        if (pos + 4 <= decompressed_len) {
+            uint32_t start_len = *(uint32_t*)(decompressed + pos);
+            start_len ^= (uint32_t)archive->key;
+            pos += 4;
+
+            if (start_len > 0 && start_len < 4096 && pos + start_len <= decompressed_len) {
+                archive->entries[i].start = (char*)malloc(start_len);
+                if (archive->entries[i].start) {
+                    memcpy(archive->entries[i].start, decompressed + pos, start_len);
+                }
+            }
+        }
+    }
+
+    free(decompressed);
+    archive->entry_count = entry_count;
+    return RPA_OK;
+}
+
+static int read_v2_index(RPAArchive* archive) {
+    char header[24];
+    if (SDL_RWread(archive->file, header, 1, 24) != 24) {
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    archive->index_offset = parse_hex_uint64(header + 8, 16);
+
+    if (SDL_RWseek(archive->file, (Sint64)archive->index_offset, RW_SEEK_SET) < 0) {
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    Sint64 remaining = SDL_RWsize(archive->file) - SDL_RWtell(archive->file);
+    if (remaining <= 0) {
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    size_t compressed_len = (size_t)remaining;
+    uint8_t* compressed = (uint8_t*)malloc(compressed_len);
+    if (!compressed) {
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    size_t read_len = SDL_RWread(archive->file, compressed, 1, compressed_len);
+    if (read_len != compressed_len) {
+        free(compressed);
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    size_t decompressed_len;
+    uint8_t* decompressed = decompress_zlib_data(compressed, compressed_len, &decompressed_len);
+    free(compressed);
+
+    if (!decompressed) {
+        return RPA_ERROR_ZLIB_ERROR;
+    }
+
+    size_t pos = 0;
+    int entry_count = 0;
+
+    while (pos + 4 <= decompressed_len) {
+        uint32_t num_entries = *(uint32_t*)(decompressed + pos);
+        entry_count = num_entries;
+        pos += 4;
+
+        if (entry_count < 0 || entry_count > 100000) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+        break;
+    }
+
+    archive->entries = (RPAEntry*)malloc(sizeof(RPAEntry) * entry_count);
+    archive->entry_names = (char**)malloc(sizeof(char*) * entry_count);
+
+    if (!archive->entries || !archive->entry_names) {
+        free(decompressed);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    for (int i = 0; i < entry_count; i++) {
+        if (pos + 4 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint32_t name_len = *(uint32_t*)(decompressed + pos);
+        pos += 4;
+
+        if (name_len >= RPA_MAX_PATH || pos + name_len > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        archive->entry_names[i] = (char*)malloc(name_len + 1);
+        if (!archive->entry_names[i]) {
+            free(decompressed);
+            return RPA_ERROR_OUT_OF_MEMORY;
+        }
+
+        memcpy(archive->entry_names[i], decompressed + pos, name_len);
+        archive->entry_names[i][name_len] = '\0';
+        pos += name_len;
+
+        if (pos + 16 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint64_t offset, length;
+        memcpy(&offset, decompressed + pos, 8);
+        pos += 8;
+
+        memcpy(&length, decompressed + pos, 8);
+        pos += 8;
+
+        archive->entries[i].offset = offset;
+        archive->entries[i].length = length;
+        archive->entries[i].start = NULL;
+    }
+
+    free(decompressed);
+    archive->entry_count = entry_count;
+    return RPA_OK;
+}
+
+static int read_v1_index(RPAArchive* archive) {
+    Sint64 remaining = SDL_RWsize(archive->file) - SDL_RWtell(archive->file);
+    if (remaining <= 0) {
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    size_t compressed_len = (size_t)remaining;
+    uint8_t* compressed = (uint8_t*)malloc(compressed_len);
+    if (!compressed) {
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    size_t read_len = SDL_RWread(archive->file, compressed, 1, compressed_len);
+    if (read_len != compressed_len) {
+        free(compressed);
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    size_t decompressed_len;
+    uint8_t* decompressed = decompress_zlib_data(compressed, compressed_len, &decompressed_len);
+    free(compressed);
+
+    if (!decompressed) {
+        return RPA_ERROR_ZLIB_ERROR;
+    }
+
+    size_t pos = 0;
+    int entry_count = 0;
+
+    while (pos + 4 <= decompressed_len) {
+        uint32_t num_entries = *(uint32_t*)(decompressed + pos);
+        entry_count = num_entries;
+        pos += 4;
+
+        if (entry_count < 0 || entry_count > 100000) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+        break;
+    }
+
+    archive->entries = (RPAEntry*)malloc(sizeof(RPAEntry) * entry_count);
+    archive->entry_names = (char**)malloc(sizeof(char*) * entry_count);
+
+    if (!archive->entries || !archive->entry_names) {
+        free(decompressed);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    for (int i = 0; i < entry_count; i++) {
+        if (pos + 4 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint32_t name_len = *(uint32_t*)(decompressed + pos);
+        pos += 4;
+
+        if (name_len >= RPA_MAX_PATH || pos + name_len > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        archive->entry_names[i] = (char*)malloc(name_len + 1);
+        if (!archive->entry_names[i]) {
+            free(decompressed);
+            return RPA_ERROR_OUT_OF_MEMORY;
+        }
+
+        memcpy(archive->entry_names[i], decompressed + pos, name_len);
+        archive->entry_names[i][name_len] = '\0';
+        pos += name_len;
+
+        if (pos + 8 > decompressed_len) {
+            free(decompressed);
+            return RPA_ERROR_INDEX_CORRUPT;
+        }
+
+        uint64_t offset, length;
+        memcpy(&offset, decompressed + pos, 8);
+        pos += 8;
+
+        memcpy(&length, decompressed + pos, 8);
+        pos += 8;
+
+        archive->entries[i].offset = offset;
+        archive->entries[i].length = length;
+        archive->entries[i].start = NULL;
+    }
+
+    free(decompressed);
+    archive->entry_count = entry_count;
+    return RPA_OK;
+}
+
+int rpa_archive_open(const char* path, RPAArchive** out_archive) {
+    if (!path || !out_archive) {
+        return RPA_ERROR_FILE_NOT_FOUND;
+    }
+
+    SDL_RWops* file = SDL_RWFromFile(path, "rb");
+    if (!file) {
+        return RPA_ERROR_FILE_NOT_FOUND;
+    }
+
+    char header[16];
+    if (SDL_RWread(file, header, 1, 8) != 8) {
+        SDL_RWclose(file);
+        return RPA_ERROR_INVALID_HEADER;
+    }
+
+    if (SDL_RWseek(file, 0, RW_SEEK_SET) < 0) {
+        SDL_RWclose(file);
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    if (strncmp(header, RPA_HEADER_V3, 7) == 0) {
+        return rpa_archive_open_v3(path, out_archive);
+    } else if (strncmp(header, RPA_HEADER_V2, 7) == 0) {
+        return rpa_archive_open_v2(path, out_archive);
+    } else if (header[0] == '\x78' && header[1] == '\x9c') {
+        return rpa_archive_open_v1(path, out_archive);
+    }
+
+    SDL_RWclose(file);
+    return RPA_ERROR_INVALID_HEADER;
+}
+
+int rpa_archive_open_v3(const char* path, RPAArchive** out_archive) {
+    SDL_RWops* file = SDL_RWFromFile(path, "rb");
+    if (!file) {
+        return RPA_ERROR_FILE_NOT_FOUND;
+    }
+
+    RPAArchive* archive = (RPAArchive*)calloc(1, sizeof(RPAArchive));
+    if (!archive) {
+        SDL_RWclose(file);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    archive->filename = (char*)malloc(strlen(path) + 1);
+    if (!archive->filename) {
+        SDL_RWclose(file);
+        free(archive);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+    strcpy(archive->filename, path);
+    archive->file = file;
+    archive->version = RPA_VERSION_3;
+    archive->is_open = true;
+
+    int result = read_v3_index(archive);
+    if (result != RPA_OK) {
+        rpa_archive_close(archive);
+        return result;
+    }
+
+    *out_archive = archive;
+    return RPA_OK;
+}
+
+int rpa_archive_open_v2(const char* path, RPAArchive** out_archive) {
+    SDL_RWops* file = SDL_RWFromFile(path, "rb");
+    if (!file) {
+        return RPA_ERROR_FILE_NOT_FOUND;
+    }
+
+    RPAArchive* archive = (RPAArchive*)calloc(1, sizeof(RPAArchive));
+    if (!archive) {
+        SDL_RWclose(file);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    archive->filename = (char*)malloc(strlen(path) + 1);
+    if (!archive->filename) {
+        SDL_RWclose(file);
+        free(archive);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+    strcpy(archive->filename, path);
+    archive->file = file;
+    archive->version = RPA_VERSION_2;
+    archive->is_open = true;
+
+    int result = read_v2_index(archive);
+    if (result != RPA_OK) {
+        rpa_archive_close(archive);
+        return result;
+    }
+
+    *out_archive = archive;
+    return RPA_OK;
+}
+
+int rpa_archive_open_v1(const char* path, RPAArchive** out_archive) {
+    SDL_RWops* file = SDL_RWFromFile(path, "rb");
+    if (!file) {
+        return RPA_ERROR_FILE_NOT_FOUND;
+    }
+
+    RPAArchive* archive = (RPAArchive*)calloc(1, sizeof(RPAArchive));
+    if (!archive) {
+        SDL_RWclose(file);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    archive->filename = (char*)malloc(strlen(path) + 1);
+    if (!archive->filename) {
+        SDL_RWclose(file);
+        free(archive);
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+    strcpy(archive->filename, path);
+    archive->file = file;
+    archive->version = RPA_VERSION_1;
+    archive->is_open = true;
+
+    int result = read_v1_index(archive);
+    if (result != RPA_OK) {
+        rpa_archive_close(archive);
+        return result;
+    }
+
+    *out_archive = archive;
+    return RPA_OK;
+}
+
+void rpa_archive_close(RPAArchive* archive) {
+    if (!archive) {
+        return;
+    }
+
+    if (archive->entries) {
+        for (int i = 0; i < archive->entry_count; i++) {
+            if (archive->entries[i].start) {
+                free(archive->entries[i].start);
+            }
+        }
+        free(archive->entries);
+    }
+
+    if (archive->entry_names) {
+        for (int i = 0; i < archive->entry_count; i++) {
+            if (archive->entry_names[i]) {
+                free(archive->entry_names[i]);
+            }
+        }
+        free(archive->entry_names);
+    }
+
+    if (archive->file) {
+        SDL_RWclose(archive->file);
+    }
+
+    if (archive->filename) {
+        free(archive->filename);
+    }
+
+    archive->is_open = false;
+    free(archive);
+}
+
+int rpa_archive_has_entry(RPAArchive* archive, const char* name) {
+    if (!archive || !name) {
+        return 0;
+    }
+
+    for (int i = 0; i < archive->entry_count; i++) {
+        if (archive->entry_names[i] && strcmp(archive->entry_names[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int rpa_archive_read_entry(RPAArchive* archive, const char* name, uint8_t** out_data, size_t* out_len) {
+    if (!archive || !name || !out_data || !out_len) {
+        return RPA_ERROR_ENTRY_NOT_FOUND;
+    }
+
+    int entry_index = -1;
+    for (int i = 0; i < archive->entry_count; i++) {
+        if (archive->entry_names[i] && strcmp(archive->entry_names[i], name) == 0) {
+            entry_index = i;
+            break;
+        }
+    }
+
+    if (entry_index < 0) {
+        return RPA_ERROR_ENTRY_NOT_FOUND;
+    }
+
+    RPAEntry* entry = &archive->entries[entry_index];
+
+    if (entry->start && entry->length == 0) {
+        size_t start_len = strlen(entry->start);
+        *out_data = (uint8_t*)malloc(start_len);
+        if (!*out_data) {
+            return RPA_ERROR_OUT_OF_MEMORY;
+        }
+        memcpy(*out_data, entry->start, start_len);
+        *out_len = start_len;
+        return RPA_OK;
+    }
+
+    if (SDL_RWseek(archive->file, (Sint64)entry->offset, RW_SEEK_SET) < 0) {
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    uint8_t* data = (uint8_t*)malloc((size_t)entry->length);
+    if (!data) {
+        return RPA_ERROR_OUT_OF_MEMORY;
+    }
+
+    size_t read_len = SDL_RWread(archive->file, data, 1, (size_t)entry->length);
+    if (read_len != (size_t)entry->length) {
+        free(data);
+        return RPA_ERROR_READ_ERROR;
+    }
+
+    *out_data = data;
+    *out_len = (size_t)entry->length;
+    return RPA_OK;
+}
+
+int rpa_archive_get_entry_count(RPAArchive* archive) {
+    if (!archive) {
+        return 0;
+    }
+    return archive->entry_count;
+}
+
+const char* rpa_archive_get_entry_name(RPAArchive* archive, int index) {
+    if (!archive || index < 0 || index >= archive->entry_count) {
+        return NULL;
+    }
+    return archive->entry_names[index];
+}

--- a/src/rpa_archive.h
+++ b/src/rpa_archive.h
@@ -1,0 +1,67 @@
+#ifndef RENPY_RPA_ARCHIVE_H
+#define RENPY_RPA_ARCHIVE_H
+
+#include <Python.h>
+#include <SDL2/SDL.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RPA_VERSION_1 1
+#define RPA_VERSION_2 2
+#define RPA_VERSION_3 3
+
+#define RPA_MAX_PATH 4096
+
+typedef struct {
+    uint64_t offset;
+    uint64_t length;
+    char* start;
+} RPAEntry;
+
+typedef struct {
+    char* filename;
+    int version;
+    SDL_RWops* file;
+    uint64_t index_offset;
+    uint64_t key;
+    RPAEntry* entries;
+    char** entry_names;
+    int entry_count;
+    bool is_open;
+} RPAArchive;
+
+typedef enum {
+    RPA_OK = 0,
+    RPA_ERROR_FILE_NOT_FOUND = -1,
+    RPA_ERROR_INVALID_HEADER = -2,
+    RPA_ERROR_INDEX_CORRUPT = -3,
+    RPA_ERROR_ENTRY_NOT_FOUND = -4,
+    RPA_ERROR_READ_ERROR = -5,
+    RPA_ERROR_ZLIB_ERROR = -6,
+    RPA_ERROR_OUT_OF_MEMORY = -7
+} RPAError;
+
+int rpa_archive_open(const char* path, RPAArchive** out_archive);
+int rpa_archive_open_v3(const char* path, RPAArchive** out_archive);
+int rpa_archive_open_v2(const char* path, RPAArchive** out_archive);
+int rpa_archive_open_v1(const char* path, RPAArchive** out_archive);
+
+void rpa_archive_close(RPAArchive* archive);
+
+int rpa_archive_read_entry(RPAArchive* archive, const char* name, uint8_t** out_data, size_t* out_len);
+int rpa_archive_has_entry(RPAArchive* archive, const char* name);
+
+const char* rpa_archive_error_string(int error);
+
+int rpa_archive_get_entry_count(RPAArchive* archive);
+const char* rpa_archive_get_entry_name(RPAArchive* archive, int index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/rpa_archive.h
+++ b/src/rpa_archive.h
@@ -22,6 +22,8 @@ typedef struct {
     char* start;
 } RPAEntry;
 
+#include "rpa_encryption.h"
+
 typedef struct {
     char* filename;
     int version;
@@ -32,6 +34,8 @@ typedef struct {
     char** entry_names;
     int entry_count;
     bool is_open;
+    bool is_encrypted;
+    uint8_t encryption_key[RPA_ENCRYPTION_KEY_SIZE];
 } RPAArchive;
 
 typedef enum {

--- a/src/rpa_encryption.c
+++ b/src/rpa_encryption.c
@@ -1,0 +1,121 @@
+#include "rpa_encryption.h"
+#include <zlib.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define HYDROGEN_IMPLEMENTATION
+#include "libhydrogen/hydrogen.h"
+
+static const char* error_strings[] = {
+    "Success",
+    "Invalid key",
+    "Encryption failed",
+    "Decryption failed",
+    "Out of memory",
+    "Invalid data"
+};
+
+const char* rpa_encryption_error_string(int error) {
+    if (error >= RPA_ENCRYPTION_OK && error <= RPA_ENCRYPTION_ERROR_INVALID_DATA) {
+        return error_strings[-error];
+    }
+    return "Unknown error";
+}
+
+int rpa_encryption_init(void) {
+    if (hydro_init() != 0) {
+        return RPA_ENCRYPTION_ERROR_ENCRYPTION_FAILED;
+    }
+    return RPA_ENCRYPTION_OK;
+}
+
+int rpa_encryption_encrypt(const uint8_t* data, size_t len, const uint8_t* key, uint8_t** out_encrypted, size_t* out_len) {
+    if (!data || !key || !out_encrypted || !out_len) {
+        return RPA_ENCRYPTION_ERROR_INVALID_DATA;
+    }
+
+    if (len == 0) {
+        *out_encrypted = NULL;
+        *out_len = 0;
+        return RPA_ENCRYPTION_OK;
+    }
+
+    size_t encrypted_len = hydro_secretbox_HEADERBYTES + len;
+    uint8_t* encrypted = (uint8_t*)malloc(encrypted_len);
+    if (!encrypted) {
+        return RPA_ENCRYPTION_ERROR_OUT_OF_MEMORY;
+    }
+
+    int result = hydro_secretbox_encrypt(
+        encrypted,
+        data,
+        len,
+        0,
+        RPA_ENCRYPTION_CONTEXT,
+        key
+    );
+
+    if (result != 0) {
+        free(encrypted);
+        return RPA_ENCRYPTION_ERROR_ENCRYPTION_FAILED;
+    }
+
+    *out_encrypted = encrypted;
+    *out_len = encrypted_len;
+    return RPA_ENCRYPTION_OK;
+}
+
+int rpa_encryption_decrypt(const uint8_t* encrypted, size_t len, const uint8_t* key, uint8_t** out_decrypted, size_t* out_len) {
+    if (!encrypted || !key || !out_decrypted || !out_len) {
+        return RPA_ENCRYPTION_ERROR_INVALID_DATA;
+    }
+
+    if (len < hydro_secretbox_HEADERBYTES) {
+        return RPA_ENCRYPTION_ERROR_INVALID_DATA;
+    }
+
+    size_t decrypted_len = len - hydro_secretbox_HEADERBYTES;
+    uint8_t* decrypted = (uint8_t*)malloc(decrypted_len);
+    if (!decrypted) {
+        return RPA_ENCRYPTION_ERROR_OUT_OF_MEMORY;
+    }
+
+    int result = hydro_secretbox_decrypt(
+        decrypted,
+        encrypted,
+        len,
+        0,
+        RPA_ENCRYPTION_CONTEXT,
+        key
+    );
+
+    if (result != 0) {
+        free(decrypted);
+        return RPA_ENCRYPTION_ERROR_DECRYPTION_FAILED;
+    }
+
+    *out_decrypted = decrypted;
+    *out_len = decrypted_len;
+    return RPA_ENCRYPTION_OK;
+}
+
+int rpa_encryption_derive_key(const char* password, uint8_t* out_key) {
+    if (!password || !out_key) {
+        return RPA_ENCRYPTION_ERROR_INVALID_KEY;
+    }
+
+    hydro_hash_state state;
+    hydro_hash_init(&state, RPA_ENCRYPTION_CONTEXT, NULL);
+    hydro_hash_update(&state, (const uint8_t*)password, strlen(password));
+    hydro_hash_final(&state, out_key, RPA_ENCRYPTION_KEY_SIZE);
+
+    return RPA_ENCRYPTION_OK;
+}
+
+bool rpa_encryption_is_encrypted(const uint8_t* data, size_t len) {
+    if (!data || len < hydro_secretbox_HEADERBYTES) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/rpa_encryption.h
+++ b/src/rpa_encryption.h
@@ -1,0 +1,37 @@
+#ifndef RENPY_RPA_ENCRYPTION_H
+#define RENPY_RPA_ENCRYPTION_H
+
+#include <Python.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RPA_ENCRYPTION_KEY_SIZE 32
+#define RPA_ENCRYPTION_HEADER_SIZE 16
+#define RPA_ENCRYPTION_CONTEXT "shirocat"
+
+typedef enum {
+    RPA_ENCRYPTION_OK = 0,
+    RPA_ENCRYPTION_ERROR_INVALID_KEY = -1,
+    RPA_ENCRYPTION_ERROR_ENCRYPTION_FAILED = -2,
+    RPA_ENCRYPTION_ERROR_DECRYPTION_FAILED = -3,
+    RPA_ENCRYPTION_ERROR_OUT_OF_MEMORY = -4,
+    RPA_ENCRYPTION_ERROR_INVALID_DATA = -5
+} RPAEncryptionError;
+
+int rpa_encryption_init(void);
+int rpa_encryption_encrypt(const uint8_t* data, size_t len, const uint8_t* key, uint8_t** out_encrypted, size_t* out_len);
+int rpa_encryption_decrypt(const uint8_t* encrypted, size_t len, const uint8_t* key, uint8_t** out_decrypted, size_t* out_len);
+int rpa_encryption_derive_key(const char* password, uint8_t* out_key);
+bool rpa_encryption_is_encrypted(const uint8_t* data, size_t len);
+
+const char* rpa_encryption_error_string(int error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/rpa_packer.c
+++ b/src/rpa_packer.c
@@ -1,0 +1,413 @@
+#include "rpa_packer.h"
+#include "rpa_encryption.h"
+#include <zlib.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define RPA_HEADER_V3 "RPA-3.0 "
+#define RPA_PADDING "Made with Ren'Py."
+#define INITIAL_CAPACITY 1024
+#define ZLIB_CHUNK 16384
+
+static const char* error_strings[] = {
+    "Success",
+    "File not found",
+    "File write error",
+    "Out of memory",
+    "Zlib compression error",
+    "Invalid path",
+    "Entry already exists"
+};
+
+const char* rpa_packer_error_string(int error) {
+    if (error >= RPA_PACKER_OK && error <= RPA_PACKER_ERROR_ENTRY_EXISTS) {
+        return error_strings[-error];
+    }
+    return "Unknown error";
+}
+
+static int rpa_packer_entry_exists(RPAPacker* packer, const char* name) {
+    for (int i = 0; i < packer->entry_count; i++) {
+        if (packer->entry_names[i] && strcmp(packer->entry_names[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int rpa_packer_grow_entries(RPAPacker* packer) {
+    int new_capacity = packer->entry_capacity * 2;
+    if (new_capacity < INITIAL_CAPACITY) {
+        new_capacity = INITIAL_CAPACITY;
+    }
+
+    RPAPackerEntry* new_entries = (RPAPackerEntry*)realloc(packer->entries, sizeof(RPAPackerEntry) * new_capacity);
+    if (!new_entries) {
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    char** new_entry_names = (char**)realloc(packer->entry_names, sizeof(char*) * new_capacity);
+    if (!new_entry_names) {
+        free(new_entries);
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    packer->entries = new_entries;
+    packer->entry_names = new_entry_names;
+    packer->entry_capacity = new_capacity;
+
+    return RPA_PACKER_OK;
+}
+
+static int rpa_packer_add_entry(RPAPacker* packer, const char* name, uint64_t offset, uint64_t length, const char* start_data, size_t start_data_length) {
+    if (rpa_packer_entry_exists(packer, name)) {
+        return RPA_PACKER_ERROR_ENTRY_EXISTS;
+    }
+
+    if (packer->entry_count >= packer->entry_capacity) {
+        int result = rpa_packer_grow_entries(packer);
+        if (result != RPA_PACKER_OK) {
+            return result;
+        }
+    }
+
+    packer->entry_names[packer->entry_count] = strdup(name);
+    if (!packer->entry_names[packer->entry_count]) {
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    packer->entries[packer->entry_count].offset = offset;
+    packer->entries[packer->entry_count].length = length;
+
+    if (start_data && start_data_length > 0) {
+        packer->entries[packer->entry_count].start_data = (char*)malloc(start_data_length);
+        if (!packer->entries[packer->entry_count].start_data) {
+            free(packer->entry_names[packer->entry_count]);
+            return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+        }
+        memcpy(packer->entries[packer->entry_count].start_data, start_data, start_data_length);
+        packer->entries[packer->entry_count].start_data_length = start_data_length;
+    } else {
+        packer->entries[packer->entry_count].start_data = NULL;
+        packer->entries[packer->entry_count].start_data_length = 0;
+    }
+
+    packer->entry_count++;
+    return RPA_PACKER_OK;
+}
+
+static size_t rpa_packer_compress_data(const uint8_t* data, size_t data_len, uint8_t** out_compressed) {
+    z_stream strm;
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    strm.avail_in = data_len;
+    strm.next_in = (Bytef*)data;
+
+    if (deflateInit(&strm, Z_BEST_COMPRESSION) != Z_OK) {
+        return 0;
+    }
+
+    uint8_t* compressed = (uint8_t*)malloc(ZLIB_CHUNK);
+    if (!compressed) {
+        deflateEnd(&strm);
+        return 0;
+    }
+
+    size_t total_compressed = 0;
+    int ret;
+
+    do {
+        strm.avail_out = ZLIB_CHUNK;
+        strm.next_out = compressed + total_compressed;
+
+        ret = deflate(&strm, Z_FINISH);
+
+        if (ret != Z_STREAM_END && ret != Z_OK) {
+            free(compressed);
+            deflateEnd(&strm);
+            return 0;
+        }
+
+        size_t just_compressed = ZLIB_CHUNK - strm.avail_out;
+        total_compressed += just_compressed;
+
+        if (ret == Z_STREAM_END) {
+            break;
+        }
+
+        if (strm.avail_out == 0) {
+            uint8_t* new_buffer = (uint8_t*)realloc(compressed, total_compressed + ZLIB_CHUNK);
+            if (!new_buffer) {
+                free(compressed);
+                deflateEnd(&strm);
+                return 0;
+            }
+            compressed = new_buffer;
+        }
+
+    } while (ret != Z_STREAM_END);
+
+    deflateEnd(&strm);
+
+    uint8_t* final_buffer = (uint8_t*)realloc(compressed, total_compressed);
+    if (!final_buffer && total_compressed > 0) {
+        free(compressed);
+        return 0;
+    }
+
+    *out_compressed = final_buffer ? final_buffer : compressed;
+    return total_compressed;
+}
+
+static size_t rpa_packer_build_index(RPAPacker* packer, uint8_t** out_index_data) {
+    size_t index_size = 0;
+    index_size += 4; // entry count
+
+    for (int i = 0; i < packer->entry_count; i++) {
+        index_size += 4; // name length
+        index_size += strlen(packer->entry_names[i]);
+        index_size += 8; // offset
+        index_size += 8; // length
+        index_size += 4; // start data length
+        index_size += packer->entries[i].start_data_length;
+    }
+
+    uint8_t* index_data = (uint8_t*)malloc(index_size);
+    if (!index_data) {
+        return 0;
+    }
+
+    size_t pos = 0;
+    uint32_t entry_count = packer->entry_count ^ (uint32_t)packer->key;
+    memcpy(index_data + pos, &entry_count, 4);
+    pos += 4;
+
+    for (int i = 0; i < packer->entry_count; i++) {
+        const char* name = packer->entry_names[i];
+        uint32_t name_len = strlen(name) ^ (uint32_t)packer->key;
+        memcpy(index_data + pos, &name_len, 4);
+        pos += 4;
+
+        memcpy(index_data + pos, name, strlen(name));
+        pos += strlen(name);
+
+        uint64_t offset = packer->entries[i].offset ^ packer->key;
+        memcpy(index_data + pos, &offset, 8);
+        pos += 8;
+
+        uint64_t length = packer->entries[i].length ^ packer->key;
+        memcpy(index_data + pos, &length, 8);
+        pos += 8;
+
+        uint32_t start_data_len = packer->entries[i].start_data_length ^ (uint32_t)packer->key;
+        memcpy(index_data + pos, &start_data_len, 4);
+        pos += 4;
+
+        if (packer->entries[i].start_data && packer->entries[i].start_data_length > 0) {
+            memcpy(index_data + pos, packer->entries[i].start_data, packer->entries[i].start_data_length);
+            pos += packer->entries[i].start_data_length;
+        }
+    }
+
+    *out_index_data = index_data;
+    return index_size;
+}
+
+int rpa_packer_create(const char* output_path, RPAOptions* options, RPAPacker** out_packer) {
+    if (!output_path || !out_packer) {
+        return RPA_PACKER_ERROR_INVALID_PATH;
+    }
+
+    // Initialize encryption system
+    if (rpa_encryption_init() != RPA_ENCRYPTION_OK) {
+        return RPA_PACKER_ERROR_ZLIB_ERROR;
+    }
+
+    FILE* file = fopen(output_path, "wb");
+    if (!file) {
+        return RPA_PACKER_ERROR_FILE_NOT_FOUND;
+    }
+
+    RPAPacker* packer = (RPAPacker*)calloc(1, sizeof(RPAPacker));
+    if (!packer) {
+        fclose(file);
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    packer->output_path = strdup(output_path);
+    if (!packer->output_path) {
+        fclose(file);
+        free(packer);
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    packer->file = file;
+    packer->entry_capacity = INITIAL_CAPACITY;
+    packer->entries = (RPAPackerEntry*)malloc(sizeof(RPAPackerEntry) * packer->entry_capacity);
+    packer->entry_names = (char**)malloc(sizeof(char*) * packer->entry_capacity);
+
+    if (!packer->entries || !packer->entry_names) {
+        rpa_packer_close(packer);
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    if (options && options->key != 0) {
+        packer->key = options->key;
+    } else {
+        packer->key = 0x42424242;
+    }
+
+    packer->is_open = true;
+
+    char padding[40];
+    snprintf(padding, sizeof(padding), "RPA-3.0 %016llx %08llx\n", 0ULL, (unsigned long long)packer->key);
+    if (fwrite(padding, 1, 39, file) != 39) {
+        rpa_packer_close(packer);
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    *out_packer = packer;
+    return RPA_PACKER_OK;
+}
+
+int rpa_packer_add_file(RPAPacker* packer, const char* name, const char* path) {
+    if (!packer || !name || !path) {
+        return RPA_PACKER_ERROR_INVALID_PATH;
+    }
+
+    if (!packer->is_open) {
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    FILE* input_file = fopen(path, "rb");
+    if (!input_file) {
+        return RPA_PACKER_ERROR_FILE_NOT_FOUND;
+    }
+
+    fseek(input_file, 0, SEEK_END);
+    size_t file_size = ftell(input_file);
+    fseek(input_file, 0, SEEK_SET);
+
+    uint8_t* data = (uint8_t*)malloc(file_size);
+    if (!data) {
+        fclose(input_file);
+        return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+    }
+
+    if (fread(data, 1, file_size, input_file) != file_size) {
+        free(data);
+        fclose(input_file);
+        return RPA_PACKER_ERROR_FILE_NOT_FOUND;
+    }
+
+    int result = rpa_packer_add_data(packer, name, data, file_size);
+    
+    free(data);
+    fclose(input_file);
+    
+    return result;
+}
+
+int rpa_packer_add_data(RPAPacker* packer, const char* name, const uint8_t* data, size_t len) {
+    if (!packer || !name || !data) {
+        return RPA_PACKER_ERROR_INVALID_PATH;
+    }
+
+    if (!packer->is_open) {
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    if (fwrite(RPA_PADDING, 1, strlen(RPA_PADDING), packer->file) != strlen(RPA_PADDING)) {
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    uint64_t offset = ftell(packer->file);
+    if (offset < 0) {
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    if (fwrite(data, 1, len, packer->file) != len) {
+        return RPA_PACKER_ERROR_FILE_WRITE;
+    }
+
+    return rpa_packer_add_entry(packer, name, offset, len, NULL, 0);
+}
+
+int rpa_packer_close(RPAPacker* packer) {
+    if (!packer) {
+        return RPA_PACKER_OK;
+    }
+
+    if (packer->is_open) {
+        packer->index_offset = ftell(packer->file);
+        if (packer->index_offset < 0) {
+            packer->is_open = false;
+            return RPA_PACKER_ERROR_FILE_WRITE;
+        }
+
+        uint8_t* index_data;
+        size_t index_size = rpa_packer_build_index(packer, &index_data);
+        if (index_size == 0) {
+            packer->is_open = false;
+            return RPA_PACKER_ERROR_OUT_OF_MEMORY;
+        }
+
+        uint8_t* compressed_index;
+        size_t compressed_size = rpa_packer_compress_data(index_data, index_size, &compressed_index);
+        free(index_data);
+
+        if (compressed_size == 0) {
+            packer->is_open = false;
+            return RPA_PACKER_ERROR_ZLIB_ERROR;
+        }
+
+        if (fwrite(compressed_index, 1, compressed_size, packer->file) != compressed_size) {
+            free(compressed_index);
+            packer->is_open = false;
+            return RPA_PACKER_ERROR_FILE_WRITE;
+        }
+
+        free(compressed_index);
+
+        rewind(packer->file);
+        char header[40];
+        snprintf(header, sizeof(header), "RPA-3.0 %016llx %08llx\n", 
+                 (unsigned long long)packer->index_offset, 
+                 (unsigned long long)packer->key);
+        if (fwrite(header, 1, 39, packer->file) != 39) {
+            packer->is_open = false;
+            return RPA_PACKER_ERROR_FILE_WRITE;
+        }
+
+        fclose(packer->file);
+        packer->file = NULL;
+        packer->is_open = false;
+    }
+
+    if (packer->entries) {
+        for (int i = 0; i < packer->entry_count; i++) {
+            if (packer->entries[i].start_data) {
+                free(packer->entries[i].start_data);
+            }
+        }
+        free(packer->entries);
+    }
+
+    if (packer->entry_names) {
+        for (int i = 0; i < packer->entry_count; i++) {
+            if (packer->entry_names[i]) {
+                free(packer->entry_names[i]);
+            }
+        }
+        free(packer->entry_names);
+    }
+
+    if (packer->output_path) {
+        free(packer->output_path);
+    }
+
+    free(packer);
+    return RPA_PACKER_OK;
+}

--- a/src/rpa_packer.h
+++ b/src/rpa_packer.h
@@ -1,0 +1,66 @@
+#ifndef RENPY_RPA_PACKER_H
+#define RENPY_RPA_PACKER_H
+
+#include <Python.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RPA_PACKER_VERSION_3 3
+#define RPA_PACKER_MAX_PATH 4096
+
+typedef struct {
+    uint64_t offset;
+    uint64_t length;
+    char* start_data;
+    size_t start_data_length;
+} RPAPackerEntry;
+
+typedef struct {
+    char* output_path;
+    FILE* file;
+    RPAPackerEntry* entries;
+    char** entry_names;
+    int entry_count;
+    int entry_capacity;
+    uint64_t key;
+    uint64_t index_offset;
+    bool is_open;
+} RPAPacker;
+
+#include "rpa_encryption.h"
+
+typedef struct {
+    int version;
+    uint64_t key;
+    bool compress_index;
+    int compression_level;
+    bool encrypt_index;
+    uint8_t encryption_key[RPA_ENCRYPTION_KEY_SIZE];
+} RPAOptions;
+
+typedef enum {
+    RPA_PACKER_OK = 0,
+    RPA_PACKER_ERROR_FILE_NOT_FOUND = -1,
+    RPA_PACKER_ERROR_FILE_WRITE = -2,
+    RPA_PACKER_ERROR_OUT_OF_MEMORY = -3,
+    RPA_PACKER_ERROR_ZLIB_ERROR = -4,
+    RPA_PACKER_ERROR_INVALID_PATH = -5,
+    RPA_PACKER_ERROR_ENTRY_EXISTS = -6
+} RPAPackerError;
+
+int rpa_packer_create(const char* output_path, RPAOptions* options, RPAPacker** out_packer);
+int rpa_packer_add_file(RPAPacker* packer, const char* name, const char* path);
+int rpa_packer_add_data(RPAPacker* packer, const char* name, const uint8_t* data, size_t len);
+int rpa_packer_close(RPAPacker* packer);
+
+const char* rpa_packer_error_string(int error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Newly Created Files:
src/rpa_archive.h | Note: C++ header file - Defines RPA archive data structures src/rpa_archive.c | Note: C++ implementation - Core reading logic (~500 lines) renpy/loader/rpa_archive.pyx | Note: Cython wrapper - Python interface renpy/loader/rpa_cxx.py | Note: Python caching layer renpy/loader/init.py | Note: Package initialization file Modified Files:
renpy/loader.py | Note: Import the C++ module and modify the load_from_archive() function to prioritize the C++ reader setup.py | Note: Add build configuration for renpy.loader.rpa_archive Optimization Points:
C++ native zlib decompression - Stream decompression via C-level zlib.h Memory optimization - Use malloc / realloc instead of Python's pickle deserialization Binary index parsing - Directly parse binary format and avoid Python's pickle.loads() Caching mechanism - CachedRPAFile class caches opened archives Backward compatibility - Automatically fall back to the Python implementation if the C++ module fails to load