### PR TITLE
Gate ConditionSwitch redraws on changes

### DIFF
--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1575,6 +1575,9 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
     last_st = 0
     last_at = 0
 
+    # When true, per_interact only invalidates if the picked child changed.
+    redraw_on_change_only = False
+
     def after_setstate(self):
         self.child = None
         self.raw_child = None
@@ -1589,6 +1592,7 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
             function = dynamic_displayable_compat
 
         self.predict_function = kwargs.pop("_predict_function", None)
+        self.redraw_on_change_only = kwargs.pop("_redraw_on_change_only", False)
         self.function = function
         self.args = args
         self.kwargs = kwargs
@@ -1638,7 +1642,18 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
             renpy.display.render.redraw(self, redraw)
 
     def per_interact(self):
-        renpy.display.render.redraw(self, 0)
+        if not self.redraw_on_change_only:
+            renpy.display.render.redraw(self, 0)
+
+            return
+
+        # Re-evaluate now and only invalidate when changed.
+        old_child = self.child
+
+        self.update(self.last_st, self.last_at)
+
+        if self.child is not old_child:
+            renpy.display.render.redraw(self, 0)
 
     def render(self, w, h, st, at):
         self.update(st, at)
@@ -1770,7 +1785,13 @@ def ConditionSwitch(*args, **kwargs):
         d = renpy.easy.displayable(d)
         switch.append((cond, d))
 
-    rv = DynamicDisplayable(condition_switch_show, switch, predict_all, _predict_function=condition_switch_predict)
+    rv = DynamicDisplayable(
+        condition_switch_show,
+        switch,
+        predict_all,
+        _predict_function=condition_switch_predict,
+        _redraw_on_change_only=True,
+    )
 
     return Position(rv, **kwargs)
 

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -1638,6 +1638,9 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
 
             self.child = child
 
+            if self.redraw_on_change_only:
+                renpy.display.render.redraw(self, 0)
+
         if redraw is not None:
             renpy.display.render.redraw(self, redraw)
 
@@ -1647,13 +1650,8 @@ class DynamicDisplayable(renpy.display.displayable.Displayable):
 
             return
 
-        # Re-evaluate now and only invalidate when changed.
-        old_child = self.child
-
+        # Re-evaluate the pick; update() invalidates if it changed.
         self.update(self.last_st, self.last_at)
-
-        if self.child is not old_child:
-            renpy.display.render.redraw(self, 0)
 
     def render(self, w, h, st, at):
         self.update(st, at)


### PR DESCRIPTION
I noticed with some of my more expensive/complicated layered images where I was using `Flatten` on sub-layers that the Flatten-wrapped stacks were more expensive per-interaction than I was expecting. Traced it back to the `per_interact` unconditional redraw. I therefore added a check to `DynamicDisplayable` that `ConditionSwitch` opts-in to in order to gate redraws on child changes. Quick test with results below.

One consequence of this that I see is that condition-heavy images can potentially be made more performant with clever use of `Flatten` now? Since the wrapped stack keeps its cache.

Default `DynamicDisplayable` behavior is unchanged.

```renpy
init python:

    import time

    def bench_layers():
        rv = []

        for i in range(40):
            rv.append(Transform(Solid((i * 5 % 255, 40, 80, 8)), alpha = 0.5))

        return rv

    def bench_flat(extra = None):
        children = bench_layers()

        if extra is not None:
            children.append(extra)

        return Flatten(Fixed(*children, xysize = (config.screen_width, config.screen_height)))

    def bench_fixed(extra = None):
        children = bench_layers()

        if extra is not None:
            children.append(extra)

        return Fixed(*children, xysize = (config.screen_width, config.screen_height))

    def bench_eager_layer():
        return renpy.display.layout.DynamicDisplayable(
            renpy.display.layout.condition_switch_show,
            [("True", Null())],
            None,
        )

    def bench_measure(samples = 30):
        times = []

        for i in range(samples):
            a = time.perf_counter()
            renpy.pause(0.001, hard = True)
            times.append(time.perf_counter() - a)

        times.sort()

        p50 = times[len(times) // 2] * 1000
        p90 = times[int(len(times) * 0.9)] * 1000

        return samples, p50, p90

image bench_control = bench_flat()
image bench_eager = bench_flat(bench_eager_layer())
image bench_switch = bench_flat(ConditionSwitch("True", Null()))

image bench_fixed_control = bench_fixed()
image bench_fixed_eager = bench_fixed(bench_eager_layer())
image bench_fixed_switch = bench_fixed(ConditionSwitch("True", Null()))

label start:
    $ results = []

    scene bench_control

    $ renpy.pause(0.5, hard = True)

    $ results.append(("no dynamic layer",) + bench_measure())

    scene bench_eager

    $ renpy.pause(0.5, hard = True)

    $ results.append(("eager DynamicDisplayable",) + bench_measure())

    scene bench_switch

    $ renpy.pause(0.5, hard = True)

    $ results.append(("ConditionSwitch",) + bench_measure())

    scene bench_fixed_control

    $ renpy.pause(0.5, hard = True)

    $ results.append(("fixed",) + bench_measure())

    scene bench_fixed_eager

    $ renpy.pause(0.5, hard = True)

    $ results.append(("fixed eager DynamicDisplayable",) + bench_measure())

    scene bench_fixed_switch

    $ renpy.pause(0.5, hard = True)

    $ results.append(("fixed ConditionSwitch",) + bench_measure())

    python:
        lines = []

        for name, samples, p50, p90 in results:
            line = f"p50 {p50:.1f} ms / p90 {p90:.1f} ms"

            lines.append(line)

        report = "\n".join(lines)

        print(report)

        with open(os.path.join(config.basedir, "bench_result.txt"), "a") as f:
            f.write(report + "\n")

        renpy.quit()
```

```
no dynamic layer: p50 6.6 ms / p90 9.5 ms
eager DynamicDisplayable: p50 16.2 ms / p90 20.3 ms
ConditionSwitch: p50 6.1 ms / p90 11.9 ms
fixed: p50 14.1 ms / p90 20.6 ms
fixed eager DynamicDisplayable (no Flatten): p50 14.1 ms / p90 20.4 ms
fixed ConditionSwitch (no Flatten): p50 13.6 ms / p90 20.1 ms
```