### PR TITLE
Cython warnings

### DIFF
--- a/renpy/ecsign.pyi
+++ b/renpy/ecsign.pyi
@@ -21,58 +21,58 @@
 
 def generate_private_key() -> bytes | None:
     """
-    Generates a EC private key and return key in DER format
+    Generates a EC private key and return key in DER format.
     """
 
 def sign_data(data: bytes, private_key: bytes) -> bytes:
     """
-    returns ecdsa signature for data using sha1 hash
+    Returns ecdsa signature for data using sha1 hash.
 
     `data`
-        The data to sign
+        The data to sign.
 
     `private_key`
-        The private key to use in DER format
+        The private key to use in DER format.
     """
 
 def verify_data(data: bytes, public_key: bytes, sign: bytes) -> bool:
     """
-    verifies ecdsa signature for data using sha1 hash and returns result
+    Verifies ecdsa signature for data using sha1 hash and returns result.
 
     `data`
-        The data to sign
+        The data to sign.
 
     `public_key`
-        The public key to use in DER format
+        The public key to use in DER format.
 
     `sign`
-        The signature to verify
+        The signature to verify.
     """
 
 def get_public_key_from_private(private_key: bytes) -> bytes | None:
     """
-    returns public key in DER format from the private key
+    returns public key in DER format from the private key.
 
     `private_key`
-        The private key to use in DER format
+        The private key to use in DER format.
     """
 
 def validate_private_key(private_key: bytes) -> bool:
     """
-    Validates if given key is a private key
+    Validates if given key is a private key.
     """
 
 def validate_public_key(public_key: bytes) -> bool:
     """
-    Validates if given key is a public key
+    Validates if given key is a public key.
     """
 
 def pem_to_der(pem: bytes | str) -> bytes:
     """
-    unpacks DER from a PEM file
+    Unpacks DER from a PEM file.
     """
 
 def der_to_pem(der: bytes, name: str) -> bytes:
     """
-    packs a DER into a PEM file
+    Packs a DER into a PEM file.
     """

--- a/renpy/ecsign.pyx
+++ b/renpy/ecsign.pyx
@@ -61,24 +61,30 @@ def generate_private_key() -> bytes | None:
 
     return rv
 
-def sign_data(data : bytes, private_key : bytes) -> bytes:
+def sign_data(data: bytes, private_key: bytes) -> bytes:
+    private_key_len = len(private_key)
+    data_len = len(data)
     sign = bytes(64)
+    sign_len = 64
 
-    if not ECSign(private_key, len(private_key), data, len(data), sign, len(sign)):
+    if not ECSign(private_key, private_key_len, data, data_len, sign, sign_len):
         raise Exception("Failed to sign data")
 
-    # print(" ".join("{:02x}".format(x) for x in sign))
     return sign
 
-def verify_data(data : bytes, public_key : bytes, sign : bytes) -> bool:
-    # print(" ".join("{:02x}".format(x) for x in sign))
-    return ECVerify(public_key, len(public_key), data, len(data), sign, len(sign))
+def verify_data(data: bytes, public_key: bytes, sign: bytes) -> bool:
+    public_key_len = len(public_key)
+    data_len = len(data)
+    sign_len = len(sign)
 
-def get_public_key_from_private(private_key : bytes) -> bytes | None:
+    return ECVerify(public_key, public_key_len, data, data_len, sign, sign_len)
+
+def get_public_key_from_private(private_key: bytes) -> bytes | None:
     cdef unsigned char* pubkey = NULL
     cdef size_t publen = 0
+    private_key_len = len(private_key)
 
-    ECGetPublicKeyFromPrivate(private_key, len(private_key), &pubkey, &publen)
+    ECGetPublicKeyFromPrivate(private_key, private_key_len, &pubkey, &publen)
 
     rv = None
     if publen > 0 and pubkey != NULL:
@@ -88,24 +94,30 @@ def get_public_key_from_private(private_key : bytes) -> bytes | None:
 
     return rv
 
-def validate_private_key(private_key : bytes) -> bool:
+def validate_private_key(private_key: bytes) -> bool:
     return ECValidateKey(0, private_key, len(private_key))
 
-def validate_public_key(public_key : bytes) -> bool:
+def validate_public_key(public_key: bytes) -> bool:
     return ECValidateKey(1, public_key, len(public_key))
 
-def _pem_lines(contents: bytes) -> typing.Iterator[bytes]:
+def pem_to_der(pem: object) -> bytes:
+    if isinstance(pem, str):
+        pem = pem.encode()
+    elif not isinstance(pem, bytes):
+        raise TypeError("pem must be str or bytes")
+
     in_pem_part = False
     seen_pem_start = False
+    fields = []
 
-    for line in contents.splitlines():
+    for line in pem.splitlines():
         line = line.strip()
 
-        # Skip empty lines
+        # Skip empty lines.
         if not line:
             continue
 
