### PR TITLE
Allow bars to render behind their thumbs

### DIFF
--- a/renpy/common/00style.rpy
+++ b/renpy/common/00style.rpy
@@ -238,6 +238,7 @@ init -1800:
         unscrollable None
         bar_invert False
         bar_resizing False
+        bar_unbroken False
         bar_vertical False
 
         # Viewport properties

--- a/renpy/common/_errorhandling.rpym
+++ b/renpy/common/_errorhandling.rpym
@@ -158,6 +158,7 @@ init label _errorhandling:
         thumb_offset 0
         unscrollable None
         bar_invert False
+        bar_unbroken False
         bar_vertical False
 
         # Viewport properties

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -2454,20 +2454,28 @@ class Bar(renpy.display.displayable.Displayable):
         fore_size += fore_gutter
         aft_size += aft_gutter
 
+        fore_bar_size = fore_size
+        aft_bar_size = aft_size
+
+        if self.style.bar_unbroken:
+            fore_extension = thumb_dim // 2
+            fore_bar_size += fore_extension
+            aft_bar_size += thumb_dim - fore_extension
+
         thumb_align = self.style.thumb_align
 
         rv = renpy.display.render.Render(width, height)
 
         if bar_vertical:
             if self.style.bar_resizing:
-                foresurf = render(self.style.fore_bar, width, fore_size, st, at)
-                aftsurf = render(self.style.aft_bar, width, aft_size, st, at)
+                foresurf = render(self.style.fore_bar, width, fore_bar_size, st, at)
+                aftsurf = render(self.style.aft_bar, width, aft_bar_size, st, at)
                 fore_leftover = (thumb_dim2 - foresurf.width) * thumb_align
                 aft_leftover = (thumb_dim2 - aftsurf.width) * thumb_align
 
                 rv.blit(thumb_shadow, (0, fore_size - fore_thumb_offset))
                 rv.blit(foresurf, (fore_leftover, 0), main=False)
-                rv.blit(aftsurf, (aft_leftover, height - aft_size), main=False)
+                rv.blit(aftsurf, (aft_leftover, height - aft_bar_size), main=False)
                 rv.blit(thumb, (0, fore_size - fore_thumb_offset))
 
             else:
@@ -2477,24 +2485,24 @@ class Bar(renpy.display.displayable.Displayable):
                 aft_leftover = (thumb_dim2 - aftsurf.width) * thumb_align
 
                 rv.blit(thumb_shadow, (0, fore_size - fore_thumb_offset))
-                rv.blit(foresurf.subsurface((0, 0, width, fore_size)), (fore_leftover, 0), main=False)
+                rv.blit(foresurf.subsurface((0, 0, width, fore_bar_size)), (fore_leftover, 0), main=False)
                 rv.blit(
-                    aftsurf.subsurface((0, height - aft_size, width, aft_size)),
-                    (aft_leftover, height - aft_size),
+                    aftsurf.subsurface((0, height - aft_bar_size, width, aft_bar_size)),
+                    (aft_leftover, height - aft_bar_size),
                     main=False,
                 )
                 rv.blit(thumb, (0, fore_size - fore_thumb_offset))
 
         else:
             if self.style.bar_resizing:
-                foresurf = render(self.style.fore_bar, fore_size, height, st, at)
-                aftsurf = render(self.style.aft_bar, aft_size, height, st, at)
+                foresurf = render(self.style.fore_bar, fore_bar_size, height, st, at)
+                aftsurf = render(self.style.aft_bar, aft_bar_size, height, st, at)
                 fore_leftover = (thumb_dim2 - foresurf.height) * thumb_align
                 aft_leftover = (thumb_dim2 - aftsurf.height) * thumb_align
 
                 rv.blit(thumb_shadow, (fore_size - fore_thumb_offset, 0))
                 rv.blit(foresurf, (0, fore_leftover), main=False)
-                rv.blit(aftsurf, (width - aft_size, aft_leftover), main=False)
+                rv.blit(aftsurf, (width - aft_bar_size, aft_leftover), main=False)
                 rv.blit(thumb, (fore_size - fore_thumb_offset, 0))
 
             else:
@@ -2504,10 +2512,10 @@ class Bar(renpy.display.displayable.Displayable):
                 aft_leftover = (thumb_dim2 - aftsurf.height) * thumb_align
 
                 rv.blit(thumb_shadow, (fore_size - fore_thumb_offset, 0))
-                rv.blit(foresurf.subsurface((0, 0, fore_size, height)), (0, fore_leftover), main=False)
+                rv.blit(foresurf.subsurface((0, 0, fore_bar_size, height)), (0, fore_leftover), main=False)
                 rv.blit(
-                    aftsurf.subsurface((width - aft_size, 0, aft_size, height)),
-                    (width - aft_size, aft_leftover),
+                    aftsurf.subsurface((width - aft_bar_size, 0, aft_bar_size, height)),
+                    (width - aft_bar_size, aft_leftover),
                     main=False,
                 )
                 rv.blit(thumb, (fore_size - fore_thumb_offset, 0))

