### PR TITLE
Cython new property syntax

### DIFF
--- a/renpy/pygame/color.pyx
+++ b/renpy/pygame/color.pyx
@@ -261,190 +261,194 @@ cdef class Color:
 
         return type(self)(r, g, b, a)
 
-    property cmy:
-        def __get__(self):
-            return 1 - (self.r / 255.0), 1 - (self.g / 255.0), 1 - (self.b / 255.0)
+    @property
+    def cmy(self):
+        return 1 - (self.r / 255.0), 1 - (self.g / 255.0), 1 - (self.b / 255.0)
 
-        def __set__(self, val):
-            c, m, y = val
-            self.r = (1 - c) * 255
-            self.g = (1 - m) * 255
-            self.b = (1 - y) * 255
+    @cmy.setter
+    def cmy(self, val):
+        c, m, y = val
+        self.r = (1 - c) * 255
+        self.g = (1 - m) * 255
+        self.b = (1 - y) * 255
 
-    property hsva:
-        def __get__(self):
-            cdef double r = self.r / 255.0
-            cdef double g = self.g / 255.0
-            cdef double b = self.b / 255.0
+    @property
+    def hsva(self):
+        cdef double r = self.r / 255.0
+        cdef double g = self.g / 255.0
+        cdef double b = self.b / 255.0
 
-            cdef double cmax = max(r, g, b)
-            cdef double cmin = min(r, g, b)
-            cdef double delta = cmax - cmin
+        cdef double cmax = max(r, g, b)
+        cdef double cmin = min(r, g, b)
+        cdef double delta = cmax - cmin
 
-            cdef double h, s, v, a
+        cdef double h, s, v, a
 
-            if r == g == b:
-                h = 0.0
+        if r == g == b:
+            h = 0.0
+            s = 0.0
+        else:
+            if cmax == r:
+                h = 60.0 * ((g - b) / delta % 6)
+            elif cmax == g:
+                h = 60.0 * ((b - r) / delta + 2)
+            else:
+                h = 60.0 * ((r - g) / delta + 4)
+
+            if cmax == 0.0:
                 s = 0.0
             else:
-                if cmax == r:
-                    h = 60.0 * ((g - b) / delta % 6)
-                elif cmax == g:
-                    h = 60.0 * ((b - r) / delta + 2)
-                else:
-                    h = 60.0 * ((r - g) / delta + 4)
+                s = delta / cmax * 100
 
-                if cmax == 0.0:
-                    s = 0.0
-                else:
-                    s = delta / cmax * 100
+        v = cmax * 100
+        a = self.a / 255.0 * 100
+        return h, s, v, a
 
-            v = cmax * 100
-            a = self.a / 255.0 * 100
-            return h, s, v, a
+    @hsva.setter
+    def hsva(self, val):
+        cdef double h, s, v, a
+        if len(val) == 3:
+            h, s, v = val
+            a = 0.0
+        else:
+            h, s, v, a = val
 
-        def __set__(self, val):
-            cdef double h, s, v, a
-            if len(val) == 3:
-                h, s, v = val
-                a = 0.0
-            else:
-                h, s, v, a = val
+        h = h % 360.0
 
-            h = h % 360.0
+        # These should be in a range of [0.0, 1.0]
+        s /= 100.0
+        v /= 100.0
+        a /= 100.0
 
-            # These should be in a range of [0.0, 1.0]
-            s /= 100.0
-            v /= 100.0
-            a /= 100.0
+        cdef double c = v * s
+        cdef double x = c * (1 - abs((h / 60.0) % 2 - 1))
+        cdef double m = v - c
 
-            cdef double c = v * s
-            cdef double x = c * (1 - abs((h / 60.0) % 2 - 1))
-            cdef double m = v - c
+        cdef double r, g, b
 
-            cdef double r, g, b
+        if 0 <= h < 60:
+            r, g, b = c, x, 0
+        elif 60 <= h < 120:
+            r, g, b = x, c, 0
+        elif 120 <= h < 180:
+            r, g, b = 0, c, x
+        elif 180 <= h < 240:
+            r, g, b = 0, x, c
+        elif 240 <= h < 300:
+            r, g, b = x, 0, c
+        elif 300 <= h < 360:
+            r, g, b = c, 0, x
+        else:
+            raise ValueError()
 
