### PR TITLE
doc: Explain ATL event handling

### DIFF
--- a/sphinx/source/transforms.rst
+++ b/sphinx/source/transforms.rst
@@ -1298,6 +1298,25 @@ The ``event`` statement causes an event with the given name to be produced.
     to the event handler. Otherwise, the event propagates to any containing event
     handler.
 
+    The event is only handled by an enclosing ``on`` statement. It does not search
+    forward for a later ``on`` statement or propagate to a separate transform.
+
+**Example**
+
+    In this example, the ``start`` handler fades the image in and then produces
+    the ``pulse`` event. This transfers control to the ``pulse`` handler in the
+    same ``on`` statement::
+
+        transform fade_then_pulse:
+            on start:
+                alpha 0.0
+                linear 0.5 alpha 1.0
+                event pulse
+            on pulse:
+                linear 0.25 zoom 1.25
+                linear 0.25 zoom 1.0
+                event pulse
+
 
 .. _external-atl-events:
 


### PR DESCRIPTION
## Summary

- clarify that an ATL `event` is handled only by an enclosing `on` statement
- explain that events do not search forward or cross into separate transforms
- add a working example that transfers control from a `start` handler to a `pulse` handler

## Why

The existing documentation described upward event propagation but did not show the structure required for an `event` statement to reach a handler. This made a later sibling `on` statement or a handler in another transform look like they should work, even though neither encloses the event.

Fixes #6410.

## Validation

- linted a minimal Ren'Py project containing the documented transform
- Sphinx dummy parse introduced no new diagnostics in the edited event section
- `git diff --check`
