### PR TITLE
Add `for` statement to test suite

### DIFF
--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -1400,16 +1400,6 @@ class ControlFrame(Node):
     The corresponding frame instance is kept in `testexecution.control_frame_stack`.
     """
 
-    __slots__ = ("data",)
-
-    def __init__(
-        self,
-        loc: NodeLocation,
-        data: dict[str, Any] | None = None,
-    ):
-        super(ControlFrame, self).__init__(loc)
-        self.data = data or {}
-
     def execute(self, state, t):
         self.on_end_execution()
         next_node(self.next)

--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -44,6 +44,16 @@ class SelectorException(RenpyTestException):
     pass
 
 
+class LoopBreakException(Exception):
+    """Exception raised to break out of a loop."""
+    pass
+
+
+class LoopContinueException(Exception):
+    """Exception raised to continue to the next iteration of a loop."""
+    pass
+
+
 class Node(object):
     """
     An AST node for a test script.
@@ -1380,25 +1390,177 @@ class If(Node):
         return None
 
 
-class While(Node):
+class ControlFrame(Node):
+    """
+    Control-flow frame for nodes like For and While.
 
-    def __init__(self, loc: NodeLocation, condition: Condition,block):
+    This node sets up a context for the loop body to execute in, and provides hooks for handling
+    the end of the body, exceptions raised in the body, and the end of execution of the loop.
+
+    The corresponding frame instance is kept in `testexecution.control_frame_stack`.
+    """
+
+    __slots__ = ("data",)
+
+    def __init__(
+        self,
+        loc: NodeLocation,
+        data: dict[str, Any] | None = None,
+    ):
+        super(ControlFrame, self).__init__(loc)
+        self.data = data or {}
+
+    def execute(self, state, t):
+        self.on_end_execution()
+        next_node(self.next)
+        return None
+
+    def on_end_execution(self) -> None:
+        """
+        Called when execution of the control frame is ending, either by normal termination,
+        loop breaking, or exception raising.
+        """
+        return None
+
+    def on_exception(self, exc: Exception) -> bool:
+        """
+        Handles an exception raised during execution of the loop body.
+        Returns True if the exception was handled and should be suppressed, or False to propagate it.
+        """
+        return False
+
+
+class For(ControlFrame):
+    """
+    A for loop node that iterates over an expression.
+
+    `variable`
+        The loop variable pattern (e.g., "i" or "(x, y)").
+    `expression`
+        The iterable expression.
+    `block`
+        A Block containing the statements to execute in each iteration.
+    """
+
+    __slots__ = ("variable", "expression", "block", "loop_iterator")
+
+    def __init__(self, loc: NodeLocation, variable: str, expression: str, block: Block):
+        Node.__init__(self, loc)
+        self.variable = variable
+        self.expression = expression
+        self.block = block
+        self.loop_iterator = None
+
+    def chain(self, next):
+        self.next = next
+        self.block.chain(self)
+
+    def start(self) -> NodeState:
+        """Initialize and push a control frame for this loop."""
+
+        if self.loop_iterator is None:
+            iterable = scoped_eval(self.expression)
+            self.loop_iterator = iter(iterable)
+
+        renpy.test.testexecution.push_control_frame(self)
+        return self.loop_iterator
+
+    def execute(self, state: NodeState, t: float) -> NodeState:
+        """Execute the loop body or advance to the next iteration."""
+
+        iterator = state
+
+        try:
+            loop_value = next(iterator)
+            scope = renpy.test.testexecution.get_current_scope()
+
+            temp_name = "__renpy_test_loop_value__"
+            scope[temp_name] = loop_value
+            try:
+                scoped_exec(f"{self.variable} = {temp_name}")
+            finally:
+                scope.pop(temp_name, None)
+
+            if self.block.block:
+                self.block.restart()
+                next_node(self.block.block[0])
+                return None
+            else:
+                next_node(self)
+                return state
+
+        except StopIteration:
+            self.loop_iterator = None
+            renpy.test.testexecution.pop_control_frame(self)
+            next_node(self.next)
+            return None
+
+    def on_exception(self, exc: Exception) -> bool:
+        if isinstance(exc, LoopContinueException):
+            next_node(self)
+            return True
+
+        if isinstance(exc, LoopBreakException):
+            self.loop_iterator = None
+            renpy.test.testexecution.pop_control_frame(self)
+            next_node(self.next)
+            return True
+
+        return False
+
+    def get_repr_params(self) -> str:
+        return f"variable={self.variable!r}, expression={self.expression!r}"
+
+
+class While(ControlFrame):
+    def __init__(self, loc: NodeLocation, condition: Condition, block: Block):
         Node.__init__(self,loc)
