### PR TITLE
Allow statement prediction to track store-variable values and skip impossible branches

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -319,6 +319,15 @@ class Node(Object):
     can't see.
     """
 
+    predict_trust_store_after: ClassVar[bool] = False
+    """
+    True if, when this node is the statement prediction starts from, the
+    statements after it may keep evaluating against the current values of
+    store variables. This requires that executing the node can't change a
+    store variable, and defaults to False as most statements can run
+    creator-supplied code.
+    """
+
     @property
     def name(self) -> NodeName:
         """
@@ -882,6 +891,8 @@ def get_reachable_nodes(
 
 
 class Say(Node):
+    predict_trust_store_after = True
+
     who: str | None
     who_fast: bool
     what: str
@@ -1252,7 +1263,7 @@ class Python(Node):
                 else:
                     context.predict_forget()
             else:
-                new_state = renpy.pyanalysis.apply_assignments(effects, state)
+                new_state = renpy.pyanalysis.apply_assignments(effects, state, context.predict_trust_store)
 
                 if new_state is None:
                     context.predict_forget()
@@ -1798,6 +1809,10 @@ class Return(Node):
 class Menu(Node):
     translation_relevant = True
 
+    @property
+    def predict_trust_store_after(self):  # type: ignore
+        return self.set is None
+
     items: list[tuple[str, str, list[Node] | None]]
     statement_start: Node  # type: ignore
     set: str | None = None
@@ -2180,8 +2195,10 @@ class If(Node):
         state = context.predict_var_state
 
         if state is not None:
+            trust_store = context.predict_trust_store
+
             for i, (condition, block) in enumerate(self.entries):
-                truth = renpy.pyanalysis.eval_predicted_condition(condition, state)
+                truth = renpy.pyanalysis.eval_predicted_condition(condition, state, trust_store)
 
                 # This condition needs values prediction doesn't know, so
                 # every branch from here on may be taken.

--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -311,6 +311,14 @@ class Node(Object):
     True if this statement should be run while warping, False otherwise.
     """
 
+    predict_preserves_variables: ClassVar[bool] = False
+    """
+    True if prediction may carry what it has worked out about variable values
+    across this node. This defaults to False, as most statements can run
+    creator-supplied code, and so may change a variable in a way prediction
+    can't see.
+    """
+
     @property
     def name(self) -> NodeName:
         """
@@ -1126,6 +1134,10 @@ class Label(Node):
     parameters: ParameterInfo | None = None
     hide: bool = False
 
+    @property
+    def predict_preserves_variables(self):  # type: ignore
+        return self.parameters is None
+
     def __init__(self, loc, name, block, parameters, hide=False):
         """
         Constructs a new Label node.
@@ -1179,6 +1191,8 @@ class Label(Node):
 
 
 class Python(Node):
+    predict_preserves_variables = True
+
     code: PyCode
     store: str = "store"
     hide: bool = False
@@ -1218,6 +1232,34 @@ class Python(Node):
             if not renpy.game.context().init_phase:
                 for i in renpy.config.python_callbacks:
                     i()
+
+    def predict(self):
+        context = renpy.game.context()
+        state = context.predict_var_state
+
+        if state is not None:
+            effects = renpy.pyanalysis.analyze_assignments(self.code)
+
+            if effects is None:
+                context.predict_forget()
+            elif self.hide or self.store != "store":
+                # Plain assignments here don't reach the default store, but
+                # an assignment to store.name does, so every name this could
+                # store to is forgotten - as long as the code can't run
+                # creator-supplied code, which could change anything.
+                if renpy.pyanalysis.assignments_are_inert(effects):
+                    context.predict_assign({}, renpy.pyanalysis.assigned_names(effects))
+                else:
+                    context.predict_forget()
+            else:
+                new_state = renpy.pyanalysis.apply_assignments(effects, state)
+
+                if new_state is None:
+                    context.predict_forget()
+                else:
+                    context.predict_var_state = new_state
+
+        return super().predict()
 
     def scry(self):
         rv = super().scry()
@@ -1946,6 +1988,10 @@ class Jump(Node):
     expression: bool = False
     global_label: str = ""
 
+    @property
+    def predict_preserves_variables(self):  # type: ignore
+        return not self.expression
+
     def __init__(self, loc, target, expression, global_label=""):
         super(Jump, self).__init__(loc)
 
@@ -2019,6 +2065,8 @@ class Jump(Node):
 
 # GNDN
 class Pass(Node):
+    predict_preserves_variables = True
+
     def diff_info(self):
         return (Pass,)
 
@@ -2082,6 +2130,8 @@ class While(Node):
 
 
 class If(Node):
+    predict_preserves_variables = True
+
     entries: list[tuple[str, list[Node]]]
 
     def __init__(self, loc, entries):
@@ -2126,6 +2176,25 @@ class If(Node):
                 return
 
     def predict(self):
+        context = renpy.game.context()
+        state = context.predict_var_state
+
+        if state is not None:
+            for i, (condition, block) in enumerate(self.entries):
+                truth = renpy.pyanalysis.eval_predicted_condition(condition, state)
+
+                # This condition needs values prediction doesn't know, so
+                # every branch from here on may be taken.
+                if truth is None:
+                    context.predict_forget()
+
+                    return [block[0] for _condition, block in self.entries[i:]] + [self.next]
+
+                if truth:
+                    return [block[0]]
+
+            return [self.next]
+
         return [block[0] for _condition, block in self.entries] + [self.next]
 
     def scry(self):

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -126,6 +126,12 @@ class NewPredictInfo:
     var_state: dict[str, Any]
     "A map from variable name to the literal value prediction has worked out it has when this node is reached."
 
+    trust_store: bool
+    "True if the current values of variables in the store can still be used when this node is reached."
+
+    root: bool
+    "True if this is a statement prediction starts from, rather than one it has walked to."
+
     predicted: bool
     "True once this node has been predicted."
 
@@ -195,6 +201,8 @@ class Context(renpy.object.Object):
     predict_return_stack = None  # type: list|None
 
     predict_var_state = None  # type: dict|None
+
+    predict_trust_store = False
 
     exception_handler: Callable[[renpy.error.TracebackException], bool] | None
 
@@ -897,6 +905,9 @@ class Context(renpy.object.Object):
         Called during prediction to record that the variables in `bindings`
         are known to have the given literal values, while the values of the
         variables in `invalidated` can no longer be predicted.
+
+        Invalidated variables are remembered, rather than dropped, so that
+        the value one of them has in the store isn't used in its place.
         """
 
         state = self.predict_var_state
@@ -907,7 +918,7 @@ class Context(renpy.object.Object):
         state = dict(state)
 
         for name in invalidated:
-            state.pop(name, None)
+            state[name] = renpy.pyanalysis.UNKNOWN
 
         state.update(bindings)
 
@@ -915,12 +926,14 @@ class Context(renpy.object.Object):
 
     def predict_forget(self):
         """
-        Called during prediction to indicate that the values of variables
-        can no longer be predicted.
+        Called during prediction when code it can't analyze may run, so that
+        neither the values worked out so far nor the current contents of the
+        store are used from here on.
         """
 
         if self.predict_var_state is not None:
             self.predict_var_state = {}
+            self.predict_trust_store = False
 
     def predict(self):
         """
@@ -960,6 +973,8 @@ class Context(renpy.object.Object):
             npi.predict_return_stack = self.return_stack
             npi.tlids = [self.translate_identifier, self.alternate_translate_identifier]
             npi.var_state = {}
+            npi.trust_store = True
+            npi.root = True
             npi.predicted = False
 
             nodes.append(npi)
@@ -987,8 +1002,13 @@ class Context(renpy.object.Object):
             # explicitly opt-in.
             if node.predict_preserves_variables:
                 self.predict_var_state = npi.var_state
+                self.predict_trust_store = npi.trust_store
+            elif npi.root:
+                self.predict_var_state = npi.var_state
+                self.predict_trust_store = npi.trust_store and node.predict_trust_store_after
             else:
                 self.predict_var_state = {}
+                self.predict_trust_store = False
 
             try:
                 for n in node.predict():
@@ -1004,19 +1024,26 @@ class Context(renpy.object.Object):
                         next_npi.predict_return_stack = self.predict_return_stack
                         next_npi.tlids = renpy.display.predict.tlids
                         next_npi.var_state = self.predict_var_state
+                        next_npi.trust_store = self.predict_trust_store
+                        next_npi.root = False
                         next_npi.predicted = False
 
                         nodes.append(next_npi)
                         node_info[n] = next_npi
+
                     elif n.predict_preserves_variables:
                         # Another path reached this node, so keep only what
-                        # both paths agree on.
+                        # both paths agree on. If that loses information the
+                        # node was already predicted with, predict it again,
+                        # in case that information had ruled out a branch.
                         merged = renpy.pyanalysis.merge_predicted_states(
                             next_npi.var_state, self.predict_var_state
                         )
+                        trust = next_npi.trust_store and self.predict_trust_store
 
-                        if len(merged) != len(next_npi.var_state):
+                        if (merged != next_npi.var_state) or (trust != next_npi.trust_store):
                             next_npi.var_state = merged
+                            next_npi.trust_store = trust
 
                             if next_npi.predicted:
                                 next_npi.predicted = False
@@ -1033,6 +1060,7 @@ class Context(renpy.object.Object):
             self.images = old_images
             self.predict_return_stack = None
             self.predict_var_state = None
+            self.predict_trust_store = False
 
             yield True
 

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -123,6 +123,12 @@ class NewPredictInfo:
     tlids: list[str | None]
     "A list of strings giving translation identifiers that are in effect at the time of prediction."
 
+    var_state: dict[str, Any]
+    "A map from variable name to the literal value prediction has worked out it has when this node is reached."
+
+    predicted: bool
+    "True once this node has been predicted."
+
 
 class LineLogEntry(object):
     def __init__(self, filename, line, node, abnormal):
@@ -187,6 +193,8 @@ class Context(renpy.object.Object):
     deferred_translate_identifier = None
 
     predict_return_stack = None  # type: list|None
+
+    predict_var_state = None  # type: dict|None
 
     exception_handler: Callable[[renpy.error.TracebackException], bool] | None
 
@@ -884,6 +892,36 @@ class Context(renpy.object.Object):
 
         return renpy.game.script.lookup(label)
 
+    def predict_assign(self, bindings, invalidated):
+        """
+        Called during prediction to record that the variables in `bindings`
+        are known to have the given literal values, while the values of the
+        variables in `invalidated` can no longer be predicted.
+        """
+
+        state = self.predict_var_state
+
+        if state is None:
+            return
+
+        state = dict(state)
+
+        for name in invalidated:
+            state.pop(name, None)
+
+        state.update(bindings)
+
+        self.predict_var_state = state
+
+    def predict_forget(self):
+        """
+        Called during prediction to indicate that the values of variables
+        can no longer be predicted.
+        """
+
+        if self.predict_var_state is not None:
+            self.predict_var_state = {}
+
     def predict(self):
         """
         Performs image prediction, calling the given callback with each
@@ -899,11 +937,12 @@ class Context(renpy.object.Object):
 
         old_images = self.images
 
-        # A worklist of (node, images, return_stack) tuples.
+        # A worklist of NewPredictInfo objects.
         nodes = []
 
-        # The set of nodes we've seen. (We only consider each node once.)
-        seen = set()
+        # A map from each node we've seen to its NewPredictInfo. (We only
+        # consider each node once, unless a merge loses variable information.)
+        node_info = {}
 
         # Find the roots.
         for label in renpy.config.predict_statements_callback(self.current):
@@ -912,7 +951,7 @@ class Context(renpy.object.Object):
 
             node = renpy.game.script.lookup(label)
 
-            if node in seen:
+            if node in node_info:
                 continue
 
             npi = NewPredictInfo()
@@ -920,9 +959,11 @@ class Context(renpy.object.Object):
             npi.images = self.images
             npi.predict_return_stack = self.return_stack
             npi.tlids = [self.translate_identifier, self.alternate_translate_identifier]
+            npi.var_state = {}
+            npi.predicted = False
 
             nodes.append(npi)
-            seen.add(node)
+            node_info[node] = npi
 
         # Predict statements.
         for i in range(0, renpy.config.predict_statements):
@@ -930,6 +971,8 @@ class Context(renpy.object.Object):
                 break
 
             npi = nodes[i]
+            npi.predicted = True
+
             node = npi.node
             images = npi.images
             return_stack = npi.predict_return_stack
@@ -939,20 +982,45 @@ class Context(renpy.object.Object):
             self.images = renpy.display.image.ShownImageInfo(images)
             self.predict_return_stack = return_stack
 
+            # Most statements can run creator-supplied code, which may change
+            # a variable without prediction seeing it. Only trust those that
+            # explicitly opt-in.
+            if node.predict_preserves_variables:
+                self.predict_var_state = npi.var_state
+            else:
+                self.predict_var_state = {}
+
             try:
                 for n in node.predict():
                     if n is None:
                         continue
 
-                    if n not in seen:
-                        npi = NewPredictInfo()
-                        npi.node = n
-                        npi.images = self.images
-                        npi.predict_return_stack = self.predict_return_stack
-                        npi.tlids = renpy.display.predict.tlids
+                    next_npi = node_info.get(n)
 
-                        nodes.append(npi)
-                        seen.add(n)
+                    if next_npi is None:
+                        next_npi = NewPredictInfo()
+                        next_npi.node = n
+                        next_npi.images = self.images
+                        next_npi.predict_return_stack = self.predict_return_stack
+                        next_npi.tlids = renpy.display.predict.tlids
+                        next_npi.var_state = self.predict_var_state
+                        next_npi.predicted = False
+
+                        nodes.append(next_npi)
+                        node_info[n] = next_npi
+                    elif n.predict_preserves_variables:
+                        # Another path reached this node, so keep only what
+                        # both paths agree on.
+                        merged = renpy.pyanalysis.merge_predicted_states(
+                            next_npi.var_state, self.predict_var_state
+                        )
+
+                        if len(merged) != len(next_npi.var_state):
+                            next_npi.var_state = merged
+
+                            if next_npi.predicted:
+                                next_npi.predicted = False
+                                nodes.append(next_npi)
 
             except Exception:
                 if renpy.config.debug_prediction:
@@ -964,6 +1032,7 @@ class Context(renpy.object.Object):
 
             self.images = old_images
             self.predict_return_stack = None
+            self.predict_var_state = None
 
             yield True
 

--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -31,6 +31,7 @@ from renpy.python import py_compile
 # Import the Python AST module, instead of the Ren'Py ast module.
 import ast
 
+import operator
 import zlib
 
 from renpy.compat.pickle import loads, dumps
@@ -969,3 +970,520 @@ def save_cache():
             f.write(data)
     except Exception:
         pass
+
+
+# A cache mapping python source to the result of analyze_assignments for that
+# source.
+assignment_cache: "dict[str, list | None]" = {}
+
+# A cache mapping a condition string to its parsed expression or None if it
+# could not be parsed.
+predict_expression_cache: "dict[str, ast.expr | None]" = {}
+
+
+def is_immutable_literal(value):
+    """
+    Returns true if `value` is immutable data, so prediction can bind it into
+    per-path variable state and share it safely.
+    """
+
+    if value is None or value is True or value is False:
+        return True
+
+    if isinstance(value, (int, float, complex, str, bytes)):
+        return True
+
+    if isinstance(value, (tuple, frozenset)):
+        return all(is_immutable_literal(i) for i in value)
+
+    return False
+
+
+class PredictRefused(Exception):
+    """
+    Raised during prediction expression evaluation when evaluating further
+    might run creator-supplied code or needs a value prediction doesn't
+    know.
+    """
+
+
+_predict_binary_ops = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+    ast.LShift: operator.lshift,
+    ast.RShift: operator.rshift,
+    ast.BitOr: operator.or_,
+    ast.BitXor: operator.xor,
+    ast.BitAnd: operator.and_,
+}
+
+_predict_unary_ops = {
+    ast.Not: operator.not_,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+    ast.Invert: operator.invert,
+}
+
+_predict_compare_ops = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.Is: operator.is_,
+    ast.IsNot: operator.is_not,
+    ast.In: lambda a, b: a in b,
+    ast.NotIn: lambda a, b: a not in b,
+}
+
+
+# A bound on the size, in bits or items, of values prediction is willing to
+# compute.
+PREDICT_SIZE_LIMIT = 65536
+
+
+def predict_binop_allowed(op_type, left, right):
+    """
+    Returns false when applying the binary operator `op_type` to `left` and
+    `right` could produce a value so large that computing it during
+    prediction would be noticed.
+    """
+
+    if op_type is ast.Pow:
+        if isinstance(left, int) and isinstance(right, int) and abs(left) > 1:
+            return abs(right) * abs(left).bit_length() <= PREDICT_SIZE_LIMIT
+    elif op_type is ast.LShift:
+        if isinstance(left, int) and isinstance(right, int) and left != 0:
+            return right <= PREDICT_SIZE_LIMIT
+    elif op_type is ast.Mult:
+        if isinstance(left, int) and isinstance(right, int):
+            return abs(left).bit_length() + abs(right).bit_length() <= PREDICT_SIZE_LIMIT
+
+        for count, seq in ((left, right), (right, left)):
+            if isinstance(count, int) and isinstance(seq, (str, bytes, tuple, list)):
+                return count * len(seq) <= PREDICT_SIZE_LIMIT
+
+    return True
+
+
+def resolve_predicted_name(name, state):
+    """
+    Returns the value prediction knows `name` to have, raising PredictRefused
+    if it doesn't know one.
+    """
+
+    if name in state:
+        return state[name]
+
+    raise PredictRefused(name)
+
+
+def eval_predicted_expression(node, state):
+    """
+    Evaluates the expression `node` using only values prediction has proven,
+    raising PredictRefused otherwise.
+    """
+
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    if isinstance(node, ast.Name):
+        return resolve_predicted_name(node.id, state)
+
+    # An attribute of `store` is the same variable a bare name is.
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "store"
+        and "store" not in state
+    ):
+        return resolve_predicted_name(node.attr, state)
+
+    if isinstance(node, ast.Tuple):
+        return tuple(eval_predicted_expression(i, state) for i in node.elts)
+
+    if isinstance(node, ast.List):
+        return [eval_predicted_expression(i, state) for i in node.elts]
+
+    if isinstance(node, ast.Set):
+        return {eval_predicted_expression(i, state) for i in node.elts}
+
+    if isinstance(node, ast.Dict):
+        rv = {}
+
+        for k, v in zip(node.keys, node.values):
+            if k is None: # A None key is a ** unpacking.
+                raise PredictRefused(node)
+
+            rv[eval_predicted_expression(k, state)] = eval_predicted_expression(v, state)
+
+        return rv
+
+    if isinstance(node, ast.UnaryOp):
+        op = _predict_unary_ops.get(type(node.op))
+
+        if op is None:
+            raise PredictRefused(node)
+
+        return op(eval_predicted_expression(node.operand, state))
+
+    if isinstance(node, ast.BinOp):
+        op_type = type(node.op)
+        op = _predict_binary_ops.get(op_type)
+
+        if op is None:
+            raise PredictRefused(node)
+
+        left = eval_predicted_expression(node.left, state)
+        right = eval_predicted_expression(node.right, state)
+
+        if not predict_binop_allowed(op_type, left, right):
+            raise PredictRefused(node)
+
+        return op(left, right)
+
+    if isinstance(node, ast.BoolOp):
+        value = None
+
+        for i in node.values:
+            value = eval_predicted_expression(i, state)
+
+            if isinstance(node.op, ast.And):
+                if not value:
+                    return value
+            else:
+                if value:
+                    return value
+
+        return value
+
+    if isinstance(node, ast.Compare):
+        left = eval_predicted_expression(node.left, state)
+
+        for op_node, comparator in zip(node.ops, node.comparators):
+            op_type = type(op_node)
+            op = _predict_compare_ops.get(op_type)
+
+            if op is None:
+                raise PredictRefused(node)
+
+            right = eval_predicted_expression(comparator, state)
+
+            # Identity of anything but the singletons None, True, and False
+            # isn't preserved between prediction and runtime.
+            if op_type in (ast.Is, ast.IsNot):
+                if not any(i is None or i is True or i is False for i in (left, right)):
+                    raise PredictRefused(node)
+
+            if not op(left, right):
+                return False
+
+            left = right
+
+        return True
+
+    if isinstance(node, ast.IfExp):
+        if eval_predicted_expression(node.test, state):
+            return eval_predicted_expression(node.body, state)
+
+        return eval_predicted_expression(node.orelse, state)
+
+    if isinstance(node, ast.Subscript):
+        value = eval_predicted_expression(node.value, state)
+
+        if isinstance(node.slice, ast.Slice):
+            def bound(b):
+                return None if b is None else eval_predicted_expression(b, state)
+
+            index = slice(bound(node.slice.lower), bound(node.slice.upper), bound(node.slice.step))
+        else:
+            index = eval_predicted_expression(node.slice, state)
+
+        return value[index]
+
+    raise PredictRefused(node)
+
+
+def eval_predicted_condition(condition, state):
+    """
+    Tries to evaluate `condition` using only the variable values in `state`.
+
+    Returns True or False if the condition could be evaluated or None if it
+    could not be.
+    """
+
+    tree = predict_expression_cache.get(condition, False)
+
+    if tree is False:
+        try:
+            tree = ast.parse(condition, mode="eval").body
+        except Exception:
+            tree = None
+
+        predict_expression_cache[condition] = tree
+
+    if tree is None:
+        return None
+
+    try:
+        return bool(eval_predicted_expression(tree, state))
+    except PredictRefused:
+        return None
+    except Exception:
+        return None
+
+
+def assignment_target_names(target):
+    """
+    Returns (names, simple) for an assignment target, where `names` are the
+    variables the target stores to, and `simple` is true if the assigned
+    value binds to a single name. Returns None if the target can't be
+    analyzed or if storing to it could run creator-supplied code.
+    """
+
+    if isinstance(target, ast.Name):
+        # Rebinding store would change the meaning of store.x elsewhere.
+        if target.id == "store":
+            return None
+
+        return [target.id], True
+
+    # StoreModule.__setattr__ only writes to the store's dict.
+    if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "store":
+        return [target.attr], True
+
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names = []
+
+        for i in target.elts:
+            sub = assignment_target_names(i)
+
+            if sub is None:
+                return None
+
+            names.extend(sub[0])
+
+        return names, False
+
+    if isinstance(target, ast.Starred):
+        sub = assignment_target_names(target.value)
+
+        if sub is None:
+            return None
+
+        return sub[0], False
+
+    # Attribute and subscript targets run __setattr__ or __setitem__.
+    return None
+
+
+def expression_is_inert(node):
+    """
+    Returns true if evaluating `node` at runtime can't run creator-supplied
+    code no matter what its names hold - it only reads names and builds
+    containers, with no operators, calls, or subscripts.
+    """
+
+    if isinstance(node, (ast.Constant, ast.Name)):
+        return True
+
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return all(expression_is_inert(i) for i in node.elts)
+
+    if isinstance(node, ast.Starred):
+        return expression_is_inert(node.value)
+
+    return False
+
+
+def analyze_assignments(code):
+    """
+    Analyzes a PyCode object into a list of assignment effects that
+    apply_assignments can replay against prediction variable state. Returns
+    None if executing the code may change variables in a way that can't be
+    followed.
+    """
+
+    rv = assignment_cache.get(code.source, False)
+
+    if rv is False:
+        rv = analyze_assignments_core(code.source)
+        assignment_cache[code.source] = rv
+
+    return rv
+
+
+def analyze_assignments_core(source):
+    """
+    Implements analyze_assignments without caching.
+    """
+
+    try:
+        tree = ast.parse(source)
+    except Exception:
+        return None
+
+    ops = []
+
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Pass):
+            continue
+
+        if isinstance(stmt, ast.Expr):
+            # A docstring or other constant does nothing.
+            if isinstance(stmt.value, ast.Constant):
+                continue
+
+            # Anything else is checked when the effects are applied.
+            ops.append(((), stmt.value, False))
+
+            continue
+
+        if isinstance(stmt, ast.Delete):
+            names = []
+
+            for i in stmt.targets:
+                sub = assignment_target_names(i)
+
+                if sub is None or not sub[1]:
+                    return None
+
+                names.extend(sub[0])
+
+            ops.append((tuple(names), None, False))
+
+            continue
+
+        if isinstance(stmt, ast.Assign):
+            targets = stmt.targets
+        elif isinstance(stmt, ast.AnnAssign):
+            if stmt.value is None:
+                continue
+
+            targets = [stmt.target]
+        elif isinstance(stmt, ast.AugAssign):
+            sub = assignment_target_names(stmt.target)
+
+            if sub is None or not sub[1]:
+                return None
+
+            name = sub[0][0]
+
+            # x += y has the effect of x = x + y when x is an immutable
+            # literal, which is the only case a result is bound in.
+            expr = ast.BinOp(left=ast.Name(id=name, ctx=ast.Load()), op=stmt.op, right=stmt.value)
+
+            ops.append(((name,), expr, True))
+
+            continue
+        else:
+            return None
+
+        names = []
+        bind = True
+
+        for target in targets:
+            sub = assignment_target_names(target)
+
+            if sub is None:
+                return None
+
+            names.extend(sub[0])
+
+            # When a target unpacks, which name takes what isn't tracked.
+            if not sub[1]:
+                bind = False
+
+        ops.append((tuple(names), stmt.value, bind))
+
+    return ops
+
+
+def apply_assignments(ops, state):
+    """
+    Applies the effects returned by analyze_assignments to `state`, returning
+    the new state, or None if variables may have changed in ways prediction
+    can't follow.
+    """
+
+    state = dict(state)
+
+    for names, expr, bind in ops:
+        if expr is None:
+            for name in names:
+                state.pop(name, None)
+
+            continue
+
+        try:
+            value = eval_predicted_expression(expr, state)
+        except PredictRefused:
+            # The expression couldn't be evaluated. If evaluating it at
+            # runtime can't touch other variables either, only the assigned
+            # names are lost.
+            if not expression_is_inert(expr):
+                return None
+
+            for name in names:
+                state.pop(name, None)
+
+            continue
+        except Exception:
+            return None
+
+        if bind and is_immutable_literal(value):
+            for name in names:
+                state[name] = value
+        else:
+            for name in names:
+                state.pop(name, None)
+
+    return state
+
+
+def assignments_are_inert(ops):
+    """
+    Returns true if replaying the effects returned by analyze_assignments at
+    runtime can't run creator-supplied code, no matter what values the names
+    involved hold.
+    """
+
+    return all((expr is None or expression_is_inert(expr)) for _names, expr, _bind in ops)
+
+
+def assigned_names(ops):
+    """
+    Returns the set of every name the effects returned by analyze_assignments
+    may store to.
+    """
+
+    rv = set()
+
+    for names, _expr, _bind in ops:
+        rv.update(names)
+
+    return rv
+
+
+def merge_predicted_states(a, b):
+    """
+    Returns the variable state holding what the states `a` and `b` agree on,
+    for when two prediction paths reach the same node.
+    """
+
+    rv = {}
+
+    for name, value in a.items():
+        if name in b:
+            other = b[name]
+
+            if (value is other) or (type(value) is type(other) and value == other):
+                rv[name] = value
+
+    return rv

