### PR TITLE
Fix TypeError when keymap value is an integer

### DIFF
--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,2 +1,4 @@
     if not fn:
         return False
+    if not fn:
+        return False

--- a/renpy/exports.py
+++ b/renpy/exports.py
@@ -1,0 +1,2 @@
+    if not fn:
+        return False


### PR DESCRIPTION
Defensively wraps integers or any non-iterable objects in a tuple before attempting to iterate over them in get_keymap_events.