### PR TITLE
[Video] Add macOS hardware-surface import for Movie displayables

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -894,11 +894,23 @@ class Channel(object):
 
         return renpysound.read_video(self.number)
 
+    def read_video_hardware(self):
+        if not pcm_ok:
+            return None
+
+        return renpysound.read_video_hardware(self.number)
+
     def video_ready(self):
         if not pcm_ok:
             return 1
 
         return renpysound.video_ready(self.number)
+
+    def video_stats(self):
+        if not pcm_ok:
+            return {"state": "audio-disabled"}
+
+        return renpysound.video_stats(self.number)
 
 
 # A list of channels we know about.

--- a/renpy/audio/renpysound.pyx
+++ b/renpy/audio/renpysound.pyx
@@ -79,6 +79,8 @@ cdef extern from "renpysound_core.h":
     void RPS_advance_time()
     int RPS_video_ready(int channel)
     object RPS_read_video(int channel)
+    object RPS_read_video_hardware(int channel)
+    object RPS_video_stats(int channel)
     void RPS_set_video(int channel, int video)
 
     void RPS_sample_surfaces(object, object)
@@ -402,6 +404,18 @@ def read_video(channel):
     # This has to be set to the same number it is in ffmedia.c
     FRAME_PADDING = 4
     return rv.subsurface((FRAME_PADDING, FRAME_PADDING, w - FRAME_PADDING * 2, h - FRAME_PADDING * 2))
+
+
+def read_video_hardware(channel):
+    """Returns a retained native VideoToolbox frame capsule when available."""
+
+    return RPS_read_video_hardware(channel)
+
+
+def video_stats(channel):
+    """Returns decoder and presentation statistics for a video channel."""
+
+    return RPS_video_stats(channel)
 
 
 # No video will be played from this channel.

--- a/renpy/common/_shaders.rpym
+++ b/renpy/common/_shaders.rpym
@@ -32,6 +32,51 @@ init python:
         gl_Position = u_transform * gl_Position;
     """)
 
+    renpy.register_shader("renpy.movie_yuv", private_uniforms=True, variables="""
+        uniform sampler2DRect tex0;
+        uniform sampler2DRect tex1;
+        uniform float u_movie_yuv_full_range;
+        uniform float u_movie_yuv_bt709;
+        attribute vec2 a_tex_coord;
+        varying vec2 v_tex_coord;
+    """, vertex_200="""
+        v_tex_coord = a_tex_coord;
+    """, fragment_200="""
+        vec4 y_sample = texture2DRect(tex0, v_tex_coord);
+        vec4 uv_sample = texture2DRect(tex1, v_tex_coord * 0.5);
+        float y;
+        float u;
+        float v;
+        float r;
+        float g;
+        float b;
+
+        if (u_movie_yuv_full_range > 0.5) {
+            y = y_sample.r;
+            u = uv_sample.r - 0.5;
+            v = uv_sample.a - 0.5;
+        } else {
+            y = (y_sample.r - 16.0 / 255.0) * (255.0 / 219.0);
+            u = (uv_sample.r - 0.5) * (255.0 / 224.0);
+            v = (uv_sample.a - 0.5) * (255.0 / 224.0);
+        }
+
+        if (u_movie_yuv_bt709 > 0.5) {
+            r = y + 1.5748 * v;
+            g = y - 0.187324 * u - 0.468124 * v;
+            b = y + 1.8556 * u;
+        } else {
+            r = y + 1.402 * v;
+            g = y - 0.344136 * u - 0.714136 * v;
+            b = y + 1.772 * u;
+        }
+
+        gl_FragColor = vec4(clamp(r, 0.0, 1.0),
+                            clamp(g, 0.0, 1.0),
+                            clamp(b, 0.0, 1.0),
+                            1.0);
+    """)
+
     renpy.register_shader("renpy.texture", variables="""
         uniform float u_lod_bias;
         uniform sampler2D tex0;

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -59,6 +59,9 @@ debug = False
 # Ditto, but for sound operations
 debug_sound = os.environ.get("RENPY_DEBUG_SOUND", False)
 
+# Logs periodic decoder, conversion, texture upload, and presentation metrics.
+debug_video = os.environ.get("RENPY_DEBUG_VIDEO", False)
+
 # Is rollback enabled? (This only controls if the user-invoked
 # rollback command does anything)
 rollback_enabled = True

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -25,6 +25,7 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 import math
 import collections
 import re
+import time
 
 import renpy
 
@@ -116,6 +117,112 @@ reset_channels = set()
 # These store the textures for movies in the same group.
 group_texture = {}
 
+# Main-thread stages are measured here because the media backend cannot see
+# deferred GL texture uploads or the window present call.
+movie_upload_stats = {}
+movie_gpu_import_stats = {}
+movie_present_stats = {}
+movie_present_pending = set()
+movie_debug_log_time = 0.0
+
+
+def _movie_stat_bucket(stats, channel):
+    return stats.setdefault(channel, {"frames": 0, "time_ns": 0})
+
+
+def _resolve_movie_channel(channel):
+    if channel != "movie" or renpy.audio.music.get_playing(channel):
+        return channel
+
+    for candidate in channel_movie:
+        if renpy.audio.music.get_playing(candidate):
+            return candidate
+
+    return channel
+
+
+def record_movie_upload(channel, elapsed_ns):
+    stats = _movie_stat_bucket(movie_upload_stats, channel)
+    stats["frames"] += 1
+    stats["time_ns"] += elapsed_ns
+
+
+def record_movie_gpu_import(channel, elapsed_ns, failed=False):
+    stats = movie_gpu_import_stats.setdefault(channel, {"frames": 0, "time_ns": 0, "failures": 0})
+    if failed:
+        stats["failures"] += 1
+    else:
+        stats["frames"] += 1
+        stats["time_ns"] += elapsed_ns
+
+
+def record_movie_present(elapsed_ns):
+    for channel in movie_present_pending:
+        stats = _movie_stat_bucket(movie_present_stats, channel)
+        stats["frames"] += 1
+        stats["time_ns"] += elapsed_ns
+
+    movie_present_pending.clear()
+
+
+def get_movie_stats(channel="movie"):
+    """Returns a snapshot of decoder and display costs for a movie channel."""
+
+    channel = _resolve_movie_channel(channel)
+    rv = dict(renpy.audio.music.get_channel(channel).video_stats())
+
+    upload = _movie_stat_bucket(movie_upload_stats, channel)
+    gpu_import = movie_gpu_import_stats.setdefault(channel, {"frames": 0, "time_ns": 0, "failures": 0})
+    present = _movie_stat_bucket(movie_present_stats, channel)
+
+    gpu_frames = gpu_import["frames"]
+    upload_frames = upload["frames"]
+    if gpu_frames and upload_frames:
+        upload_backend = "mixed"
+        gpu_yuv_backend = "mixed"
+    elif gpu_frames:
+        upload_backend = "iosurface-import"
+        gpu_yuv_backend = "iosurface-rectangle+glsl"
+    elif upload_frames:
+        upload_backend = "deferred-texture-loader"
+        gpu_yuv_backend = "disabled"
+    else:
+        upload_backend = "none"
+        gpu_yuv_backend = "disabled"
+
+    rv.update(
+        {
+            "channel": channel,
+            "channel_playing": bool(renpy.audio.music.get_playing(channel)),
+            "upload_frames": upload["frames"],
+            "upload_time_ns": upload["time_ns"],
+            "present_frames": present["frames"],
+            "present_time_ns": present["time_ns"],
+            "upload_backend": upload_backend,
+            "gpu_import_frames": gpu_frames,
+            "gpu_import_time_ns": gpu_import["time_ns"],
+            "gpu_import_failures": gpu_import["failures"],
+            "gpu_yuv_backend": gpu_yuv_backend,
+        }
+    )
+
+    return rv
+
+
+def _debug_movie_stats():
+    global movie_debug_log_time
+
+    if not renpy.config.debug_video:
+        return
+
+    now = time.monotonic()
+    if now < movie_debug_log_time:
+        return
+
+    movie_debug_log_time = now + 1.0
+    stats = get_movie_stats("movie")
+    renpy.display.log.write("movie stats: %r", stats)
+
 
 def early_interact():
     """
@@ -165,6 +272,40 @@ def get_movie_texture(channel, mask_channel=None, side_mask=False, mipmap=None):
         return get_movie_texture_web(channel, mask_channel, side_mask, mipmap)
 
     c = renpy.audio.music.get_channel(channel)
+    hardware_frame = None
+    hardware_tex = None
+
+    if renpy.macintosh and not side_mask and not mask_channel and hasattr(c, "read_video_hardware"):
+        try:
+            hardware_frame = c.read_video_hardware()
+        except Exception:
+            renpy.display.log.write("VideoToolbox surface read failed; using CPU movie path.")
+            renpy.display.log.exception()
+
+        if hardware_frame is not None:
+            from renpy.gl2 import gl2texture
+
+            gpu_import_start = time.perf_counter_ns()
+            try:
+                hardware_tex = gl2texture.load_videotoolbox_frame(
+                    hardware_frame,
+                    {"mipmap": mipmap, "movie_channel": channel},
+                )
+            except Exception:
+                record_movie_gpu_import(channel, 0, failed=True)
+                renpy.display.log.write("VideoToolbox IOSurface import failed; using CPU movie path.")
+                renpy.display.log.exception()
+            else:
+                if hardware_tex is not None:
+                    record_movie_gpu_import(channel, time.perf_counter_ns() - gpu_import_start)
+                else:
+                    record_movie_gpu_import(channel, 0, failed=True)
+
+    if hardware_tex is not None:
+        movie_present_pending.add(channel)
+        texture[channel] = hardware_tex
+        return hardware_tex, True
+
     surf = c.read_video()
 
     if side_mask:
@@ -193,7 +334,8 @@ def get_movie_texture(channel, mask_channel=None, side_mask=False, mipmap=None):
 
     if surf is not None:
         renpy.display.render.mutated_surface(surf)
-        tex = renpy.display.draw.load_texture(surf, True, {"mipmap": mipmap})
+        movie_present_pending.add(channel)
+        tex = renpy.display.draw.load_texture(surf, True, {"mipmap": mipmap, "movie_channel": channel})
         texture[channel] = tex
         new = True
     else:
@@ -355,6 +497,14 @@ def find_oversampled(new, filename):
 
 
 def default_play_callback(old, new):
+    movie_upload_stats.pop(new.channel, None)
+    movie_gpu_import_stats.pop(new.channel, None)
+    movie_present_stats.pop(new.channel, None)
+    movie_present_pending.discard(new.channel)
+
+    if renpy.config.debug_video:
+        renpy.display.log.write("movie play: channel=%r file=%r loop=%r", new.channel, new._play, new.loop)
+
     if new.mask:
         renpy.audio.music.play(find_oversampled(new, new.mask), channel=new.mask_channel, loop=new.loop)
 
@@ -881,6 +1031,8 @@ def frequent():
     """
 
     update_playing()