--- a/renpy/pyanalysis.py
+++ b/renpy/pyanalysis.py
@@ -32,6 +32,7 @@ from renpy.python import py_compile
 import ast
 
 import operator
+import types
 import zlib
 
 from renpy.compat.pickle import loads, dumps
@@ -972,6 +973,10 @@ def save_cache():
         pass
 
 
+# A sentinel used in prediction variable state to mark a variable whose value
+# has changed in a way prediction can't follow.
+UNKNOWN = renpy.object.Sentinel("PREDICT_UNKNOWN")
+
 # A cache mapping python source to the result of analyze_assignments for that
 # source.
 assignment_cache: "dict[str, list | None]" = {}
@@ -1043,8 +1048,52 @@ _predict_compare_ops = {
 }
 
 
+# A bound on the number of values is_readable_value examines.
+PREDICT_READ_LIMIT = 256
+
+
+def is_readable_value(value, _budget=None):
+    """
+    Returns true if `value` is safe for prediction to evaluate over - every
+    operation reading it has builtin semantics. Immutable literals are
+    readable, and so are builtin and Ren'Py revertable containers whose
+    contents are, as long as they hold no more than PREDICT_READ_LIMIT
+    values in total.
+    """
+
+    if _budget is None:
+        _budget = [PREDICT_READ_LIMIT]
+
+    if is_immutable_literal(value):
+        return True
+
+    revertable = renpy.revertable
+    kind = type(value)
+
+    if kind is dict or kind is revertable.RevertableDict:
+        items = []
+
+        for k, v in value.items():
+            items.append(k)
+            items.append(v)
+    elif kind is list or kind is tuple or kind is revertable.RevertableList:
+        items = value
+    elif kind is set or kind is frozenset or kind is revertable.RevertableSet:
+        items = list(value)
+    else:
+        return False
+
+    _budget[0] -= len(items)
+
+    if _budget[0] < 0:
+        return False
+
+    return all(is_readable_value(i, _budget) for i in items)
+
+
 # A bound on the size, in bits or items, of values prediction is willing to
