### PR TITLE
Support base styles for custom screen language statements

### DIFF
--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -2248,7 +2248,7 @@ class SLCustomUse(SLNode):
 
     variable = None
 
-    def __init__(self, loc, target, positional, block, variable):
+    def __init__(self, loc, target, positional, block, variable, style):
         SLNode.__init__(self, loc)
 
         # The name of the screen we're accessing.
@@ -2266,6 +2266,9 @@ class SLCustomUse(SLNode):
         # The variable the main displayable is assigned to.
         self.variable = variable
 
+        # The default style suffix passed to the screen.
+        self.style = style
+
     def copy(self, transclude):
         rv = self.instantiate(transclude)
 
@@ -2274,6 +2277,7 @@ class SLCustomUse(SLNode):
 
         rv.positional = self.positional
         rv.block = self.block.copy(transclude)
+        rv.style = self.style
 
         return rv
 
@@ -2346,7 +2350,7 @@ class SLCustomUse(SLNode):
                 kwargs.update(properties)
 
             # If we don't know the style, figure it out.
-            style_suffix = kwargs.pop("style_suffix", None)
+            style_suffix = kwargs.pop("style_suffix", None) or self.style
             if ("style" not in kwargs) and style_suffix:
                 if ctx.style_prefix is None:
                     kwargs["style"] = style_suffix

--- a/renpy/sl2/slparser.py
+++ b/renpy/sl2/slparser.py
@@ -1075,12 +1075,16 @@ class CustomParser(Parser):
     `screen`
         The screen to use. If not given, defaults to `name`.
 
+    `style`
+        The base name of the style passed to the screen. If the style property
+        is not given, this will have the current style prefix added to it.
+
     Returns an object that can have positional arguments and properties
     added to it. This object has the same .add_ methods as the objects
     returned by :class:`renpy.register_sl_displayable`.
     """
 
-    def __init__(self, name, children="many", screen=None):
+    def __init__(self, name, children="many", screen=None, style=None):
         Parser.__init__(self, name)
 
         if children == "many":
@@ -1114,6 +1118,8 @@ class CustomParser(Parser):
         else:
             self.screen = name
 
+        self.style = style
+
         self.variable = True
 
     def parse(self, loc, l, parent, keyword):
@@ -1144,7 +1150,7 @@ class CustomParser(Parser):
         variable = block.variable
         block.variable = None
 
-        return slast.SLCustomUse(loc, self.screen, arguments, block, variable)
+        return slast.SLCustomUse(loc, self.screen, arguments, block, variable, self.style)
 
 
 class ScreenParser(Parser):

--- a/sphinx/source/screen_python.rst
+++ b/sphinx/source/screen_python.rst
@@ -262,16 +262,23 @@ call looks like::
 
 
     python early:
-        renpy.register_sl_statement("titledwindow", children=1).add_positional("title").add_property("icon").add_property("pos")
+        renpy.register_sl_statement("titledwindow", children=1, style="titledwindow").add_positional("title").add_property("icon").add_property("pos")
+
+The optional ``style`` argument gives the custom statement a base style. When
+the statement is used inside a style prefix, the prefix and base style are
+combined and passed to the implementing screen as its ``style`` argument. An
+explicit ``style_suffix`` property, when registered, replaces the base style,
+while an explicit ``style`` property takes precedence over both.
 
 Then, we define a screen that implements the custom statement. This screen can be defined in
 any file. One such screen is::
 
-    screen titledwindow(title, icon=None, pos=(0, 0)):
+    screen titledwindow(title, icon=None, pos=(0, 0), style=None):
         drag:
             pos pos
 
             frame:
+                style style
                 background "#00000080"
 
                 has vbox
@@ -290,8 +297,9 @@ any file. One such screen is::
 When are used large property groups like a `add_property_group`, it makes sense to use
 the \*\*properties syntax with a properties keyword in some place. For example::
 
-    screen titledwindow(title, icon=None, **properties):
+    screen titledwindow(title, icon=None, style=None, **properties):
         frame:
+            style style
             # When background not in properties it will use it as default value.
             background "#00000080"
 

--- a/testcases/game/01custom_sl.rpy
+++ b/testcases/game/01custom_sl.rpy
@@ -1,0 +1,2 @@
+python early:
+    renpy.register_sl_statement("test_custom_style", children=0, screen="_test_custom_style", style="test_custom_sl").add_positional("marker").add_property("style").add_property("style_suffix")

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -1,5 +1,26 @@
 ## This file tests the testcase system itself
 
+screen _test_custom_style(marker, style):
+    text marker:
+        id marker
+        style style
+
+style test_custom_sl is text
+style prefixed_test_custom_sl is test_custom_sl
+style prefixed_test_custom_alternate is text
+style test_custom_direct is text
+
+screen test_custom_sl_styles():
+    style_prefix "prefixed"
+
+    test_custom_style "registered"
+
+    test_custom_style "suffix":
+        style_suffix "test_custom_alternate"
+
+    test_custom_style "explicit":
+        style "test_custom_direct"
+
 label three_messages:
     "Message 1"
     "Message 2"
@@ -32,6 +53,15 @@ testsuite flow:
     #         renpy.watch("waitch")
     #         renpy.watch("whether")
     #         waitch = 5
+
+testsuite custom_sl_style:
+    testcase base_style:
+        run Show("test_custom_sl_styles")
+        pause until screen "test_custom_sl_styles"
+        assert eval renpy.get_widget("test_custom_sl_styles", "registered").style.parent == ("prefixed_test_custom_sl",)
+        assert eval renpy.get_widget("test_custom_sl_styles", "suffix").style.parent == ("prefixed_test_custom_alternate",)
+        assert eval renpy.get_widget("test_custom_sl_styles", "explicit").style.parent == ("test_custom_direct",)
+        run Hide("test_custom_sl_styles")
 
 testsuite parameter_field:
 


### PR DESCRIPTION
## Summary

- add an optional `style` base name to `renpy.register_sl_statement`
- combine the registered style with the active screen style prefix
- preserve explicit `style` and `style_suffix` override behavior
- document the API and cover all three precedence cases with a rendering testcase

Closes #6621.

## Validation

- `./run.sh testcases test 'custom_sl_style::base_style'` (1 testcase, 3 assertions passed)\n- `./run.sh testcases lint` (no new lint findings)\n- `.venv/bin/sphinx-build -b dummy ...` (build succeeded; existing missing generated `inc/*` warnings only)\n- `python3 -m compileall -q renpy/sl2/slparser.py renpy/sl2/slast.py`\n- `git diff --check`