### PR TITLE
Remove glUnmapBuffer applied to never-mapped buffer

### DIFF
--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -565,7 +565,6 @@ cdef class GLTexture(GL2Model):
             glBufferData(GL_PIXEL_UNPACK_BUFFER, s.h * s.pitch, s.pixels, GL_STATIC_DRAW)
             glPixelStorei(GL_UNPACK_ROW_LENGTH, s.pitch // 4)
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, self.width, self.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, <void *> 0)
-            glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER)
             glDeleteBuffers(1, &pixel_buffer)
 
         else:


### PR DESCRIPTION
`GL_PIXEL_UNPACK_BUFFER` is never mapped with `glMapBuffer`, the data is uploaded directly with `glBufferData`. When `glUnmapBuffer` is then called, it returns `GL_FALSE` and raises an error that pollutes GL debuggers. It can be removed without side-effects.