-# compute.
+# compute, so evaluating a branch that runtime may never take can't eat a
+# noticeable amount of time or memory.
 PREDICT_SIZE_LIMIT = 65536
 
 
@@ -1072,47 +1121,175 @@ def predict_binop_allowed(op_type, left, right):
     return True
 
 
-def resolve_predicted_name(name, state):
+def predicted_store_value(name):
+    """
+    Returns the value `name` has in the default store, if prediction can
+    safely evaluate over it, and raises PredictRefused otherwise.
+    """
+
+    try:
+        value = renpy.python.store_dicts["store"][name]
+    except Exception:
+        raise PredictRefused(name)
+
+    if not is_readable_value(value):
+        raise PredictRefused(name)
+
+    return value
+
+
+def resolve_predicted_name(name, state, trust_store):
     """
     Returns the value prediction knows `name` to have, raising PredictRefused
     if it doesn't know one.
+
+    Invalidated names are remembered in `state`, rather than dropped, so that
+    the value one has in the store isn't used in its place.
     """
 
     if name in state:
-        return state[name]
+        value = state[name]
+
+        if value is UNKNOWN:
+            raise PredictRefused(name)
+
+        return value
+
+    if trust_store:
+        return predicted_store_value(name)
 
     raise PredictRefused(name)
 
 