+
+    _debug_movie_stats()
 
     renpy.audio.audio.advance_time()
 

--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -967,6 +967,7 @@ cdef class GL2Draw:
         """
 
         start = time.time()
+        present_start = time.perf_counter_ns()
 
         renpy.plog(1, "flip")
 
@@ -975,6 +976,8 @@ cdef class GL2Draw:
         except pygame.error as e:
             renpy.display.log.write("Flip failed %r", e)
             renpy.game.interface.display_reset = True
+
+        renpy.display.video.record_movie_present(time.perf_counter_ns() - present_start)
 
         end = time.time()
 

--- a/renpy/gl2/gl2shader.pyx
+++ b/renpy/gl2/gl2shader.pyx
@@ -73,6 +73,7 @@ UNIFORM_TYPES = {
     "mat3",
     "mat4",
     "sampler2D",
+    "sampler2DRect",
 }
 
 VARYING_TYPES = set(ATTRIBUTE_TYPES)| set(UNIFORM_TYPES)

--- a/renpy/gl2/gl2texture.pxd
+++ b/renpy/gl2/gl2texture.pxd
@@ -57,6 +57,10 @@ cdef class GLTexture(GL2Model):
     # The number of the texture in OpenGL.
     cdef public unsigned int number
 
+    # The texture target, normally GL_TEXTURE_2D. macOS IOSurface imports use
+    # GL_TEXTURE_RECTANGLE_ARB.
+    cdef public GLenum target
+
     # Has this texture been loaded yet?
     cdef public bint loaded
 

--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -32,6 +32,7 @@ from renpy.pygame.surface cimport PySurface_AsSurface
 
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
+from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid
 
 import sys
 import time
@@ -51,6 +52,11 @@ from renpy.display.matrix cimport Matrix
 
 # This has different names in GL and GLES, but the same value.
 cdef GLenum RGBA8 = 0x8058
+cdef GLenum GL_TEXTURE_RECTANGLE_ARB = 0x84F5
+
+cdef extern from "renpy_macos_video.h":
+    int renpy_macos_video_frame_info(void *frame, void **iosurface, int *width, int *height, int *full_range, int *bt709)
+    int renpy_macos_video_import_texture(void *context, GLuint texture, int width, int height, void *iosurface, int plane)
 
 # An extension here,
 cdef GLenum TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE
@@ -276,6 +282,8 @@ cdef class GLTexture(GL2Model):
         # represents.
         self.number = 0
 
+        self.target = GL_TEXTURE_2D
+
         # True if the texture has been loaded into OpenGL, False otherwise.
         self.loaded = False
 
@@ -348,6 +356,54 @@ cdef class GLTexture(GL2Model):
             )
 
         self.loader.texture_load_queue.add(self)
+
+    def from_videotoolbox(GLTexture self, frame, int plane):
+        """Imports one NV12 plane from a retained macOS VideoToolbox frame."""
+
+        cdef void *frame_ptr
+        cdef void *iosurface
+        cdef void *context
+        cdef int width
+        cdef int height
+        cdef int full_range
+        cdef int bt709
+        cdef GLuint number
+
+        if not PyCapsule_IsValid(frame, b"renpy.videoframe"):
+            return False
+
+        frame_ptr = PyCapsule_GetPointer(frame, b"renpy.videoframe")
+        if renpy_macos_video_frame_info(frame_ptr, &iosurface, &width, &height, &full_range, &bt709) != 0:
+            return False
+
+        if plane:
+            width = (width + 1) // 2
+            height = (height + 1) // 2
+
+        context = SDL_GL_GetCurrentContext()
+        if not context:
+            return False
+
+        glGenTextures(1, &number)
+        self.target = GL_TEXTURE_RECTANGLE_ARB
+        self.number = number
+
+        if renpy_macos_video_import_texture(context, number, width, height, iosurface, plane) != 0:
+            glDeleteTextures(1, &number)
+            self.number = 0
+            self.target = GL_TEXTURE_2D
+            return False
+
+        self.width = width
+        self.height = height
+        self.texture_width = width
+        self.texture_height = height
+        self.properties = {"mipmap": False, "movie_hardware": True}
+        self.surface = frame
+        self.mesh = Mesh2.texture_rectangle(0.0, 0.0, width, height, 0.0, 0.0, width, height)
+        self.loader.allocated.add(number)
+        self.loaded = True
+        return True
 
     def from_render(GLTexture self, what, properties, oversample=1.0):
         """
@@ -449,6 +505,9 @@ cdef class GLTexture(GL2Model):
         if self.loaded:
             return
 
+        movie_channel = self.properties.get("movie_channel")
+        movie_upload_start = time.perf_counter_ns() if movie_channel is not None else 0
+
         draw = self.loader.draw
 
         s = PySurface_AsSurface(self.surface)
@@ -523,6 +582,9 @@ cdef class GLTexture(GL2Model):
         self.loaded = True
         self.surface = None
 
+        if movie_channel is not None:
+            renpy.display.video.record_movie_upload(movie_channel, time.perf_counter_ns() - movie_upload_start)
+
     def load_gltexture_premultiplied(GLTexture self):
         """
         Loads this texture. When it's loaded, generation and number are set,
@@ -536,6 +598,9 @@ cdef class GLTexture(GL2Model):
 
         if self.loaded:
             return
+
+        movie_channel = self.properties.get("movie_channel")
+        movie_upload_start = time.perf_counter_ns() if movie_channel is not None else 0
 
         draw = self.loader.draw
 
@@ -580,6 +645,9 @@ cdef class GLTexture(GL2Model):
 
         self.loaded = True
         self.surface = None
+
+        if movie_channel is not None:
+            renpy.display.video.record_movie_upload(movie_channel, time.perf_counter_ns() - movie_upload_start)
 
     def allocate_texture(GLTexture self, GLuint tex, int tw, int th, properties={}):
         """