-            if 0 <= h < 60:
-                r, g, b = c, x, 0
-            elif 60 <= h < 120:
-                r, g, b = x, c, 0
-            elif 120 <= h < 180:
-                r, g, b = 0, c, x
-            elif 180 <= h < 240:
-                r, g, b = 0, x, c
-            elif 240 <= h < 300:
-                r, g, b = x, 0, c
-            elif 300 <= h < 360:
-                r, g, b = c, 0, x
-            else:
-                raise ValueError()
+        self.r = int(255 * (r + m))
+        self.g = int(255 * (g + m))
+        self.b = int(255 * (b + m))
+        self.a = int(255 * a)
 
-            self.r = int(255 * (r + m))
-            self.g = int(255 * (g + m))
-            self.b = int(255 * (b + m))
-            self.a = int(255 * a)
+    @property
+    def hsla(self):
+        cdef double h, s, l, a
+        cdef double r, g, b
+        cdef double cmin, cmax, delta
 
-    property hsla:
-        def __get__(self):
-            cdef double h, s, l, a
-            cdef double r, g, b
-            cdef double cmin, cmax, delta
+        h = self.hsva[0] % 360.0
 
-            h = self.hsva[0] % 360.0
+        r = self.r / 255.0
+        g = self.g / 255.0
+        b = self.b / 255.0
 
-            r = self.r / 255.0
-            g = self.g / 255.0
-            b = self.b / 255.0
+        cmin = min(r, g, b)
+        cmax = max(r, g, b)
+        delta = cmax - cmin
 
-            cmin = min(r, g, b)
-            cmax = max(r, g, b)
-            delta = cmax - cmin
+        l = (cmax + cmin) / 2.0
 
-            l = (cmax + cmin) / 2.0
+        if delta == 0:
+            s = 0.0
+        else:
+            s = delta / (1 - abs(2 * l - 1))
 
-            if delta == 0:
-                s = 0.0
-            else:
-                s = delta / (1 - abs(2 * l - 1))
+        a = self.a / 255.0 * 100
 
-            a = self.a / 255.0 * 100
+        s = min(100.0, s * 100)
+        l = min(100.0, l * 100)
 
-            s = min(100.0, s * 100)
-            l = min(100.0, l * 100)
+        return h, s, l, a
 
-            return h, s, l, a
+    @hsla.setter
+    def hsla(self, val):
+        cdef double h, s, l, a
+        if len(val) == 3:
+            h, s, l = val
+            a = 0.0
+        else:
+            h, s, l, a = val
 
-        def __set__(self, val):
-            cdef double h, s, l, a
-            if len(val) == 3:
-                h, s, l = val
-                a = 0.0
-            else:
-                h, s, l, a = val
+        s /= 100.0
+        l /= 100.0
+        a /= 100.0
 
-            s /= 100.0
-            l /= 100.0
-            a /= 100.0
+        cdef double c = (1 - abs(2*l - 1)) * s
+        cdef double x = c * (1 - abs((h / 60.0) % 2 - 1))
+        cdef double m = l - c / 2.0
 
-            cdef double c = (1 - abs(2*l - 1)) * s
-            cdef double x = c * (1 - abs((h / 60.0) % 2 - 1))
-            cdef double m = l - c / 2.0
+        cdef double r, g, b
+        if 0 <= h < 60:
+            r, g, b = c, x, 0
+        elif 60 <= h < 120:
+            r, g, b = x, c, 0
+        elif 120 <= h < 180:
+            r, g, b = 0, c, x
+        elif 180 <= h < 240:
+            r, g, b = 0, x, c
+        elif 240 <= h < 300:
+            r, g, b = x, 0, c
+        elif 300 <= h < 360:
+            r, g, b = c, 0, x
+        else:
+            raise ValueError()
 
-            cdef double r, g, b
-            if 0 <= h < 60:
-                r, g, b = c, x, 0
-            elif 60 <= h < 120:
-                r, g, b = x, c, 0
-            elif 120 <= h < 180:
-                r, g, b = 0, c, x
-            elif 180 <= h < 240:
-                r, g, b = 0, x, c
-            elif 240 <= h < 300:
-                r, g, b = x, 0, c
-            elif 300 <= h < 360:
-                r, g, b = c, 0, x
-            else:
-                raise ValueError()
+        self.r = int(255 * (r + m))
+        self.g = int(255 * (g + m))
+        self.b = int(255 * (b + m))
+        self.a = int(255 * a)
 