-def eval_predicted_expression(node, state):
+def predicted_namespace(name, state, trust_store):
     """
-    Evaluates the expression `node` using only values prediction has proven,
-    raising PredictRefused otherwise.
+    Returns the object `name` refers to in the default store, if reading an
+    attribute of it is known not to run creator-supplied code, and raises
+    PredictRefused otherwise.
+    """
+
+    if not trust_store or name in state:
+        raise PredictRefused(name)
+
+    try:
+        value = renpy.python.store_dicts["store"][name]
+    except Exception:
+        raise PredictRefused(name)
+
+    if isinstance(value, (renpy.python.StoreModule, renpy.persistent.Persistent)):
+        return value
+
+    if isinstance(value, types.ModuleType) and "__getattr__" not in vars(value):
+        return value
+
+    raise PredictRefused(name)
+
+
+def eval_predicted_call(node, state, trust_store):
+    """
+    Evaluates a call to a function registered pure. Purity means the call
+    can't have side effects, so the only risk in making it is an inaccurate
+    result, which costs prediction accuracy rather than correctness.
+    """
+
+    if not isinstance(node.func, ast.Name):
+        raise PredictRefused(node)
+
+    name = node.func.id
+
+    if name not in pure_functions:
+        raise PredictRefused(node)
+
+    # Without the store, there is no way to know the name still refers to
+    # the registered function - even a builtin can be shadowed by a store
+    # variable. A name assigned along this path may have been rebound too.
+    if not trust_store or name in state:
+        raise PredictRefused(node)
+
+    builtin_func = getattr(builtins, name, None)
+
+    try:
+        func = renpy.python.store_dicts["store"][name]
+    except Exception:
+        func = builtin_func
+
+    if func is None or not callable(func):
+        raise PredictRefused(node)
+
+    # A builtin name that no longer refers to its builtin has been shadowed,
+    # and there's no way to know what replaced it is still pure.
+    if (builtin_func is not None) and (func is not builtin_func):
+        raise PredictRefused(node)
+
+    args = []
+
+    for a in node.args:
+        if isinstance(a, ast.Starred):
+            raise PredictRefused(node)
+
+        args.append(eval_predicted_expression(a, state, trust_store))
+
+    kwargs = {}
+
+    for k in node.keywords:
+        if k.arg is None:
+            raise PredictRefused(node)
+
+        kwargs[k.arg] = eval_predicted_expression(k.value, state, trust_store)
+
+    value = func(*args, **kwargs)
+
+    if not is_readable_value(value):
+        raise PredictRefused(node)
+
+    return value
+
+
+def eval_predicted_expression(node, state, trust_store):
+    """
+    Evaluates the expression `node` using the values prediction has proven
+    in `state`, and where `trust_store` is true, the current values of
+    variables in the default store. Raises PredictRefused when evaluation
+    might run creator-supplied code, or needs a value prediction doesn't
+    know.
     """
 
     if isinstance(node, ast.Constant):
         return node.value
 
     if isinstance(node, ast.Name):
