### PR TITLE
Use YUV plane textures for desktop video playback

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -894,6 +894,12 @@ class Channel(object):
 
         return renpysound.read_video(self.number)
 
+    def read_video_yuv(self):
+        if not pcm_ok:
+            return None
+
+        return renpysound.read_video_yuv(self.number)
+
     def video_ready(self):
         if not pcm_ok:
             return 1

--- a/renpy/audio/renpysound.pyx
+++ b/renpy/audio/renpysound.pyx
@@ -79,6 +79,7 @@ cdef extern from "renpysound_core.h":
     void RPS_advance_time()
     int RPS_video_ready(int channel)
     object RPS_read_video(int channel)
+    object RPS_read_video_yuv(int channel)
     void RPS_set_video(int channel, int video)
 
     void RPS_sample_surfaces(object, object)
@@ -402,6 +403,12 @@ def read_video(channel):
     # This has to be set to the same number it is in ffmedia.c
     FRAME_PADDING = 4
     return rv.subsurface((FRAME_PADDING, FRAME_PADDING, w - FRAME_PADDING * 2, h - FRAME_PADDING * 2))
+
+
+def read_video_yuv(channel):
+    """Returns a capsule containing a packed YUV420 frame, or None."""
+
+    return RPS_read_video_yuv(channel)
 
 
 # No video will be played from this channel.

--- a/renpy/common/_shaders.rpym
+++ b/renpy/common/_shaders.rpym
@@ -32,6 +32,51 @@ init python:
         gl_Position = u_transform * gl_Position;
     """)
 
+    renpy.register_shader("renpy.movie_yuv", private_uniforms=True, variables="""
+        uniform sampler2D tex0;
+        uniform sampler2D tex1;
+        uniform float u_movie_yuv_full_range;
+        uniform float u_movie_yuv_bt709;
+        attribute vec2 a_tex_coord;
+        varying vec2 v_tex_coord;
+    """, vertex_200="""
+        v_tex_coord = a_tex_coord;
+    """, fragment_200="""
+        vec4 y_sample = texture2D(tex0, v_tex_coord);
+        vec4 uv_sample = texture2D(tex1, v_tex_coord);
+        float y;
+        float u;
+        float v;
+        float r;
+        float g;
+        float b;
+
+        if (u_movie_yuv_full_range > 0.5) {
+            y = y_sample.r;
+            u = uv_sample.r - 0.5;
+            v = uv_sample.a - 0.5;
+        } else {
+            y = (y_sample.r - 16.0 / 255.0) * (255.0 / 219.0);
+            u = (uv_sample.r - 0.5) * (255.0 / 224.0);
+            v = (uv_sample.a - 0.5) * (255.0 / 224.0);
+        }
+
+        if (u_movie_yuv_bt709 > 0.5) {
+            r = y + 1.5748 * v;
+            g = y - 0.187324 * u - 0.468124 * v;
+            b = y + 1.8556 * u;
+        } else {
+            r = y + 1.402 * v;
+            g = y - 0.344136 * u - 0.714136 * v;
+            b = y + 1.772 * u;
+        }
+
+        gl_FragColor = vec4(clamp(r, 0.0, 1.0),
+                            clamp(g, 0.0, 1.0),
+                            clamp(b, 0.0, 1.0),
+                            1.0);
+    """)
+
     renpy.register_shader("renpy.texture", variables="""
         uniform float u_lod_bias;
         uniform sampler2D tex0;

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -165,6 +165,19 @@ def get_movie_texture(channel, mask_channel=None, side_mask=False, mipmap=None):
         return get_movie_texture_web(channel, mask_channel, side_mask, mipmap)
 
     c = renpy.audio.music.get_channel(channel)
+
+    # Keep the surface path for masks; ordinary desktop movies use YUV planes
+    # when the decoder provides the supported 4:2:0 format.
+    if not side_mask and not mask_channel:
+        from renpy.gl2 import gl2texture
+
+        yuv = c.read_video_yuv()
+        if yuv is not None:
+            tex = gl2texture.load_yuv420_frame(yuv, mipmap)
+            if tex is not None:
+                texture[channel] = tex
+                return tex, True
+
     surf = c.read_video()
 
     if side_mask:

