### PR TITLE
Interpolate zpos in MoveTransition

### DIFF
--- a/renpy/display/movetransition.py
+++ b/renpy/display/movetransition.py
@@ -379,6 +379,34 @@ class MoveInterpolate(renpy.display.displayable.Displayable):
         self.delay = delay  # type: int|float
         self.st = 0
 
+    def _completion(self):
+        if self.st > self.delay:
+            done = 1.0
+        else:
+            done = self.st / self.delay
+
+        if self.time_warp is not None:
+            done = self.time_warp(done)
+
+        return done
+
+    def _child_zpos(self, child):
+        """Returns the combined zpos of transforms wrapping a child."""
+
+        rv = 0.0
+        seen = set()
+
+        while child is not None and id(child) not in seen:
+            seen.add(id(child))
+            child = child._target()
+
+            if isinstance(child, renpy.display.transform.Transform):
+                rv += child.state.zpos
+
+            child = getattr(child, "child", None)
+
+        return rv
+
     def render(self, width, height, st, at):
         self.screen_width = width
         self.screen_height = height
@@ -397,7 +425,23 @@ class MoveInterpolate(renpy.display.displayable.Displayable):
         if self.st < self.delay:
             renpy.display.render.redraw(self, 0)
 
-        return cr
+        old_zpos = self._child_zpos(self.old)
+        new_zpos = self._child_zpos(self.new)
+        done = self._completion()
+
+        zpos = old_zpos + done * (new_zpos - old_zpos)
+        child_zpos = old_zpos if self.use_old else new_zpos
+        zoffset = zpos - child_zpos
+
+        if not zoffset:
+            return cr
+
+        rv = renpy.display.render.Render(cr.width, cr.height)
+        rv.blit(cr, (0, 0))
+        rv.reverse = renpy.display.matrix.Matrix.offset(0, 0, zoffset)
+        rv.forward = rv.reverse.inverse()
+
+        return rv
 
     def child_placement(self, child):
         """
@@ -423,13 +467,7 @@ class MoveInterpolate(renpy.display.displayable.Displayable):
         return xpos, ypos, xanchor, yanchor, xoffset, yoffset, subpixel
 
     def get_placement(self):
-        if self.st > self.delay:
-            done = 1.0
-        else:
-            done = self.st / self.delay
-
-        if self.time_warp is not None:
-            done = self.time_warp(done)
+        done = self._completion()
 
         absolute = renpy.display.core.absolute
 
@@ -473,7 +511,8 @@ def MoveTransition(
 
     With these transitions, images changing position between the old and new
     scenes will be interpolated, which means their movement will be smooth
-    instead of instantaneous.
+    instead of instantaneous. The :tpref:`zpos` transform property is
+    interpolated along with the two-dimensional position.
 
     As only layers have tags, MoveTransitions can only be applied to a single
     layer or all layers at once, using the :ref:`with statement <with-statement>`.

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -1,5 +1,24 @@
 ## This file tests the testcase system itself
 
+init python:
+    def move_interpolate_zpos(st, use_old, warped=False):
+        old = Transform(Solid("#fff", xsize=1, ysize=1), zpos=-100)
+        new = Transform(Solid("#fff", xsize=1, ysize=1), zpos=100)
+        old = renpy.display.layout.AdjustTimes(old, None, None)
+        new = renpy.display.layout.AdjustTimes(new, None, None)
+        time_warp = (lambda done: done * done) if warped else None
+        move = renpy.display.movetransition.MoveInterpolate(2.0, old, new, use_old, time_warp)
+        render = renpy.render(move, 100, 100, st, st)
+
+        zpos = 0.0
+        while hasattr(render, "children"):
+            if render.reverse is not None:
+                zpos += render.reverse.zdw
+
+            render = next((child[0] for child in render.children if hasattr(child[0], "children")), None)
+
+        return zpos
+
 label three_messages:
     "Message 1"
     "Message 2"
@@ -32,6 +51,16 @@ testsuite flow:
     #         renpy.watch("waitch")
     #         renpy.watch("whether")
     #         waitch = 5
+
+testsuite move_interpolate:
+    testcase zpos:
+        assert eval move_interpolate_zpos(0.0, False) == -100.0
+        assert eval move_interpolate_zpos(1.0, False) == 0.0
+        assert eval move_interpolate_zpos(2.0, False) == 100.0
+        assert eval move_interpolate_zpos(0.0, True) == -100.0
+        assert eval move_interpolate_zpos(1.0, True) == 0.0
+        assert eval move_interpolate_zpos(2.0, True) == 100.0
+        assert eval move_interpolate_zpos(1.0, False, True) == -50.0
 
 testsuite parameter_field:
 


### PR DESCRIPTION
## Summary

- interpolate the combined endpoint `zpos` during `MoveTransition`
- apply only the z-axis delta needed for the selected old or new render
- reuse the same completion and time-warp calculation as two-dimensional placement
- document `zpos` interpolation and add endpoint, midpoint, `old`, and warped regression coverage

Closes #6808.

## Validation

- `./run.sh testcases test 'move_interpolate::zpos'` (1 testcase, 7 assertions passed)\n- `./run.sh testcases lint` (no new lint findings)\n- `.venv/bin/sphinx-build -b dummy ...` (build succeeded; existing missing generated `inc/*` warnings only)\n- `python3 -m compileall -q renpy/display/movetransition.py`\n- `git diff --check`