-        return resolve_predicted_name(node.id, state)
+        return resolve_predicted_name(node.id, state, trust_store)
 
-    # An attribute of `store` is the same variable a bare name is.
-    if (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "store"
-        and "store" not in state
-    ):
-        return resolve_predicted_name(node.attr, state)
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        # An attribute of `store` is the same variable a bare name is.
+        if node.value.id == "store" and "store" not in state:
+            return resolve_predicted_name(node.attr, state, trust_store)
+
+        # Dunder and private attributes could reach machinery rather than
+        # data.
+        if node.attr.startswith("_"):
+            raise PredictRefused(node)
+
+        namespace = predicted_namespace(node.value.id, state, trust_store)
+
+        value = getattr(namespace, node.attr, UNKNOWN)
+
+        if value is UNKNOWN or not is_readable_value(value):
+            raise PredictRefused(node)
+
+        return value
+
+    if isinstance(node, ast.Call):
+        return eval_predicted_call(node, state, trust_store)
 
     if isinstance(node, ast.Tuple):
-        return tuple(eval_predicted_expression(i, state) for i in node.elts)
+        return tuple(eval_predicted_expression(i, state, trust_store) for i in node.elts)
 
     if isinstance(node, ast.List):
-        return [eval_predicted_expression(i, state) for i in node.elts]
+        return [eval_predicted_expression(i, state, trust_store) for i in node.elts]
 
     if isinstance(node, ast.Set):