--- a/renpy/gl2/gl2texture.pxd
+++ b/renpy/gl2/gl2texture.pxd
@@ -91,6 +91,8 @@ cdef class GLTexture(GL2Model):
 
     cdef bint has_mipmaps(self)
 
+    cdef bint from_yuv_plane_pointer(self, const unsigned char *data, int width, int height, GLenum format, bint mipmap)
+
     cpdef subsurface(GLTexture self, t)
 
     cpdef GL2Model get_texture(self, int i)

--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -32,6 +32,7 @@ from renpy.pygame.surface cimport PySurface_AsSurface
 
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy
+from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid
 
 import sys
 import time
@@ -48,6 +49,15 @@ from renpy.gl2.gl2mesh2 cimport Mesh2
 from renpy.gl2.gl2model cimport GL2Model
 
 from renpy.display.matrix cimport Matrix
+
+cdef extern from "ffmedia.h":
+    ctypedef struct MediaVideoYUV:
+        int width
+        int height
+        unsigned char *y
+        unsigned char *uv
+        int full_range
+        int bt709
 
 # This has different names in GL and GLES, but the same value.
 cdef GLenum RGBA8 = 0x8058
@@ -348,6 +358,49 @@ cdef class GLTexture(GL2Model):
             )
 
         self.loader.texture_load_queue.add(self)
+
+    cdef bint from_yuv_plane_pointer(GLTexture self, const unsigned char *data, int width, int height, GLenum format, bint mipmap):
+        """Uploads one tightly packed 8-bit video plane as a 2D texture."""
+
+        cdef GLuint texture
+
+        glGenTextures(1, &texture)
+        glBindTexture(GL_TEXTURE_2D, texture)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0)
+        glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data)
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 4)
+
+        self.number = texture
+        self.width = width
+        self.height = height
+        self.texture_width = width
+        self.texture_height = height
+        self.properties = {
+            "mipmap": mipmap,
+            "movie_yuv": True,
+            "movie_yuv_components": 2 if format == GL_LUMINANCE_ALPHA else 1,
+        }
+        self.mesh = Mesh2.texture_rectangle(0.0, 0.0, width, height, 0.0, 0.0, 1.0, 1.0)
+        self.loader.allocated.add(texture)
+        texture_size = width * height * self.properties["movie_yuv_components"]
+        if mipmap:
+            texture_size = int(texture_size * 1.34)
+        self.loader.total_texture_size += texture_size
+
+        self.mipmap_texture(texture, width, height, self.properties)
+        if mipmap:
+            self.min_filter = GL_LINEAR_MIPMAP_NEAREST
+            self.default_min_filter = self.min_filter
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, self.min_filter)
+
+        self.loaded = True
+        self.surface = None
+        return True
 
     def from_render(GLTexture self, what, properties, oversample=1.0):
         """
@@ -688,7 +741,12 @@ cdef class GLTexture(GL2Model):
             if self.loaded:
                 self.loader.free_list.append(self.number)
 
-                if self.has_mipmaps():
+                if self.properties.get("movie_yuv", False):
+                    texture_size = self.width * self.height * self.properties["movie_yuv_components"]
+                    if self.has_mipmaps():
+                        texture_size = int(texture_size * 1.34)
+                    self.loader.total_texture_size -= texture_size
+                elif self.has_mipmaps():
                     self.loader.total_texture_size -= int(self.width * self.height * 4 * 1.34)
                 else:
                     self.loader.total_texture_size -= int(self.width * self.height * 4)
@@ -724,3 +782,51 @@ class Texture(GLTexture):
     """
 
     pass
