### PR TITLE
Update CLI documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ link in a nightly build, or compile the modules as described above. You'll
 also need the `Sphinx <https://www.sphinx-doc.org>`_ documentation generator.
 If you have pip working, install Sphinx using::
 
-    pip install -U sphinx sphinx_rtd_theme sphinx_rtd_dark_mode
+    pip install -U sphinx sphinx_rtd_theme sphinx_rtd_dark_mode sphinx-tabs
 
 Once Sphinx is installed, change into the ``sphinx`` directory inside the
 Ren'Py checkout and run::
@@ -130,7 +130,8 @@ Format
 
 Ren'Py's documentation consists of reStructuredText files found in sphinx/source, and
 generated documentation found in function docstrings scattered throughout the code. Do
-not edit the files in sphinx/source/inc directly, as they will be overwritten.
+not edit the files in the ``sphinx/source/inc`` folder directly, as they will be
+overwritten.
 
 Docstrings may include tags on the first few lines:
 

--- a/launcher/game/ios.rpy
+++ b/launcher/game/ios.rpy
@@ -428,7 +428,7 @@ init python:
     def ios_create_command():
         ap = renpy.arguments.ArgumentParser()
         ap.add_argument("project", help="The path to the Ren'Py project.")
-        ap.add_argument("destination", help="The path the iOS project that will be created.")
+        ap.add_argument("destination", help="The path to the iOS project that will be created.")
 
         args = ap.parse_args()
 
@@ -447,7 +447,7 @@ init python:
     def ios_populate_command():
         ap = renpy.arguments.ArgumentParser()
         ap.add_argument("project", help="The path to the Ren'Py project.")
-        ap.add_argument("destination", help="The path the iOS project that will be created.")
+        ap.add_argument("destination", help="The path to the iOS project that will be created.")
 
         args = ap.parse_args()
 

--- a/launcher/game/web.rpy
+++ b/launcher/game/web.rpy
@@ -597,7 +597,7 @@ init python:
     def web_build_command():
         ap = renpy.arguments.ArgumentParser()
         ap.add_argument("web_project", help="The path to the project directory.")
-        ap.add_argument("--launch", action="store_true", help="Launches the app after build and install complete. Implies --install.")
+        ap.add_argument("--launch", action="store_true", help="Starts a webserver and launches the game after build.")
         ap.add_argument("--destination", "--dest", default=None, action="store", help="The directory where the packaged files should be placed.")
 
         args = ap.parse_args()

--- a/renpy/translation/extract.py
+++ b/renpy/translation/extract.py
@@ -60,7 +60,11 @@ def extract_strings():
         help="If given, the current contents of the file are preserved, and new contents are merged into the file.",
         action="store_true",
     )
-    ap.add_argument("--force", help="If given, noting happens if the language does not exist.", action="store_true")
+    ap.add_argument(
+        "--force",
+        help="If given, no exceptions are thrown if the language does not exist.",
+        action="store_true"
+    )
 
     args = ap.parse_args()
 