-        return {eval_predicted_expression(i, state) for i in node.elts}
+        return {eval_predicted_expression(i, state, trust_store) for i in node.elts}
 
     if isinstance(node, ast.Dict):
         rv = {}
@@ -1121,7 +1298,7 @@ def eval_predicted_expression(node, state):
             if k is None: # A None key is a ** unpacking.
                 raise PredictRefused(node)
 
-            rv[eval_predicted_expression(k, state)] = eval_predicted_expression(v, state)
+            rv[eval_predicted_expression(k, state, trust_store)] = eval_predicted_expression(v, state, trust_store)
 
         return rv
 
@@ -1131,7 +1308,7 @@ def eval_predicted_expression(node, state):
         if op is None:
             raise PredictRefused(node)
 
-        return op(eval_predicted_expression(node.operand, state))
+        return op(eval_predicted_expression(node.operand, state, trust_store))
 
     if isinstance(node, ast.BinOp):
         op_type = type(node.op)
@@ -1140,8 +1317,8 @@ def eval_predicted_expression(node, state):
         if op is None:
             raise PredictRefused(node)
 
-        left = eval_predicted_expression(node.left, state)
-        right = eval_predicted_expression(node.right, state)
+        left = eval_predicted_expression(node.left, state, trust_store)
+        right = eval_predicted_expression(node.right, state, trust_store)
 
         if not predict_binop_allowed(op_type, left, right):
             raise PredictRefused(node)