-        
+
         self.condition = condition
         self.block = block
 
+    def start(self) -> NodeState:
+        renpy.test.testexecution.push_control_frame(self)
+        return 0
+
     def chain(self,next):
         self.next = next
-    
+        self.block.chain(self)
+
     def execute(self, state, t):
         if self.condition.ready():
-            self.block.chain(self)
+            self.block.restart()
             next_node(self.block.block[0])
             return None
-        
+
         next_node(self.next)
         return None
+
+    def on_exception(self, exc: Exception) -> bool:
+        if isinstance(exc, LoopContinueException):
+            next_node(self)
+            return True
+
+        if isinstance(exc, LoopBreakException):
+            renpy.test.testexecution.pop_control_frame(self)
+            next_node(self.next)
+            return True
+
+        return False
+
+
+class Break(Node):
+    """Breaks out of the nearest enclosing loop."""
+
+    def execute(self, state, t):
+        raise LoopBreakException()
+
+
+class Continue(Node):
+    """Continues to the next iteration of the nearest enclosing loop."""
+
+    def execute(self, state, t):
+        raise LoopContinueException()
 
 
 class Python(Node):

--- a/renpy/test/testexecution.py
+++ b/renpy/test/testexecution.py
@@ -27,7 +27,7 @@ import renpy
 import renpy.pygame as pygame
 
 from renpy.error import FrameSummary
-from renpy.test.testast import Node, BaseTestBlock, TestSuite, TestCase, TestHook, Exit
+from renpy.test.testast import Node, BaseTestBlock, TestSuite, TestCase, TestHook, Exit, ControlFrame
 from renpy.test.types import NodeState, NodeLocation, RenpyTestTimeoutError, HookType
 import renpy.test.testreporter as testreporter
 from renpy.test.testsettings import _test
@@ -38,6 +38,7 @@ global_testsuite_name = "global"
 reached_labels: set[str] = set()
 suite_stack: list[TestSuite] = []
 scope_stack: list[dict[str, Any]] = [{}]
+control_frame_stack: list[ControlFrame] = []
 
 testcases: dict[str, TestCase] = {}
 node_executor: "NodeExecutor"
@@ -156,6 +157,25 @@ def push_scope_stack(new_scope: dict[str, Any]) -> None:
     scope_stack.append(updated_scope)
 
 
+def pop_control_frame(control_frame: ControlFrame | None = None) -> ControlFrame:
+    if not control_frame_stack:
+        raise RuntimeError("No control frames are currently active.")
+
+    if control_frame is None:
+        control_frame = control_frame_stack[-1]
+
+    if control_frame_stack[-1] is not control_frame:
+        raise RuntimeError("Attempted to pop a non-top control frame.")
+
+    rv = control_frame_stack.pop()
+    rv.on_end_execution()
+    return rv
+
+
+def push_control_frame(control_frame: ControlFrame) -> None:
+    control_frame_stack.append(control_frame)
+
+
 def quit_handler() -> int:
     """
     Handles the quit command and QuitException thrown by the test.
@@ -210,6 +230,7 @@ def scoped_exec(source: str, hide: bool = False, store: str = "store") -> None:
     """
 
     scope = renpy.test.testexecution.get_current_scope()
