### PR TITLE
Make error for missing `id "what"` less obscure.

### DIFF
--- a/renpy/character.py
+++ b/renpy/character.py
@@ -825,20 +825,27 @@ def display_say(
 
             # What text is (screen, id, layer) tuple if we're using a screen.
             if isinstance(what_text, tuple):
+                screen_tag, widget_id, screen_layer = what_text
+
                 # If this is not the first pause, set the transform event to "replace".
                 if i != 0 and renpy.config.say_replace_event:
-                    screen_displayable = renpy.display.screen.get_screen(what_text[0], what_text[2])
+                    screen_displayable = renpy.display.screen.get_screen(screen_tag, screen_layer)
                     if screen_displayable is not None:
                         screen_displayable.set_transform_event("replace")
 
                         if not retain and not last_pause:
                             sls = renpy.game.context().scene_lists
-                            sls.set_transient_prefix(what_text[2], what_text[0], "replaced")
+                            sls.set_transient_prefix(screen_layer, screen_tag, "replaced")
 
-                slow_done.screen_tag = what_text[0]
-                slow_done.screen_layer = what_text[2]
+                slow_done.screen_tag = screen_tag
+                slow_done.screen_layer = screen_layer
 
-                what_text = renpy.display.screen.get_widget(what_text[0], what_text[1], what_text[2])
+                what_text = renpy.display.screen.get_widget(screen_tag, widget_id, screen_layer)
+
+                if what_text is None:
+                    exc = Exception(f"Could not find the widget with id {widget_id!r} on screen {screen_tag!r}.")
+                    exc.add_note(f'Did you forget to add id "{widget_id}" or put it under condition?')
+                    raise exc
 
             if not multiple:
                 afm_text_queue = [what_text]


### PR DESCRIPTION
I had a `text what id "what"` with some condition and when it have evaluated to False, say statement errored with obscure error.
```
  File "renpy/ast.py", line 2935, in execute
    Say.execute(self)
  File "renpy/ast.py", line 994, in execute
    renpy.exports.say(who, what, *args, **kwargs)
  File "renpy/exports/sayexports.py", line 129, in say
    who(what, *args, **kwargs)
  File "renpy/character.py", line 1572, in __call__
    self.do_display(who, what, cb_args=self.cb_args, dtt=dtt, **display_args)
  File "renpy/character.py", line 1227, in do_display
    display_say(who, what, self.do_show, **display_args)
  File "renpy/character.py", line 862, in display_say
    raise Exception("The say screen (or show_function) must return a Text object.")
Exception: The say screen (or show_function) must return a Text object.
```

This makes it more obvious what is wrong by erroring as
```
  File "renpy/character.py", line 848, in display_say
    raise exc
Exception: Could not find the widget with id 'what' on screen 'say'.
Did you forget to add id "what" or put it under condition?
```

I am not sure if it is correct to error on that branch of code, without testing for `interact or what_string or (what_ctc is not None) or (behavior and afm)`, so this PR is to decide what is correct.