-            self.r = int(255 * (r + m))
-            self.g = int(255 * (g + m))
-            self.b = int(255 * (b + m))
-            self.a = int(255 * a)
+    @property
+    def i1i2i3(self):
+        # Take the dot product as described here:
+        # http://de.wikipedia.org/wiki/I1I2I3-Farbraum
 
-    property i1i2i3:
-        def __get__(self):
-            # Take the dot product as described here:
-            # http://de.wikipedia.org/wiki/I1I2I3-Farbraum
+        cdef double i1, i2, i3
+        cdef double r, g, b
 
-            cdef double i1, i2, i3
-            cdef double r, g, b
+        r = self.r / 255.0
+        g = self.g / 255.0
+        b = self.b / 255.0
 
-            r = self.r / 255.0
-            g = self.g / 255.0
-            b = self.b / 255.0
+        i1 = (r + g + b) / 3.0
+        i2 = (r - b) / 2.0
+        i3 = (2*g - r - b) / 4.0
 
-            i1 = (r + g + b) / 3.0
-            i2 = (r - b) / 2.0
-            i3 = (2*g - r - b) / 4.0
+        return i1, i2, i3
 
-            return i1, i2, i3
+    @i1i2i3.setter
+    def i1i2i3(self, val):
+        # Dot product with the inverted matrix.
 
-        def __set__(self, val):
-            # Dot product with the inverted matrix.
+        cdef double i1, i2, i3
+        cdef double r, g, b
 
-            cdef double i1, i2, i3
-            cdef double r, g, b
+        i1, i2, i3 = val
 
-            i1, i2, i3 = val
+        r = i1 + i2 - (2.0/3.0 * i3)
+        g = i1 + (4.0/3.0 * i3)
+        b = i1 - i2  - (2.0/3.0 * i3)
 
-            r = i1 + i2 - (2.0/3.0 * i3)
-            g = i1 + (4.0/3.0 * i3)
-            b = i1 - i2  - (2.0/3.0 * i3)
-
-            # Don't change alpha.
-            self.r = int(r * 255)
-            self.g = int(g * 255)
-            self.b = int(b * 255)
+        # Don't change alpha.
+        self.r = int(r * 255)
+        self.g = int(g * 255)
+        self.b = int(b * 255)
 
     def normalize(self):
         return self.r / 255.0, self.g / 255.0, self.b / 255.0, self.a / 255.0

--- a/renpy/pygame/rect.pyx
+++ b/renpy/pygame/rect.pyx
@@ -98,113 +98,149 @@ cdef class Rect:
         else:
             raise IndexError(key)
 
-    property left:
-        def __get__(self):
-            return self.x
-        def __set__(self, val):
-            self.x = val
+    @property
+    def left(self):
+        return self.x
 
-    property top:
-        def __get__(self):
-            return self.y
-        def __set__(self, val):
-            self.y = val
+    @left.setter
+    def left(self, val):
+        self.x = val
 
-    property width:
-        def __get__(self):
-            return self.w
-        def __set__(self, val):
-            self.w = val
+    @property
+    def top(self):
+        return self.y
 
-    property height:
-        def __get__(self):
-            return self.h
-        def __set__(self, val):
-            self.h = val
+    @top.setter
+    def top(self, val):
+        self.y = val
 
-    property right:
-        def __get__(self):
-            return self.x + self.width
-        def __set__(self, val):
-            self.x += val - self.right
+    @property
+    def width(self):
+        return self.w
 
-    property bottom:
-        def __get__(self):
-            return self.y + self.height
-        def __set__(self, val):
-            self.y += val - self.bottom
+    @width.setter
+    def width(self, val):
+        self.w = val
 
-    property size:
-        def __get__(self):
-            return (self.w, self.h)
-        def __set__(self, val):
-            self.w, self.h = val
+    @property
+    def height(self):
+        return self.h
 
-    property topleft:
-        def __get__(self):
-            return (self.left, self.top)
-        def __set__(self, val):
-            self.left, self.top = val
+    @height.setter
+    def height(self, val):
+        self.h = val
 
-    property topright:
-        def __get__(self):
-            return (self.right, self.top)
-        def __set__(self, val):
-            self.right, self.top = val
+    @property
+    def right(self):
+        return self.x + self.width
 
-    property bottomright:
-        def __get__(self):
-            return (self.right, self.bottom)
-        def __set__(self, val):
-            self.right, self.bottom = val
+    @right.setter
+    def right(self, val):
+        self.x += val - self.right
 
