### PR TITLE
Add statement information API

### DIFF
--- a/renpy/display/predict.py
+++ b/renpy/display/predict.py
@@ -45,6 +45,9 @@ screens = []
 # A list of translation ids for the statement being predicted.
 tlids = list[str | None]
 
+# The statement currently being predicted, or None outside statement prediction.
+statement = None
+
 
 def displayable(d):
     """

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -940,19 +940,26 @@ class Context(renpy.object.Object):
             self.predict_return_stack = return_stack
 
             try:
-                for n in node.predict():
-                    if n is None:
-                        continue
+                old_statement = renpy.display.predict.statement
+                renpy.display.predict.statement = node
 
-                    if n not in seen:
-                        npi = NewPredictInfo()
-                        npi.node = n
-                        npi.images = self.images
-                        npi.predict_return_stack = self.predict_return_stack
-                        npi.tlids = renpy.display.predict.tlids
+                try:
+                    for n in node.predict():
+                        if n is None:
+                            continue
 
-                        nodes.append(npi)
-                        seen.add(n)
+                        if n not in seen:
+                            npi = NewPredictInfo()
+                            npi.node = n
+                            npi.images = self.images
+                            npi.predict_return_stack = self.predict_return_stack
+                            npi.tlids = renpy.display.predict.tlids
+
+                            nodes.append(npi)
+                            seen.add(n)
+
+                finally:
+                    renpy.display.predict.statement = old_statement
 
             except Exception:
                 if renpy.config.debug_prediction:

--- a/renpy/exports/__init__.py
+++ b/renpy/exports/__init__.py
@@ -595,9 +595,11 @@ from renpy.exports.scriptexports import (
 )
 
 from renpy.exports.statementexports import (
+    StatementInfo as StatementInfo,
     call_screen as call_screen,
     call as call,
     execute_default_statement as execute_default_statement,
+    get_statement_info as get_statement_info,
     get_statement_name as get_statement_name,
     imagemap as imagemap,
     jump as jump,

--- a/renpy/exports/statementexports.py
+++ b/renpy/exports/statementexports.py
@@ -394,3 +394,60 @@ def get_statement_name():
     """
 
     return renpy.ast.current_statement_name
+
+
+class StatementInfo(object):
+    """
+    :doc: other class
+    :args: ()
+
+    Information about a statement that is executing or being predicted.
+
+    This is returned by :func:`renpy.get_statement_info`.
+
+    .. attribute:: filename
+
+        The filename containing the statement.
+
+    .. attribute:: linenumber
+
+        The line number of the statement.
+
+    .. attribute:: tlid
+
+        The translation identifier associated with the statement, or None if
+        there is no translation identifier.
+    """
+
+    def __init__(self, node, tlid):
+        self.filename = node.filename
+        self.linenumber = node.linenumber
+        self.tlid = tlid
+
+
+def get_statement_info():
+    """
+    :doc: other
+
+    Returns a :class:`StatementInfo` object describing the statement that is
+    currently executing or being predicted. This can be called from the
+    predict function of a creator-defined statement.
+
+    Returns None if there is no current statement.
+    """
+
+    node = renpy.display.predict.statement
+
+    if node is not None:
+        tlids = renpy.display.predict.tlids
+        tlid = tlids[0] if tlids else None
+
+    else:
+        ctx = renpy.game.context()
+        node = renpy.game.script.namemap.get(ctx.current, None)
+        tlid = ctx.translate_identifier or ctx.deferred_translate_identifier
+
+    if node is None:
+        return None
+
+    return StatementInfo(node, tlid)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -88,6 +88,9 @@ Menu text filtering can now be disabled with :var:`config.use_menu_text_filter`,
 
 The new :func:`renpy.get_statement_name` function returns the name of the current statement.
 
+The new :func:`renpy.get_statement_info` function returns the filename, line number, and translation identifier
+of the statement that is currently executing or being predicted.
+
 The :class:`Confirm` action and :func:`renpy.confirm` function now take a `screen` argument, allowing
 a custom screen to be used instead of the default confirm screen.
 