@@ -724,3 +792,51 @@ class Texture(GLTexture):
     """
 
     pass
+
+
+def load_videotoolbox_frame(frame, properties=None):
+    """Builds a GPU YUV model from a retained VideoToolbox frame capsule."""
+
+    if properties is None:
+        properties = {}
+
+    if not PyCapsule_IsValid(frame, b"renpy.videoframe"):
+        return None
+
+    cdef void *frame_ptr = PyCapsule_GetPointer(frame, b"renpy.videoframe")
+    cdef void *iosurface
+    cdef int width
+    cdef int height
+    cdef int full_range
+    cdef int bt709
+
+    if renpy_macos_video_frame_info(frame_ptr, &iosurface, &width, &height, &full_range, &bt709) != 0:
+        return None
+
+    draw = renpy.display.draw
+    loader = getattr(draw, "texture_loader", None)
+    if loader is None:
+        return None
+
+    y_texture = Texture((width, height), loader)
+    uv_texture = Texture(((width + 1) // 2, (height + 1) // 2), loader)
+
+    if not y_texture.from_videotoolbox(frame, 0):
+        return None
+
+    if not uv_texture.from_videotoolbox(frame, 1):
+        return None
+
+    mesh = Mesh2.texture_rectangle(0.0, 0.0, width, height, 0.0, 0.0, width, height)
+    model = GL2Model(
+        (width, height),
+        mesh,
+        ("renpy.movie_yuv",),
+        {
+            "u_movie_yuv_full_range": 1.0 if full_range else 0.0,
+            "u_movie_yuv_bt709": 1.0 if bt709 else 0.0,
+        },
+    )
+    model.set_texture(0, y_texture)
+    model.set_texture(1, uv_texture)
+    return model

--- a/renpy/gl2/gl2uniform.pyx
+++ b/renpy/gl2/gl2uniform.pyx
@@ -335,7 +335,7 @@ cdef class Sampler2DSetter(Setter):
         # GLTexture case.
         cdef GLTexture texture = value
 
-        glBindTexture(GL_TEXTURE_2D, texture.number)
+        glBindTexture(texture.target, texture.number)
 
         cdef GLint wrap_s = GL_CLAMP_TO_EDGE
         cdef GLint wrap_t = GL_CLAMP_TO_EDGE
@@ -360,23 +360,23 @@ cdef class Sampler2DSetter(Setter):
             anisotropy = 1.0
 
         if wrap_s != texture.wrap_s:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_s)
+            glTexParameteri(texture.target, GL_TEXTURE_WRAP_S, wrap_s)
             texture.wrap_s = wrap_s
 
         if wrap_t != texture.wrap_t:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_t)
+            glTexParameteri(texture.target, GL_TEXTURE_WRAP_T, wrap_t)
             texture.wrap_t = wrap_t
 
         if anisotropy != texture.anisotropy and texture.loader.max_anisotropy > 1.0:
-            glTexParameterf(GL_TEXTURE_2D, TEXTURE_MAX_ANISOTROPY_EXT, anisotropy)
+            glTexParameterf(texture.target, TEXTURE_MAX_ANISOTROPY_EXT, anisotropy)
             texture.anisotropy = anisotropy
 
         if mag_filter != texture.mag_filter:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, mag_filter)
+            glTexParameteri(texture.target, GL_TEXTURE_MAG_FILTER, mag_filter)
             texture.mag_filter = mag_filter
 
         if min_filter != texture.min_filter:
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, min_filter)
+            glTexParameteri(texture.target, GL_TEXTURE_MIN_FILTER, min_filter)
             texture.min_filter = min_filter
 
 
@@ -689,7 +689,10 @@ def generate_uniform_setter(shader_name: str, location: int, uniform_name: str, 
         getter = ContextGetter(uniform_name)
         require_type = None
 
-    if require_type is not None and uniform_type != require_type:
+    if require_type is not None and uniform_type != require_type and not (
+        base_name in ("tex0", "tex1", "tex2", "tex3") and
+        uniform_type in ("sampler2D", "sampler2DRect")
+    ):
         raise TypeError(
             f"Uniform {uniform_name} in shader {shader_name} has type {uniform_type}, "
             f"but requires type {require_type}."
@@ -718,7 +721,7 @@ def generate_uniform_setter(shader_name: str, location: int, uniform_name: str, 
             f"{operation}."
         )
 
-    if uniform_type == "sampler2D":
+    if uniform_type in ("sampler2D", "sampler2DRect"):
         setter = Sampler2DSetter(uniform_name, uniform_type, location, getter, sampler)
         sampler += 1
     elif (array is None) and (setter_class := NON_ARRAY_SETTERS.get(uniform_type, None)):

--- a/scripts/setuplib.py
+++ b/scripts/setuplib.py
@@ -85,6 +85,7 @@ class ExtensionData(TypedDict):
     sources: list[str]
     language: Literal["c", "c++"]
     extra_compile_args: list[str]
+    extra_link_args: list[str]
     define_macros: list[tuple[str, str | None]]
     packages: list[str]
     depends: list[str]
@@ -107,6 +108,7 @@ def cython(
     define_macros: list[tuple[str, str | None]] | None = None,
     packages: str = "",
     setup_filename: str = "Setup",
+    link_args: list[str] | None = None,
 ):
     """
     Compiles a cython module. This takes care of regenerating it as necessary