--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -248,3 +248,21 @@ html[data-theme='dark'] .execution-entry3 {
 .highlighted {
     color: #000000;
 }
+
+
+/* Tabs */
+
+html[data-theme='dark'] .sphinx-tabs-tab {
+    background-color: transparent !important;
+    color: #55a5d9 !important;
+}
+
+html[data-theme='dark'] .sphinx-tabs-tab[aria-selected="true"] {
+    background-color: #141414 !important;
+    border-bottom: 1px solid #141414;
+    color: #55a5d9 !important;
+}
+
+html[data-theme='dark'] .sphinx-tabs-panel {
+    background: #141414 !important;
+}

--- a/sphinx/source/build.rst
+++ b/sphinx/source/build.rst
@@ -223,6 +223,9 @@ Supported package types are "zip" and "tar.bz2" to generate files in
 those formats, and "directory" to create a directory filled with
 files.
 
+
+.. _archives:
+
 Archives
 --------
 

--- a/sphinx/source/cli.rst
+++ b/sphinx/source/cli.rst
@@ -1,5 +1,3 @@
-.. highlight:: text
-
 ======================
 Command Line Interface
 ======================
@@ -10,43 +8,470 @@ releases. For most purposes, this isn't necessary - all these tasks can be
 done through the Ren'Py launcher.
 
 The examples on this page assume you're running the CLI from the Ren'Py SDK
-directory (the directory that contains renpy.py, renpy.sh, and renpy.exe). The
-examples also assume you're running on Linux or macOS. On Windows, you'll need
-to replace ``./renpy.sh`` with ``lib\\py3-windows-x86_64\\python.exe renpy.py``.
+directory (the directory that contains renpy.py, renpy.sh, and renpy.exe).
+Examples are provided for Linux/macOS, and Windows.
 
 The CLI isn't a stable interface - it may change between Ren'Py releases,
-as required.
+as required. This page is current as of Ren'Py 8.5.3.
 
-.. describe:: <base>
 
-    In the description of the commands below, <base> is the path to the
+Quick Tasks
+===========
+
+Use these quick workflows as copy-paste starting points. Replace paths/language codes as needed.
+
+Run project
+-----------
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            cd /path/to/renpy
+            ./renpy.sh /path/to/project run
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            cd C:\path\to\renpy
+            .\lib\py3-windows-x86_64\python.exe renpy.py C:\path\to\project run
+
+
+Build distributions
+-------------------
+
+Build desktop distributions (Windows/macOS/Linux) from the launcher tool.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            cd /path/to/renpy
+            ./renpy.sh launcher distribute /path/to/project --destination /path/to/output
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            cd C:\path\to\renpy
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher distribute C:\path\to\project --destination C:\path\to\output
+
+
+Generate/update translations
+----------------------------
+
+Generate or update translation files, then export dialogue/strings for translators.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            cd /path/to/renpy
+            ./renpy.sh /path/to/project translate french
+            ./renpy.sh /path/to/project dialogue french --strings
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            cd C:\path\to\renpy
+            .\lib\py3-windows-x86_64\python.exe renpy.py C:\path\to\project translate french
+            .\lib\py3-windows-x86_64\python.exe renpy.py C:\path\to\project dialogue french --strings
+
+
+Syntax
+======
+
+.. note::
+
+    Notation used on this page:
+
+    * ``<name>`` is a value you replace, such as a project path or language code.
+    * ``[item]`` is optional and does not need to be included.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh [global options...] [<basedir>] [<command>] [command options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py [global options...] [<basedir>] [command] [command options...]
+
+.. describe:: <basedir>
+
+    :default: The directory containing the Ren'Py executable (the launcher)
+
+    In the description of the commands below, <basedir> is the path to the
     base directory of the project.
 
+.. describe:: <command>
 
-Check and Test Commands
-=======================
+    :default: ``run``
+
+    Specifies the command to execute.
+
+Global options
+--------------
+
+The following flags may be used with any command:
+
+.. option:: --savedir <directory>
+
+    Specifies the directory where saves and persistent data are placed.
+
+.. option:: --trace <level>
+
+    Specifies the level of trace Ren'Py will log to trace.txt. (1=per-call, 2=per-line)
+
+.. option:: --version
+
+    Displays the version of Ren'Py in use.
+
+.. option:: --compile
+
+    Forces all .rpy scripts to be recompiled before proceeding.
+
+.. option:: --compile-python
+
+    Forces all Python files to be recompiled, rather than read from
+    :file:`game/cache/bytecode-*.rpyb`.
+
+.. option:: --keep-orphan-rpyc
+
+    If compiling, prevents Ren'Py from deleting :file:`.rpyc` files that are not associated with
+    a :file:`.rpy` or :file:`_ren.py` file of the same name.
+
+.. option:: --errors-in-editor
+
+    Causes errors to open in a text editor.
+
+.. option:: --safe-mode
+
+    Forces Ren'Py to start in safe mode, allowing the player to configure graphics.
+
+.. option:: --help, -h
+
+    Displays a help message showing commands and syntax, then exits. This returns
+    the most up-to-date command information.
+
+Ren'Py can dump information about the game to a JSON file.
+These options let you select the file, and choose what is dumped.
+
+.. option:: --json-dump <file>
+
+    Specifies the name of the JSON file.
+
+.. option:: --json-dump-private
+
+    Includes private names in the dump. (Names beginning with an underscore `_`)
+
+.. option:: --json-dump-common
+
+    Includes names defined in the common directory in the dump.
+
+.. note::
+
+    The CLI may change between different releases. To see the latest commands
+    and flags, run:
+
+    .. tabs::
+
+        .. tab:: Linux / macOS
+
+            .. code-block:: bash
+
+                ./renpy.sh --help
+
+        .. tab:: Windows
+
+            .. code-block:: bash
+
+                .\lib\py3-windows-x86_64\python.exe renpy.py --help
+
+    To see the latest options for a particular command, run:
+
+    .. tabs::
+
+        .. tab:: Linux / macOS
+
+            .. code-block:: bash
+
+                ./renpy.sh <basedir> <command> --help
+
+        .. tab:: Windows
+
+            .. code-block:: bash
+
+                .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> <command> --help
+
+
+Core Workflow Commands
+======================
+
+.. _cli-run:
+
+Run Project
+-----------
+
+Runs the current project normally. This is the default command that is run if no command is given.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> run [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> run [options...]
+
+.. option:: --profile-display
+
+    Reports the amount of time it takes to draw the screen.
+
+    Equivalent to setting :var:`config.profile` to True.
+
+.. option:: --debug-image-cache
+
+    Writes information about the :ref:`image cache <images>` to image_cache.txt.
+
+    Equivalent to setting :var:`config.debug_image_cache` to True.
+
+.. option:: --warp <filename:linenumber>
+
+    Tries to warp to just before the specified line. This takes as an argument a
+    ``filename:linenumber`` pair.
+
+    The :ref:`warp feature <warping_to_a_line>` requires :var:`config.developer` to be True to operate.
+
+
+.. _cli-quit:
+
+Quit
+----
+
+Quits the game immediately.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> quit
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> quit
+
+
+.. _cli-compile:
+
+Compile
+-------
+
+Compiles the game, creating .rpyc files from .rpy files. The
+equivalent of the "Force Recompile" button in the Ren'Py launcher.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> compile [--keep-orphan-rpyc]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> compile [--keep-orphan-rpyc]
+
+.. option:: --keep-orphan-rpyc
+
+    Prevents Ren'Py from deleting :file:`.rpyc` files that are not associated with
+    a :file:`.rpy` or :file:`_ren.py` file of the same name.
+
+
+.. _cli-director:
+
+Interactive Director
+--------------------
+
+Starts the :doc:`director` and runs the game afterwards.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> director
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> director
+
+
+.. _cli-rmpersistent:
+
+Remove Persistent Data
+----------------------
+
+Deletes :doc:`persistent` data. This can be handy since persistent data is
+found in multiple locations:
+
+- the game save folder
+- the location specified by :var:`config.save_directory`
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> rmpersistent
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> rmpersistent
+
+.. warning::
+
+    This will reset all game progress, including unlocks, read messages, and preferences.
+
+
+.. _cli-update:
+
+Update Project
+--------------
+
+Download and install updates to a Ren'Py game from a web host.
+For more information, see :doc:`updater`.
+
+The parameters are identical to those used in :meth:`updater.update`.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> update <url> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> update <url> [options...]
+
+.. option:: <url>
+
+    Specifies the URL to the updates.json file.
+
+.. option:: --base <directory>
+
+    Specifies the base directory of the game to update. Defaults to the current game.
+
+.. option:: --force
+
+    Forces the update to run even if the version numbers are the same.
+
+.. option:: --key <key>
+
+    A file giving the public key to use of the update.
+
+.. option:: --simulate <option>
+
+    A simulation mode to test update GUIs without actually performing an update.
+    One of ``available``, ``not_available``, or ``error``.
+
+.. warning::
+
+    This will modify your game's files. Use with caution.
+
+
+Validation and Testing
+======================
+
+.. _cli-lint:
 
 Check Script (Lint)
 -------------------
 
-::
+This runs a :ref:`lint` report on the game. This checks the script for errors and
+prints script statistics. It's equivalent to the "Check Script (Lint)" button
+in the launcher.
 
-    ./renpy.sh <base> lint [ filename ] [ options... ]
+.. tabs::
 
-This runs a lint report on the game. It's equivalent to the "Check Script (Lint)"
-button in the launcher.
+    .. tab:: Linux / macOS
 
-.. option:: filename
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> lint [<filename>] [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> lint [<filename>] [options...]
+
+.. option:: <filename>
 
     If given, the lint report will be written to this file rather than
     printed to standard output.
 
-Lint takes many options, which can change from release to release. To view
-them, run:
+.. option:: --error-code
 
-::
+    Exits with an error code of 1 if there was a lint error. This is useful for CI systems to detect when lint fails.
 
-    ./renpy.sh <base> lint --help
+.. option:: --no-orphan-tl
+
+    Does not report orphan translations. Orphaned translations are
+    :ref:`Translation Statements <translation_statement>` that do not reference a string
+    in the primary language.
+
+.. option:: --reserved-parameters
+
+    Reports Ren'Py or python reserved names in renpy statement parameters.
+
+    In particular it looks for :doc:`label <label>`, :doc:`screen <screens>`, and :ref:`ATL <atl>` statements.
+
+.. option:: --by-character
+
+    Reports the count of blocks, words, and characters for each character.
+
+.. option:: --check-unclosed-tags
+
+    Reports unclosed text tags.
+
+.. option:: --all-problems
+
+    Reports all problems of a kind, not just the first ten issues.
 
 
 .. _cli-test:
@@ -54,55 +479,67 @@ them, run:
 Run Testcases
 -------------
 
-::
+This runs :doc:`automated tests <testcases>` on the game.
 
-    ./renpy.sh <base> test [ testcase ] [ options... ]
+Examples:
+ * `<https://github.com/renpy/renpy/blob/master/tutorial/game/testcases.rpy>`_
+ * `<https://github.com/renpy/renpy/blob/master/gui/game/testcases.rpy>`_
+ * `<https://github.com/renpy/renpy/blob/master/launcher/game/testcases.rpy>`_
 
-This runs :file:`automated tests <testcases>` on the game.
+.. tabs::
 
-.. option:: testcase
+    .. tab:: Linux / macOS
 
-    The name of the testcase or test suite to run. If not given, the "global"
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> test [<testcase>] [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> test [<testcase>] [options...]
+
+.. option:: <testcase>
+
+    Specifies the name of the testcase or test suite to run. If not given, the "global"
     test suite will be run.
 
 .. option:: --enable_all
 
-    If provided, all test cases and test suites will be executed, regardless
-    of their ``enabled`` property.
+    Executes all test cases and test suites, regardless of their ``enabled`` property.
 
 .. option:: --overwrite_screenshots
 
-    If provided, existing screenshots will be overwritten when a
+    Overwrite existing screenshots when a
     :ref:`screenshot statement <test-screenshot-statement>` is executed.
 
 .. option:: --hide-header
 
-    If provided, the header at the start of the test run will be disabled.
+    Disables the header at the start of the test run.
 
-.. option:: --hide-execution [no|hooks|testcases|all]
+.. option:: --hide-execution {no|hooks|testcases|all}
 
-    If provided, test execution output will be hidden. ``hooks`` hides hooks,
-    ``testcases`` hides test cases and hooks, and ``all`` hides everything.
+    Hides information about test execution. ``--hide-execution hooks`` hides hooks,
+    ``--hide-execution testcases`` hides test cases and hooks, and ``--hide-execution all``
+    hides everything.
 
 .. option:: --hide-summary
 
-    If provided, the summary at the end of the test run will be disabled.
+    Disables the summary at the end of the test run.
 
 .. option:: --report-detailed
 
-    If provided, detailed information about each test will be shown during
-    the run.
+    Shows detailed information about each test during the run.
 
 .. option:: --report-skipped
 
-    If provided, information about skipped tests will be shown. This option
-    should be used together with ``--report-detailed``.
+    Shows information about skipped tests. This option should be used together
+    with ``--report-detailed``.
 
 
-
-
-Build Commands
-==============
+Build and Distribution
+======================
 
 .. note::
 
@@ -113,158 +550,447 @@ Build Commands
     may result in a game that can't load saves.
 
 
-Android Build
--------------
+.. _cli-add-from:
 
-::
+Add From To Calls
+-----------------
 
-    ./renpy.sh launcher android_build <base> [ options... ]
+Adds a ``from`` clause to each :ref:`call statement <call-statement>`
+that does not have one. Generally, this should be done before a release, to help
+Ren'Py locate the return point of calls in a modified game.
+
+Implies :option:`--compile`.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> add_from
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> add_from
+
+.. warning::
+
+    This will modify your game's script files.
 
 
-This builds a release of the game for Android. It's assumed that the launcher
-has been used to install the Android SDK, generate keys, and configure the
-project.
+.. _cli-distribute:
+
+Distribute
+----------
+
+:doc:`Builds distributions <build>` of the game for Windows, macOS, and Linux.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher distribute <basedir> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher distribute <basedir> [options...]
 
 .. option:: --destination <directory>
 
-    The directory to place the output in. The default is a directory
+    Specifies the directory to place the distributions in. The default is a directory
+    named "`name`-`version`-dists" in the current directory, taking information
+    from :var:`build.name` and :var:`build.version`.
+
+.. option:: --format <format>
+
+    Forces the format of the distribution to be this.
+
+.. option:: --macapp <app>
+
+    Specifies the path to a macapp that's used to sign mac
+    packages instead of the macapp that's included with Ren'Py.
+
+.. option:: --no-archive
+
+    Does not add files to :ref:`archives`.
+
+.. option:: --no-update
+
+    Does not build update files which allow the :doc:`updater` to work.
+
+.. option:: --package <package>
+
+    Specifies the name of the package to build, where package is a package
+    name like "pc", "mac", or "markets". This option can be given multiple
+    times to build multiple packages. The default is to build all packages.
+
+.. option:: --packagedest <package>
+
+    Specify the output name for a package (without any
+    extensions). Requires that exactly one :option:`--package` is specified.
+
+
+.. _cli-android-build:
+
+Android Build
+-------------
+
+This builds a release of the game for :doc:`android`. It's assumed that the launcher
+has been used to install the Android SDK, generate keys, and configure the
+project.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher android_build <basedir> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher android_build <basedir> [options...]
+
+.. option:: --destination <directory>
+
+    Specifies the directory to place the output in. The default is a directory
     named "`name`-`version`-dists" in the current directory, taking information
     from :var:`build.name` and :var:`build.version`.
 
 .. option:: --bundle
 
-    When given, Ren'Py will produce a .aab bundle. If not given, Ren'Py will
-    produce an .apk file.
+    Produces a :file:`.aab` bundle if given. If not given, Ren'Py will
+    produce a :file:`.apk` file.
 
 .. option:: --install
 
-    When given, Ren'Py will install the .apk or .aab file to a connected device.
+    Installs the :file:`.apk` or :file:`.aab` file to a connected device.
 
 .. option:: --launch
 
-    When given, Ren'Py will launch the game on a connected device. This implies
-    ``--install``.
-
-
-Add From To Call
-----------------
-
-::
-
-    ./renpy.sh <base> add_from
-
-This command adds a ``from`` clause to each ``call`` statement that does not
-have one. Generally, this should be done before a release, to help Ren'Py
-locate the return point of calls in a modified game.
-
-.. note::
-
-    This will modify your game's script files, and assumes that you will include
-    the changes it makes into your game.
-
-
-Compile
--------
-
-::
-
-    ./renpy.sh <base> compile [ --keep-orphan-rpyc ]
-
-This command compiles the game, creating .rpyc files from .rpy files. The
-equialent of the "Force Recompile" button in the Ren'Py launcher.
-
-.. option:: --keep-orphan-rpyc
-
-    By default, Ren'Py will delete .rpyc files that are not associated with
-    a .rpy or _ren.py file of the same name. If this option is given, Ren'Py
-    will not delete these files.
-
-
-Distribute
-----------
-
-::
-
-    ./renpy.sh launcher distribute <base> [ options... ]
-
-This builds distributions of the game for windows, macOS, and Linux. Some
-options this command takes are:
-
-.. option:: --destination <directory>
-
-    The directory to place the distributions in. The default is a directory
-    named "`name`-`version`-dists" in the current directory, taking information
-    from :var:`build.name` and :var:`build.version`.
-
-.. option:: --no-update
-
-    When given, Ren'Py will not build update files.
+    Launches the game on a connected device. This implies :option:`--install`.
 
 .. option:: --package <package>
 
-    This gives the name of the package to build, where package is a package
-    name like "pc", "mac", or "markets". This option can be given multiple
-    times to build multiple packages. The default is to build all packages.
+    Specifies the package to build. Defaults to building the 'android' package.
 
-(There are other options, but these are more useful for building Ren'Py
-itself.)
+
+.. _cli-ios-create:
 
 iOS Create
 ----------
 
-::
-
-    ./renpy.sh launcher ios_create <base> <destination>
-
-This creates an Xcode project that can be used to build an iOS version of
+Creates an Xcode project that can be used to build an :doc:`ios` version of
 the game. It's assumed that the launcher has been used to install iOS
 support once.
 
-.. option:: destination
+.. tabs::
 
-    The directory to place the Xcode project in.
+    .. tab:: Linux / macOS
 
+        .. code-block:: bash
+
+            ./renpy.sh launcher ios_create <basedir> <destination>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher ios_create <basedir> <destination>
+
+.. describe:: <basedir>
+
+    Specifies the path to the Ren'Py project.
+
+.. describe:: <destination>
+
+    Specifies the path to the iOS project that will be created.
+
+
+.. _cli-ios-populate:
 
 iOS Populate
 ------------
 
-::
-
-    ./renpy.sh launcher ios_populate <base> <destination>
-
-This copies the game into an Xcode project created by :command:`ios_create`. This
+Copies the game into an Xcode project created by :ref:`ios_create <cli-ios-create>`. This
 is used to update a project created with the same version of Ren'Py.
 
-.. option:: destination
+.. tabs::
 
-    The directory to update.
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher ios_populate <basedir> <destination>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher ios_populate <basedir> <destination>
+
+.. describe:: <basedir>
+
+    Specifies the path to the Ren'Py project.
+
+.. describe:: <destination>
+
+    Specifies the path to the iOS project that will be updated.
 
 
-Update Old Game
----------------
-
-::
-
-    ./renpy.sh launcher update_old_game <base>
-
-This command will copy .rpyc files from <base>/game to <base>/old-game.
-
+.. _cli-web-build:
 
 Web Build
--------------
+---------
 
-::
-
-    ./renpy.sh launcher web_build <base> [ options... ]
-
-
-This builds a release of the game for web. It's assumed that the
+Builds a release of the game for web. It's assumed that the
 launcher has been used to install web support and that any configuration
-files (such as ``progressive_download.txt``) are in place.
+files (such as :file:`progressive_download.txt`) are in place.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher web_build <basedir> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher web_build <basedir> [options...]
+
+
 
 .. option:: --destination <directory>
 
-    The directory to place the web root in.
+    Specifies the directory where the packaged files should be placed.
+
+.. option:: --launch
+
+    Starts a webserver and launches the game after build.
+
+
+Translation and Localization
+============================
+
+.. seealso::
+
+    * :doc:`translation`
+
+
+.. _cli-translate:
+
+Translate
+---------
+
+Creates or updates translation files in ``tl/<language>`` for the project.
+It writes missing dialogue and string entries while leaving existing translated entries unchanged.
+Use :option:`--count` to report missing translations without writing files.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> translate <language> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> translate <language> [options...]
+
+.. option:: <language>
+
+    Specifies the language to generate translations for.
+
+.. option:: --count
+
+    Prints a count of missing translations without generating files.
+
+.. option:: --rot13
+
+    Applies rot13 while generating translations.
+
+.. option:: --piglatin
+
+    Applies pig latin while generating translations. Overridden by :option:`--rot13`.
+
+.. option:: --empty
+
+    Produces empty strings while generating translations. Overridden by :option:`--rot13` and :option:`--piglatin`.
+
+.. option:: --min-priority <int>
+
+    Translates strings with priority greater than this value.
+
+.. option:: --max-priority <int>
+
+    :default: 499 if :var:`config.translate_launcher` is True, otherwise 299.
+
+    Translates strings with less than this priority.
+
+.. option:: --strings-only
+
+    Only translates strings (not dialogue).
+
+.. option:: --common-only
+
+    Only translates strings from common code.
+
+.. option:: --no-todo
+
+    Does not include the TODO flag at the top of generated translation files.
+
+.. option:: --string <string>
+
+    Translates a specific string. This option can be given multiple
+    times to translate multiple strings.
+
+
+.. _cli-dialogue:
+
+Dialogue
+-----------
+
+Exports dialogue (and optionally translatable strings) to :file:`dialogue.tab`
+by default, or :file:`dialogue.txt` when :option:`--text` is used.
+
+If a language is provided, it outputs translated text when available. Otherwise, it outputs
+source text.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> dialogue <language> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> dialogue <language> [options...]
+
+.. note::
+
+    This is an export/reporting command. It does not create :file:`tl/<language>`
+    translation script files.
+
+.. describe:: <language>
+
+    Specifies the language to extract dialogue for.
+
+.. option:: --text
+
+    Outputs the dialogue as plain text. If not given, outputs a tab-delimited file.
+
+.. option:: --strings
+
+    Outputs all translatable strings, not just dialogue.
+
+    Most of these are defined with the :func:`_` and :func:`__` functions, as well as
+    :doc:`menu choices <menus>`.
+
+.. option:: --notags
+
+    Strips text tags from the dialogue.
+
+.. option:: --escape
+
+    Escapes quotes and other special characters.
+
+
+.. _cli-extract-strings:
+
+Extract Strings
+---------------
+
+Exports existing translations from the game to a JSON file.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> extract_strings <language> <destination> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> extract_strings <language> <destination> [options...]
+
+.. option:: <language>
+
+    Specifies the language to extract translated strings from.
+
+.. option:: <destination>
+
+    Specifies the json file to store the translated strings into.
+
+.. option:: --merge
+
+    Merges the current contents of the file with new contents, preserving existing translations.
+
+.. option:: --force
+
+    Does not throw exceptions if the language does not exist.
+
+
+.. _cli-merge-strings:
+
+Merge Strings
+-------------
+
+Imports translations from JSON file back into the game.
+
+Implies :option:`--compile`.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> merge_strings <language> <source> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> merge_strings <language> <source> [options...]
+
+.. option:: <language>
+
+    Specifies the language to merge translated strings to.
+
+.. option:: <source>
+
+    Specifies the json file to take translated strings from.
+
+.. option:: --reverse
+
+    Reverses the languages in the json file.
+
+.. option:: --replace
+
+    Replaces non-trivial translations. A trivial translation is
+    one that does not exist or if the translation is the same as the primary
+    language.
 
 
 Launcher Commands
@@ -273,30 +999,330 @@ Launcher Commands
 These commands are used to control the Ren'Py launcher from the command line.
 
 
+.. _cli-generate-gui:
+
+Generate GUI
+------------
+
+Generates a GUI for an existing Ren'Py game.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher generate_gui <basedir> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher generate_gui <basedir> [options...]
+
+.. option:: --width <width>
+
+    :default: 1280
+
+    Specifies the width of the generated gui.
+
+.. option:: --height <height>
+
+    :default: 720
+
+    Specifies the height of the generated gui.
+
+.. option:: --accent <color>
+
+    :default: #00B8C3
+
+    Specifies the accent color used throughout the gui.
+
+.. option:: --boring <color>
+
+    :default: #000000
+
+    Specifies the boring color used for the gui background.
+
+.. option:: --light
+
+    Considers this a light theme.
+
+.. option:: --template <directory>
+
+    :default: "gui"
+
+    Specifies the template directory containing source code.
+
+.. option:: --language <language>
+
+    :default: None
+
+    Specifies the language to translate strings and comments to.
+
+.. option:: --start
+
+    Starts a new project, replacing images and code.
+
+.. option:: --replace-images
+
+    Overwrites existing images.
+
+.. option:: --replace-code
+
+    Overwrites existing gui.rpy file.
+
+.. option:: --update-code
+
+    Updates existing gui.rpy file.
+
+.. option:: --minimal
+
+    Only updates option.rpy and translations.
+
+
+.. _cli-gui-images:
+
+GUI Images
+----------
+
+Generates images (e.g. for buttons, bars, radio buttons, etc) based on :doc:`GUI variables <gui>`.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher gui_images <basedir> [options...]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher gui_images <basedir> [options...]
+
+.. _cli-get-projects-directory:
+
+Get Projects Directory
+----------------------
+
+Prints the directory that the Ren'Py launcher uses to store projects.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher get_projects_directory
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher get_projects_directory
+
+
+.. _cli-set-projects-directory:
+
 Set Projects Directory
 ----------------------
 
-::
-
-    ./renpy.sh launcher set_projects_directory <directory>
-
-
-This sets the directory that the Ren'Py launcher uses to store projects. It's
+Sets the directory that the Ren'Py launcher uses to store projects. It's
 intended for use on minimal systems where none of the options for selecting
 a projects directory are available.
 
 This can only be done when the launcher is not running.
 
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher set_projects_directory <projects>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher set_projects_directory <projects>
+
+.. describe:: <projects>
+
+    Specifies the path to the projects directory.
+
+
+.. _cli-set-project:
 
 Set Project
 -----------
-
-::
-
-    ./renpy.sh launcher set_project <base>
 
 Sets the current project to the given project. This will change the
 projects directory and currently selected project in the launcher
 to accomplish this goal.
 
 This can only be done when the launcher is not running.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher set_project <project>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher set_project <project>
+
+.. describe:: <project>
+
+    Specifies the full path to the project to select.
+
+
+.. _cli-update-old-game:
+
+Update Old Game
+---------------
+
+Copies .rpyc files from :file:`<basedir>/game` to :file:`<basedir>/old-game`.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher update_old_game <basedir>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher update_old_game <basedir>
+
+.. seealso::
+
+    * :ref:`old-game`
+
+
+Custom Commands
+===============
+
+In addition to the commands defined above, it is possible to create commands
+for a particular project using :func:`renpy.arguments.register_command`.
+
+When running a command, the :doc:`game will first initialize <lifecycle>`, then
+run the command.
+
+.. function:: renpy.arguments.register_command(name, function, uses_display=False)
+
+    Registers a command that can be invoked when Ren'Py is run on the command
+    line. When the command is run, `function` is called with no arguments.
+
+    .. describe:: name
+
+        :type: str
+
+        Specifies the name of the command in the interface.
+
+    .. describe:: function
+
+        :type: function
+
+        Specifies the function that is called when the command is run. `function` is
+        called with no arguments.
+
+        If `function` needs to take additional command-line arguments, it should
+        instantiate a :class:`renpy.arguments.ArgumentParser`, and then call :func:`parse_args`
+        on it. Otherwise, it should call :func:`renpy.arguments.takes_no_arguments`.
+
+        If `function` returns True, Ren'Py startup proceeds normally. Otherwise,
+        Ren'Py will terminate when ``function()`` returns.
+
+        .. seealso::
+
+            For more information about command line parsing, look at the
+            `ArgumentParser documentation <https://docs.python.org/3/library/argparse.html>`_.
+
+    .. describe:: uses_display
+
+        :type: bool
+
+        If True, Ren'Py will initialize the display. If False, Ren'Py will
+        use dummy video and audio drivers.
+
+
+Example
+-------
+
+.. code-block:: renpy
+
+    init python:
+
+        def compute_area_command():
+            ap = renpy.arguments.ArgumentParser(description='Compute the area of various shapes.')
+            ap.add_argument("dimensions", nargs="*", type=float, help="The dimension of the shape.")
+            ap.add_argument("--square", action="store_true", help="If given, compute the area as a square.")
+            ap.add_argument("--rectangle", action="store_true", help="If given, compute the area as a rectangle.")
+            ap.add_argument("--circle", action="store_true", help="If given, compute the area as a circle.")
+
+            args = ap.parse_args()
+
+            if args.square:
+                print(f"Square: {args.dimensions[0] ** 2}")
+
+            elif args.rectangle:
+                print(f"Rectangle: {args.dimensions[0] * args.dimensions[1]}")
+
+            elif args.circle:
+                print(f"Circle: {3.14 * args.dimensions[0] ** 2}")
+
+            # Terminate and do not run Ren'Py normally
+            return False
+
+        renpy.arguments.register_command("compute_area", compute_area_command)
+
+The command can then be called as follows:
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            > ./renpy.sh <basedir> compute_area 3 --square
+
+            Square: 9.0
+
+            > ./renpy.sh <basedir> compute_area 3 2 --rectangle
+
+            Rectangle: 6.0
+
+            > ./renpy.sh <basedir> compute_area 1 --circle
+
+            Circle: 3.14
+
+            > ./renpy.sh <basedir> compute_area --help
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            > .\lib\py3-windows-x86_64\python.exe renpy.py basedir compute_area 3 --square
+
+            Square: 9.0
+
+            > .\lib\py3-windows-x86_64\python.exe renpy.py basedir compute_area 3 2 --rectangle
+
+            Rectangle: 6.0
+
+            > .\lib\py3-windows-x86_64\python.exe renpy.py basedir compute_area 1 --circle
+
+            Circle: 3.14
+
+            > .\lib\py3-windows-x86_64\python.exe renpy.py basedir compute_area --help

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -54,6 +54,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_rtd_theme',
     'sphinx_rtd_dark_mode',
+    'sphinx_tabs.tabs',
     ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -117,6 +117,9 @@ The third unit has the identifier start_9e949aac, and contains::
 These units are created automatically by Ren'Py when the game script
 is loaded.
 
+
+.. _translation_statement:
+
 Translate Statement
 -------------------
 


### PR DESCRIPTION
Addresses #3239, targets the `fix` branch (original PR was #5749)

Updated the command line documentation to match what's present in 8.5.3.

To make it easier to copy/paste commands for different operating systems, I've added [Sphinx Tabs](https://github.com/executablebooks/sphinx-tabs) as a requirement and created a dark theme for it. It can be installed with:
``` bash
pip install -U sphinx-tabs
```

NOTE: I wasn't able to test the `gui_images` and `director` commands myself, but the documentation should be accurate.