### PR TITLE
Expose the current rollback identifier

### DIFF
--- a/renpy/exports/__init__.py
+++ b/renpy/exports/__init__.py
@@ -553,6 +553,7 @@ from renpy.exports.rollbackexports import (
     checkpoint as checkpoint,
     fix_rollback as fix_rollback,
     get_identifier_checkpoints as get_identifier_checkpoints,
+    get_rollback_identifier as get_rollback_identifier,
     get_roll_forward as get_roll_forward,
     in_fixed_rollback as in_fixed_rollback,
     in_rollback as in_rollback,

--- a/renpy/exports/rollbackexports.py
+++ b/renpy/exports/rollbackexports.py
@@ -250,3 +250,25 @@ def get_identifier_checkpoints(identifier):
     """
 
     return renpy.game.log.get_identifier_checkpoints(identifier)
+
+
+def get_rollback_identifier():
+    """
+    :doc: rollback
+
+    Returns the rollback identifier for the currently executing statement. This
+    can be passed to :func:`RollbackToIdentifier` or
+    :func:`renpy.get_identifier_checkpoints`.
+
+    This returns None when the current context does not support rollback or a
+    rollback entry is not available.
+    """
+
+    if not renpy.game.context().rollback:
+        return None
+
+    current = renpy.game.log.current
+    if current is None:
+        return None
+
+    return current.identifier

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -211,7 +211,9 @@ which automatically gets pluralized.  For example::
 
     A list of functions that are called when a statement is executed.
     These functions are generally called with the name of the statement
-    in question. However, there are some special statement names.
+    in question. The callback can use :func:`renpy.get_rollback_identifier`
+    to obtain the rollback identifier for that statement. However, there are
+    some special statement names.
 
     "say"
         Normal say statements.

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -11,6 +11,16 @@ label hard_pause:
     $ renpy.pause(0.5, hard=True)
     "End"
 
+label rollback_identifier_menu:
+    menu:
+        "Done":
+            return
+
+init python:
+    def capture_menu_rollback_identifier(statement):
+        if statement == "menu":
+            store.menu_rollback_identifier = renpy.get_rollback_identifier()
+
 screen teleporting_button(x=0, y=0, remaining=20):
     textbutton "Teleporting Button":
         id "teleporting_button"
@@ -237,6 +247,21 @@ testsuite context:
         assert eval ("context_test_inner_val" in globals())
         $ renpy.end_replay()
         assert eval ("replay_scope" in globals())
+
+testsuite rollback_identifier:
+    setup:
+        $ config.statement_callbacks.append(capture_menu_rollback_identifier)
+
+    teardown:
+        $ config.statement_callbacks.remove(capture_menu_rollback_identifier)
+
+    testcase current_statement:
+        $ menu_rollback_identifier = None
+        run Start("rollback_identifier_menu")
+        pause until screen "choice"
+        assert eval menu_rollback_identifier is not None
+        assert eval renpy.get_identifier_checkpoints(menu_rollback_identifier) is not None
+        click "Done"
 
     testcase replay_python:
         description "Tests that `renpy.call_replay` properly updates context variables."


### PR DESCRIPTION
## Summary

- add `renpy.get_rollback_identifier()` for the currently executing statement
- return `None` when the current context has no rollback entry
- document its use from `config.statement_callbacks`
- add a testcase that captures a menu identifier and resolves it through the rollback history

## Why

Rollback identifiers were only exposed through dialogue `HistoryEntry` objects. Other statements, such as menus, already execute within rollback entries but had no public way to expose the corresponding identifier.

This makes it possible for a statement callback to remember a menu location and later pass it to `RollbackToIdentifier()`.

## Validation

- `CPPFLAGS="-I$(brew --prefix fribidi)/include" LDFLAGS="-L$(brew --prefix fribidi)/lib" ./run.sh testcases test "rollback_identifier::current_statement"`
  - 1 testcase passed
  - 2 assertions passed
  - 5 hooks passed
- `./.venv/bin/sphinx-build -b dummy -D master_doc=config sphinx/source /tmp/renpy-sphinx-rollback-identifier`
- `./.venv/bin/python -m compileall -q renpy/exports/rollbackexports.py renpy/exports/__init__.py`
- `git diff --check`

The Sphinx build succeeds with the checkout's existing warnings for missing generated includes and unresolved references.

Fixes #7111