+
+
+def load_yuv420_frame(frame, mipmap=False):
+    """Creates a two-plane model whose fragment shader performs YUV conversion."""
+
+    cdef MediaVideoYUV *video_frame
+    cdef int width
+    cdef int height
+    cdef int chroma_width
+    cdef int chroma_height
+    cdef GLTexture y_texture
+    cdef GLTexture uv_texture
+
+    if not PyCapsule_IsValid(frame, b"renpy.videoyuv"):
+        return None
+
+    video_frame = <MediaVideoYUV *> PyCapsule_GetPointer(frame, b"renpy.videoyuv")
+    if video_frame == NULL:
+        return None
+
+    width = video_frame.width
+    height = video_frame.height
+    chroma_width = (width + 1) // 2
+    chroma_height = (height + 1) // 2
+
+    loader = renpy.display.draw.texture_loader
+    y_texture = Texture((width, height), loader)
+    uv_texture = Texture((chroma_width, chroma_height), loader)
+
+    if not y_texture.from_yuv_plane_pointer(video_frame.y, width, height, GL_LUMINANCE, mipmap):
+        return None
+
+    if not uv_texture.from_yuv_plane_pointer(video_frame.uv, chroma_width, chroma_height, GL_LUMINANCE_ALPHA, mipmap):
+        return None
+
+    mesh = Mesh2.texture_rectangle(0.0, 0.0, width, height, 0.0, 0.0, 1.0, 1.0)
+    model = GL2Model(
+        (width, height),
+        mesh,
+        ("renpy.movie_yuv",),
+        {
+            "u_movie_yuv_full_range": float(video_frame.full_range),
+            "u_movie_yuv_bt709": float(video_frame.bt709),
+        },
+    )
+    model.set_texture(0, y_texture)
+    model.set_texture(1, uv_texture)
+    return model

--- a/src/ffmedia.c
+++ b/src/ffmedia.c
@@ -9,6 +9,9 @@
 #include <SDL3/SDL_thread.h>
 
 #include <stdlib.h>
+#include <string.h>
+
+#include "ffmedia.h"
 
 #ifndef _WIN32
 #define USE_POSIX_MEMALIGN
@@ -146,6 +149,15 @@ typedef struct SurfaceQueueEntry {
 
 	SDL_Surface *surf;
 
+	/* Packed YUV420 data for GPU conversion. */
+	int yuv;
+	int yuv_width, yuv_height;
+	int yuv_y_pitch, yuv_uv_pitch;
+	uint8_t *yuv_y;
+	uint8_t *yuv_uv;
+	int yuv_full_range;
+	int yuv_bt709;
+
 	/* The pts, converted to seconds. */
 	double pts;
 
@@ -255,6 +267,9 @@ typedef struct MediaState {
 	/* Software rescaling context. */
 	struct SwsContext *sws;
 
+	/* Software rescaling context for surface consumers of YUV frames. */
+	struct SwsContext *yuv_sws;
+
 	/* A queue of decoded video frames. */
 	SurfaceQueueEntry *surface_queue; // Lock
 	int surface_queue_size; // Lock
@@ -280,6 +295,24 @@ static AVFrame *dequeue_frame(FrameQueue *fq);
 static void free_packet_queue(PacketQueue *pq);
 static SurfaceQueueEntry *dequeue_surface(SurfaceQueueEntry **queue);
 
+static void free_surface_entry(SurfaceQueueEntry *sqe) {
+	if (!sqe) {
+		return;
+	}
+
+	if (sqe->pixels) {
+#ifndef USE_POSIX_MEMALIGN
+		SDL_free(sqe->pixels);
+#else
+		free(sqe->pixels);
+#endif
+	}
+
+	av_free(sqe->yuv_y);
+	av_free(sqe->yuv_uv);
+	av_free(sqe);
+}
+
 
 /* A queue of MediaState objects that are awaiting deallocation.*/
 static MediaState *deallocate_queue = NULL;
@@ -297,18 +330,15 @@ static void deallocate(MediaState *ms) {
 			break;
 		}
 
-		if (sqe->pixels) {
-#ifndef USE_POSIX_MEMALIGN
-			SDL_free(sqe->pixels);
-#else
-			free(sqe->pixels);
-#endif
-		}
-		av_free(sqe);
+		free_surface_entry(sqe);
 	}
 
 	if (ms->sws) {
 		sws_freeContext(ms->sws);
+	}
+
+	if (ms->yuv_sws) {
+		sws_freeContext(ms->yuv_sws);
 	}
 
 	if (ms->video_decode_frame) {
@@ -856,6 +886,60 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 		}
 	}
 
