### PR TITLE
Support idle imagebutton focus masks

### DIFF
--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -998,7 +998,7 @@ class Button(renpy.display.layout.Window):
                 fw = rv.width - self.style.right_margin
                 fh = rv.height - self.style.bottom_margin
 
-            mask = self.style.focus_mask
+            mask = self.get_focus_mask()
 
             if mask is True:
                 mask = rv
@@ -1021,6 +1021,9 @@ class Button(renpy.display.layout.Window):
             rv.add_focus(self, None, fx, fy, fw, fh, fmx, fmy, mask)
 
         return rv
+
+    def get_focus_mask(self):
+        return self.style.focus_mask
 
     def focus(self, default=False):
         super(Button, self).focus(default)
@@ -1285,6 +1288,17 @@ class ImageButton(Button):
             self.imagebutton_child.per_interact()
 
         return self.imagebutton_child
+
+    def get_focus_mask(self):
+        mask = self.style.focus_mask
+
+        if isinstance(mask, str) and mask == "idle":
+            if self.style.prefix.startswith("selected_"):
+                return self.state_children["selected_idle_"]
+            else:
+                return self.state_children["idle_"]
+
+        return mask
 
 
 # This is used for an input that takes its focus from a button.

--- a/renpy/styledata/styleutil.py
+++ b/renpy/styledata/styleutil.py
@@ -47,6 +47,8 @@ def expand_focus_mask(v):
         return v
     elif v is True:
         return v
+    elif isinstance(v, str) and v == "idle":
+        return v
     elif callable(v):
         return v
     else:

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -975,6 +975,11 @@ Button Style Properties
         The button itself is used as the displayable (so
         non-transparent areas of the button cause the button to be
         focused).
+    "idle"
+        For an imagebutton, the idle image is used as the mask, even while the
+        button is hovered. For a selected imagebutton, the selected idle image
+        is used. This avoids changes in the hover image changing whether the
+        imagebutton is focused.
     callable
         If a non-displayable callable (like a function, method, or object
         with a ``__call__`` method) is given, the function is called with two

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -21,6 +21,36 @@ screen teleporting_button(x=0, y=0, remaining=20):
         else:
             action Hide("teleporting_button")
 
+image focus_mask_idle:
+    Solid("#fff", xysize=(100, 100))
+
+image focus_mask_hover:
+    Composite((100, 100), (0, 50), Solid("#fff", xysize=(100, 50)))
+
+screen imagebutton_idle_focus_mask:
+    imagebutton:
+        id "idle_focus_mask_button"
+        idle "focus_mask_idle"
+        hover "focus_mask_hover"
+        focus_mask "idle"
+        action NullAction()
+
+        xpos 100
+        ypos 100
+
+    imagebutton:
+        id "selected_idle_focus_mask_button"
+        idle "focus_mask_idle"
+        hover "focus_mask_hover"
+        selected_idle "focus_mask_idle"
+        selected_hover "focus_mask_hover"
+        selected True
+        focus_mask "idle"
+        action NullAction()
+
+        xpos 250
+        ypos 100
+
 testsuite flow:
     testcase skip:
         enabled False
@@ -189,6 +219,18 @@ testsuite selectors:
         run Show("teleporting_button")
         pause until screen "teleporting_button"
         click id "teleporting_button" until not screen "teleporting_button"
+
+    testcase imagebutton_idle_focus_mask:
+        run Show("imagebutton_idle_focus_mask")
+        pause until screen "imagebutton_idle_focus_mask"
+        move id "idle_focus_mask_button" pos (0.5, 0.25)
+        pause 0.1
+        assert eval renpy.display.focus.get_focused().style.prefix == "hover_"
+
+        move id "selected_idle_focus_mask_button" pos (0.5, 0.25)
+        pause 0.1
+        assert eval renpy.display.focus.get_focused().style.prefix == "selected_hover_"
+        run Hide("imagebutton_idle_focus_mask")
 
     testcase drag_and_drop:
         run Show("drag_and_drop")


### PR DESCRIPTION
## Summary

- allow `focus_mask "idle"` to use an imagebutton's idle image as its focus mask
- use the selected idle image when the imagebutton is selected
- document the new `focus_mask` value
- add testcase coverage for normal and selected imagebuttons

## Why

With `focus_mask True`, an imagebutton uses its currently rendered child as the mask. If the hover image makes an area transparent that was opaque in the idle image, moving over that area can repeatedly switch the button between idle and hover.

The `"idle"` value keeps focus testing tied to a stable image while leaving all existing `focus_mask` values unchanged.

## Validation

- `CPPFLAGS="-I$(brew --prefix fribidi)/include" LDFLAGS="-L$(brew --prefix fribidi)/lib" ./run.sh testcases test "selectors::imagebutton_idle_focus_mask"`
  - 1 testcase passed
  - 2 assertions passed
- `./.venv/bin/sphinx-build -b dummy -D master_doc=style_properties sphinx/source /tmp/renpy-sphinx-idle-focus-mask`
- `./.venv/bin/python -m compileall -q renpy/display/behavior.py renpy/styledata/styleutil.py`
- `git diff --check`

The Sphinx build succeeds with the checkout's existing warnings for missing generated includes and unresolved references.

Fixes #5862