### PR TITLE
Execute actions and python once if new context is created

### DIFF
--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -982,10 +982,26 @@ class Action(Node):
         action = scoped_eval(self.expr)
         return renpy.display.behavior.is_sensitive(action)
 
+    def start(self):
+        return {"executed_already": False}
+
     def execute(self, state, t):
+        # execute() may be re-run when an action like Replay creates a new context,
+        # and the test executor keeps ticking inside that context.
+        # We advance to the next node inside the replay context so the test continues,
+        # and we skip the redundant next_node() call when run() eventually returns.
+
+        if t > 0:
+            state["executed_already"] = True
+            next_node(self.next)
+            return None
+
         action = scoped_eval(self.expr)
         renpy.display.behavior.run(action)
-        next_node(self.next)
+
+        if not state["executed_already"]:
+            next_node(self.next)
+
         return None
 
 
@@ -1372,10 +1388,25 @@ class Python(Node):
         self.source = source
         self.hide = hide
 
+    def start(self):
+        return {"executed_already": False}
+
     def execute(self, state, t):
+        # execute() may be re-run when an action like Replay creates a new context,
+        # and the test executor keeps ticking inside that context.
+        # We advance to the next node inside the replay context so the test continues,
+        # and we skip the redundant next_node() call when run() eventually returns.
+
+        if t > 0:
+            state["executed_already"] = True
+            next_node(self.next)
+            return None
+
         scoped_exec(self.source, self.hide)
 
-        next_node(self.next)
+        if not state["executed_already"]:
+            next_node(self.next)
+
         return None
 
 

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -69,7 +69,6 @@ testsuite parameter_field:
             assert eval (a + b + c == x or a + b + c == y)
 
 
-
 testsuite screenshot:
     testcase main_menu:
         screenshot "main_menu.png" #crop (0, 0, 400, 300)
@@ -227,3 +226,24 @@ testsuite timeout:
     testcase hard_pause_pass_timeout:
         $ _test.timeout = 1.0
         advance until "End"
+
+testsuite context:
+    testcase replay_action:
+        description "Tests that the Replay action properly updates context variables."
+
+        $ replay_scope = {"context_test_inner_val": True}
+        run Replay("start", scope=replay_scope)
+        assert eval (not "replay_scope" in globals())
+        assert eval ("context_test_inner_val" in globals())
+        $ renpy.end_replay()
+        assert eval ("replay_scope" in globals())
+
+    testcase replay_python:
+        description "Tests that `renpy.call_replay` properly updates context variables."
+
+        $ replay_scope = {"context_test_inner_val": True}
+        $ renpy.call_replay("start", scope=replay_scope)
+        assert eval (not "replay_scope" in globals())
+        assert eval ("context_test_inner_val" in globals())
+        $ renpy.end_replay()
+        assert eval ("replay_scope" in globals())


### PR DESCRIPTION
Fixes #7051 

Test with `./lib/py3-windows-x86_64/python.exe main.py testcases test context` (Windows, use the equivalent with Linux)