+    old_scope = dict(scope)
     old_keys = set(scope.keys())
     globals = renpy.python.store_dicts[store]
 
@@ -217,6 +238,7 @@ def scoped_exec(source: str, hide: bool = False, store: str = "store") -> None:
     renpy.python.py_exec_bytecode(dedent(source), hide, globals=globals, locals=scope)
 
     if hide:
+        scope_stack[-1] = old_scope
         return
 
     new_keys = set(scope.keys()) - old_keys
@@ -438,6 +460,7 @@ class NodeExecutor:
         self.old_state = None
         self.old_loc = None
         self.last_state_change = renpy.display.core.get_time()
+        control_frame_stack.clear()
 
     def set_next_node(self, next: Node | None) -> None:
         self.next_node = next
@@ -481,10 +504,23 @@ class NodeExecutor:
             self.next_node = self.node.next
             self.move_to_next_node_if_possible()
             raise
+        except Exception as exc:
+            if self.dispatch_exception_to_control_frame(exc):
+                self.node_state = None
+                self.move_to_next_node_if_possible()
+                return
+            raise
 
         self.move_to_next_node_if_possible()
 
         self.check_for_timeout(now)
+
+    def dispatch_exception_to_control_frame(self, exc: Exception) -> bool:
+        for control_frame in reversed(control_frame_stack):
+            if control_frame.on_exception(exc):
+                return True
+
+        return False
 
     def move_to_next_node_if_possible(self) -> None:
         if self.node_state is not None:

--- a/renpy/test/testparser.py
+++ b/renpy/test/testparser.py
@@ -120,6 +120,39 @@ def while_statement(l: Lexer, loc: NodeLocation) -> testast.While:
     return testast.While(loc, condition, block)
 
 
+@test_statement("for")
+def for_statement(l: Lexer, loc: NodeLocation) -> testast.For:
+    variable_pattern = l.require(l.simple_expression, comma=True, operator=False)
+    l.require("in")
+    expression = l.require(l.simple_expression)
+    l.require(":")
+    l.expect_eol()
+    l.expect_block("for statement")
+
+    block, _ = parse_block(l.subblock_lexer(False), loc)
+
+    l.advance()
+    return testast.For(loc, variable_pattern, expression, block)
+
+
+@test_statement("break")
+def break_statement(l: Lexer, loc: NodeLocation) -> testast.Break:
+    l.expect_eol()
+    l.expect_noblock("break statement")
+    l.advance()
+
+    return testast.Break(loc)
+
+
+@test_statement("continue")
+def continue_statement(l: Lexer, loc: NodeLocation) -> testast.Continue:
+    l.expect_eol()
+    l.expect_noblock("continue statement")
+    l.advance()
+
+    return testast.Continue(loc)
+
+
 ##############################################################################
 # Statement functions: Actions
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -60,6 +60,8 @@ The ability to create these updates will be removed in Ren'Py 8.7.0.
 
 Ren'Py's PC presplash system has been updated to support WEBP and AVIF images, in addition to PNG and JPG.
 
+It is now possible to use `for` and `while` loops in automated tests.
+
 
 .. _renpy-8.5.3:
 
@@ -263,7 +265,7 @@ the Cubism SDK for Web, and support in Ren'Py for loading Live2D models in the w
 Automated Testing
 -----------------
 
-Ren'Py now includes a testing framework that makes it possible to define and run automate tests of games and of
+Ren'Py now includes a :doc:`testing framework <testcases>` that makes it possible to define and run automate tests of games and of
 Ren'Py itself. The testing framework is designed to perform automated functional testing -
 for example, clicking through a predefined sequence of dialogue and choice, and making sure the game
 reaches the end without crashing, even when the game or engine is changed.

--- a/sphinx/source/testcases.rst
+++ b/sphinx/source/testcases.rst
@@ -740,7 +740,7 @@ Click
 
     Type: :dfn:`Command`
 
