### PR TITLE
Interpolate Matrix correctly if animation interrupted/replaced

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -176,8 +176,32 @@ def interpolate(t, a, b, typ):
     # If something is callable, call it and return the result.
     elif callable(b):
         a_origin = getattr(a, "origin", None)
-        rv = b(a_origin, t)
+
+        b_is_BaseMatrix = hasattr(b, "value")
+
+        # Pass a Matrix directly when `a` is a Matrix (from a previous interpolation)
+        # and `b` is a _BaseMatrix (class in store namespace, interpolates via `.value`).
+        # This allows _BaseMatrix.__call__ to use `a.origin_value` so that
+        # interpolation after an interruption (e.g. replaced by a new transform)
+        # continues from where the old one was interrupted.
+        # Other callables (SplineMatrix, user functions) keep the old behaviour.
+        if isinstance(a, renpy.display.matrix.Matrix) and b_is_BaseMatrix:
+            rv = b(a, t)
+        else:
+            rv = b(a_origin, t)
+
         rv.origin = b
+
+        # Record the effective value on the result Matrix, so a future
+        # interpolation can continue from here.
+        if b_is_BaseMatrix:
+            if isinstance(a, renpy.display.matrix.Matrix) and a.origin_value is not None:
+                rv.origin_value = a.origin_value + (b.value - a.origin_value) * t
+            elif a_origin is not None and hasattr(a_origin, "value"):
+                rv.origin_value = a_origin.value + (b.value - a_origin.value) * t
+            else:
+                rv.origin_value = b.value
+
         return rv
 
     # Interpolate everything else.

--- a/renpy/common/00matrixcolor.rpy
+++ b/renpy/common/00matrixcolor.rpy
@@ -42,6 +42,16 @@ init -1500 python:
                 other = other.matrix
 
             if type(other) is not type(self):
+
+                # If `other` is a Matrix produced by a previous interpolation
+                # (which records the current value in `origin_value`), continue
+                # interpolating from that current value rather than the target.
+                if isinstance(other, Matrix):
+                    origin_value = getattr(other, "origin_value", None)
+                    if origin_value is not None:
+                        value = origin_value + (self.value - origin_value) * done
+                        return self.get(value)
+
                 return self.get(self.value)
 
             value = other.value + (self.value - other.value) * done

--- a/renpy/display/matrix.pxd
+++ b/renpy/display/matrix.pxd
@@ -27,6 +27,11 @@ cdef class Matrix:
     # When this matrix is generated, where it was generated from.
     cdef public object origin
 
+    # When a callable matrix is interpolated, the effective value that produced
+    # this matrix. Used so a subsequent (possibly interrupted) interpolation can
+    # continue from the current value rather than the previous target.
+    cdef public object origin_value
+
     # The inverse of this Matrix.
     cdef Matrix inverse_cache
 

--- a/renpy/display/matrix.pyx
+++ b/renpy/display/matrix.pyx
@@ -141,6 +141,7 @@ cdef class Matrix:
             rv[fields[i]] = self.m[i]
 
         rv["origin"] = getattr(self, "origin", None)
+        rv["origin_value"] = getattr(self, "origin_value", None)
 
         return rv
 
@@ -156,6 +157,7 @@ cdef class Matrix:
                 self.m[i] = state[fields[i]]
 
         self.origin = state.get("origin", None)
+        self.origin_value = state.get("origin_value", None)
         self.inverse_cache = None
         self.transpose_cache = None
 

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -236,6 +236,9 @@ a class of issues that could occur with NVL-mode, retained bubbles, and other co
 rendering the text without a click-to-continue indicator, and then placing the CTC indicator next to the end of the
 rendered text. (This is similar to how {w}, {p}, and extend were already handled.)
 
+If an interpolated :tpref:`matrixcolor` property is replaced by another interpolation, it now correctly
+continues from the point where it got interrupted.
+
 Translations
 ------------
 

