### PR TITLE
Don't try to kill the image Cache if renpy.display.draw isn't available

### DIFF
--- a/renpy/bootstrap.py
+++ b/renpy/bootstrap.py
@@ -430,9 +430,9 @@ def bootstrap(renpy_base):
 
         renpy.display.tts.tts(None)  # type: ignore
 
-        renpy.display.im.cache.quit()  # type: ignore
 
         if renpy.display.draw:  # type: ignore
+            renpy.display.im.cache.quit()  # type: ignore
             renpy.display.draw.quit()  # type: ignore
 
         renpy.audio.audio.quit()


### PR DESCRIPTION
In some cases, such as linting, by the time display.im.cache.quit is called, display.draw is no longer available, causing a key error in im.cache.kill

Fix:
Moved im.cache.kill into the if-block in bootstrap containing the display.draw.quit() function