--- a/renpy/sl2/slproperties.py
+++ b/renpy/sl2/slproperties.py
@@ -192,6 +192,7 @@ bar_property_names = [
     "bar_vertical",
     "bar_invert",
     "bar_resizing",
+    "bar_unbroken",
     "left_gutter",
     "right_gutter",
     "top_gutter",

--- a/scripts/generate_styles.py
+++ b/scripts/generate_styles.py
@@ -127,6 +127,7 @@ style_properties: dict[str, None | str] = {
     "background": "renpy.easy.displayable_or_none",
     "bar_invert": None,
     "bar_resizing": None,
+    "bar_unbroken": None,
     "bar_vertical": None,
     "black_color": "renpy.easy.color",
     "bold": None,

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -96,6 +96,8 @@ The `changed` property of bars can now be supplied in addition to a bar value.
 Bars now take an `action` property, which is an action that is run when the bar value changes. Unlike `change`, `action`
 is not supplied the bar value, and so can be used with the same actions as buttons.
 
+The new :propref:`bar_unbroken` style property allows a bar to be drawn continuously underneath its thumb.
+
 Layered images now support ``at`` and ``at transform`` clauses at the same time.
 
 The new :var:`config.special_directory_map` variable maps special directory names

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -1051,6 +1051,11 @@ left and right sides are used.
     If True, we resize the sides of the bar. If False, we render the
     sides of the bar at full size, and then crop them.
 
+.. style-property:: bar_unbroken boolean
+
+    If True, the sides of the bar meet underneath the thumb, drawing the bar
+    continuously behind it. If False, the sides end at the edges of the thumb.
+
 .. style-property:: left_gutter int
 
     The size of the gutter on the left side of the bar, in pixels.

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -21,6 +21,19 @@ screen teleporting_button(x=0, y=0, remaining=20):
         else:
             action Hide("teleporting_button")
 
+init python:
+    class BarSizeRecorder(renpy.Displayable):
+        def __init__(self, calls=None, xsize=None, ysize=None):
+            super().__init__()
+            self.calls = calls
+            self.xsize = xsize
+            self.ysize = ysize
+
+        def render(self, width, height, st, at):
+            if self.calls is not None:
+                self.calls.append((width, height))
+            return renpy.Render(self.xsize or width, self.ysize or height)
+
 testsuite flow:
     testcase skip:
         enabled False
@@ -211,6 +224,26 @@ testsuite selectors:
         scroll id "scroll_vp" amount 50
         click id "close_screen_button"
         assert not screen "scroll_screen"
+
+testsuite bar:
+    testcase unbroken_horizontal:
+        $ bar_render_sizes = []
+        $ bar = renpy.display.behavior.Bar(100, 50, page=25, bar_resizing=True, bar_unbroken=True, thumb_offset=0, fore_bar=BarSizeRecorder(bar_render_sizes), aft_bar=BarSizeRecorder(bar_render_sizes), thumb=BarSizeRecorder(xsize=20))
+        $ bar.render(100, 10, 0, 0)
+        assert eval bar.style.bar_unbroken
+        assert eval bar_render_sizes == [(50, 10), (50, 10)]
+
+        $ bar_render_sizes = []
+        $ bar = renpy.display.behavior.Bar(100, 50, page=25, bar_resizing=True, thumb_offset=0, fore_bar=BarSizeRecorder(bar_render_sizes), aft_bar=BarSizeRecorder(bar_render_sizes), thumb=BarSizeRecorder(xsize=20))
+        $ bar.render(100, 10, 0, 0)
+        assert eval bar_render_sizes == [(40, 10), (40, 10)]
+
+    testcase unbroken_vertical:
+        $ bar_render_sizes = []
+        $ bar = renpy.display.behavior.Bar(100, 50, page=25, vertical=True, bar_resizing=True, bar_unbroken=True, thumb_offset=0, fore_bar=BarSizeRecorder(bar_render_sizes), aft_bar=BarSizeRecorder(bar_render_sizes), thumb=BarSizeRecorder(ysize=20))
+        $ bar.render(10, 100, 0, 0)
+        assert eval bar.style.bar_unbroken
+        assert eval bar_render_sizes == [(10, 50), (10, 50)]
 
 testsuite timeout:
     setup:


### PR DESCRIPTION
## Summary

- add a `bar_unbroken` boolean style property, defaulting to `False`
- extend both sides of horizontal and vertical bars underneath the thumb when enabled
- support both resized and cropped bar rendering paths
- document the property and add focused rendering regression tests

## Why

Bars currently leave a gap for the thumb. `thumb_offset` can make a fixed-size thumb overlap that gap, but it cannot reliably handle thumbs whose rendered size changes, such as viewport scrollbar thumbs.

With `bar_unbroken True`, the fore and aft bar surfaces meet underneath the thumb while the thumb geometry and draggable range remain unchanged. Existing bars retain their current rendering by default.

Fixes #5840.

## Validation

- `./run.sh testcases test 'bar' --report-detailed` (2 testcases, 5 assertions)
- `.venv/bin/python setup.py build_ext --inplace`
- `python3.12 scripts/generate_styles.py`
- `python3.12 -m compileall -q scripts/generate_styles.py renpy/display/behavior.py renpy/sl2/slproperties.py`
- `ruff format --check scripts/generate_styles.py renpy/display/behavior.py renpy/sl2/slproperties.py`
- `git diff --check`