@@ -139,6 +141,7 @@ def cython(
         sources=[c_fn] + (source or []),
         language=language,
         extra_compile_args=list(compile_args or []),
+        extra_link_args=list(link_args or []),
         define_macros=list(define_macros or []),
         packages=packages.split(),
         depends=[],
@@ -296,6 +299,7 @@ def setup(name, version):
 
         link_args: list[str] = []
         link_args += package_kwargs["extra_link_args"]
+        link_args += data["extra_link_args"]
         link_args += extra_link_args
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,9 @@ def main():
     setuplib.extra_compile_args = ["-Wno-unused-function"]
     setuplib.extra_link_args = []
 
+    macos_video_link_args = []
     if sys.platform == "darwin":
-        setuplib.extra_link_args += [
+        macos_video_link_args = [
             "-framework", "CoreVideo",
             "-framework", "IOSurface",
             "-framework", "OpenGL",
@@ -104,6 +105,7 @@ def main():
     cython(
         "renpy.audio.renpysound",
         ["src/renpysound_core.c", "src/ffmedia.c", "src/renpy_macos_video.c"],
+        link_args=macos_video_link_args,
         compile_args=["-Wno-deprecated-declarations"]
         if ("RENPY_FFMPEG_NO_DEPRECATED_DECLARATIONS" in os.environ)
         else [],

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,13 @@ def main():
     setuplib.extra_compile_args = ["-Wno-unused-function"]
     setuplib.extra_link_args = []
 
+    if sys.platform == "darwin":
+        setuplib.extra_link_args += [
+            "-framework", "CoreVideo",
+            "-framework", "IOSurface",
+            "-framework", "OpenGL",
+        ]
+
     cubism = os.environ.get("CUBISM", None)
     if cubism:
         setuplib.include_dirs.append(f"{cubism}/Core/include")
@@ -96,7 +103,7 @@ def main():
     # renpy.audio
     cython(
         "renpy.audio.renpysound",
-        ["src/renpysound_core.c", "src/ffmedia.c"],
+        ["src/renpysound_core.c", "src/ffmedia.c", "src/renpy_macos_video.c"],
         compile_args=["-Wno-deprecated-declarations"]
         if ("RENPY_FFMPEG_NO_DEPRECATED_DECLARATIONS" in os.environ)
         else [],

--- a/src/ffmedia.c
+++ b/src/ffmedia.c
@@ -3,12 +3,17 @@
 #include <libswresample/swresample.h>
 #include <libavutil/time.h>
 #include <libavutil/pixfmt.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/hwcontext.h>
 #include <libswscale/swscale.h>
+
+#include "ffmedia.h"
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_thread.h>
 
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef _WIN32
 #define USE_POSIX_MEMALIGN
@@ -144,6 +149,9 @@ typedef struct FrameQueue {
 typedef struct SurfaceQueueEntry {
 	struct SurfaceQueueEntry *next;
 
+	/* A VideoToolbox frame that can be imported by the renderer. */
+	AVFrame *hw_frame;
+
 	SDL_Surface *surf;
 
 	/* The pts, converted to seconds. */
@@ -160,7 +168,7 @@ typedef struct SurfaceQueueEntry {
 
 } SurfaceQueueEntry;
 
-typedef struct MediaState {
+struct MediaState {
 
     /* The next entry in a list of MediaStates */
     struct MediaState *next;
@@ -249,6 +257,14 @@ typedef struct MediaState {
 
 	/* A frame that video is decoded into. */
 	AVFrame *video_decode_frame;
+	AVBufferRef *video_hw_device_ctx;
+	int video_hardware_decode;
+	int video_hardware_surface;
+	int video_hardware_attempted;
+	int video_hardware_available;
+	int video_software_fallback_requested; // Lock.
+	const char *video_hardware_status;
+	enum AVPixelFormat video_transfer_format; // Lock.
 
 	/* Video Stuff ***********************************************************/
 
@@ -268,17 +284,52 @@ typedef struct MediaState {
 	/* Are frame drops allowed? */
 	int frame_drops;
 
+	/* Video diagnostics. These counters are protected by lock when read. */
+	uint64_t video_decoded_frames;
+	uint64_t video_converted_frames;
+	uint64_t video_submitted_frames;
+	uint64_t video_dropped_frames;
+	uint64_t video_decode_time_ns;
+	uint64_t video_hardware_transfer_frames;
+	uint64_t video_hardware_transfer_time_ns;
+	uint64_t video_hardware_transfer_failures;
+	uint64_t video_color_convert_time_ns;
+	uint64_t video_present_lateness_ns;
+	uint64_t video_present_lateness_max_ns;
+	double video_last_pts;
+
 	/* The time the pause happened, or 0 if we're not paused. */
 	double pause_time;
 
 	/* The offset between now and the time of the current frame, at least for video. */
 	double time_offset;
 
-} MediaState;
+};
 
 static AVFrame *dequeue_frame(FrameQueue *fq);
 static void free_packet_queue(PacketQueue *pq);
 static SurfaceQueueEntry *dequeue_surface(SurfaceQueueEntry **queue);
+
+
+static void free_surface_entry(SurfaceQueueEntry *sqe) {
+	if (!sqe) {
+		return;
+	}
+
+	if (sqe->hw_frame) {
+		av_frame_free(&sqe->hw_frame);
+	}
+
+	if (sqe->pixels) {
+#ifndef USE_POSIX_MEMALIGN
+		SDL_free(sqe->pixels);
+#else
+		free(sqe->pixels);
+#endif
+	}
+
+	av_free(sqe);
+}
 
 
 /* A queue of MediaState objects that are awaiting deallocation.*/
@@ -297,14 +348,7 @@ static void deallocate(MediaState *ms) {
 			break;
 		}
 
-		if (sqe->pixels) {
-#ifndef USE_POSIX_MEMALIGN
-			SDL_free(sqe->pixels);
-#else
-			free(sqe->pixels);
-#endif
-		}
-		av_free(sqe);
+		free_surface_entry(sqe);
 	}
 
 	if (ms->sws) {
@@ -344,6 +388,9 @@ static void deallocate(MediaState *ms) {
 
 	if (ms->video_context) {
 		avcodec_free_context(&ms->video_context);
+	}
+	if (ms->video_hw_device_ctx) {
+		av_buffer_unref(&ms->video_hw_device_ctx);
 	}
 	if (ms->audio_context) {
 		avcodec_free_context(&ms->audio_context);
@@ -559,6 +606,18 @@ static SurfaceQueueEntry *dequeue_surface(SurfaceQueueEntry **queue) {
 }
 
 
+static void clear_surface_queue(MediaState *ms) {
+	SurfaceQueueEntry *sqe;
+
+	while ((sqe = dequeue_surface(&ms->surface_queue)) != NULL) {
+		free_surface_entry(sqe);
+		ms->surface_queue_size -= 1;
+	}
+
+	ms->surface_queue_size = 0;
+}
+
+
 #if 0
 static void check_surface_queue(MediaState *ms) {
 
@@ -581,7 +640,53 @@ static void check_surface_queue(MediaState *ms) {
 /* Find decoder context ******************************************************/
 
 
-static AVCodecContext *find_context(AVFormatContext *ctx, int index) {
+static int codec_supports_videotoolbox(const AVCodec *codec) {
+#if defined(__APPLE__)
+	for (int i = 0;; i++) {
+		const AVCodecHWConfig *config = avcodec_get_hw_config(codec, i);
+		if (config == NULL) {
+			break;
+		}
+
+		if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+			config->device_type == AV_HWDEVICE_TYPE_VIDEOTOOLBOX &&
+			config->pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX) {
+			return 1;
+		}
+	}
+#endif
+
+	return 0;
+}
+
+
+static enum AVPixelFormat get_video_format(AVCodecContext *codec_ctx, const enum AVPixelFormat *formats) {
+	MediaState *ms = (MediaState *) codec_ctx->opaque;
+
+	for (const enum AVPixelFormat *format = formats; *format != AV_PIX_FMT_NONE; format++) {
+		if (*format == AV_PIX_FMT_VIDEOTOOLBOX) {
+			if (ms) {
+				ms->video_hardware_decode = 1;
+				ms->video_hardware_surface = 1;
+				ms->video_hardware_status = "active";
+			}
+			return *format;
+		}
+	}
+
+	if (ms) {
+		ms->video_hardware_decode = 0;
+		ms->video_hardware_surface = 0;
+		if (ms->video_hardware_attempted) {
+			ms->video_hardware_status = "software-fallback";
+		}
+	}
+
+	return formats[0];
+}
+
+
+static AVCodecContext *find_context(MediaState *ms, AVFormatContext *ctx, int index, int is_video, int force_software) {
 
     AVDictionary *opts = NULL;
 
@@ -589,43 +694,68 @@ static AVCodecContext *find_context(AVFormatContext *ctx, int index) {
 		return NULL;
 	}
 
-	const AVCodec *codec = NULL;
+	const AVCodec *codec = avcodec_find_decoder(ctx->streams[index]->codecpar->codec_id);
 	AVCodecContext *codec_ctx = NULL;
-
-	codec_ctx = avcodec_alloc_context3(NULL);
-
-	if (codec_ctx == NULL) {
+	if (codec == NULL) {
 		return NULL;
 	}
 
-	if (avcodec_parameters_to_context(codec_ctx, ctx->streams[index]->codecpar) < 0) {
-		goto fail;
+	for (int attempt = 0; attempt < 2; attempt++) {
+		int use_videotoolbox = is_video && !force_software && attempt == 0 && codec_supports_videotoolbox(codec);
+		int opened_with_hardware = 0;
+
+		codec_ctx = avcodec_alloc_context3(NULL);
+		if (codec_ctx == NULL) {
+			return NULL;
+		}
+
+		if (avcodec_parameters_to_context(codec_ctx, ctx->streams[index]->codecpar) < 0) {
+			avcodec_free_context(&codec_ctx);
+			return NULL;
+		}
+
+		codec_ctx->pkt_timebase = ctx->streams[index]->time_base;
+
+		if (use_videotoolbox) {
+			ms->video_hardware_attempted = 1;
+			if (!ms->video_hardware_status) {
+				ms->video_hardware_status = "initializing";
+			}
+
+			if (av_hwdevice_ctx_create(&ms->video_hw_device_ctx,
+				AV_HWDEVICE_TYPE_VIDEOTOOLBOX, NULL, NULL, 0) >= 0) {
+				ms->video_hardware_available = 1;
+				codec_ctx->hw_device_ctx = av_buffer_ref(ms->video_hw_device_ctx);
+				codec_ctx->opaque = ms;
+				codec_ctx->get_format = get_video_format;
+				opened_with_hardware = codec_ctx->hw_device_ctx != NULL;
+			} else {
+				ms->video_hardware_status = "unavailable";
+			}
+		}
+
+		codec_ctx->codec_id = codec->id;
+		av_dict_set(&opts, "threads", "auto", 0);
+		av_dict_set(&opts, "refcounted_frames", "0", 0);
+
+		if (avcodec_open2(codec_ctx, codec, &opts) == 0) {
+			av_dict_free(&opts);
+			return codec_ctx;
+		}
+
+		av_dict_free(&opts);
+		avcodec_free_context(&codec_ctx);
+
+		if (!opened_with_hardware) {
+			break;
+		}
+
+		ms->video_hardware_decode = 0;
+		ms->video_hardware_surface = 0;
+		ms->video_hardware_status = "software-fallback";
+		force_software = 1;
 	}
 
-	codec_ctx->pkt_timebase = ctx->streams[index]->time_base;
-
-    codec = avcodec_find_decoder(codec_ctx->codec_id);
-
-    if (codec == NULL) {
-        goto fail;
-    }
-
-    codec_ctx->codec_id = codec->id;
-
-    av_dict_set(&opts, "threads", "auto", 0);
-    av_dict_set(&opts, "refcounted_frames", "0", 0);
-
-	if (avcodec_open2(codec_ctx, codec, &opts)) {
-		goto fail;
-	}
-
-	return codec_ctx;
-
-fail:
-
-    av_dict_free(&opts);
-
-	avcodec_free_context(&codec_ctx);
 	return NULL;
 }
 
@@ -803,10 +933,181 @@ static enum AVPixelFormat get_pixel_format(SDL_Surface *surf) {
 }
 
 
+static void video_record_decode(MediaState *ms, Uint64 elapsed_ns) {
+#ifndef __EMSCRIPTEN__
+	SDL_LockMutex(ms->lock);
+#endif
+	ms->video_decoded_frames += 1;
+	ms->video_decode_time_ns += elapsed_ns;
+#ifndef __EMSCRIPTEN__
+	SDL_UnlockMutex(ms->lock);
+#endif
+}
+
+
+static void video_record_drop(MediaState *ms) {
+#ifndef __EMSCRIPTEN__
+	SDL_LockMutex(ms->lock);
+#endif
+	ms->video_dropped_frames += 1;
+#ifndef __EMSCRIPTEN__
+	SDL_UnlockMutex(ms->lock);
+#endif
+}
+
+
+static void video_record_conversion(MediaState *ms, Uint64 elapsed_ns, double pts) {
+#ifndef __EMSCRIPTEN__
+	SDL_LockMutex(ms->lock);
+#endif
+	ms->video_converted_frames += 1;
+	ms->video_color_convert_time_ns += elapsed_ns;
+	ms->video_last_pts = pts;
+#ifndef __EMSCRIPTEN__
+	SDL_UnlockMutex(ms->lock);
+#endif
+}
+
+
+static void video_record_hardware_transfer(MediaState *ms, Uint64 elapsed_ns, int failed) {
+#ifndef __EMSCRIPTEN__
+	SDL_LockMutex(ms->lock);
+#endif
+	ms->video_hardware_transfer_time_ns += elapsed_ns;
+	if (failed) {
+		ms->video_hardware_transfer_failures += 1;
+	} else {
+		ms->video_hardware_transfer_frames += 1;
+	}
+#ifndef __EMSCRIPTEN__
+	SDL_UnlockMutex(ms->lock);
+#endif
+}
+
+
+static int video_fallback_to_software(MediaState *ms) {
+	AVCodecContext *software_context = find_context(ms, ms->ctx, ms->video_stream, 1, 1);
+	if (!software_context) {
+		return -1;
+	}
+
+	avcodec_free_context(&ms->video_context);
+	ms->video_context = software_context;
+	ms->video_hardware_decode = 0;
+	ms->video_hardware_surface = 0;
+	ms->video_hardware_status = "software-fallback";
+
+	if (ms->sws) {
+		sws_freeContext(ms->sws);
+		ms->sws = NULL;
+	}
+
+	if (ms->video_decode_frame) {
+		av_frame_unref(ms->video_decode_frame);
+	}
+
+	return 0;
+}
+
+
+static SurfaceQueueEntry *convert_video_frame(MediaState *ms, AVFrame *source_frame, double pts) {
+	SDL_Surface *sample = rgba_surface;
+
+	if (ms->sws == NULL) {
+		ms->sws = sws_getContext(
+			source_frame->width,
+			source_frame->height,
+			source_frame->format,
+
+			source_frame->width,
+			source_frame->height,
+			get_pixel_format(sample),
+
+			SWS_POINT | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT,
+
+			NULL,
+			NULL,
+			NULL
+			);
+
+
+		if (!ms->sws) {
+			ms->video_finished = 1;
+			return NULL;
+		}
+
+		int colorspace = source_frame->colorspace;
+		if (colorspace == AVCOL_SPC_UNSPECIFIED) {
+			colorspace = SWS_CS_DEFAULT;
+		}
+
+		int src_range = (source_frame->color_range == AVCOL_RANGE_JPEG) ? 1 : 0;
+
+		sws_setColorspaceDetails(ms->sws,
+			sws_getCoefficients(colorspace), src_range,
+			sws_getCoefficients(SWS_CS_DEFAULT), 0,
+			0, 1 << 16, 1 << 16);
+	}
+
+	SurfaceQueueEntry *rv = av_malloc(sizeof(SurfaceQueueEntry));
+	if (rv == NULL) {
+		ms->video_finished = 1;
+		return NULL;
+	}
+
+	memset(rv, 0, sizeof(*rv));
+	rv->w = source_frame->width + FRAME_PADDING * 2;
+	rv->h = source_frame->height + FRAME_PADDING * 2;
+
+	const SDL_PixelFormatDetails *sample_fmt = SDL_GetPixelFormatDetails(sample->format);
+
+	rv->pitch = rv->w * sample_fmt->bytes_per_pixel;
+
+	if (rv->pitch % ROW_ALIGNMENT) {
+		rv->pitch += ROW_ALIGNMENT - (rv->pitch % ROW_ALIGNMENT);
+	}
+
+#ifndef USE_POSIX_MEMALIGN
+	rv->pixels = SDL_calloc(rv->pitch * rv->h, 1);
+#else
+	if (posix_memalign(&rv->pixels, ROW_ALIGNMENT, rv->pitch * rv->h)) {
+		av_free(rv);
+		return NULL;
+	}
+	memset(rv->pixels, 0, rv->pitch * rv->h);
+#endif
+
+	rv->format = sample->format;
+	rv->next = NULL;
+	rv->pts = pts;
+
+	uint8_t *surf_pixels = (uint8_t *) rv->pixels;
+	uint8_t *surf_data[] = { &surf_pixels[FRAME_PADDING * rv->pitch + FRAME_PADDING * sample_fmt->bytes_per_pixel] };
+	int surf_linesize[] = { rv->pitch };
+
+	Uint64 color_convert_start = SDL_GetTicksNS();
+
+	sws_scale(
+		ms->sws,
+		(const uint8_t * const *) source_frame->data,
+		source_frame->linesize,
+		0,
+		source_frame->height,
+		surf_data,
+		surf_linesize
+		);
+
+	video_record_conversion(ms, SDL_GetTicksNS() - color_convert_start, pts);
+
+	return rv;
+}
+
+
 static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 	int ret;
 
 	while (1) {
+		Uint64 decode_start = SDL_GetTicksNS();
 
 		AVPacket *pkt = read_packet(ms, &ms->video_packet_queue);
 		ret = avcodec_send_packet(ms->video_context, pkt);
@@ -833,12 +1134,16 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 			return NULL;
 		}
 
+		video_record_decode(ms, SDL_GetTicksNS() - decode_start);
+
 		break;
 	}
 
+	AVFrame *source_frame = ms->video_decode_frame;
 	double pts = ms->video_decode_frame->best_effort_timestamp * av_q2d(ms->ctx->streams[ms->video_stream]->time_base);
 
 	if (pts < ms->skip) {
+		video_record_drop(ms);
 		return NULL;
 	}
 
@@ -852,100 +1157,39 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 		}
 
 		if (ms->frame_drops) {
+			video_record_drop(ms);
 		    return NULL;
 		}
 	}
 
-	SDL_Surface *sample = rgba_surface;
-
-	if (ms->sws == NULL) {
-		ms->sws = sws_getContext(
-			ms->video_decode_frame->width,
-			ms->video_decode_frame->height,
-			ms->video_decode_frame->format,
-
-			ms->video_decode_frame->width,
-			ms->video_decode_frame->height,
-			get_pixel_format(sample),
-
-			SWS_POINT | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT,
-
-			NULL,
-			NULL,
-			NULL
-			);
-
-
-		if (!ms->sws) {
+	if (source_frame->format == AV_PIX_FMT_VIDEOTOOLBOX) {
+		SurfaceQueueEntry *rv = av_mallocz(sizeof(SurfaceQueueEntry));
+		if (!rv) {
 			ms->video_finished = 1;
 			return NULL;
 		}
 
-		int colorspace = ms->video_decode_frame->colorspace;
-		if (colorspace == AVCOL_SPC_UNSPECIFIED) {
-			colorspace = SWS_CS_DEFAULT;
+		rv->hw_frame = av_frame_alloc();
+		if (!rv->hw_frame || av_frame_ref(rv->hw_frame, source_frame) < 0) {
+			free_surface_entry(rv);
+			ms->video_finished = 1;
+			return NULL;
 		}
 
-		int src_range = (ms->video_decode_frame->color_range == AVCOL_RANGE_JPEG) ? 1 : 0;
-
-		sws_setColorspaceDetails(ms->sws,
-			sws_getCoefficients(colorspace), src_range,
-			sws_getCoefficients(SWS_CS_DEFAULT), 0,
-			0, 1 << 16, 1 << 16);
+		rv->pts = pts;
+		rv->w = source_frame->width;
+		rv->h = source_frame->height;
+		return rv;
 	}
 
-	SurfaceQueueEntry *rv = av_malloc(sizeof(SurfaceQueueEntry));
-	if (rv == NULL) {
-		ms->video_finished = 1;
-		return NULL;
-	}
-	rv->w = ms->video_decode_frame->width + FRAME_PADDING * 2;
-	rv->h = ms->video_decode_frame->height + FRAME_PADDING * 2;
-
-	const SDL_PixelFormatDetails *sample_fmt = SDL_GetPixelFormatDetails(sample->format);
-
-	rv->pitch = rv->w * sample_fmt->bytes_per_pixel;
-
-	if (rv->pitch % ROW_ALIGNMENT) {
-	    rv->pitch += ROW_ALIGNMENT - (rv->pitch % ROW_ALIGNMENT);
-	}
-
-#ifndef USE_POSIX_MEMALIGN
-    rv->pixels = SDL_calloc(rv->pitch * rv->h, 1);
-#else
-	if (posix_memalign(&rv->pixels, ROW_ALIGNMENT, rv->pitch * rv->h)) {
-		av_free(rv);
-		return NULL;
-	}
-    memset(rv->pixels, 0, rv->pitch * rv->h);
-#endif
-
-	rv->format = sample->format;
-	rv->next = NULL;
-	rv->pts = pts;
-
-	uint8_t *surf_pixels = (uint8_t *) rv->pixels;
-	uint8_t *surf_data[] = { &surf_pixels[FRAME_PADDING * rv->pitch + FRAME_PADDING * sample_fmt->bytes_per_pixel] };
-	int surf_linesize[] = { rv->pitch };
-
-	sws_scale(
-		ms->sws,
-
-		(const uint8_t * const *) ms->video_decode_frame->data,
-		ms->video_decode_frame->linesize,
-
-		0,
-		ms->video_decode_frame->height,
-
-		surf_data,
-		surf_linesize
-		);
-
-	return rv;
+	return convert_video_frame(ms, source_frame, pts);
 }
 
 
 static void decode_video(MediaState *ms) {
+	int fallback_requested;
+	int fallback_result;
+
 	if (!ms->video_context) {
 		ms->video_finished = 1;
 		return;
@@ -961,7 +1205,29 @@ static void decode_video(MediaState *ms) {
 	}
 
 	SDL_LockMutex(ms->lock);
+	fallback_requested = ms->video_software_fallback_requested;
+	ms->video_software_fallback_requested = 0;
+	SDL_UnlockMutex(ms->lock);
 
+	if (fallback_requested) {
+		fallback_result = video_fallback_to_software(ms);
+
+		SDL_LockMutex(ms->lock);
+		if (fallback_result < 0) {
+			ms->video_hardware_status = "software-fallback-failed";
+			ms->video_finished = 1;
+			SDL_UnlockMutex(ms->lock);
+			return;
+		}
+
+		/* Hardware frames queued before the transfer failure cannot be
+		 * consumed by the software decoder path. */
+		clear_surface_queue(ms);
+		SDL_UnlockMutex(ms->lock);
+		return;
+	}
+
+	SDL_LockMutex(ms->lock);
 	if (!ms->video_finished && (ms->surface_queue_size < FRAMES)) {
 
 		SDL_UnlockMutex(ms->lock);
@@ -1024,18 +1290,12 @@ int media_video_ready(struct MediaState *ms) {
 				break;
 			}
 
-			/* Otherwise, drop it without display. */
-			SurfaceQueueEntry *sqe = dequeue_surface(&ms->surface_queue);
-			ms->surface_queue_size -= 1;
+				/* Otherwise, drop it without display. */
+				SurfaceQueueEntry *sqe = dequeue_surface(&ms->surface_queue);
+				ms->surface_queue_size -= 1;
+				ms->video_dropped_frames += 1;
 
-			if (sqe->pixels) {
-#ifndef USE_POSIX_MEMALIGN
-				SDL_free(sqe->pixels);
-#else
-				free(sqe->pixels);
-#endif
-			}
-			av_free(sqe);
+			free_surface_entry(sqe);
 
 			consumed = 1;
 		}
@@ -1070,9 +1330,7 @@ done:
 }
 
 
-SDL_Surface *media_read_video(MediaState *ms) {
-
-	SDL_Surface *rv = NULL;
+static SurfaceQueueEntry *media_read_video_entry(MediaState *ms, int hardware_only) {
 	SurfaceQueueEntry *sqe = NULL;
 
 	if (ms->video_stream == -1) {
@@ -1089,11 +1347,7 @@ SDL_Surface *media_read_video(MediaState *ms) {
 	}
 #endif
 
-	if (ms->pause_time > 0) {
-	    goto done;
-	}
-
-	if (!ms->surface_queue_size) {
+	if (ms->pause_time > 0 || !ms->surface_queue_size) {
 		goto done;
 	}
 
@@ -1101,38 +1355,190 @@ SDL_Surface *media_read_video(MediaState *ms) {
 		ms->video_pts_offset = offset_time - ms->surface_queue->pts;
 	}
 
-	if (ms->surface_queue->pts + ms->video_pts_offset <= offset_time + frame_early_delivery) {
+	if (ms->surface_queue->pts + ms->video_pts_offset <= offset_time + frame_early_delivery &&
+		(!hardware_only || ms->surface_queue->hw_frame)) {
 		sqe = dequeue_surface(&ms->surface_queue);
 		ms->surface_queue_size -= 1;
-
 	}
 
 done:
-
-    /* Only signal if we've consumed something. */
 	if (sqe) {
 		ms->needs_decode = 1;
 		ms->video_read_time = offset_time;
+		ms->video_submitted_frames += 1;
+
+		double lateness = offset_time - (sqe->pts + ms->video_pts_offset);
+		if (lateness > 0.0) {
+			uint64_t lateness_ns = (uint64_t) (lateness * 1000000000.0);
+			ms->video_present_lateness_ns += lateness_ns;
+			if (lateness_ns > ms->video_present_lateness_max_ns) {
+				ms->video_present_lateness_max_ns = lateness_ns;
+			}
+		}
+
 		SDL_BroadcastCondition(ms->cond);
 	}
 
 	SDL_UnlockMutex(ms->lock);
+	return sqe;
+}
 
-	if (sqe) {
-		rv = SDL_CreateSurfaceFrom(
-			sqe->w,
-			sqe->h,
-			sqe->format,
-			sqe->pixels,
-			sqe->pitch
-		);
 
-		/* Force SDL to take over management of pixels. */
-		rv->flags &= ~SDL_SURFACE_PREALLOCATED;
-		av_free(sqe);
+void *media_read_video_hardware(MediaState *ms) {
+	SurfaceQueueEntry *sqe = media_read_video_entry(ms, 1);
+	AVFrame *frame;
+
+	if (!sqe) {
+		return NULL;
 	}
 
+	frame = sqe->hw_frame;
+	sqe->hw_frame = NULL;
+	free_surface_entry(sqe);
+	return frame;
+}
+
+
+void media_video_frame_free(void *frame) {
+	AVFrame *av_frame = (AVFrame *) frame;
+	if (av_frame) {
+		av_frame_free(&av_frame);
+	}
+}
+
+
+SDL_Surface *media_read_video(MediaState *ms) {
+	SurfaceQueueEntry *sqe = media_read_video_entry(ms, 0);
+	SurfaceQueueEntry *converted = NULL;
+
+	if (!sqe) {
+		return NULL;
+	}
+
+	if (sqe->hw_frame) {
+		AVFrame *transfer_frame = av_frame_alloc();
+		Uint64 transfer_start = SDL_GetTicksNS();
+		int ret = transfer_frame ? av_hwframe_transfer_data(transfer_frame, sqe->hw_frame, 0) : AVERROR(ENOMEM);
+		Uint64 transfer_time = SDL_GetTicksNS() - transfer_start;
+
+		if (ret < 0) {
+			video_record_hardware_transfer(ms, transfer_time, 1);
+			SDL_LockMutex(ms->lock);
+			ms->video_software_fallback_requested = 1;
+			ms->needs_decode = 1;
+			SDL_BroadcastCondition(ms->cond);
+			SDL_UnlockMutex(ms->lock);
+			av_frame_free(&transfer_frame);
+			free_surface_entry(sqe);
+			return NULL;
+		}
+
+		video_record_hardware_transfer(ms, transfer_time, 0);
+		SDL_LockMutex(ms->lock);
+		ms->video_transfer_format = transfer_frame->format;
+		SDL_UnlockMutex(ms->lock);
+		converted = convert_video_frame(ms, transfer_frame, sqe->pts);
+		av_frame_free(&transfer_frame);
+		free_surface_entry(sqe);
+		sqe = converted;
+	}
+
+	if (!sqe || !sqe->pixels) {
+		free_surface_entry(sqe);
+		return NULL;
+	}
+
+	SDL_Surface *rv = SDL_CreateSurfaceFrom(
+		sqe->w,
+		sqe->h,
+		sqe->format,
+		sqe->pixels,
+		sqe->pitch
+		);
+
+	if (!rv) {
+		free_surface_entry(sqe);
+		return NULL;
+	}
+
+	/* Force SDL to take over management of pixels. */
+	rv->flags &= ~SDL_SURFACE_PREALLOCATED;
+	av_free(sqe);
 	return rv;
+}
+
+
+void media_video_stats(MediaState *ms, RPSVideoStats *stats) {
+	memset(stats, 0, sizeof(*stats));
+	stats->state = "stopped";
+	stats->decoder_backend = "unknown";
+	stats->decoder_name = "unknown";
+	stats->codec_name = "unknown";
+	stats->input_pixel_format = "unknown";
+	stats->surface_backend = "unknown";
+	stats->output_pixel_format = "unknown";
+	stats->transfer_pixel_format = "unknown";
+	stats->hardware_status = "disabled";
+
+	if (!ms) {
+		return;
+	}
+
+	#ifndef __EMSCRIPTEN__
+	SDL_LockMutex(ms->lock);
+	#endif
+
+	stats->state = ms->ready ? "ready" : "initializing";
+	stats->decoder_backend = ms->video_hardware_decode ? "ffmpeg-videotoolbox" : "ffmpeg-software";
+	stats->surface_backend = ms->video_hardware_decode ? "videotoolbox-surface" : "cpu-surface";
+	stats->hardware_status = ms->video_hardware_status ? ms->video_hardware_status : "software-only";
+	stats->hardware_decode = ms->video_hardware_decode;
+	stats->hardware_surface = ms->video_hardware_surface;
+	stats->hardware_attempted = ms->video_hardware_attempted;
+	stats->hardware_available = ms->video_hardware_available;
+	stats->queue_depth = ms->surface_queue_size;
+	stats->decoded_frames = ms->video_decoded_frames;
+	stats->converted_frames = ms->video_converted_frames;
+	stats->submitted_frames = ms->video_submitted_frames;
+	stats->dropped_frames = ms->video_dropped_frames;
+	stats->decode_time_ns = ms->video_decode_time_ns;
+	stats->hardware_transfer_frames = ms->video_hardware_transfer_frames;
+	stats->hardware_transfer_time_ns = ms->video_hardware_transfer_time_ns;
+	stats->hardware_transfer_failures = ms->video_hardware_transfer_failures;
+	stats->color_convert_time_ns = ms->video_color_convert_time_ns;
+	stats->present_lateness_ns = ms->video_present_lateness_ns;
+	stats->present_lateness_max_ns = ms->video_present_lateness_max_ns;
+	stats->last_pts = ms->video_last_pts;
+
+	if (ms->video_context) {
+		stats->decoder_name = avcodec_get_name(ms->video_context->codec_id);
+		stats->codec_name = avcodec_get_name(ms->video_context->codec_id);
+		stats->width = ms->video_context->width;
+		stats->height = ms->video_context->height;
+		stats->input_pixel_format = av_get_pix_fmt_name(ms->video_context->pix_fmt);
+	}
+
+	if (ms->video_decode_frame) {
+		const char *pixel_format = av_get_pix_fmt_name(ms->video_decode_frame->format);
+		if (pixel_format) {
+			stats->input_pixel_format = pixel_format;
+		}
+	}
+
+	if (ms->video_transfer_format != AV_PIX_FMT_NONE) {
+		const char *pixel_format = av_get_pix_fmt_name(ms->video_transfer_format);
+		if (pixel_format) {
+			stats->transfer_pixel_format = pixel_format;
+		}
+	}
+
+	if (rgba_surface) {
+		stats->output_pixel_format = ms->video_hardware_surface ? "gpu-nv12" : SDL_GetPixelFormatName(rgba_surface->format);
+	}
+
+	#ifndef __EMSCRIPTEN__
+	SDL_UnlockMutex(ms->lock);
+	#endif
 }
 
 
@@ -1183,8 +1589,8 @@ static int decode_thread(void *arg) {
 		}
 	}
 
-	ms->video_context = find_context(ctx, ms->video_stream);
-	ms->audio_context = find_context(ctx, ms->audio_stream);
+	ms->video_context = find_context(ms, ctx, ms->video_stream, 1, 0);
+	ms->audio_context = find_context(ms, ctx, ms->audio_stream, 0, 1);
 
 	ms->swr = swr_alloc();
 	if (ms->swr == NULL) {
@@ -1347,8 +1753,8 @@ static int decode_sync_start(void *arg) {
 		}
 	}
 
-	ms->video_context = find_context(ctx, ms->video_stream);
-	ms->audio_context = find_context(ctx, ms->audio_stream);
+	ms->video_context = find_context(ms, ctx, ms->video_stream, 1, 0);
+	ms->audio_context = find_context(ms, ctx, ms->audio_stream, 0, 1);
 
 	ms->swr = swr_alloc();
 	if (ms->swr == NULL) {
@@ -1567,6 +1973,7 @@ MediaState *media_open(SDL_IOStream *rwops, const char *filename) {
 
 	ms->audio_duration = -1;
 	ms->frame_drops = 1;
+	ms->video_transfer_format = AV_PIX_FMT_NONE;
 
 	return ms;
 }

--- a/src/ffmedia.h
+++ b/src/ffmedia.h
@@ -1,0 +1,50 @@
+/*
+ * Shared declarations for Ren'Py's FFmpeg media backend.
+ */
+
+#ifndef RENPY_FFMEDIA_H
+#define RENPY_FFMEDIA_H
+
+#include <stdint.h>
+
+typedef struct MediaState MediaState;
+
+typedef struct RPSVideoStats {
+    const char *state;
+    const char *decoder_backend;
+    const char *decoder_name;
+    const char *codec_name;
+    const char *input_pixel_format;
+    const char *surface_backend;
+    const char *output_pixel_format;
+    const char *transfer_pixel_format;
+    const char *hardware_status;
+    int hardware_decode;
+    int hardware_surface;
+    int hardware_attempted;
+    int hardware_available;
+    int width;
+    int height;
+    int queue_depth;
+    uint64_t decoded_frames;
+    uint64_t converted_frames;
+    uint64_t submitted_frames;
+    uint64_t dropped_frames;
+    uint64_t decode_time_ns;
+    uint64_t hardware_transfer_frames;
+    uint64_t hardware_transfer_time_ns;
+    uint64_t hardware_transfer_failures;
+    uint64_t color_convert_time_ns;
+    uint64_t present_lateness_ns;
+    uint64_t present_lateness_max_ns;
+    double last_pts;
+} RPSVideoStats;
+
+void media_video_stats(MediaState *ms, RPSVideoStats *stats);
+
+/* Returns a retained AVFrame-backed hardware surface, or NULL when the next
+ * frame is not a VideoToolbox surface. The caller owns the returned frame. */
+void *media_read_video_hardware(MediaState *ms);
+void media_video_frame_free(void *frame);
+
+#endif

--- a/src/renpy_macos_video.c
+++ b/src/renpy_macos_video.c
@@ -1,0 +1,126 @@
+#include "renpy_macos_video.h"
+
+#ifdef __APPLE__
+
+#include <CoreVideo/CoreVideo.h>
+#include <OpenGL/CGLCurrent.h>
+#include <OpenGL/CGLIOSurface.h>
+#include <OpenGL/gl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <libavutil/frame.h>
+#include <libavutil/pixfmt.h>
+
+static void renpy_video_debug(const char *format, ...) {
+    va_list args;
+    FILE *file;
+
+    if (!getenv("RENPY_DEBUG_VIDEO")) {
+        return;
+    }
+
+    file = fopen("/tmp/renpy-video-import.log", "a");
+    if (!file) {
+        return;
+    }
+
+    va_start(args, format);
+    vfprintf(file, format, args);
+    va_end(args);
+    fclose(file);
+}
+
+int renpy_macos_video_frame_info(void *frame_ptr, void **iosurface, int *width, int *height, int *full_range, int *bt709) {
+	AVFrame *frame = (AVFrame *) frame_ptr;
+	CVPixelBufferRef pixel_buffer;
+	IOSurfaceRef surface;
+	OSType pixel_format;
+
+    if (!frame || frame->format != AV_PIX_FMT_VIDEOTOOLBOX || !frame->data[3]) {
+        renpy_video_debug("frame info invalid\\n");
+        return -1;
+    }
+
+    pixel_buffer = (CVPixelBufferRef) frame->data[3];
+    surface = CVPixelBufferGetIOSurface(pixel_buffer);
+    if (!surface) {
+        renpy_video_debug("frame has no IOSurface\\n");
+        return -2;
+    }
+
+	pixel_format = CVPixelBufferGetPixelFormatType(pixel_buffer);
+	if (pixel_format != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange &&
+		pixel_format != kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
+		renpy_video_debug("unsupported pixel format: %u\\n", (unsigned) pixel_format);
+		return -3;
+	}
+
+    *iosurface = (void *) surface;
+	*width = (int) CVPixelBufferGetWidth(pixel_buffer);
+	*height = (int) CVPixelBufferGetHeight(pixel_buffer);
+	*full_range = pixel_format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
+	*bt709 = frame->colorspace == AVCOL_SPC_BT709;
+	return 0;
+}
+
+int renpy_macos_video_import_texture(void *context_ptr, GLuint texture, int width, int height, void *iosurface_ptr, int plane) {
+    CGLContextObj context = CGLGetCurrentContext();
+    IOSurfaceRef surface = (IOSurfaceRef) iosurface_ptr;
+    GLenum format = plane ? GL_LUMINANCE_ALPHA : GL_LUMINANCE;
+    CGLError error;
+
+    (void) context_ptr;
+
+    if (!context || !surface || width <= 0 || height <= 0 || (plane != 0 && plane != 1)) {
+        return -1;
+    }
+
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, texture);
+    glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    error = CGLTexImageIOSurface2D(
+        context,
+        GL_TEXTURE_RECTANGLE_ARB,
+        format,
+        width,
+        height,
+        format,
+        GL_UNSIGNED_BYTE,
+        surface,
+        (GLuint) plane);
+
+    if (error != kCGLNoError) {
+        renpy_video_debug("IOSurface import failed: plane=%d error=%d width=%d height=%d\\n", plane, (int) error, width, height);
+    }
+
+    return error == kCGLNoError ? 0 : (int) error;
+}
+
+#else
+
+int renpy_macos_video_frame_info(void *frame, void **iosurface, int *width, int *height, int *full_range, int *bt709) {
+	(void) frame;
+	(void) iosurface;
+	(void) width;
+	(void) height;
+	(void) full_range;
+	(void) bt709;
+    return -1;
+}
+
+int renpy_macos_video_import_texture(void *context, GLuint texture, int width, int height, void *iosurface, int plane) {
+    (void) context;
+    (void) texture;
+    (void) width;
+    (void) height;
+    (void) iosurface;
+    (void) plane;
+    return -1;
+}
+
+#endif

--- a/src/renpy_macos_video.h
+++ b/src/renpy_macos_video.h
@@ -1,0 +1,19 @@
+#ifndef RENPY_MACOS_VIDEO_H
+#define RENPY_MACOS_VIDEO_H
+
+#include <stdint.h>
+
+#ifdef __APPLE__
+#include <OpenGL/gltypes.h>
+#else
+typedef unsigned int GLuint;
+#endif
+
+/* Extracts the IOSurface and NV12 dimensions from an AV_PIX_FMT_VIDEOTOOLBOX
+ * AVFrame. The AVFrame remains owned by the caller. */
+int renpy_macos_video_frame_info(void *frame, void **iosurface, int *width, int *height, int *full_range, int *bt709);
+
+/* Imports one IOSurface plane into the current legacy OpenGL texture. */
+int renpy_macos_video_import_texture(void *context, GLuint texture, int width, int height, void *iosurface, int plane);
+
+#endif

--- a/src/renpysound_core.c
+++ b/src/renpysound_core.c
@@ -58,9 +58,6 @@ SDL_Mutex *name_mutex;
 #endif
 
 /* Declarations of ffdecode functions. */
-struct MediaState;
-typedef struct MediaState MediaState;
-
 void media_init(int rate, int status, int equal_mono);
 
 void media_advance_time(void);
@@ -1294,6 +1291,124 @@ PyObject *RPS_read_video(int channel) {
         return Py_None;
     }
 
+}
+
+
+static void RPS_video_frame_capsule_destructor(PyObject *capsule) {
+	void *frame = PyCapsule_GetPointer(capsule, "renpy.videoframe");
+	if (frame) {
+		media_video_frame_free(frame);
+	}
+}
+
+
+PyObject *RPS_read_video_hardware(int channel) {
+	struct Channel *c;
+	void *frame = NULL;
+	PyObject *capsule;
+
+	if (check_channel(channel)) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	c = &channels[channel];
+	if (c->playing) {
+		Py_BEGIN_ALLOW_THREADS
+		frame = media_read_video_hardware(c->playing);
+		Py_END_ALLOW_THREADS
+	}
+
+	if (!frame) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	capsule = PyCapsule_New(frame, "renpy.videoframe", RPS_video_frame_capsule_destructor);
+	if (!capsule) {
+		media_video_frame_free(frame);
+	}
+
+	error(SUCCESS);
+	return capsule;
+}
+
+
+PyObject *RPS_video_stats(int channel) {
+    struct Channel *c;
+    RPSVideoStats stats;
+    PyObject *rv = PyDict_New();
+
+    if (!rv) {
+        return NULL;
+    }
+
+    if (check_channel(channel)) {
+        PyObject *state = PyUnicode_FromString("invalid-channel");
+        if (state) {
+            PyDict_SetItemString(rv, "state", state);
+            Py_DECREF(state);
+        }
+        return rv;
+    }
+
+    c = &channels[channel];
+
+    if (c->playing) {
+        media_video_stats(c->playing, &stats);
+    } else {
+        memset(&stats, 0, sizeof(stats));
+        stats.state = "stopped";
+        stats.decoder_backend = "unknown";
+        stats.decoder_name = "unknown";
+        stats.codec_name = "unknown";
+        stats.input_pixel_format = "unknown";
+        stats.surface_backend = "unknown";
+        stats.output_pixel_format = "unknown";
+        stats.transfer_pixel_format = "unknown";
+        stats.hardware_status = "disabled";
+    }
+
+#define VIDEO_STAT_STRING(name) do { PyObject *value = PyUnicode_FromString(stats.name ? stats.name : "unknown"); PyDict_SetItemString(rv, #name, value); Py_DECREF(value); } while (0)
+#define VIDEO_STAT_INT(name) do { PyObject *value = PyLong_FromLong((long) stats.name); PyDict_SetItemString(rv, #name, value); Py_DECREF(value); } while (0)
+#define VIDEO_STAT_UINT(name) do { PyObject *value = PyLong_FromUnsignedLongLong((unsigned long long) stats.name); PyDict_SetItemString(rv, #name, value); Py_DECREF(value); } while (0)
+
+    VIDEO_STAT_STRING(state);
+    VIDEO_STAT_STRING(decoder_backend);
+    VIDEO_STAT_STRING(decoder_name);
+    VIDEO_STAT_STRING(codec_name);
+    VIDEO_STAT_STRING(input_pixel_format);
+    VIDEO_STAT_STRING(surface_backend);
+    VIDEO_STAT_STRING(output_pixel_format);
+    VIDEO_STAT_STRING(transfer_pixel_format);
+    VIDEO_STAT_STRING(hardware_status);
+    VIDEO_STAT_INT(hardware_decode);
+    VIDEO_STAT_INT(hardware_surface);
+    VIDEO_STAT_INT(hardware_attempted);
+    VIDEO_STAT_INT(hardware_available);
+    VIDEO_STAT_INT(width);
+    VIDEO_STAT_INT(height);
+    VIDEO_STAT_INT(queue_depth);
+    VIDEO_STAT_UINT(decoded_frames);
+    VIDEO_STAT_UINT(converted_frames);
+    VIDEO_STAT_UINT(submitted_frames);
+    VIDEO_STAT_UINT(dropped_frames);
+    VIDEO_STAT_UINT(decode_time_ns);
+    VIDEO_STAT_UINT(hardware_transfer_frames);
+    VIDEO_STAT_UINT(hardware_transfer_time_ns);
+    VIDEO_STAT_UINT(hardware_transfer_failures);
+    VIDEO_STAT_UINT(color_convert_time_ns);
+    VIDEO_STAT_UINT(present_lateness_ns);
+    VIDEO_STAT_UINT(present_lateness_max_ns);
+    PyObject *last_pts = PyFloat_FromDouble(stats.last_pts);
+    PyDict_SetItemString(rv, "last_pts", last_pts);
+    Py_DECREF(last_pts);
+
+#undef VIDEO_STAT_STRING
+#undef VIDEO_STAT_INT
+#undef VIDEO_STAT_UINT
+
+    return rv;
 }
 
 int RPS_video_ready(int channel) {

--- a/src/renpysound_core.h
+++ b/src/renpysound_core.h
@@ -27,6 +27,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <Python.h>
 #include <SDL3/SDL.h>
 
+#include "ffmedia.h"
+
 void RPS_play(int channel, SDL_IOStream *rw, const char *ext, const char *name, int synchro_start, int fadeout, int tight, double start, double end, float relative_volume, PyObject *audio_filter);
 void RPS_queue(int channel, SDL_IOStream *rw, const char *ext, const char *name, int synchro_start, int fadeout, int tight, double start, double end, float relative_volume, PyObject *audio_filter);
 void RPS_stop(int channel);
@@ -47,6 +49,8 @@ void RPS_replace_audio_filter(int channel, PyObject *audio_filter, int primary);
 
 int RPS_video_ready(int channel);
 PyObject *RPS_read_video(int channel);
+PyObject *RPS_read_video_hardware(int channel);
+PyObject *RPS_video_stats(int channel);
 void RPS_sample_surfaces(PyObject *rgb, PyObject *rgba);
 void RPS_set_video(int channel, int video);
 


### PR DESCRIPTION
Related to [#7223](https://github.com/renpy/renpy/issues/7223) and [#4817](https://github.com/renpy/renpy/issues/4817).

### Summary

This PR adds an experimental macOS VideoToolbox-to-IOSurface path for composited `Movie` displayables. It covers macOS only; issue #7223 describes the broader cross-platform problem of CPU-bound desktop Movie playback at 4K/60.

The default `Movie` API and software fallback remain intact. Hardware decoding is optional and does not require an external codec, driver, or platform media player.

### Before and after

Before, the desktop path is approximately:

```text
FFmpeg software decode
  -> CPU YUV/RGB conversion
  -> CPU RGBA surface
  -> GL texture upload
  -> Ren'Py composition and present
```

On macOS, this PR enables the following path for compatible movies and renderer capabilities:

```text
FFmpeg VideoToolbox decode
  -> retained NV12 IOSurface
  -> IOSurface plane import
  -> GPU YUV conversion
  -> Ren'Py composition and present
```

This removes the CPU surface transfer, CPU color conversion, CPU RGBA allocation, and CPU texture upload for the supported path. It does not make playback zero-cost: GPU conversion, composition, synchronization, and present/vsync remain.

### Changes

- Add FFmpeg VideoToolbox capability detection and hardware-surface retention.
- Import compatible NV12 IOSurface planes into the macOS OpenGL renderer.
- Convert NV12 to RGBA in GLSL, including video/full-range and color-matrix metadata.
- Fall back to software decoding if hardware setup, transfer, or surface handling fails.