-        # Handle start marker
+        # Handle start marker.
         if line.startswith(b'-----BEGIN'):
             if in_pem_part:
                 raise ValueError('Seen start marker twice')
@@ -114,37 +126,32 @@ def _pem_lines(contents: bytes) -> typing.Iterator[bytes]:
             seen_pem_start = True
             continue
 
-        # Skip stuff before first marker
+        # Skip stuff before first marker.
         if not in_pem_part:
             continue
 
-        # Handle end marker
-        if in_pem_part and line.startswith(b'-----END'):
+        # Handle end marker.
+        if line.startswith(b'-----END'):
             in_pem_part = False
             break
 
-        # Load fields
+        # Ignore PEM header fields.
         if b":" in line:
             continue
 
-        yield line
+        fields.append(line)
 
-    # Do some sanity checks
+    # Sanity checks for malformed PEM blocks.
     if not seen_pem_start:
         raise ValueError('No PEM start marker found')
 
     if in_pem_part:
         raise ValueError('No PEM end marker found')
 
-def pem_to_der(pem : bytes | str) -> bytes:
-    if isinstance(pem, str):  # pragma: no branch
-        pem = pem.encode()
-
-    d = b"".join(_pem_lines(pem))
+    d = b"".join(fields)
     return base64.b64decode(d)
 