+	if (ms->video_decode_frame->format == AV_PIX_FMT_YUV420P ||
+		ms->video_decode_frame->format == AV_PIX_FMT_YUVJ420P) {
+		int width = ms->video_decode_frame->width;
+		int height = ms->video_decode_frame->height;
+		int chroma_width = (width + 1) / 2;
+		int chroma_height = (height + 1) / 2;
+		SurfaceQueueEntry *rv = av_mallocz(sizeof(SurfaceQueueEntry));
+
+		if (!rv) {
+			ms->video_finished = 1;
+			return NULL;
+		}
+
+		rv->yuv_y_pitch = width;
+		rv->yuv_uv_pitch = chroma_width * 2;
+		rv->yuv_y = av_malloc((size_t) width * height);
+		rv->yuv_uv = av_malloc((size_t) rv->yuv_uv_pitch * chroma_height);
+
+		if (!rv->yuv_y || !rv->yuv_uv) {
+			free_surface_entry(rv);
+			ms->video_finished = 1;
+			return NULL;
+		}
+
+		for (int y = 0; y < height; y++) {
+			const uint8_t *src = ms->video_decode_frame->data[0];
+			int stride = ms->video_decode_frame->linesize[0];
+			memcpy(rv->yuv_y + (size_t) y * rv->yuv_y_pitch,
+				src + y * stride, width);
+		}
+
+		for (int y = 0; y < chroma_height; y++) {
+			const uint8_t *src_u = ms->video_decode_frame->data[1];
+			const uint8_t *src_v = ms->video_decode_frame->data[2];
+			int stride_u = ms->video_decode_frame->linesize[1];
+			int stride_v = ms->video_decode_frame->linesize[2];
+
+			for (int x = 0; x < chroma_width; x++) {
+				rv->yuv_uv[y * rv->yuv_uv_pitch + x * 2] = src_u[y * stride_u + x];
+				rv->yuv_uv[y * rv->yuv_uv_pitch + x * 2 + 1] = src_v[y * stride_v + x];
+			}
+		}
+
+		rv->yuv = 1;
+		rv->yuv_width = width;
+		rv->yuv_height = height;
+		rv->yuv_full_range =
+			ms->video_decode_frame->color_range == AVCOL_RANGE_JPEG ||
+			ms->video_decode_frame->format == AV_PIX_FMT_YUVJ420P;
+		rv->yuv_bt709 = ms->video_decode_frame->colorspace == AVCOL_SPC_BT709;
+		rv->pts = pts;
+		return rv;
+	}
+
 	SDL_Surface *sample = rgba_surface;
 
 	if (ms->sws == NULL) {
@@ -899,6 +983,7 @@ static SurfaceQueueEntry *decode_video_frame(MediaState *ms) {
 		ms->video_finished = 1;
 		return NULL;
 	}
+	memset(rv, 0, sizeof(*rv));
 	rv->w = ms->video_decode_frame->width + FRAME_PADDING * 2;
 	rv->h = ms->video_decode_frame->height + FRAME_PADDING * 2;
 
@@ -1028,14 +1113,7 @@ int media_video_ready(struct MediaState *ms) {
 			SurfaceQueueEntry *sqe = dequeue_surface(&ms->surface_queue);
 			ms->surface_queue_size -= 1;
 
-			if (sqe->pixels) {
-#ifndef USE_POSIX_MEMALIGN
-				SDL_free(sqe->pixels);
-#else
-				free(sqe->pixels);
-#endif
-			}
-			av_free(sqe);
+			free_surface_entry(sqe);
 
 			consumed = 1;
 		}
@@ -1069,6 +1147,161 @@ done:
 	return rv;
 }
 
