### PR TITLE
Refresh Movie paths when they become loadable

### DIFF
--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -565,6 +565,13 @@ class Movie(renpy.display.displayable.Displayable):
             if self.mask_channel is not None:
                 self.mask_channel = "movie_mask"
 
+    def _refresh_loadable(self):
+        if (self._play is None) and (self._original_play is not None) and self.any_loadable(self._original_play):
+            self._play = self._original_play
+
+        if (self._queue is None) and (self._original_queue is not None) and self.any_loadable(self._original_queue):
+            self._queue = self._original_queue
+
     def ensure_channel(self, name):
         if name is None:
             return
@@ -648,6 +655,7 @@ class Movie(renpy.display.displayable.Displayable):
             self._play = play
 
         if not isinstance(loop, bool):
+            self._original_queue = loop
 
             if self.any_loadable(loop):
                 self._queue = loop
@@ -806,6 +814,7 @@ class Movie(renpy.display.displayable.Displayable):
                     renpy.audio.music.stop(channel=self.mask_channel, fadeout=0)  # type: ignore
 
     def per_interact(self):
+        self._refresh_loadable()
         self.ensure_channels()
 
         displayable_channels[(self.channel, self.mask_channel)].append(self)

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -212,6 +212,25 @@ testsuite selectors:
         click id "close_screen_button"
         assert not screen "scroll_screen"
 
+    testsuite movie:
+        setup:
+            $ original_movie_any_loadable = renpy.display.video.Movie.any_loadable
+            $ movie_source_loadable = False
+            $ renpy.display.video.Movie.any_loadable = staticmethod(lambda name: movie_source_loadable)
+
+        teardown:
+            $ renpy.display.video.Movie.any_loadable = staticmethod(original_movie_any_loadable)
+
+        testcase late_search_prefix:
+            $ movie_started = []
+            $ movie = renpy.display.video.Movie(play="late.webm", loop="late-loop.webm", channel="movie", play_callback=lambda old, new: movie_started.append((new._play, new._queue)))
+            assert eval movie._play is None and movie._queue is None
+            $ movie_source_loadable = True
+            $ movie.per_interact()
+            assert eval movie._play == "late.webm" and movie._queue == "late-loop.webm"
+            $ movie.play(None)
+            assert eval movie_started == [("late.webm", "late-loop.webm")]
+
 testsuite timeout:
     setup:
         run Jump("hard_pause")


### PR DESCRIPTION
## Summary

- retain unresolved movie `play` and filename-based `loop` paths
- retry their loadability from `Movie.per_interact()` before playback tracking
- add a regression testcase for paths that become loadable after construction

## Why

`Movie.__init__` only assigned `_play` when the path was loadable at construction time. If a later init block changed `config.search_prefixes`, the original path could become loadable, but the normal display lifecycle never checked it again and playback never started.

The refresh stops once each path resolves, and boolean `loop` behavior is unchanged.

Fixes #7105.

## Validation

- `./run.sh testcases test 'selectors.movie::late_search_prefix' --report-detailed` (1 testcase, 3 assertions)
- `python3.12 -m compileall -q renpy/display/video.py`
- `git diff --check`