-
-def der_to_pem(der : bytes, name : str) -> bytes:
+def der_to_pem(der: bytes, name: str) -> bytes:
     b64 = base64.b64encode(der)
     lines = [("-----BEGIN %s KEY-----\n" % name).encode()]
     lines.extend(

--- a/renpy/lexersupport.pyx
+++ b/renpy/lexersupport.pyx
@@ -19,13 +19,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import cython
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cdef inline Py_UCS4 _get_c_unbounded(str data, Py_ssize_t pos) noexcept:
-    return data[pos]
+from cpython.unicode cimport PyUnicode_GET_LENGTH, PyUnicode_DATA, PyUnicode_KIND, PyUnicode_READ
 
 
 def match_whitespace(str data not None, Py_ssize_t pos, /):
@@ -34,11 +28,13 @@ def match_whitespace(str data not None, Py_ssize_t pos, /):
     if current position is not at the start of whitespace.
     """
 
+    cdef int kind = PyUnicode_KIND(data)
+    cdef const void *buf = PyUnicode_DATA(data)
+    cdef Py_ssize_t length = PyUnicode_GET_LENGTH(data)
     cdef Py_ssize_t i = pos
-    cdef Py_ssize_t length = len(data)
 
-    for i in range(pos, len(data)):
-        if _get_c_unbounded(data, i) != ' ':
+    for i in range(pos, length):
+        if PyUnicode_READ(kind, buf, i) != ' ':
             break
     else:
         i = length
@@ -53,12 +49,14 @@ def match_logical_word(str data not None, Py_ssize_t pos, /):
     start of a logical word.
     """
 
+    cdef int kind = PyUnicode_KIND(data)
+    cdef const void *buf = PyUnicode_DATA(data)
+    cdef Py_ssize_t length = PyUnicode_GET_LENGTH(data)
     cdef Py_ssize_t i = pos
-    cdef Py_ssize_t length = len(data)
     cdef Py_UCS4 c
 
     for i in range(pos, length):
-        c = _get_c_unbounded(data, i)
+        c = PyUnicode_READ(kind, buf, i)
         # Condition is the same as `is_potential_identifier_char` in CPython.
         if not (
             'a' <= c <= 'z' or
@@ -80,19 +78,21 @@ def match_operator(str data not None, Py_ssize_t pos, /):
     is not at the start of an operator.
     """
 
-    cdef Py_ssize_t length = len(data)
+    cdef int kind = PyUnicode_KIND(data)
+    cdef const void *buf = PyUnicode_DATA(data)
+    cdef Py_ssize_t length = PyUnicode_GET_LENGTH(data)
 
     cdef Py_UCS4 c1 = 0
     if pos + 0 < length:
-        c1 = _get_c_unbounded(data, pos)
+        c1 = PyUnicode_READ(kind, buf, pos + 0)
 
     cdef Py_UCS4 c2 = 0
     if pos + 1 < length:
-        c2 = _get_c_unbounded(data, pos + 1)
+        c2 = PyUnicode_READ(kind, buf, pos + 1)
 
     cdef Py_UCS4 c3 = 0
     if pos + 2 < length:
-        c3 = _get_c_unbounded(data, pos + 2)
+        c3 = PyUnicode_READ(kind, buf, pos + 2)
 
     # 3-character operators
     if c3 == '.' and c2 == '.' and c1 == '.' or c3 == '=' and (
@@ -134,30 +134,33 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
     string need to be compiled again if it is used in Python expression.
     """
 
-    cdef Py_ssize_t length = len(data)
+    cdef int kind = PyUnicode_KIND(data)
+    cdef const void *buf = PyUnicode_DATA(data)
+    cdef Py_ssize_t length = PyUnicode_GET_LENGTH(data)
+
     if pos >= length:
         return None
 
-    cdef Py_UCS4 c = _get_c_unbounded(data, pos)
+    cdef Py_UCS4 c = PyUnicode_READ(kind, buf, pos)
     if c not in '"\'`':
         return None
 
     # Check if we have a valid prefix. Otherwise we have (word, string) sequence.
-    # # Valid prefixes are case-insensitive: r, u, b, br, rb, f, fr, rf
+    # Valid prefixes are case-insensitive: r, u, b, br, rb, f, fr, rf
     cdef Py_ssize_t prefix_len = pos - prefix_pos
     cdef Py_UCS4 c1, c2
     cdef str prefix_lower
     cdef bint f_string = False
     if prefix_len == 1:
-        c1 = _get_c_unbounded(data, prefix_pos)
+        c1 = PyUnicode_READ(kind, buf, prefix_pos)
         if c1 in 'fF':
             f_string = True
         elif c1 not in 'rRuUbB':
             return None
 
     elif prefix_len == 2:
-        c1 = _get_c_unbounded(data, prefix_pos)
-        c2 = _get_c_unbounded(data, prefix_pos + 1)
+        c1 = PyUnicode_READ(kind, buf, prefix_pos + 0)
+        c2 = PyUnicode_READ(kind, buf, prefix_pos + 1)
         prefix_lower = f"{c1}{c2}".lower()
         if prefix_lower in ('rf', 'fr'):
             f_string = True
@@ -172,10 +175,10 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
     cdef int quote_size = 1
 
     # Compute quote size
-    if pos < length and _get_c_unbounded(data, pos) == quote:
+    if pos < length and PyUnicode_READ(kind, buf, pos) == quote:
         pos += 1
 
-        if pos < length and _get_c_unbounded(data, pos) == quote:
+        if pos < length and PyUnicode_READ(kind, buf, pos) == quote:
             quote_size = 3
             pos += 1
 
@@ -184,9 +187,9 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
             return pos, False, 0, None
 
     cdef:
-        int newlines = 0
-        int brace_depth = 0
-        int line_startpos = -1
+        Py_ssize_t newlines = 0
+        Py_ssize_t brace_depth = 0
+        Py_ssize_t line_startpos = -1
         int end_quote_size = 0
         bint need_munge = False
         Py_UCS4 last_c = 0
@@ -197,15 +200,19 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
             return -1
 
         last_c = c
-        c = _get_c_unbounded(data, pos)
+        c = PyUnicode_READ(kind, buf, pos)
 
         pos += 1
 
         # Skip escaped char.
         if c == '\\':
+            # Unterminated string literal (trailing backslash).
+            if pos >= length:
+                return -1
+
             # But line continuation should add to newlines.
-            if _get_c_unbounded(data, pos) == '\n':
-                line_startpos = pos
+            if PyUnicode_READ(kind, buf, pos) == '\n':
+                line_startpos = pos + 1
                 newlines += 1
 
             end_quote_size = 0
@@ -215,7 +222,7 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
         # In f-string, it is valid to have _anything_ inside {}, even comments
         # and strings with the same quotes. So here we look for closing brace
         # disregarding anything else.
-        if f_string and c == '{' and pos < length and _get_c_unbounded(data, pos) != '{':
+        if f_string and c == '{' and pos < length and PyUnicode_READ(kind, buf, pos) != '{':
             end_quote_size = 0
             brace_depth = 1
             while brace_depth:
@@ -224,15 +231,18 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
                     return -1
 
                 last_c = c
-                c = _get_c_unbounded(data, pos)
+                c = PyUnicode_READ(kind, buf, pos)
 
                 # Do not catch braces inside comments.
                 if c == '#':
-                    for i in range(pos, length):
-                        if _get_c_unbounded(data, i) != '\n':
-                            break
-                    else:
-                        # Unterminated string literal.
+                    while (
+                        pos < length and
+                        PyUnicode_READ(kind, buf, pos) != '\n'
+                    ):
+                        pos += 1
+
+                    # Unterminated string literal.
+                    if pos >= length:
                         return -1
 
                     c = '\n'
@@ -249,7 +259,7 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
 
             continue
 
-        if c == "\n":
+        if c == '\n':
             end_quote_size = 0
             line_startpos = pos
             newlines += 1
@@ -259,7 +269,7 @@ def match_string(str data not None, Py_ssize_t prefix_pos, Py_ssize_t pos, /):
         else:
             end_quote_size = 0
 
-        if last_c == "_" and c == "_":
+        if last_c == '_' and c == '_':
             need_munge = True
 
     return pos, need_munge, newlines, line_startpos if newlines else None


### PR DESCRIPTION
This PR fixes
`Argument evaluation order in C function call is undefined and may not be as expected` and `Unknown type declaration in annotation, ignoring` in ecsign
and
`Unraisable exception in function 'renpy.lexersupport._get_c_unbounded'` in lexersupport.