@@ -1152,7 +1329,7 @@ def eval_predicted_expression(node, state):
         value = None
 
         for i in node.values:
-            value = eval_predicted_expression(i, state)
+            value = eval_predicted_expression(i, state, trust_store)
 
             if isinstance(node.op, ast.And):
                 if not value:
@@ -1164,7 +1341,7 @@ def eval_predicted_expression(node, state):
         return value
 
     if isinstance(node, ast.Compare):
-        left = eval_predicted_expression(node.left, state)
+        left = eval_predicted_expression(node.left, state, trust_store)
 
         for op_node, comparator in zip(node.ops, node.comparators):
             op_type = type(op_node)
@@ -1173,7 +1350,7 @@ def eval_predicted_expression(node, state):
             if op is None:
                 raise PredictRefused(node)
 
-            right = eval_predicted_expression(comparator, state)
+            right = eval_predicted_expression(comparator, state, trust_store)
 
             # Identity of anything but the singletons None, True, and False
             # isn't preserved between prediction and runtime.
@@ -1189,30 +1366,32 @@ def eval_predicted_expression(node, state):
         return True
 
     if isinstance(node, ast.IfExp):
-        if eval_predicted_expression(node.test, state):
-            return eval_predicted_expression(node.body, state)
+        if eval_predicted_expression(node.test, state, trust_store):
+            return eval_predicted_expression(node.body, state, trust_store)
 
