### PR TITLE
 Layeredimage exception handling fix

### DIFF
--- a/renpy/common/00layeredimage_ren.py
+++ b/renpy/common/00layeredimage_ren.py
@@ -735,10 +735,18 @@ class LayeredImage(object):
             args.args = tuple(unknown)
             args.extraneous()
 
-        if unknown and config.developer:
-            message = [" ".join(args.name), "unknown attributes:", " ".join(sorted(unknown))]
+        if unknown:          
+            args = args.copy()
+            args.args = tuple(unknown)
+        
+            args.extraneous()
+            
+            # If execution reaches here, no exception was raised.
 
-            text = Text(
+            if config.developer:
+                message = [" ".join(args.name), "unknown attributes:", " ".join(sorted(unknown))]
+
+                text = Text(
                 "\n".join(message),
                 size=16,
                 xalign=0.5,
@@ -746,9 +754,9 @@ class LayeredImage(object):
                 textalign=0.5,
                 color="#fff",
                 outlines=[(1, "#0008", 0, 0)],
-            )
-
-            rv = Fixed(rv, text, fit_first=True)
+                )
+                
+                rv = Fixed(rv, text, fit_first=True)
 
         rv = At(rv, *self.at)
 

--- a/testcases/game/script.rpy
+++ b/testcases/game/script.rpy
@@ -58,6 +58,12 @@ label start:
         "Drag and Drop":
             call drag_and_drop
 
+        "Layered Image Exceptions":
+            call test_layered_image_exceptions
+        
+        "Layered Image Overlay Fallback":
+            call test_layered_image_overlay_fallback
+
         "Done.":
             return
 
@@ -217,6 +223,40 @@ label get_image_bounds:
 
     return
 
+###############################################################################
+# Layered Image Exceptions
+###############################################################################
+
+layeredimage testchar:
+
+    attribute happy
+
+    always:
+        "eileen_happy.png"
+
+label test_layered_image_exceptions:
+
+    $ config.developer = True
+    $ config.report_extraneous_attributes = True
+    $ config.raise_image_exceptions = True
+
+    show testchar happy typo_attribute
+
+    "This line should not be reached if the exception handling works." 
+
+    return
+
+label test_layered_image_overlay_fallback:
+
+    $ config.developer = True
+    $ config.report_extraneous_attributes = False
+    $ config.raise_image_exceptions = True
+
+    show testchar happy typo_attribute
+
+    "This line should be reached."
+
+    return
 
 ###############################################################################
 # Retain on Load


### PR DESCRIPTION
## Issue Type
- Task
- Bug

## Description
Implementation of missing exception handling for layered images.

## Testing
Added testcases to verify that layered image attribute errors now follow the standard `report_extraneous_attributes` and `raise_image_exceptions handling`.

## Related Issue
Closes #7020
