### PR TITLE
Release uniforms holding renders when renders are killed

### DIFF
--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -1211,6 +1211,10 @@ cdef class Render:
         self.cached_texture = None
         self.cached_model = None
 
+        # drop uniforms that hold Renders so killed renders release their textures
+        if self.uniforms_has_render:
+            self.uniforms = None
+
     NO_MOUSE_FOCUS = renpy.object.Sentinel("NO_MOUSE_FOCUS")
 
     def add_focus(self, d, arg=None, x=0, y=0, w=None, h=None, mx=None, my=None, mask=None):


### PR DESCRIPTION
Makes it so a killed Render drops its uniforms dict if it holds other Renders, freeing those Renders and their textures instead of being retained by the dead parent Render until GC.