### PR TITLE
Document Ren'Py version scheme

### DIFF
--- a/renpy/versions.py
+++ b/renpy/versions.py
@@ -98,7 +98,12 @@ def _make_version_string(
     if not official and branch not in {"main", "master"}:
         suffixes.append(branch)
 
-    return f"{major}.{minor}.{patch}.{commit:08d}+{'.'.join(suffixes)}"
+    version = f"{major}.{minor}.{patch}.{commit:08d}"
+
+    if suffixes:
+        version += "+" + ".".join(suffixes)
+
+    return version
 
 
 def get_vc_version() -> VersionDict | None:

--- a/sphinx/source/other.rst
+++ b/sphinx/source/other.rst
@@ -11,18 +11,39 @@ Ren'Py Version
 
 .. include:: inc/renpy_version
 
+Ren'Py version numbers have the form ``major.minor.patch.YYMMDDCC``. The first
+three components identify the release series. In the final component, ``YY``,
+``MM``, and ``DD`` give the date of the latest commit, and ``CC`` gives the
+number of commits made on that date.
+
+The version may be followed by a `PEP 440 local version identifier
+<https://peps.python.org/pep-0440/#local-version-identifiers>`__. Its components
+have the following meanings and are included in this order when applicable:
+
+* ``unofficial`` indicates a build that was not made by the Ren'Py release
+  process. Otherwise, ``nightly`` indicates an official nightly build.
+* ``dirty`` indicates that the build was made from a working tree with
+  uncommitted changes.
+* The branch name is included for unofficial builds not made from the main
+  branch.
+
+For example, ``8.6.0.26080401+unofficial.dirty.topic`` is an unofficial build
+from the ``topic`` branch whose working tree contained uncommitted changes.
+
 .. var:: renpy.version_string
 
-    The version number of Ren'Py, as a string of the form "Ren'Py 1.2.3.456".
+    The version number of Ren'Py, as a string of the form
+    ``"Ren'Py 8.6.0.26080401"``. This includes any local version identifier.
 
 .. var:: renpy.version_only
 
     The version number of Ren'Py, without the Ren'Py prefix. A string of
-    the form "1.2.3.456".
+    the form ``"8.6.0.26080401"``. This includes any local version identifier.
 
 .. var:: renpy.version_tuple
 
-    The version number of Ren'Py, as a tuple of the form (1, 2, 3, 456).
+    The version number of Ren'Py, as a tuple of the form
+    ``(8, 6, 0, 26080401)``. This does not include the local version identifier.
 
     This is a namedtuple with four fields: ``major``, ``minor``, ``patch``,
     and ``commit``.

--- a/unittests/testversions.py
+++ b/unittests/testversions.py
@@ -1,0 +1,17 @@
+import unittest
+
+from renpy.versions import _make_version_string
+
+
+class TestVersions(unittest.TestCase):
+    def test_official_version(self):
+        version = _make_version_string((8, 6, 0, 26080401), "main", True, False, False)
+        self.assertEqual(version, "8.6.0.26080401")
+
+    def test_official_nightly_version(self):
+        version = _make_version_string((8, 6, 0, 26080401), "main", True, True, False)
+        self.assertEqual(version, "8.6.0.26080401+nightly")
+
+    def test_unofficial_branch_version(self):
+        version = _make_version_string((8, 6, 0, 26080401), "topic", False, False, True)
+        self.assertEqual(version, "8.6.0.26080401+unofficial.dirty.topic")


### PR DESCRIPTION
## Summary

- document the `major.minor.patch.YYMMDDCC` version format and each local-version component
- update the public version variable examples to reflect the current format
- omit the local-version separator when an official release has no suffixes
- add focused tests for release, nightly, and unofficial branch versions

## Why

The version implementation gained explicit `unofficial`, `nightly`, `dirty`, and branch markers, but the public documentation still only showed the older unsuffixed shape. The formatter also always appended `+`, producing an invalid trailing separator for a clean official non-nightly build.

## Validation

- `./.venv/bin/python -m unittest unittests.testversions -v`
- `ruff check renpy/versions.py unittests/testversions.py`
- `ruff format --check renpy/versions.py unittests/testversions.py`
- `./.venv/bin/sphinx-build -b dummy -D master_doc=other sphinx/source /tmp/renpy-sphinx-version`
- `git diff --check`

The Sphinx build succeeds; the checkout reports its existing warnings for missing generated `inc/*` files.

Fixes #6769