--- a/testcases/game/tests/00_statement_info.rpy
+++ b/testcases/game/tests/00_statement_info.rpy
@@ -1,0 +1,32 @@
+python early:
+    statement_info_execution = None
+    statement_info_predictions = []
+
+    def parse_record_statement_info(l):
+        l.expect_eol()
+        return True
+
+    def execute_record_statement_info(parsed):
+        global statement_info_execution
+        statement_info_execution = renpy.get_statement_info()
+
+    def predict_record_statement_info(parsed):
+        statement_info_predictions.append(renpy.get_statement_info())
+
+    def predict_fail_statement_info(parsed):
+        raise Exception("statement info prediction failure")
+
+    renpy.register_statement(
+        "record statement info",
+        parse=parse_record_statement_info,
+        execute=execute_record_statement_info,
+        predict=predict_record_statement_info,
+        predict_all=False,
+    )
+
+    renpy.register_statement(
+        "fail statement info prediction",
+        parse=parse_record_statement_info,
+        predict=predict_fail_statement_info,
+        predict_all=False,
+    )

--- a/testcases/game/tests/test_statement_info.rpy
+++ b/testcases/game/tests/test_statement_info.rpy
@@ -1,0 +1,58 @@
+init python:
+    def collect_statement_info_prediction(label="statement_info_target"):
+        ctx = renpy.game.context()
+        old_callback = config.predict_statements_callback
+        old_count = config.predict_statements
+        old_identifier = ctx.translate_identifier
+        old_alternate = ctx.alternate_translate_identifier
+        before = renpy.get_statement_info()
+
+        statement_info_predictions[:] = []
+
+        try:
+            config.predict_statements_callback = lambda current: [label]
+            config.predict_statements = 3
+            ctx.translate_identifier = "statement_info_tlid"
+            ctx.alternate_translate_identifier = None
+            list(ctx.predict())
+        finally:
+            config.predict_statements_callback = old_callback
+            config.predict_statements = old_count
+            ctx.translate_identifier = old_identifier
+            ctx.alternate_translate_identifier = old_alternate
+
+        after = renpy.get_statement_info()
+        return list(statement_info_predictions), before, after
+
+
+label statement_info_target:
+    record statement info
+    return
+
+
+label statement_info_failure_target:
+    fail statement info prediction
+    return
+
+
+testcase statement_info:
+    run Jump("statement_info_target")
+
+    assert eval statement_info_execution is not None
+    assert eval statement_info_execution.filename.endswith("tests/test_statement_info.rpy")
+    assert eval statement_info_execution.linenumber > 0
+    assert eval statement_info_execution.tlid is None
+
+    $ predictions, before_prediction, after_prediction = collect_statement_info_prediction()
+
+    assert eval len(predictions) == 1
+    assert eval predictions[0].filename == statement_info_execution.filename
+    assert eval predictions[0].linenumber == statement_info_execution.linenumber
+    assert eval predictions[0].tlid == "statement_info_tlid"
+    assert eval after_prediction.filename == before_prediction.filename
+    assert eval after_prediction.linenumber == before_prediction.linenumber
+
+    $ _, before_failure, after_failure = collect_statement_info_prediction("statement_info_failure_target")
+
+    assert eval after_failure.filename == before_failure.filename
+    assert eval after_failure.linenumber == before_failure.linenumber


### PR DESCRIPTION
## Summary

- add `renpy.get_statement_info()` and `renpy.StatementInfo`
- expose the filename, line number, and translation identifier for executing and predicted statements
- track the active prediction node with exception-safe restoration
- document the API and cover execution, prediction, tlid propagation, and prediction failure cleanup

## Motivation

Creator-defined statement prediction callbacks currently have no supported way to determine which statement Ren'Py is predicting. Existing helpers only report the statement being executed by the context, so they can return unrelated information during prediction.

The new API uses the current execution node normally and the active prediction worklist node while `node.predict()` is running. It also uses the translation identifiers already carried by prediction state.

## Validation

- `./run.sh testcases test 'statement_info'` (1 testcase, 12 assertions passed)
- `ruff check --select E9,F63,F7,F82` on changed Python modules
- `ruff format --check` on changed Python modules
- `python -m compileall` on changed Python modules
- Sphinx dummy build (succeeded; 4 pre-existing warnings)
- `git diff --check`

Fixes #7064
