### PR TITLE
Support partial playback in MusicRoom

### DIFF
--- a/renpy/common/00musicroom.rpy
+++ b/renpy/common/00musicroom.rpy
@@ -44,7 +44,7 @@ init -1500 python:
 
             renpy.restart_interaction()
 
-            if renpy.music.get_playing(self.mr.channel) == self.filename:
+            if self.mr._get_playing() == self.filename:
                 if renpy.music.get_pause(self.mr.channel):
                     renpy.music.set_pause(False, self.mr.channel)
                     return
@@ -55,7 +55,7 @@ init -1500 python:
             return self.mr.is_unlocked(self.filename)
 
         def get_selected(self):
-            return renpy.music.get_playing(self.mr.channel) == self.filename
+            return self.mr._get_playing() == self.filename
 
         def periodic(self, st):
             if self.selected != self.get_selected():
@@ -276,7 +276,7 @@ init -1500 python:
 
             self.st = st
 
-            current_playing = renpy.music.get_playing(self.channel)
+            current_playing = self._get_playing()
             if current_playing is None:
                 current_playing = ""
 
@@ -285,6 +285,20 @@ init -1500 python:
                 renpy.run_action(action)
 
                 self.last_playing = current_playing
+
+        def _get_playing(self):
+            filename = renpy.music.get_playing(self.channel)
+
+            if filename in self.filenames:
+                return filename
+
+            if isinstance(filename, str) and filename.startswith("<"):
+                _spec, separator, plain_filename = filename.rpartition(">")
+
+                if separator and plain_filename in self.filenames:
+                    return plain_filename
+
+            return filename
 
         def add(self, filename, always_unlocked=False, action=None):
             """
@@ -376,7 +390,7 @@ init -1500 python:
                 return
 
             if filename is None:
-                filename = renpy.music.get_playing(channel=self.channel)
+                filename = self._get_playing()
 
             try:
                 idx = playlist.index(filename)
@@ -405,7 +419,7 @@ init -1500 python:
             queued up.
             """
 
-            filename = renpy.music.get_playing(channel=self.channel)
+            filename = self._get_playing()
             if filename is None:
                 return
 
@@ -427,7 +441,7 @@ init -1500 python:
             Plays the next file in the playlist.
             """
 
-            filename = renpy.music.get_playing(channel=self.channel)
+            filename = self._get_playing()
             if filename is None:
                 return self.play(None, 0)
             else:

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -212,6 +212,24 @@ testsuite selectors:
         click id "close_screen_button"
         assert not screen "scroll_screen"
 
+    testsuite musicroom:
+        setup:
+            $ original_get_playing = renpy.music.get_playing
+            $ original_play = renpy.music.play
+            $ musicroom_played = []
+            $ renpy.music.get_playing = lambda channel="music": "<from 10>sound/2.ogg"
+            $ renpy.music.play = lambda filenames, **kwargs: musicroom_played.extend(filenames)
+
+        teardown:
+            $ renpy.music.get_playing = original_get_playing
+            $ renpy.music.play = original_play
+
+        testcase partial_playback:
+            assert eval mr._get_playing() == "sound/2.ogg"
+            assert eval mr.Play("sound/2.ogg").get_selected()
+            run mr.Next()
+            assert eval musicroom_played[0] == "sound/3.ogg"
+
 testsuite timeout:
     setup:
         run Jump("hard_pause")


### PR DESCRIPTION
## Summary

- recognize a MusicRoom track when `renpy.music.get_playing()` includes an audio specifier such as `<from 10>`
- use the normalized track identity for button selection, track actions, queue rebuilding, and next/previous navigation
- keep exact playlist entries unchanged, including entries that intentionally contain their own specifier

## Why

`renpy.music.get_playing()` correctly returns the name passed to the audio system, including audio specifiers. MusicRoom compared that value directly with its registered filenames, so seeking by replaying `<from X>file.ogg` made the current track look unknown. This broke selected buttons and caused next/previous navigation to restart from the beginning of the playlist.

MusicRoom now strips a leading specifier only when the remaining asset name is registered in that room. The public `get_playing()` behavior remains unchanged.

Fixes #2354

## Validation

- `selectors.musicroom::partial_playback` (3 assertions covering track identity, selected state, and next-track navigation)
- `git diff --check`