+
+int media_read_video_yuv(MediaState *ms, MediaVideoYUV *rv) {
+	SurfaceQueueEntry *sqe = NULL;
+	double offset_time = current_time - ms->time_offset;
+
+	memset(rv, 0, sizeof(*rv));
+
+	if (ms->video_stream == -1) {
+		return 0;
+	}
+
+	SDL_LockMutex(ms->lock);
+
+#ifndef __EMSCRIPTEN__
+	while (!ms->ready) {
+		SDL_WaitCondition(ms->cond, ms->lock);
+	}
+#endif
+
+	if (ms->pause_time > 0 || !ms->surface_queue_size || !ms->surface_queue->yuv) {
+		goto done;
+	}
+
+	if (ms->video_pts_offset == 0.0) {
+		ms->video_pts_offset = offset_time - ms->surface_queue->pts;
+	}
+
+	if (ms->surface_queue->pts + ms->video_pts_offset <= offset_time + frame_early_delivery) {
+		sqe = dequeue_surface(&ms->surface_queue);
+		ms->surface_queue_size -= 1;
+	}
+
+done:
+	if (sqe) {
+		ms->needs_decode = 1;
+		ms->video_read_time = offset_time;
+		SDL_BroadcastCondition(ms->cond);
+	}
+
+	SDL_UnlockMutex(ms->lock);
+
+	if (!sqe) {
+		return 0;
+	}
+
+	rv->width = sqe->yuv_width;
+	rv->height = sqe->yuv_height;
+	rv->y = sqe->yuv_y;
+	rv->uv = sqe->yuv_uv;
+	rv->full_range = sqe->yuv_full_range;
+	rv->bt709 = sqe->yuv_bt709;
+
+	sqe->yuv_y = NULL;
+	sqe->yuv_uv = NULL;
+	free_surface_entry(sqe);
+	return 1;
+}
+
+
+void media_free_video_yuv(MediaVideoYUV *frame) {
+	if (!frame) {
+		return;
+	}
+
+	av_free(frame->y);
+	av_free(frame->uv);
+	memset(frame, 0, sizeof(*frame));
+}
+
+static SDL_Surface *convert_yuv_surface(MediaState *ms, SurfaceQueueEntry *sqe) {
+	SDL_Surface *sample = rgba_surface;
+	const SDL_PixelFormatDetails *sample_fmt = SDL_GetPixelFormatDetails(sample->format);
+
+	ms->yuv_sws = sws_getCachedContext(
+		ms->yuv_sws,
+		sqe->yuv_width,
+		sqe->yuv_height,
+		AV_PIX_FMT_NV12,
+		sqe->yuv_width,
+		sqe->yuv_height,
+		get_pixel_format(sample),
+		SWS_POINT | SWS_FULL_CHR_H_INP | SWS_FULL_CHR_H_INT,
+		NULL,
+		NULL,
+		NULL
+	);
+
+	if (!ms->yuv_sws) {
+		return NULL;
+	}
+
+	int colorspace = sqe->yuv_bt709 ? SWS_CS_ITU709 : SWS_CS_DEFAULT;
+	int src_range = sqe->yuv_full_range ? 1 : 0;
+
+	sws_setColorspaceDetails(
+		ms->yuv_sws,
+		sws_getCoefficients(colorspace),
+		src_range,
+		sws_getCoefficients(SWS_CS_DEFAULT),
+		0,
+		0,
+		1 << 16,
+		1 << 16
+	);
+
+	int w = sqe->yuv_width + FRAME_PADDING * 2;
+	int h = sqe->yuv_height + FRAME_PADDING * 2;
+	int pitch = w * sample_fmt->bytes_per_pixel;
+
+	if (pitch % ROW_ALIGNMENT) {
+		pitch += ROW_ALIGNMENT - (pitch % ROW_ALIGNMENT);
+	}
+
+	void *pixels;
+#ifndef USE_POSIX_MEMALIGN
+	pixels = SDL_calloc(pitch * h, 1);
+#else
+	if (posix_memalign(&pixels, ROW_ALIGNMENT, pitch * h)) {
+		return NULL;
+	}
+	memset(pixels, 0, pitch * h);
+#endif
+
+	uint8_t *surf_pixels = (uint8_t *) pixels;
+	uint8_t *surf_data[] = {
+		&surf_pixels[FRAME_PADDING * pitch + FRAME_PADDING * sample_fmt->bytes_per_pixel]
+	};
+	int surf_linesize[] = { pitch };
+	const uint8_t *yuv_data[] = { sqe->yuv_y, sqe->yuv_uv };
+	int yuv_linesize[] = { sqe->yuv_y_pitch, sqe->yuv_uv_pitch };
+
+	sws_scale(
+		ms->yuv_sws,
+		yuv_data,
+		yuv_linesize,
+		0,
+		sqe->yuv_height,
+		surf_data,
+		surf_linesize
+	);
+
+	SDL_Surface *rv = SDL_CreateSurfaceFrom(w, h, sample->format, pixels, pitch);
+	if (!rv) {
+#ifndef USE_POSIX_MEMALIGN
+		SDL_free(pixels);
+#else
+		free(pixels);
+#endif
+		return NULL;
+	}
+
+	/* Force SDL to take over management of pixels. */
+	rv->flags &= ~SDL_SURFACE_PREALLOCATED;
+	return rv;
+}
 
 SDL_Surface *media_read_video(MediaState *ms) {
 
@@ -1117,6 +1350,12 @@ done:
 	}
 
 	SDL_UnlockMutex(ms->lock);