-    .. describe:: click [button (int)] [selector] [pos (x, y)]
+    .. describe:: click [button (int)] [selector] [expression (expr)] [pos (x, y)]
 
 Executes a simulated click on the screen. It takes the following optional
 properties:
@@ -749,6 +749,9 @@ properties:
     with. It takes an integer and defaults to 1. 1 is a left-click, 2 is a
     right-click, 3 is a middle-click, 4 and 5 are additional buttons found on
     some mouses. Normally only 1 and 2 trigger any response from Ren'Py.
+- ``expression`` specifies a test expression that identifies the click target.
+    It is evaluated according to the rules of the :ref:`pattern <test-text-selector>`\ -taking
+    clause.
 
 If ``selector`` and/or ``pos`` are given, the virtual test mouse is moved according to
 the rules of the :ref:`move statement <test-move-statement>` before the click is sent.
@@ -759,7 +762,24 @@ Click behaves like a :ref:`pattern <test-text-selector>`\ -taking clause which w
 not be given a pattern: if no ``pos`` is provided, it will look for a neutral
 place where a click would not occur on a focusable element.
 
-.. give example for both
+::
+
+    # Click at the current mouse position
+    click
+
+    # Click a button with specific text
+    click "Start"
+
+    # Right-click on a specific target.
+    click id "inventory_button" button 2
+
+    # Click the center of the selected target.
+    click id "inventory_button" pos (0.5, 0.5)
+
+    # Click a button using an expression.
+    $ button_name = "Load"
+    click expression button_name
+
 
 .. note::
 
@@ -1125,6 +1145,36 @@ assertion fails. If the condition is not met, the assertion passes.
     - `Python asserts <https://docs.python.org/reference/simple_stmts.html#the-assert-statement>`__
     - `Boolean evaluation <https://docs.python.org/library/stdtypes.html#truth-value-testing>`__
 
+For
+^^^
+
+    Type: :dfn:`Control`
+
+    .. describe:: for <variable> in <iterable>
+
+This statement executes a block of test statements for each item in the provided
+iterable. You can use `break` and `continue` statements to control the flow of the loop.
+
+Example::
+
+    # Click "Next" three times
+    for _ in range(3):
+        click "Next"
+
+    # Click each of the choices, skipping "Trade" if the shop is not unlocked
+    for choice in ["Talk", "Trade", "Leave"]:
+        if eval (choice == "Trade" and not persistent.shop_unlocked):
+            continue
+        click expression choice
+        if screen "shop":
+            break
+
+    # Click each of the tabs in the stats screen, skipping "Quests" if quests are not enabled
+    for stat_tab in ["Stats", "Skills", "Quests"]:
+        click expression stat_tab
+        if eval (stat_tab == "Quests" and not persistent.quests_enabled):
+            continue
+        assert text stat_tab timeout 2.0
 
 If
 ^^^^^^^^^
@@ -1246,20 +1296,25 @@ This timeout temporarily overrides the global ``_test.timeout`` setting.
     skip until screen "inventory" timeout 20.0
 
 While
-^^^^^^^^^
+^^^^^
 
     Type: :dfn:`Control`
 
     .. describe:: while <condition>
 
 This statement executes a block of test statements while the provided
-condition remains met.
+condition remains met. You can use `break` and `continue` statements
+to control the flow of the loop.
 
 Example::
 
-    while eval shouldAdvance:
+    $ should_advance = True
+    while eval should_advance:
         advance
-        $ shouldAdvance = some_evaluation_function()
+        if screen "main_menu":
+            break
+
+        $ should_advance = some_evaluation_function()
 
 Python Blocks And Dollar-Lines
 ------------------------------

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -247,3 +247,298 @@ testsuite context:
         assert eval ("context_test_inner_val" in globals())
         $ renpy.end_replay()
         assert eval ("replay_scope" in globals())
