### PR TITLE
Fix renpy.loadable('') returning True incorrectly

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,2 +1,4 @@
     if not fn:
         return False
+    if not fn:
+        return False

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,0 +1,2 @@
+    if not fn:
+        return False


### PR DESCRIPTION
Adds a guard clause to renpy.loadable to return False immediately if the filename is empty or falsy.