-    property bottomleft:
-        def __get__(self):
-            return (self.left, self.bottom)
-        def __set__(self, val):
-            self.left, self.bottom = val
+    @property
+    def bottom(self):
+        return self.y + self.height
 
-    property centerx:
-        def __get__(self):
-            return self.x + (self.w / 2)
-        def __set__(self, val):
-            self.x += val - self.centerx
+    @bottom.setter
+    def bottom(self, val):
+        self.y += val - self.bottom
 
-    property centery:
-        def __get__(self):
-            return self.y + (self.h / 2)
-        def __set__(self, val):
-            self.y += val - self.centery
+    @property
+    def size(self):
+        return (self.w, self.h)
 
-    property center:
-        def __get__(self):
-            return (self.centerx, self.centery)
-        def __set__(self, val):
-            self.centerx, self.centery = val
+    @size.setter
+    def size(self, val):
+        self.w, self.h = val
 
-    property midtop:
-        def __get__(self):
-            return (self.centerx, self.top)
-        def __set__(self, val):
-            self.centerx, self.top = val
+    @property
+    def topleft(self):
+        return (self.left, self.top)
 
-    property midleft:
-        def __get__(self):
-            return (self.left, self.centery)
-        def __set__(self, val):
-            self.left, self.centery = val
+    @topleft.setter
+    def topleft(self, val):
+        self.left, self.top = val
 
-    property midbottom:
-        def __get__(self):
-            return (self.centerx, self.bottom)
-        def __set__(self, val):
-            self.centerx, self.bottom = val
+    @property
+    def topright(self):
+        return (self.right, self.top)
 
-    property midright:
-        def __get__(self):
-            return (self.right, self.centery)
-        def __set__(self, val):
-            self.right, self.centery = val
+    @topright.setter
+    def topright(self, val):
+        self.right, self.top = val
+
+    @property
+    def bottomright(self):
+        return (self.right, self.bottom)
+
+    @bottomright.setter
+    def bottomright(self, val):
+        self.right, self.bottom = val
+
+    @property
+    def bottomleft(self):
+        return (self.left, self.bottom)
+
+    @bottomleft.setter
+    def bottomleft(self, val):
+        self.left, self.bottom = val
+
+    @property
+    def centerx(self):
+        return self.x + (self.w / 2)
+
+    @centerx.setter
+    def centerx(self, val):
+        self.x += val - self.centerx
+
+    @property
+    def centery(self):
+        return self.y + (self.h / 2)
+
+    @centery.setter
+    def centery(self, val):
+        self.y += val - self.centery
+
+    @property
+    def center(self):
+        return (self.centerx, self.centery)
+
+    @center.setter
+    def center(self, val):
+        self.centerx, self.centery = val
+
+    @property
+    def midtop(self):
+        return (self.centerx, self.top)
+
+    @midtop.setter
+    def midtop(self, val):
+        self.centerx, self.top = val
+
+    @property
+    def midleft(self):
+        return (self.left, self.centery)
+
+    @midleft.setter
+    def midleft(self, val):
+        self.left, self.centery = val
+
+    @property
+    def midbottom(self):
+        return (self.centerx, self.bottom)
+
+    @midbottom.setter
+    def midbottom(self, val):
+        self.centerx, self.bottom = val
+
+    @property
+    def midright(self):
+        return (self.right, self.centery)
+
+    @midright.setter
+    def midright(self, val):
+        self.right, self.centery = val
 
     def copy(self):
         return Rect(self)

--- a/renpy/pygame/surface.pyx
+++ b/renpy/pygame/surface.pyx
@@ -949,9 +949,9 @@ cdef class Surface:
         cdef Uint8 *pixels = <Uint8 *> self.surface.pixels
         return pixels[self.surface.h * self.surface.pitch]
 
-    property _pixels_address:
-        def __get__(self):
-            return <Uint64> self.surface.pixels
+    @property
+    def _pixels_address(self):
+        return <Uint64> self.surface.pixels
 
     def from_data(self, data):
         cdef const SDL_PixelFormatDetails *format = SDL_GetPixelFormatDetails(self.surface.format)


### PR DESCRIPTION
This PR replaces deprecated
```
property name:
   def __get__(self): ...
```
with python-like
```
@property
def name(self): ...
```
That generates the same C code but IDE likes more.