+
+testsuite for_loops:
+    description "Tests `for` loop statements with various patterns."
+
+    testcase range:
+        description "Basic `for` loop with `range`, variable accessible after loop"
+
+        $ counter = 0
+        for i in range(4):
+            $ counter += 1
+
+        assert eval (i == 3)
+        assert eval (counter == 4)
+
+    testcase tuple_unpacking:
+        description "Tuple unpacking"
+
+        $ counter = 0
+        for (x, y) in [(1, 2), (3, 4), (5, 6)]:
+            $ counter += 1
+
+        # After loop, variables should have last iteration values
+        assert eval (x == 5)
+        assert eval (y == 6)
+        assert eval (counter == 3)
+
+    testcase tuple_unpacking2:
+        description "Tuple unpacking with nested tuples"
+
+        $ counter = 0
+        for z, (x, y) in [("a", (1, 2)), ("b", (3, 4)), ("c", (5, 6))]:
+            $ counter += 1
+
+        # After loop, variables should have last iteration values
+        assert eval (z == "c")
+        assert eval (x == 5)
+        assert eval (y == 6)
+        assert eval (counter == 3)
+
+    testcase break:
+        description "`break` statement exits the loop early"
+
+        $ counter = 0
+        for i in range(10):
+            $ counter += 1
+            if eval (i == 3):
+                break
+
+        assert eval (i == 3)
+        assert eval (counter == 4)
+
+    testcase continue:
+        description "`continue` statement skips to the next iteration"
+
+        $ counter = 0
+        for i in range(4):
+            $ counter += 1
+            if eval (i == 1):
+                continue
+
+        # After continue, loop should have continued normally
+        assert eval (i == 3)
+        assert eval (counter == 4)
+
+    testcase string:
+        description "Iterating over a string"
+
+        $ counter = 0
+        for char in "hello":
+            $ counter += 1
+
+        assert eval (char == 'o')
+        assert eval (counter == 5)
+
+    testcase empty_loop:
+        description "Empty iterable"
+
+        $ counter = 0
+        for test_for_empty_loop_i in []:
+            $ counter = 0
+
+        # Loop should not execute, so i is undefined (or should not exist)
+        assert eval (not "test_for_empty_loop_i" in locals() and not "test_for_empty_loop_i" in globals())
+        assert eval (counter == 0)
+
+    testcase list:
+        description "Iterating over a list"
+
+        $ counter = 0
+        for item in [10, 20, 30, 40]:
+            $ counter += 1
+
+        assert eval (item == 40)
+        assert eval (counter == 4)
+
+    testcase enumerate:
+        description "Enumerate with tuple unpacking"
+
+        $ counter = 0
+        for i, val in enumerate(['a', 'b', 'c']):
+            $ counter += 1
+
+        # After loop, i and val should have last iteration values
+        assert eval (i == 2)
+        assert eval (val == 'c')
+        assert eval (counter == 3)
+
+    testcase enumerate_break:
+        description "Enumerate with `break` in middle"
+
+        $ counter = 0
+        for idx, val in enumerate(['x', 'y', 'z']):
+            $ counter += 1
+            if eval (idx == 1):
+                break
+
+        assert eval (idx == 1)
+        assert eval (val == 'y')
+        assert eval (counter == 2)
+
+    testcase nested_loops:
+        description "Nested for loops"
+
+        $ counter = 0
+        for i in range(3):
+            for j in range(2):
+                $ counter += 1
+
+        # After nested loops, both should have last iteration values
+        assert eval (i == 2)
+        assert eval (j == 1)
+        assert eval (counter == 6)
+
+    testcase break_inner_loop:
+        description "Break in inner loop should not affect outer loop"
+
+        $ counter = 0
+        for i in range(3):
+            for j in range(3):
+                $ counter += 1
+                if eval (j == 1):
+                    break
+
+        assert eval (i == 2)
+        assert eval (j == 1)
+        assert eval (counter == 6)
+
+    testcase continue_inner_loop:
+        description "Continue in inner loop should skip to next iteration of inner loop"
+
+        $ counter = 0
+        for i in range(3):
+            for j in range(3):
+                if eval (j == 1):
+                    continue
+                $ counter += 1
+
+        assert eval (i == 2)
+        assert eval (j == 2)
+        assert eval (counter == 6)
+
+    testcase break_outer_loop:
+        description "Break in outer loop should exit both loops"
+
+        $ counter = 0
+        for i in range(3):
+            for j in range(3):
+                $ counter += 1
+            if eval (i == 1):
+                break
+        assert eval (i == 1)
+        assert eval (j == 2)
+        assert eval (counter == 6)
+
+    testcase continue_outer_loop:
+        description "Continue in outer loop should skip to next iteration of outer loop"
+        $ counter = 0
+        for i in range(3):
+            if eval (i == 1):
+                continue
+            for j in range(3):
+                $ counter += 1
+
+        assert eval (i == 2)
+        assert eval (j == 2)
+        assert eval (counter == 6)
+
+    testcase menu_choices:
+        description "Clicks menu choices on loop"
+
+        run Start("branching.variable_test")
+        pause until screen "choice"
+
+        for option in ["Increment", "Increment", "Decrement", "Increment", "Increment"]:
+            click expression option
+
+        assert "Value: 3" timeout 2.0
+        click "Done"
+
+
+testsuite while_loops:
+    description "Tests `while` loop statements with various patterns."
+
+    testcase basic_while:
+        description "Basic while loop increments until condition becomes false"
+
+        $ i = 0
+        $ counter = 0
+
+        while eval (i < 4):
+            $ counter += 1
+            $ i += 1
+
+        assert eval (i == 4)
+        assert eval (counter == 4)
+
+    testcase while_break:
+        description "`break` exits the loop early"
+
+        $ i = 0
+        $ counter = 0
+
+        while eval (i < 10):
+            $ counter += 1
+            if eval (i == 3):
+                break
+            $ i += 1
+
+        assert eval (i == 3)
+        assert eval (counter == 4)
+
+    testcase while_continue:
+        description "`continue` skips body segment and keeps iterating"
+
+        $ i = 0
+        $ counter = 0
+        $ hits = []
+
+        while eval (i < 5):
+            $ i += 1
+            if eval (i == 3):
+                continue
+            $ counter += 1
+            $ hits.append(i)
+
+        assert eval (i == 5)
+        assert eval (counter == 4)
+        assert eval (hits == [1, 2, 4, 5])
+
+    testcase while_never_runs:
+        description "Does not execute when condition starts false"
+
+        $ i = 10
+        $ counter = 0
+
+        while eval (i < 5):
+            $ counter += 1
+            $ i += 1
+
+        assert eval (i == 10)
+        assert eval (counter == 0)
+
+    testcase nested_while:
+        description "Nested while loops"
+
+        $ i = 0
+        $ counter = 0
+
+        while eval (i < 3):
+            $ j = 0
+            while eval (j < 2):
+                $ counter += 1
+                $ j += 1
+            $ i += 1
+
+        assert eval (i == 3)
+        assert eval (j == 2)
+        assert eval (counter == 6)
+
+    testcase real_choices:
+        description "Clicks menu choices on loop"
+
+        run Start("branching.variable_test")
+        pause until screen "choice"
+
+        $ clicks = 0
+        while eval (menu_var < 3):
+            click "Increment"
+            click "Increment"
+            click "Decrement"
+            $ clicks += 1
+
+        assert eval (clicks == 3)
+        assert "Value: 3" timeout 2.0
+        click "Done"


### PR DESCRIPTION
Builds on #7035

- Add `for` loop
- Add `break` and `continue`. Modify `while` loops to use them
- Update documentation

**Note**:
- Does not currently handle `for-else` or `while-else`
- ControlFrame can be extended later to handle `try-catch` blocks

Test with the following commands (Windows):
```
./lib/py3-windows-x86_64/python.exe main.py testcases test for_loops
./lib/py3-windows-x86_64/python.exe main.py testcases test while_loops
```