### PR TITLE
Correctly oversample Live2D mask renders

### DIFF
--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -1130,12 +1130,10 @@ cdef class GL2Draw:
             tx, ty = reverse.transform(1, 1)
             oversample = math.hypot(tx, ty) / math.hypot(1, 1)
 
-            cap = renpy.config.mesh_oversample
-            
             if r.properties is not None:
-                cap = r.properties.get("mesh_oversample", cap)
+                oversample *= r.properties.get("mesh_oversample_scale", 1.0)
 
-            oversample = max(1.0, min(oversample, cap))
+            oversample = max(1.0, min(oversample, renpy.config.mesh_oversample))
 
             for i, c in enumerate(r.children):
                 model.set_texture(i, self.render_to_texture(c[0], properties=r.properties, oversample=oversample))

--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -1130,7 +1130,12 @@ cdef class GL2Draw:
             tx, ty = reverse.transform(1, 1)
             oversample = math.hypot(tx, ty) / math.hypot(1, 1)
 
-            oversample = max(1.0, min(oversample, renpy.config.mesh_oversample))
+            cap = renpy.config.mesh_oversample
+            
+            if r.properties is not None:
+                cap = r.properties.get("mesh_oversample", cap)
+
+            oversample = max(1.0, min(oversample, cap))
 
             for i, c in enumerate(r.children):
                 model.set_texture(i, self.render_to_texture(c[0], properties=r.properties, oversample=oversample))

--- a/renpy/gl2/live2dmodel.pyx
+++ b/renpy/gl2/live2dmodel.pyx
@@ -591,6 +591,9 @@ cdef class Live2DModel:
             r.add_uniform("u_live2d_ppu", ppu)
             r.add_uniform("u_live2d_offset", (offset_x, offset_y))
 
+            # don't oversample masks
+            r.add_property("mesh_oversample", 1.0)
+
             r.blit(m, (0, 0))
 
         renders.sort()

--- a/renpy/gl2/live2dmodel.pyx
+++ b/renpy/gl2/live2dmodel.pyx
@@ -591,8 +591,8 @@ cdef class Live2DModel:
             r.add_uniform("u_live2d_ppu", ppu)
             r.add_uniform("u_live2d_offset", (offset_x, offset_y))
 
-            # don't oversample masks
-            r.add_property("mesh_oversample", 1.0)
+            # correct the mesh oversample estimate for ppu-space
+            r.add_property("mesh_oversample_scale", 1.0 / ppu)
 
             r.blit(m, (0, 0))
 


### PR DESCRIPTION
Introduced by https://github.com/renpy/renpy/commit/825c4c7d767873434abdd8a579ed40d1d54b0ea9, the issue is that Live2D mask renders are oversampled by the new default factor of 8.0 when flattened. This PR passes the default `mesh_oversample` value as a render property in that path.

Fixes https://github.com/renpy/renpy/issues/7140.