--- a/testcases/game/tests/test_transforms.rpy
+++ b/testcases/game/tests/test_transforms.rpy
@@ -1,0 +1,142 @@
+# This file tests transform interpolation and replacement behavior.
+
+# ==============
+# == Fixtures ==
+# ==============
+
+label transforms__matrixcolor__label:
+    scene bg room
+    show eileen happy:
+        matrixcolor BrightnessMatrix(0.0)
+    "Start"
+    show eileen happy:
+        linear 0.2 matrixcolor BrightnessMatrix(1.0)
+    "Brightening"
+    show eileen happy:
+        linear 0.2 matrixcolor BrightnessMatrix(0.0)
+    "Done"
+    return
+
+transform transforms__matrixcolor_shared__brighten:
+    matrixcolor BrightnessMatrix(0.0) xoffset 0
+    linear 0.5 matrixcolor BrightnessMatrix(1.0) xoffset 200
+
+label transforms__matrixcolor_shared__label:
+    scene bg room
+    show eileen happy
+    "Start"
+    show eileen happy at transforms__matrixcolor_shared__brighten onlayer master
+    "Master brightening"
+    show eileen happy at transforms__matrixcolor_shared__brighten onlayer overlay
+    "Both brightening"
+    show eileen happy at transforms__matrixcolor_shared__brighten onlayer overlay
+    "Overlay restarted"
+    return
+
+# ==============
+# === Tests ====
+# ==============
+
+testsuite transforms:
+    after testcase:
+        if not screen "main_menu":
+            run MainMenu(confirm=False, save=False)
+
+    testsuite matrixcolor:
+        testcase interrupt_preserves_brightness_state:
+            description "Matrixcolor continues from interrupted value, not jumping to old target"
+            # GH-2591: When a matrixcolor interpolation is interrupted and replaced, the new
+            # interpolation must continue from the *current* value, not the target
+            # value of the interrupted interpolation.
+            # https://github.com/renpy/renpy/issues/2591
+
+            run Start("transforms__matrixcolor__label")
+            advance # Begin animation
+            pause 0.2 * 0.25 # 25% brightness
+
+            # Verify we're partway through the first animation.
+            python:
+                d = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                mc = d.state.matrixcolor
+                # BrightnessMatrix.get(value) puts value in xdw/ydw/zdw.
+                first_brightness = mc.ydw
+                assert abs (first_brightness - 0.25) < 0.1, \
+                    f"First animation: expected brightness ~0.25, got {first_brightness}"
+
+            # Interrupt by advancing to the next show statement, then let the new
+            # reverse animation run partway.
+            advance
+            pause 0.2 * 0.3  # 30% reverse animation
+
+            # The new animation should be reversing from ~0.25 toward 0.0, not
+            # jumping toward the old target (1.0) first.
+            python:
+                d = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                mc = d.state.matrixcolor
+                second_brightness = mc.ydw
+                # Continue from interrupted value (~0.25), decreasing by ~0.25*0.15.
+                expected = first_brightness * (1.0 - 0.15)
+                assert abs(second_brightness - expected) < 0.1, \
+                    f"Expected brightness ~{expected:.2f} (continuing from {first_brightness:.2f}), got {second_brightness:.2f}"
+                assert second_brightness < first_brightness, \
+                    f"Expected brightness to decrease from {first_brightness}, got {second_brightness}"
+
+            # Let the reverse animation complete; brightness should reach 0.0.
+            pause 0.2
+            python:
+                d = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                mc = d.state.matrixcolor
+                final_brightness = mc.ydw
+                assert abs(final_brightness - 0.0) < 0.05, \
+                    f"Expected final brightness near 0.0, got {final_brightness}"
+
+
+        testcase continuous_interpolation_reaches_target:
+            description "A non-interrupted matrixcolor interpolation reaches its target"
+
+            run Start("transforms__matrixcolor__label")
+            advance  # start the 0→1 animation
+            pause 0.2  # let it complete
+
+            python:
+                d = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                mc = d.state.matrixcolor
+                brightness = mc.ydw
+                assert abs(brightness - 1.0) < 0.05, \
+                    f"Expected brightness near 1.0, got {brightness}"
+
+
+        testcase shared_callable_not_corrupted:
+            description "Interrupting one image does not corrupt a shared matrixcolor callable used by another"
+
+            run Start("transforms__matrixcolor_shared__label")
+
+            # Begin animation on master layer
+            advance until "Master brightening"
+            pause 0.5 * 0.25  # 25% brightness on master
+
+            # Begin animation on overlay layer (shares the callable).
+            advance until "Both brightening"
+            pause 0.5 * 0.25  # 25% brightness on overlay, 50% brightness on master
+
+            python:
+                m = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                o = renpy.game.context().scene_lists.get_displayable_by_tag("overlay", "eileen")
+                m_b = m.state.matrixcolor.ydw
+                o_b = o.state.matrixcolor.ydw
+                assert abs(m_b - 0.5) < 0.05, f"Expected master brightness ~0.5, got {m_b}"
+                assert abs(o_b - 0.25) < 0.05, f"Expected overlay brightness ~2.5, got {o_b}"
+
+            # Restart the overlay transform (interrupts it).
+            advance until "Overlay restarted"
+            pause 0.5 * 0.1
+
+            python:
+                m = renpy.game.context().scene_lists.get_displayable_by_tag("master", "eileen")
+                o = renpy.game.context().scene_lists.get_displayable_by_tag("overlay", "eileen")
+                m_b = m.state.matrixcolor.ydw
+                o_b = o.state.matrixcolor.ydw
+                # Master has been brightening uninterrupted for 60% of the full run.
+                assert abs(m_b - 0.6) < 0.05, f"Expected master brightness ~0.6, got {m_b}"
+                # Overlay just restarted, should be near 20%, NOT corrupted by master's value.
+                assert abs(o_b - 0.1) < 0.05, f"Shared callable corrupted: overlay brightness {o_b} (should be ~0.1 fresh restart)"


### PR DESCRIPTION
Fixes #2591

## Problem
When a `matrixcolor` Matrix (e.g. `BrightnessMatrix`) is interrupted midway by a `show` statement and replaced with a new one, the new interpolation would jump to the __old target__ value first, rather than continuing from the __current__ value. This contradicted how other ATL properties (like `xalign`) behave when interrupted.

## Root cause
The `interpolate()` function in `renpy/atl.py` handles callable `matrixcolor` values by passing the "origin" of the previous result (the `a.origin` callable) to the new callable. The `a.origin` `_BaseMatrix` stores the __target__ of the previous interpolation, and after an interruption, the old target's `.value` was still being used as the starting point for the new interpolation.

## Fix

- `renpy/display/matrix.pxd` / `.pyx`: Added an `origin_value` field to the `Matrix` class. This records the effective value that produced the `Matrix`, so a subsequent interpolation can continue from the correct point.

- `renpy/atl.py`: the `interpolate()` function now passes the current `Matrix` directly to `_BaseMatrix`, and records the effective value on the result as `origin_value`. Because `_BaseMatrix` is in the store, the type isn't checked directly and it's guarded by `hasattr(b, "value")`. `SplineMatrix` and user-defined callables keep their original behavior.

- `renpy/common/00matrixcolor.rpy`: `_BaseMatrix.__call__` now handles a `Matrix` argument by reading `origin_value` from it, allowing interpolation to continue from the current value rather than the previous target.

## Tests
Three test cases in `testcases/game/tests/test_transforms.rpy`, run with `renpy.sh testcases test transforms`.

All three pass after creating a new renpy build.