### PR TITLE
Preserve channel volume during audio emphasis

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -298,6 +298,9 @@ class Channel(object):
         # The time the secondary volume of this channel was last set.
         self.secondary_volume_time = None
 
+        # The volume adjustment applied while other channels are emphasized.
+        self.emphasis_volume = 1.0
+
         # Should we stop playing on mute?
         self.stop_on_mute = stop_on_mute
 
@@ -696,7 +699,7 @@ class Channel(object):
 
             if self.secondary_volume_time != self.context.secondary_volume_time:
                 self.secondary_volume_time = self.context.secondary_volume_time
-                renpysound.set_secondary_volume(self.number, self.context.secondary_volume, 0)
+                renpysound.set_secondary_volume(self.number, self._get_secondary_volume(), 0)
 
         if not self.queue and self.callback:
             self.callback()  # E1102
@@ -875,7 +878,17 @@ class Channel(object):
 
             if pcm_ok:
                 self.secondary_volume_time = self.context.secondary_volume_time
-                renpysound.set_secondary_volume(self.number, self.context.secondary_volume, delay)
+                renpysound.set_secondary_volume(self.number, self._get_secondary_volume(), delay)
+
+    def _get_secondary_volume(self):
+        return self.context.secondary_volume * self.emphasis_volume
+
+    def set_emphasis_volume(self, volume, delay):
+        with lock:
+            self.emphasis_volume = volume
+
+            if pcm_ok:
+                renpysound.set_secondary_volume(self.number, self._get_secondary_volume(), delay)
 
     def pause(self):
         with lock:
@@ -1261,7 +1274,7 @@ def periodic_pass():
                 if c in emphasize_channels:
                     continue
 
-                c.set_secondary_volume(vol, renpy.config.emphasize_audio_time)
+                c.set_emphasis_volume(vol, renpy.config.emphasize_audio_time)
 
         for c in all_channels:
             c.periodic()

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -2187,13 +2187,13 @@ Voice
 
     If the "emphasize audio" preference is enabled, when one of the audio
     channels listed starts playing a sound, all channels that are not
-    listed in this variable have their secondary audio volume reduced
-    to :var:`config.emphasize_audio_volume` over :var:`config.emphasize_audio_time`
+    listed in this variable have their secondary audio volume multiplied
+    by :var:`config.emphasize_audio_volume` over :var:`config.emphasize_audio_time`
     seconds.
 
     When no channels listed in this variable are playing audio, all channels
-    that are not listed have their secondary audio volume raised to 1.0 over
-    :var:`config.emphasize_audio_time` seconds.
+    that are not listed have their previous secondary audio volume restored
+    over :var:`config.emphasize_audio_time` seconds.
 
     For example, setting this to ``[ 'voice' ]`` will lower the volume of all
     non-voice channels when a voice is played.

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -212,6 +212,27 @@ testsuite selectors:
         click id "close_screen_button"
         assert not screen "scroll_screen"
 
+testsuite audio:
+    setup:
+        $ original_pcm_ok = renpy.audio.audio.pcm_ok
+        $ renpy.audio.audio.pcm_ok = False
+        $ emphasis_channel = renpy.audio.audio.Channel("test_emphasis_volume", False, True, False, "", "", True, False, True, False)
+
+    teardown:
+        $ renpy.audio.audio.pcm_ok = original_pcm_ok
+        $ renpy.game.context().music.pop("test_emphasis_volume", None)
+
+    testcase emphasize_volume:
+        $ emphasis_channel.set_secondary_volume(0.2, 0)
+        $ emphasis_channel.set_emphasis_volume(0.5, 0.5)
+        assert eval emphasis_channel.context.secondary_volume == 0.2
+        assert eval emphasis_channel._get_secondary_volume() == 0.1
+        $ emphasis_channel.set_secondary_volume(0.4, 0)
+        assert eval emphasis_channel._get_secondary_volume() == 0.2
+        $ emphasis_channel.set_emphasis_volume(1.0, 0.5)
+        assert eval emphasis_channel.context.secondary_volume == 0.4
+        assert eval emphasis_channel._get_secondary_volume() == 0.4
+
 testsuite timeout:
     setup:
         run Jump("hard_pause")


### PR DESCRIPTION
## Summary

- track audio emphasis as a separate per-channel volume multiplier
- combine that multiplier with the channel's configured secondary volume when updating the audio backend
- document the multiplicative behavior and add a regression testcase

## Why

Audio emphasis previously wrote `config.emphasize_audio_volume` directly into each non-emphasized channel's secondary volume. When emphasis ended, it wrote `1.0`, discarding any volume set with `renpy.music.set_volume()`.

Keeping emphasis separate preserves the configured channel volume. It also means changing the channel volume while emphasis is active immediately uses the new value, and removing emphasis restores that latest value rather than a stale snapshot.

Fixes #6579.

## Validation

- `./run.sh testcases test 'audio::emphasize_volume' --report-detailed` (1 testcase, 5 assertions)
- `python3.12 -m compileall -q renpy/audio/audio.py`
- `ruff format --check renpy/audio/audio.py`
- Sphinx dummy parse (no new diagnostics in `config.rst`; the checkout lacks generated `sphinx/source/inc/*` files)
- `git diff --check`
