### PR TITLE
doc: Make the while statement searchable

### DIFF
--- a/sphinx/source/conditional.rst
+++ b/sphinx/source/conditional.rst
@@ -56,6 +56,8 @@ the ``else`` clause is executed, if the ``else`` clause is present.
 While Statement
 ---------------
 
+.. index:: ! while
+
 The ``while`` statement executes a block of statements while an expression
 evaluates True. For example::
 


### PR DESCRIPTION
Fixes #7109.

Sphinx treats `while` as an English stopword, so the While Statement section is omitted from the full-text search index. Add an explicit main index entry so searches for `while` return the relevant section without changing the global stopword behavior.

The generated search result points into the existing While Statement section, while its canonical `#while-statement` anchor remains unchanged.

Validation:

- Built the HTML documentation with Sphinx.
- Verified `while` is a main entry in the generated `searchindex.js`.
- Verified the existing section anchor remains `#while-statement`.
