### PR TITLE
Fix masking out of non-OpenGL window flags

### DIFF
--- a/renpy/pygame/display.pyx
+++ b/renpy/pygame/display.pyx
@@ -351,7 +351,7 @@ cdef class Window:
         rv = SDL_GetWindowFlags(self.window)
 
         if self.gl_context:
-            rv = rv & SDL_WINDOW_OPENGL
+            rv = rv | SDL_WINDOW_OPENGL
         else:
             rv = rv & ~SDL_WINDOW_OPENGL
 


### PR DESCRIPTION
One of the effects was blocking switching between fullscreen and windowed modes, as reported in https://github.com/renpy/renpy/issues/7157.