-        return eval_predicted_expression(node.orelse, state)
+        return eval_predicted_expression(node.orelse, state, trust_store)
 
     if isinstance(node, ast.Subscript):
-        value = eval_predicted_expression(node.value, state)
+        value = eval_predicted_expression(node.value, state, trust_store)
 
         if isinstance(node.slice, ast.Slice):
             def bound(b):
-                return None if b is None else eval_predicted_expression(b, state)
+                return None if b is None else eval_predicted_expression(b, state, trust_store)
 
             index = slice(bound(node.slice.lower), bound(node.slice.upper), bound(node.slice.step))
         else:
-            index = eval_predicted_expression(node.slice, state)
+            index = eval_predicted_expression(node.slice, state, trust_store)
 
         return value[index]
 
     raise PredictRefused(node)
 
 
-def eval_predicted_condition(condition, state):
+def eval_predicted_condition(condition, state, trust_store):
     """
-    Tries to evaluate `condition` using only the variable values in `state`.
+    Tries to evaluate `condition` using the variable values in `state`, and
+    where `trust_store` is true, the current values of variables in the
+    default store.
 
     Returns True or False if the condition could be evaluated or None if it
     could not be.
@@ -1232,7 +1411,7 @@ def eval_predicted_condition(condition, state):
         return None
 
     try:
-        return bool(eval_predicted_expression(tree, state))
+        return bool(eval_predicted_expression(tree, state, trust_store))
     except PredictRefused:
         return None
     except Exception:
@@ -1405,11 +1584,14 @@ def analyze_assignments_core(source):
     return ops
 
 
-def apply_assignments(ops, state):
+def apply_assignments(ops, state, trust_store):
     """
     Applies the effects returned by analyze_assignments to `state`, returning
     the new state, or None if variables may have changed in ways prediction
     can't follow.
+
+    Invalidated names are marked UNKNOWN, rather than dropped, so that the
+    value one has in the store isn't used in its place.
     """
 
     state = dict(state)
@@ -1417,12 +1599,12 @@ def apply_assignments(ops, state):
     for names, expr, bind in ops:
         if expr is None:
             for name in names:
-                state.pop(name, None)
+                state[name] = UNKNOWN
 
             continue
 
         try:
-            value = eval_predicted_expression(expr, state)
+            value = eval_predicted_expression(expr, state, trust_store)
         except PredictRefused:
             # The expression couldn't be evaluated. If evaluating it at
             # runtime can't touch other variables either, only the assigned
@@ -1431,7 +1613,7 @@ def apply_assignments(ops, state):
                 return None
 
             for name in names:
-                state.pop(name, None)
+                state[name] = UNKNOWN
 
             continue
         except Exception:
@@ -1442,7 +1624,7 @@ def apply_assignments(ops, state):
                 state[name] = value
         else:
             for name in names:
-                state.pop(name, None)
+                state[name] = UNKNOWN
 
     return state
 
@@ -1473,17 +1655,21 @@ def assigned_names(ops):
 
 def merge_predicted_states(a, b):
     """
-    Returns the variable state holding what the states `a` and `b` agree on,
-    for when two prediction paths reach the same node.
+    Returns the variable state prediction is entitled to at a node reached
+    along two paths with states `a` and `b`.
     """
 
     rv = {}
 
-    for name, value in a.items():
-        if name in b:
+    for name in a.keys() | b.keys():
+        if (name in a) and (name in b):
+            value = a[name]
             other = b[name]
 
             if (value is other) or (type(value) is type(other) and value == other):
                 rv[name] = value
+                continue
+
+        rv[name] = UNKNOWN
 
     return rv


### PR DESCRIPTION
Statement prediction currently walks every branch of every `if`, predicting images the game cannot show from its current state. These changes make prediction follow what it can prove about store variables so that `If.predict` can evaluate its conditions and return only the reachable branches.

I tried to set this up conservatively so prediction defaults to not pruning rather than pruning too aggressively on statements that could change game state in unexpected ways. Let me know if I missed any situations you can think of and what you think of the overall approach!