### PR TITLE
doc: Clarify button style customization

### DIFF
--- a/sphinx/source/gui.rst
+++ b/sphinx/source/gui.rst
@@ -1340,6 +1340,24 @@ add (to the end of :file:`screens.rpy`, or somewhere in :file:`options.rpy`) the
 
 A huge number of customizations are possible using style statements.
 
+Not every button inherits from the ``button`` style. In projects created from
+the default template, the quick menu uses the ``quick_button`` style, which
+inherits from ``default``. Imagebuttons use the ``image_button`` style. To give
+these buttons the same sound and mouse cursor as other buttons, style them
+separately::
+
+    style button:
+        activate_sound "click.ogg"
+        mouse "hand_cursor"
+
+    style quick_button:
+        activate_sound "click.ogg"
+        mouse "hand_cursor"
+
+    style image_button:
+        activate_sound "click.ogg"
+        mouse "hand_cursor"
+
 
 Screens - Navigation
 --------------------

--- a/sphinx/source/rooms.rst
+++ b/sphinx/source/rooms.rst
@@ -176,6 +176,24 @@ accomplishing it is to add the following line::
 
 to the main menu screen.
 
+By default, :meth:`Gallery.make_button` uses the ``empty`` style. A style can
+be created and passed to each gallery button to give them shared properties::
+
+    style gallery_thumbnail is empty:
+        activate_sound "click.ogg"
+        mouse "hand_cursor"
+
+    screen gallery:
+
+        grid 3 3:
+
+            add g.make_button("dark", "gal-dark.png", style="gallery_thumbnail")
+            add g.make_button("dawn", "gal-dawn.png", style="gallery_thumbnail")
+
+Style properties can also be supplied directly to individual gallery buttons::
+
+    add g.make_button("dark", "gal-dark.png", mouse="hand_cursor", activate_sound="click.ogg")
+
 .. include:: inc/gallery
 
 


### PR DESCRIPTION
Fixes #3649.

Document the button styles that need separate customization in projects created from the default template:

- Quick menu buttons use `quick_button`, which inherits from `default`.
- Imagebuttons use `image_button`.
- Gallery buttons created by `Gallery.make_button` default to `empty` and can receive either a shared style or individual style properties.

The added examples show how to apply an activation sound and mouse cursor in each case.

Validation:

- Built the HTML documentation with Sphinx.
- Confirmed the build has the same 147 pre-existing warnings as an unmodified baseline build and no new warning messages.
- Inspected the generated `gui.html` and `rooms.html` examples.
