### PR TITLE
Add `config.failed_save_dump`

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -524,6 +524,9 @@ python_callbacks = []
 # If true, we dump information about a save upon save.
 save_dump = False
 
+# Same as save_dump, but only triggers when the save fails.
+failed_save_dump = False
+
 # Can we resize a gl window?
 gl_resize = True
 

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -525,7 +525,7 @@ python_callbacks = []
 save_dump = False
 
 # Same as save_dump, but only triggers when the save fails.
-failed_save_dump = False
+failed_save_dump = True
 
 # Can we resize a gl window?
 gl_resize = True

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -193,7 +193,10 @@ def save(slotname, extra_info="", mutate_flag=False, include_screenshot=True, ex
             pass
 
         if renpy.config.failed_save_dump and not renpy.config.save_dump:
-            dump_paths("save_dump.txt", **{"renpy.game.log": renpy.game.log}, **roots)
+            try:
+                dump_paths("save_dump.txt", **{"renpy.game.log": renpy.game.log}, **roots)
+            except Exception:
+                pass
 
         raise
 

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -196,7 +196,8 @@ def save(slotname, extra_info="", mutate_flag=False, include_screenshot=True, ex
             try:
                 dump_paths("save_dump.txt", **{"renpy.game.log": renpy.game.log}, **roots)
             except Exception:
-                pass
+                renpy.display.log.write("While writing save_dump.txt:")
+                renpy.display.log.exception()
 
         raise
 

--- a/renpy/loadsave.py
+++ b/renpy/loadsave.py
@@ -192,6 +192,9 @@ def save(slotname, extra_info="", mutate_flag=False, include_screenshot=True, ex
         except Exception:
             pass
 
+        if renpy.config.failed_save_dump and not renpy.config.save_dump:
+            dump_paths("save_dump.txt", **{"renpy.game.log": renpy.game.log}, **roots)
+
         raise
 
     if mutate_flag and renpy.revertable.mutate_flag:

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1292,7 +1292,7 @@ Saving and Loading
     to the object, information about if the object is an alias, and a
     representation of the object.
 
-.. var:: config.failed_save_dump = False
+.. var:: config.failed_save_dump = True
 
     Similar to :var:`config.save_dump`, but only triggers when the save fails.
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1292,6 +1292,10 @@ Saving and Loading
     to the object, information about if the object is an alias, and a
     representation of the object.
 
+.. var:: config.failed_save_dump = False
+
+    Similar to :var:`config.save_dump`, but only triggers when the save fails.
+
 .. var:: config.save_json_callbacks = [ ... ]
 
     A list of callback functions that are used to create the json object


### PR DESCRIPTION
This adds a save_dump option that only triggers when pickle failes. Sometimes it is hard to tell how unpickable object got into save paths by a `find_bad_reduction` path, and because the problem is with save itself there is no tracesave to show the full picture, hence this variable that I could enable in my project and ask people to send the dump file.