### PR TITLE
Add time-budgeting to texture upload

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -2279,7 +2279,9 @@ class Interface:
 
             # Step 2: Push textures to GPU.
             elif step == 2:
-                renpy.display.draw.ready_one_texture()
+                while renpy.display.draw.ready_one_texture():
+                    if not expensive and get_time() > (start + 0.0005):
+                        break
                 step += 1
 
             # Step 3: Predict more images.


### PR DESCRIPTION
In idle prediction, we upload exactly one pending texture per loop pass. With big decode loads, textures can trickle to the GPU once per iteration and lead to hitching when an interaction actually needs them.

If we change the idle step to upload as many textures as fit into some budget (I chose 0.5 ms but see what you think), or just unbound it when we're in an `expensive` loop, then textures land on the GPU sooner without measurably extending frame time (on my machine).