+
+	if (sqe && sqe->yuv) {
+		rv = convert_yuv_surface(ms, sqe);
+		free_surface_entry(sqe);
+		return rv;
+	}
 
 	if (sqe) {
 		rv = SDL_CreateSurfaceFrom(

--- a/src/ffmedia.h
+++ b/src/ffmedia.h
@@ -1,0 +1,42 @@
+/*
+Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef RENPY_FFMEDIA_H
+#define RENPY_FFMEDIA_H
+
+#include <stdint.h>
+
+struct MediaState;
+
+typedef struct MediaVideoYUV {
+    int width;
+    int height;
+    uint8_t *y;
+    uint8_t *uv;
+    int full_range;
+    int bt709;
+} MediaVideoYUV;
+
+int media_read_video_yuv(struct MediaState *ms, MediaVideoYUV *rv);
+void media_free_video_yuv(MediaVideoYUV *frame);
+
+#endif

--- a/src/renpysound_core.c
+++ b/src/renpysound_core.c
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include "renpysound_core.h"
+#include "ffmedia.h"
 #include <Python.h>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_thread.h>
@@ -1296,6 +1297,61 @@ PyObject *RPS_read_video(int channel) {
 
 }
 
+
+static void RPS_video_yuv_capsule_destructor(PyObject *capsule) {
+	MediaVideoYUV *frame = PyCapsule_GetPointer(capsule, "renpy.videoyuv");
+
+	if (frame) {
+		media_free_video_yuv(frame);
+		PyMem_Free(frame);
+	}
+}
+
+
+PyObject *RPS_read_video_yuv(int channel) {
+	struct Channel *c;
+	MediaVideoYUV *frame;
+	int got_frame;
+	PyObject *capsule;
+
+	if (check_channel(channel)) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	c = &channels[channel];
+	if (!c->playing) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	frame = PyMem_Calloc(1, sizeof(*frame));
+	if (!frame) {
+		return PyErr_NoMemory();
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	got_frame = media_read_video_yuv(c->playing, frame);
+	Py_END_ALLOW_THREADS
+
+	if (!got_frame) {
+		PyMem_Free(frame);
+		error(SUCCESS);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	capsule = PyCapsule_New(frame, "renpy.videoyuv", RPS_video_yuv_capsule_destructor);
+	if (!capsule) {
+		media_free_video_yuv(frame);
+		PyMem_Free(frame);
+		return NULL;
+	}
+
+	error(SUCCESS);
+	return capsule;
+}
+
 int RPS_video_ready(int channel) {
     struct Channel *c;
     int rv;
@@ -1331,7 +1387,6 @@ void RPS_set_video(int channel, int video) {
 
     c->video = video;
 }
-
 
 /*
  * Initializes the sound to the given frequencies, channels, and

--- a/src/renpysound_core.h
+++ b/src/renpysound_core.h
@@ -47,6 +47,7 @@ void RPS_replace_audio_filter(int channel, PyObject *audio_filter, int primary);
 
 int RPS_video_ready(int channel);
 PyObject *RPS_read_video(int channel);
+PyObject *RPS_read_video_yuv(int channel);
 void RPS_sample_surfaces(PyObject *rgb, PyObject *rgba);
 void RPS_set_video(int channel, int video);
 


### PR DESCRIPTION
Re-implements #7223

This changes desktop playback of supported YUV420 video frames to use separate luma and packed chroma textures, with YUV-to-RGB conversion in the movie shader.

The existing path converts every supported frame to RGBA with swscale before uploading it to OpenGL. Keeping the decoded YUV representation reduces CPU-side conversion and RGBA upload cost for high-resolution movies.

This does not add hardware decoding or zero-copy decoding. FFmpeg still performs decoding, frames are copied into tightly packed YUV buffers, and the planes are uploaded to OpenGL before composition.