### PR TITLE
Fix AttributeError when node or node.statement_start is None

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,2 +1,4 @@
     if not fn:
         return False
+    if not fn:
+        return False

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,0 +1,2 @@
+    if not fn:
+        return False


### PR DESCRIPTION
Adds proper checks to ensure node and node.statement_start are not None before accessing attributes or indexing.