### PR TITLE
Add support for custom cursor styles to Drag objects

### DIFF
--- a/renpy/common/00style.rpy
+++ b/renpy/common/00style.rpy
@@ -372,6 +372,7 @@ init -1800:
 
     style drag:
         focus_mask None
+        mouse "drag"
 
     # Out-of-game menu root windows
 

--- a/renpy/sl2/sldisplayables.py
+++ b/renpy/sl2/sldisplayables.py
@@ -506,6 +506,7 @@ Keyword("mouse_drop")
 Keyword("alternate")
 Style("child")
 Style("sound")
+Style("mouse")
 
 DisplayableParser("draggroup", renpy.display.dragdrop.DragGroup, None, many, replaces=True)
 Keyword("min_overlap")

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -905,7 +905,7 @@ Mouse
     Otherwise, this should be a dictionary giving the
     mouse animations for various mouse types. Keys used by the default
     library include ``default``, ``say``, ``with``, ``menu``, ``prompt``,
-    ``imagemap``, ``button``, ``pause``, ``mainmenu``, and
+    ``imagemap``, ``button``, ``drag``, ``pause``, ``mainmenu``, and
     ``gamemenu``. The ``default`` key should always be present, as it is
     used when a more specific key is absent. Keys can have an optional
     prefix ``pressed_`` to indicate that the cursor will be used when the

--- a/sphinx/source/drag_drop.rst
+++ b/sphinx/source/drag_drop.rst
@@ -62,6 +62,7 @@ of the window by dragging it around the screen.::
             drag_name "say"
             yalign 1.0
             drag_handle (0, 0, 1.0, 30)
+            mouse "drag"
 
             xalign 0.5
 

--- a/sphinx/source/mouse.rst
+++ b/sphinx/source/mouse.rst
@@ -79,6 +79,9 @@ and the corresponding usage:
  * - ``button``
    - Used when the player is hovering over a button/imagebutton.
 
+ * - ``drag``
+   - Used when the player is hovering over a Drag object.
+
  * - ``pause``
    - Used during pause, renpy.pause()
 
@@ -97,12 +100,21 @@ pressed cursor is defined.
 For example::
 
     define config.mouse = { }
+    # Default mouse cursor and its pressed state
     define config.mouse['default'] = [ ( "gui/arrow.png", 0, 0) ]
     define config.mouse['pressed_default'] = [ ( "gui/arrow_pressed.png", 0, 0) ]
+
+    # The cursor displayed when hovering over a button and its pressed state
     define config.mouse['button'] = [ ( "gui/arrow_button.png", 0, 0) ]
     define config.mouse['pressed_button'] = [ ( "gui/arrow_button_pressed.png", 0, 0) ]
-    define config.mouse['menu'] = [ ( "gui/arrow_menu.png", 0, 0) ] # This cursor will be used when the player is in a menu
-    # Since there is no "pressed_menu" cursor, "pressed_default" cursor will be used instead
+
+    # The cursor displayed when hovering over a Drag object and its pressed state
+    define config.mouse['drag'] = [ ( "gui/arrow_drag.png", 0, 0) ]
+    define config.mouse['pressed_drag'] = [ ( "gui/arrow_drag_pressed.png", 0, 0) ]
+
+    # This cursor will be used when the player is in a menu
+    define config.mouse['menu'] = [ ( "gui/arrow_menu.png", 0, 0) ] 
+    # If we do not add a "pressed_menu" cursor, "pressed_default" cursor will be used instead
 
 
 Displayable Mouse Cursor

--- a/sphinx/source/mouse.rst
+++ b/sphinx/source/mouse.rst
@@ -80,7 +80,7 @@ and the corresponding usage:
    - Used when the player is hovering over a button/imagebutton.
 
  * - ``drag``
-   - Used when the player is hovering over a Drag object.
+   - Used when the player is hovering over a Drag object. If this is not defined, ``button`` style is used instead.
 
  * - ``pause``
    - Used during pause, renpy.pause()


### PR DESCRIPTION
This is a simple change adding `mouse` style element to Drag objects. It defaults to `drag` (to differentiate it from the regular `button`), and can be overridden with any other user-defined value. It also works with the `pressed_` modifier. 

I've updated the documentation accordingly and added some examples on how this can be used.
Also, slightly reformatted the examples section to be more readable and added some comments for clarity.