### PR TITLE
Refactor iostream

### DIFF
--- a/renpy/audio/renpysound.pyx
+++ b/renpy/audio/renpysound.pyx
@@ -52,7 +52,7 @@ from __future__ import print_function
 
 from libc.stdint cimport uintptr_t
 
-from renpy.pygame.iostream cimport SDLIOStreamFromPython
+from renpy.pygame.iostream cimport SDL_IOStreamFromPython
 from renpy.pygame.sdl cimport SDL_IOStream
 
 cdef extern from "renpysound_core.h":
@@ -148,7 +148,7 @@ def play(channel, file, name, synchro_start=False, fadein=0, tight=False, start=
     if audio_filter is not None:
         audio_filter.prepare(get_sample_rate())
 
-    rw = SDLIOStreamFromPython(file)
+    rw = SDL_IOStreamFromPython(file)
 
     if rw == NULL:
         raise Exception("Could not create IOStream.")
@@ -176,7 +176,7 @@ def queue(channel, file, name, synchro_start=False, fadein=0, tight=False, start
     if audio_filter is not None:
         audio_filter.prepare(get_sample_rate())
 
-    rw = SDLIOStreamFromPython(file)
+    rw = SDL_IOStreamFromPython(file)
 
     if rw == NULL:
         raise Exception("Could not create IOStream.")

--- a/renpy/gl2/assimp.pyx
+++ b/renpy/gl2/assimp.pyx
@@ -25,7 +25,7 @@ import threading
 
 from typing import Iterable, Literal
 
-from renpy.pygame.iostream cimport SDLIOStreamFromPython
+from renpy.pygame.iostream cimport SDL_IOStreamFromPython
 from renpy.pygame.sdl cimport SDL_IOStream
 
 from assimpapi cimport (
@@ -968,7 +968,7 @@ cdef public SDL_IOStream *assimp_load(const char *filename) nogil:
 
         try:
             f = renpy.loader.load(fn)
-            rv = SDLIOStreamFromPython(f)
+            rv = SDL_IOStreamFromPython(f)
         except Exception as e:
             pass
 

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -19,12 +19,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from typing import Iterable, Literal, NamedTuple
+from typing import Callable, Literal
 
 import renpy
 import os
 import os.path
-import sys
 import threading
 import zlib
 import re
@@ -33,18 +32,13 @@ import unicodedata
 import time
 import pathlib
 
-from renpy.pygame.iostream import IOStream
+from renpy.pygame.iostream import IOPath, IOBuffer, IOSubFile
 
 from renpy.compat.pickle import loads
 from renpy.webloader import DownloadNeeded
 
-# Ensure the utf-8 codec is loaded, to prevent recursion when we use it
-# to look up filenames.
-"".encode("utf-8")
 
 # Physical Paths
-
-
 def get_path(fn):
     """
     Returns the path to `fn` relative to the gamedir. If any of the directories
@@ -163,22 +157,20 @@ class RPAv3ArchiveHandler(object):
         infile.seek(offset)
         index = loads(zlib.decompress(infile.read()))
 
-        def start_to_bytes(s):
-            if not s:
-                return b""
-
-            if not isinstance(s, bytes):
-                s = s.encode("latin-1")
-
-            return s
-
         # Deobfuscate the index.
-
         for k in index.keys():
             if len(index[k][0]) == 2:
                 index[k] = [(offset ^ key, dlen ^ key) for offset, dlen in index[k]]
             else:
-                index[k] = [(offset ^ key, dlen ^ key, start_to_bytes(start)) for offset, dlen, start in index[k]]
+                index[k] = index_list = []
+                for offset, dlen, start in index[k]:
+                    if start:
+                        if not isinstance(start, bytes):
+                            start = start.encode("latin-1")
+
+                        index_list.append(start)
+
+                    index_list.append((offset ^ key, dlen ^ key))
 
         return index
 
@@ -495,30 +487,7 @@ def listdirfiles(common=True, game=True):
     return rv
 
 
-open_file = IOStream  # type: ignore
-
-if "RENPY_TEST_RWOPS" in os.environ:
-
-    def open_file(name, mode):
-        with IOStream(name, mode) as f:
-            data = f.read(1024)
-            f.seek(0, 2)
-            length = f.tell()
-
-        try:
-            a = IOStream.from_buffer(data, name=name)
-
-            if length <= 1024:
-                return a
-
-            b = IOStream(name, mode, base=1024, length=length - 1024)
-            rv = IOStream.from_split(a, b, name=name)
-            return rv
-
-        except Exception:
-            import traceback
-
-            traceback.print_exc()
+open_file: Callable[[str | os.PathLike, Literal["rb", "wb"]], io.RawIOBase] = IOPath
 
 
 # A list of callbacks to open an open python file object of the given type.
@@ -579,38 +548,30 @@ def load_from_archive(name):
     """
     Returns an open python file object of the given type from an archive file.
     """
+
     for afn, index in archives:
-        if not name in index:
+        if name not in index:
             continue
 
-        data = []
-
         # Direct path.
-        if len(index[name]) == 1:
-            t = index[name][0]
-            if len(t) == 2:
-                offset, dlen = t
-                start = b""
-            else:
-                offset, dlen, start = t
+        if len(index[name]) == 1 and len(index[name][0]) == 2:
+            offset, dlen = index[name][0]
 
-            if start == None or len(start) == 0:
-                rv = IOStream(afn, "rb", base=offset, length=dlen)
-                return io.BufferedReader(rv)
-            else:
-                a = IOStream.from_buffer(start, name=name)
-                b = IOStream(afn, "rb", base=offset, length=dlen)
-                rv = IOStream.from_split(a, b, name=name)
-                rv = io.BufferedReader(rv)
+            stream = IOSubFile(afn, base=offset, length=dlen, name=name)
+            return io.BufferedReader(stream)
 
         # Compatibility path.
-        else:
-            with open(afn, "rb") as f:
-                for offset, dlen in index[name]:
+        parts: list[bytes] = []
+        with open(afn, "rb") as f:
+            for t in index[name]:
+                if len(t) == 1:
+                    parts.append(t[0])
+                else:
+                    offset, dlen = t
                     f.seek(offset)
-                    data.append(f.read(dlen))
+                    parts.append(f.read(dlen))
 
-                return io.BufferedReader(IOStream.from_buffer(b"".join(data), name=name))
+            return io.BufferedReader(IOBuffer(b"".join(parts), name=name))
 
     return None
 

--- a/renpy/pygame/controller.pyx
+++ b/renpy/pygame/controller.pyx
@@ -18,7 +18,8 @@
 
 from .sdl cimport *
 from .error import error
-from .iostream cimport to_sdl_iostream
+from .iostream cimport SDL_IOStreamFromPython
+
 
 def init():
     """
@@ -82,7 +83,7 @@ def add_mappings(mapping_file):
     multiple times to add multiple database files.
     """
 
-    cdef SDL_IOStream *iostream = to_sdl_iostream(mapping_file)
+    cdef SDL_IOStream *iostream = SDL_IOStreamFromPython(mapping_file)
 
     if SDL_AddGamepadMappingsFromIO(iostream, 1) == -1:
         raise error()

--- a/renpy/pygame/image.pyx
+++ b/renpy/pygame/image.pyx
@@ -20,7 +20,7 @@
 from .sdl cimport *
 from .sdl_image cimport *
 from .surface cimport *
-from .iostream cimport to_sdl_iostream
+from .iostream cimport SDL_IOStreamFromPython
 
 from .error import error
 
@@ -76,7 +76,7 @@ def load(fi, namehint="", size=None):
         if fi.lower().endswith('.tga'):
             namehint = "TGA"
 
-    iostream = to_sdl_iostream(fi)
+    iostream = SDL_IOStreamFromPython(fi)
 
     if namehint == "":
         with nogil:

--- a/renpy/pygame/iostream.pxd
+++ b/renpy/pygame/iostream.pxd
@@ -16,7 +16,79 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
-from .sdl cimport SDL_IOStream
+from cpython.buffer cimport PyObject_CheckBuffer
 
-cdef SDL_IOStream *to_sdl_iostream(filelike, mode=*, base=*, length=*) except NULL
-cdef SDL_IOStream *SDLIOStreamFromPython(filelike) except NULL
+from .sdl cimport SDL_IOStream, Sint64
+
+
+cdef class IOStream:
+    cdef SDL_IOStream *_stream
+    cdef readonly str mode
+    cdef readonly str name
+
+    cdef SDL_IOStream *borrow(self) except NULL
+    cdef SDL_IOStream *take(self) except NULL
+
+
+cdef class IOPath(IOStream):
+    cdef readonly object path
+
+
+cdef class IOSubFile(IOStream):
+    cdef readonly object path
+    cdef readonly Sint64 base
+    cdef readonly Sint64 length
+
+
+cdef class IOBuffer(IOStream):
+    cdef readonly object buffer
+
+
+cdef class IOFileLike(IOStream):
+    cdef bint _readable
+    cdef bint _writable
+    cdef bint _seekable
+    cdef bint _close_filelike
+    cdef readonly object filelike
+
+
+cdef inline SDL_IOStream *SDL_IOStreamFromPython(object obj, str name=None) except NULL:
+    """
+    This accepts, in order:
+
+    * An IOStream object, which is closed and the underlying SDL_IOStream
+      object is returned.
+
+    * A str or path-like filename, which is opened.
+
+    * An object with a name field. The name is interpreted as a filename.
+      and opened. The object will be closed.
+
+    * An object that supports the buffer protocol.
+
+    * A file-like object.
+
+    It returns an SDL_IOStream object, or NULL on error.
+
+    Call to this function assumes exclusive ownership on the object is
+    transferred to the underlying stream, including responsibility on closing
+    it.
+    """
+
+    import os
+
+    cdef IOStream stream
+    if isinstance(obj, IOStream):
+        stream = <IOStream> obj
+    elif isinstance(obj, (str, os.PathLike)):
+        stream = IOPath(obj, name=name)
+    elif isinstance(obj_path := getattr(obj, "name", None), (str, os.PathLike)):
+        stream = IOPath(obj_path, name=name)
+    elif PyObject_CheckBuffer(obj):
+        stream = IOBuffer(obj, name=name)
+    elif hasattr(obj, "read") or hasattr(obj, "write"):
+        stream = IOFileLike(obj, name=name, close=True)
+    else:
+        raise TypeError(f"{obj!r} is not a filename or file-like object.")
+
+    return stream.take()

--- a/renpy/pygame/iostream.pxd
+++ b/renpy/pygame/iostream.pxd
@@ -23,6 +23,7 @@ from .sdl cimport SDL_IOStream, Sint64
 
 cdef class IOStream:
     cdef SDL_IOStream *_stream
+    cdef bint _closed
     cdef readonly str mode
     cdef readonly str name
 
@@ -70,9 +71,8 @@ cdef inline SDL_IOStream *SDL_IOStreamFromPython(object obj, str name=None) exce
 
     It returns an SDL_IOStream object, or NULL on error.
 
-    Call to this function assumes exclusive ownership on the object is
-    transferred to the underlying stream, including responsibility on closing
-    it.
+    Calling this function transfers exclusive ownership of `obj` to the returned
+    stream, including responsibility for closing it.
     """
 
     import os
@@ -87,7 +87,7 @@ cdef inline SDL_IOStream *SDL_IOStreamFromPython(object obj, str name=None) exce
     elif PyObject_CheckBuffer(obj):
         stream = IOBuffer(obj, name=name)
     elif hasattr(obj, "read") or hasattr(obj, "write"):
-        stream = IOFileLike(obj, name=name, close=True)
+        stream = IOFileLike(obj, name=name)
     else:
         raise TypeError(f"{obj!r} is not a filename or file-like object.")
 

--- a/renpy/pygame/iostream.pyx
+++ b/renpy/pygame/iostream.pyx
@@ -94,10 +94,7 @@ cdef void set_error(object obj):
 cdef class IOStream:
     """
     Abstract base class wrapping an SDL_IOStream. Implements the io.RawIOBase
-    protocol on top of the SDL_* IO functions.
-
-    `name`
-        If given, a string with a file name this stream represents.
+    interface on top of the SDL_* IO functions.
     """
 
     def __cinit__(IOStream self not None, *args, **kwargs):

--- a/renpy/pygame/iostream.pyx
+++ b/renpy/pygame/iostream.pyx
@@ -16,17 +16,56 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
-from .sdl cimport *
-from cpython.ref cimport Py_INCREF, Py_DECREF
-from cpython.buffer cimport PyObject_CheckBuffer, PyObject_GetBuffer, PyBuffer_Release, PyBUF_CONTIG, PyBUF_CONTIG_RO
-from libc.string cimport memcpy
-from libc.stdio cimport FILE, fopen, fclose, fseek, ftell, fread, SEEK_SET, SEEK_CUR, SEEK_END
-from libc.stdlib cimport calloc, free
-from libc.stdint cimport uintptr_t
-from libcpp cimport bool
+"""
+SDL_IOStream-backed file objects.
 
-import sys
+This module provides a single family of file objects that are simultaneously:
+
+* Usable from Python as raw binary files (registered with io.RawIOBase, so
+  they can be wrapped in io.BufferedReader or io.TextIOWrapper).
+
+* Usable from Cython as SDL_IOStream pointers, via IOStream.borrow(), with
+  no conversion cost.
+
+Choosing a kind
+---------------
+
+IOPath, IOSubFile and IOBuffer are GIL-free on the read path. IOFileLike
+reacquires the GIL for every operation, so prefer the others when the data
+is reachable another way:
+
+* A path on disk                                         IOPath
+* A file as a region in other IOStream, e.g. archive     IOSubFile
+* bytes, bytearray, memoryview, mmap, array              IOBuffer
+* A BytesIO you own and will not resize                  IOBuffer(b.getbuffer())
+* Anything computed: gzip, zipfile, network              IOFileLike
+
+Thread safety
+-------------
+
+It is unsafe to read or write the same IOStream from different threads at the
+same time.
+
+SDL_Quit must be called before interpreter shutdown, or program may hung, unable
+to deallocate Python objects owned in Stream userdata.
+"""
+
+from .sdl cimport *
+
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_INCREF, Py_DECREF
+from cpython.buffer cimport (
+    PyObject_CheckBuffer,
+    PyObject_GetBuffer,
+    PyBuffer_Release,
+    PyBUF_CONTIG,
+    PyBUF_CONTIG_RO,
+)
+from cpython.exc cimport PyErr_WriteUnraisable
+from libc.string cimport memcpy
+
 import io
+import os
 
 cdef extern from "SDL3/SDL.h":
     cdef struct SDL_IOStreamInterface:
@@ -35,738 +74,1100 @@ cdef extern from "SDL3/SDL.h":
         Sint64 (*seek)(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil
         size_t (*read)(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil
         size_t (*write)(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil
-        bool (*flush)(void *userdata, SDL_IOStatus *status) noexcept nogil
-        bool (*close)(void *userdata) noexcept nogil
+        cbool (*flush)(void *userdata, SDL_IOStatus *status) noexcept nogil
+        cbool (*close)(void *userdata) noexcept nogil
 
-# The fsencoding.
-fsencoding = sys.getfilesystemencoding() or "utf-8"
 
-cdef set_error(e):
-    cdef char *msg
-    e = str(e)
-    msg = <char *> e
-    SDL_SetError("%s", msg)
+cdef str get_error():
+    cdef const char *message = SDL_GetError()
+    return message.decode("utf-8", "replace")
 
-cdef Sint64 python_size(void *userdata) noexcept with gil:
-    f = <object> userdata
+
+cdef void set_error(object obj):
+    cdef bytes msg = str(obj).encode("utf-8", "replace")
+    SDL_SetError("%s", <const char *> msg)
+
+
+################################################################################
+# Base class.
+
+cdef class IOStream:
+    """
+    Abstract base class wrapping an SDL_IOStream. Implements the io.RawIOBase
+    protocol on top of the SDL_* IO functions.
+
+    `name`
+        If given, a string with a file name this stream represents.
+    """
+
+    def __cinit__(IOStream self not None, *args, **kwargs):
+        self._stream = NULL
+
+    def __init__(IOStream self not None):
+        if type(self) is IOStream:
+            raise TypeError("IOStream is abstract, use one of its subclasses.")
+
+    def __del__(IOStream self not None, /):
+        # Let subclasses overwrite IOStream.close.
+        if self._stream != NULL:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+    def __dealloc__(IOStream self not None, /):
+        if self._stream != NULL:
+            SDL_CloseIO(self._stream)
+            self._stream = NULL
+
+    # IOBase implements them and others use it, ugly.
+    def _checkClosed(IOStream self not None, /):
+        if self._stream == NULL:
+            raise ValueError("I/O operation on closed file.")
+
+    def _checkReadable(IOStream self not None, /):
+        if not self.readable():
+            raise io.UnsupportedOperation("This stream does not support read.")
+
+    def _checkWritable(IOStream self not None, /):
+        if not self.writable():
+            raise io.UnsupportedOperation("This stream does not support write.")
+
+    def _checkSeekable(IOStream self not None, /):
+        if not self.seekable():
+            raise io.UnsupportedOperation("This stream does not support seek.")
+
+    cdef SDL_IOStream *borrow(self) except NULL:
+        """
+        Borrow the reference to the underlying SDL_IOStream.
+
+        Caller must make sure this object is kept alive while the stream
+        is used by SDL. To transfer ownership use IOStream.take().
+        """
+
+        self._checkClosed()
+        return self._stream
+
+    cdef SDL_IOStream *take(self) except NULL:
+        """
+        Transfers ownership of the underlying SDL_IOStream to the caller, and
+        caller is responsible to call SDL_CloseIO on it.
+
+        This object is closed from Python's point of view after the call.
+        """
+
+        cdef SDL_IOStream *rv = self.borrow()
+
+        self._stream = NULL
+        return rv
+
+    # io.IOBase interface.
+    def __iter__(IOStream self not None, /):
+        self._checkClosed()
+        return self
+
+    def __next__(IOStream self not None, /):
+        line = self.readline()
+
+        if not line:
+            raise StopIteration()
+
+        return line
+
+    def __enter__(IOStream self not None, /):
+        self._checkClosed()
+        return self
+
+    def __exit__(IOStream self not None, /, *exc):
+        self.close()
+        return False
+
+    def __getstate__(self):
+        raise TypeError(f"cannot pickle {type(self).__name__!r} object")
+
+    def close(IOStream self not None, /):
+        # A closed file may be closed again.
+        if self._stream == NULL:
+            return
+
+        # Mimic io.IOBase behavior.
+        cdef cbool rv
+        try:
+            self.flush()
+        finally:
+            try:
+                with nogil:
+                    rv = SDL_CloseIO(self._stream)
+            finally:
+                self._stream = NULL
+
+            if not rv:
+                raise IOError(f"Could not close: {get_error()}")
+
+    @property
+    def closed(IOStream self not None, /):
+        return self._stream == NULL
+
+    def fileno(IOStream self not None, /):
+        raise io.UnsupportedOperation("This stream is not backed by a file descriptor.")
+
+    def flush(IOStream self not None, /):
+        self._checkClosed()
+
+        if not self.writable():
+            return
+
+        with nogil:
+            rv = SDL_FlushIO(self._stream)
+
+        if not rv:
+            raise IOError(f"Could not flush: {get_error()}")
+
+    def isatty(IOStream self not None, /):
+        self._checkClosed()
+        return False
+
+    def readable(IOStream self not None, /):
+        self._checkClosed()
+        return False
+
+    def readline(IOStream self not None, object size=None, /):
+        cdef Py_ssize_t c_size = -1 if size is None else size
+        cdef list chunks = []
+        cdef bytes c
+
+        while c_size < 0 or len(chunks) < c_size:
+            c = self.read(1)
+
+            if not c:
+                break
+
+            chunks.append(c)
+
+            if c == b"\n":
+                break
+
+        return b"".join(chunks)
+
+    def readlines(IOStream self not None, object hint=None, /):
+        cdef Py_ssize_t c_hint = -1 if hint is None else hint
+        cdef Py_ssize_t total = 0
+        rv = []
+
+        while True:
+            line = self.readline()
+
+            if not line:
+                break
+
+            rv.append(line)
+            total += len(line)
+
+            if c_hint > 0 and total >= c_hint:
+                break
+
+        return rv
+
+    def seek(IOStream self not None, Sint64 offset, int whence=io.SEEK_SET, /):
+        self._checkClosed()
+        self._checkSeekable()
+
+        cdef SDL_IOStream *s = self.borrow()
+        cdef SDL_IOWhence w
+        cdef Sint64 rv
+
+        if whence == io.SEEK_SET:
+            w = SDL_IO_SEEK_SET
+        elif whence == io.SEEK_CUR:
+            w = SDL_IO_SEEK_CUR
+        elif whence == io.SEEK_END:
+            w = SDL_IO_SEEK_END
+        else:
+            raise ValueError(f"Invalid whence: {whence!r}")
+
+        with nogil:
+            rv = SDL_SeekIO(s, offset, w)
+
+        if rv < 0:
+            raise IOError(f"Could not seek: {get_error()}")
+
+        return rv
+
+    def seekable(IOStream self not None, /):
+        self._checkClosed()
+        return False
+
+    def tell(IOStream self not None, /):
+        self._checkClosed()
+        self._checkSeekable()
+
+        cdef SDL_IOStream *s = self.borrow()
+        cdef Sint64 rv
+
+        with nogil:
+            rv = SDL_TellIO(s)
+
+        if rv < 0:
+            raise IOError(f"Could not tell: {get_error()}")
+
+        return rv
+
+    def truncate(IOStream self not None, object size=None, /):
+        raise io.UnsupportedOperation("This stream does not support truncate.")
+
+    def writable(IOStream self not None, /):
+        self._checkClosed()
+        return False
+
+    def writelines(IOStream self not None, object lines, /):
+        self._checkClosed()
+        self._checkWritable()
+
+        for l in lines:
+            self.write(l)
+
+    # io.RawIOBase interface.
+    def read(IOStream self not None, Py_ssize_t size=-1, /):
+        self._checkClosed()
+        self._checkReadable()
+
+        cdef bytearray buf
+        cdef object got
+
+        if size < 0:
+            return self.readall()
+
+        if size == 0:
+            return b""
+
+        buf = bytearray(size)
+        got = self.readinto(buf)
+
+        if got is None:
+            return None
+
+        cdef Py_ssize_t n = <Py_ssize_t>got
+
+        if n == size:
+            return bytes(buf)
+
+        return bytes(memoryview(buf)[:n])
+
+    def readall(IOStream self not None, /):
+        self._checkClosed()
+        self._checkReadable()
+
+        cdef list chunks = []
+
+        while True:
+            chunk = self.read(io.DEFAULT_BUFFER_SIZE)
+
+            if chunk is None:
+                return b"".join(chunks) if chunks else None
+
+            if not chunk:
+                break
+
+            chunks.append(chunk)
+
+        return b"".join(chunks)
+
+    def readinto(IOStream self not None, object b, /):
+        self._checkClosed()
+        self._checkReadable()
+
+        cdef SDL_IOStream *s = self.borrow()
+        cdef Py_buffer view
+        cdef size_t rv
+        cdef SDL_IOStatus status
+
+        PyObject_GetBuffer(b, &view, PyBUF_CONTIG)
+
+        try:
+            if view.len == 0:
+                return 0
+
+            with nogil:
+                rv = SDL_ReadIO(s, view.buf, <size_t> view.len)
+        finally:
+            PyBuffer_Release(&view)
+
+        if rv == 0:
+            status = SDL_GetIOStatus(s)
+
+            if status == SDL_IO_STATUS_ERROR:
+                raise IOError(f"Could not read: {get_error()}")
+            elif status == SDL_IO_STATUS_WRITEONLY:
+                raise io.UnsupportedOperation("not readable")
+            elif status == SDL_IO_STATUS_NOT_READY:
+                return None
+
+        return rv
+
+    def write(IOStream self not None, object b, /):
+        self._checkClosed()
+        self._checkWritable()
+
+        cdef SDL_IOStream *s = self.borrow()
+        cdef Py_buffer view
+        cdef size_t rv
+        cdef Py_ssize_t length
+        cdef SDL_IOStatus status
+
+        PyObject_GetBuffer(b, &view, PyBUF_CONTIG_RO)
+        length = view.len
+
+        try:
+            if length == 0:
+                return 0
+
+            with nogil:
+                rv = SDL_WriteIO(s, view.buf, <size_t> length)
+        finally:
+            PyBuffer_Release(&view)
+
+        if rv == 0 and length:
+            status = SDL_GetIOStatus(s)
+
+            if status == SDL_IO_STATUS_READONLY:
+                raise io.UnsupportedOperation("not writable")
+            elif status == SDL_IO_STATUS_NOT_READY:
+                return None
+
+            raise IOError(f"Could not write: {get_error()}")
+
+        return rv
+
+
+# Make isinstance(x, io.RawIOBase) and io.BufferedReader(x) work. The protocol
+# above is implemented by hand, since Cython cannot inherit from _io._RawIOBase.
+io.RawIOBase.register(IOStream)
+
+
+# IOPath - a file on disk.
+cdef class IOPath(IOStream):
+    """
+    An IOStream backed by a file on disk, opened by SDL. All operations are
+    GIL-free.
+
+    `path`
+        The file to open, as a str or os.PathLike[str].
+
+    `mode`
+        A string, "rb" to open file for reading, "wb" to open file for writing.
+
+    `name`
+        If given, a string with a file name this stream represents.
+    """
+
+    def __init__(IOPath self not None, object path, /, str mode="rb", str name=None):
+        cdef bytes path_bytes = os.fsencode(path)
+        cdef const char* c_path = path_bytes
+        path = os.fsdecode(path)
+
+        if mode not in ("rb", "wb"):
+            raise ValueError(f"invalid mode: {mode!r}")
+        cdef bytes mode_bytes = mode.encode("utf-8")
+        cdef const char* c_mode = mode_bytes
+
+        cdef SDL_IOStream *s
+        with nogil:
+            s = SDL_IOFromFile(c_path, c_mode)
+
+        if s == NULL:
+            raise IOError(f"Could not open {path!r}: {get_error()}")
+
+        self._stream = s
+        self.path = path
+        self.mode = mode
+        self.name = path if name is None else name
+
+    def __repr__(IOPath self not None, /):
+        class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+        name = "" if self.name is None else f", name={self.name!r}"
+        return f"{class_name}({self.path!r}, mode={self.mode!r}{name})"
+
+    def readable(IOPath self not None, /):
+        self._checkClosed()
+        return self.mode == "rb"
+
+    def writable(IOPath self not None, /):
+        self._checkClosed()
+        return self.mode == "wb"
+
+    def seekable(IOPath self not None, /):
+        self._checkClosed()
+        return True
+
+
+# IOSubFile - a read-only window into a file.
+cdef struct SubFileData:
+    SDL_IOStream *parent
+    Sint64 base
+    Sint64 length
+    Sint64 pos
+
+
+cdef Sint64 sub_size(void *userdata) noexcept nogil:
+    return (<SubFileData *> userdata).length
+
+
+cdef Sint64 sub_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil:
+    cdef SubFileData *d = <SubFileData *> userdata
+    cdef Sint64 target
+
+    if whence == SDL_IO_SEEK_SET:
+        target = offset
+    elif whence == SDL_IO_SEEK_CUR:
+        target = d.pos + offset
+    elif whence == SDL_IO_SEEK_END:
+        target = d.length + offset
+    else:
+        return -1
+
+    if target < 0:
+        target = 0
+    elif target > d.length:
+        target = d.length
+
+    if SDL_SeekIO(d.parent, d.base + target, SDL_IO_SEEK_SET) < 0:
+        return -1
+
+    d.pos = target
+    return target
+
+
+cdef size_t sub_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
+    cdef SubFileData *d = <SubFileData *> userdata
+    cdef size_t left = <size_t> (d.length - d.pos)
+    cdef size_t rv
+
+    if size > left:
+        size = left
+
+    if size == 0:
+        status[0] = SDL_IO_STATUS_EOF
+        return 0
+
+    rv = SDL_ReadIO(d.parent, ptr, size)
+
+    if rv == 0:
+        status[0] = SDL_GetIOStatus(d.parent)
+        return 0
+
+    d.pos += rv
+    return rv
+
+
+cdef size_t sub_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
+    status[0] = SDL_IO_STATUS_READONLY
+    return 0
+
+
+cdef cbool sub_flush(void *userdata, SDL_IOStatus *status) noexcept nogil:
+    return True
+
+
+cdef cbool sub_close(void *userdata) noexcept nogil:
+    cdef SubFileData *d = <SubFileData *> userdata
+
+    if d.parent != NULL:
+        SDL_CloseIO(d.parent)
+
+    SDL_free(d)
+    return True
+
+
+cdef SDL_IOStreamInterface sub_interface
+sub_interface.version = <Uint32> sizeof(SDL_IOStreamInterface)
+sub_interface.size = sub_size
+sub_interface.seek = sub_seek
+sub_interface.read = sub_read
+sub_interface.write = sub_write
+sub_interface.flush = sub_flush
+sub_interface.close = sub_close
+
+
+cdef class IOSubFile(IOStream):
+    """
+    A read-only window into a file on disk, of `length` bytes starting at
+    `base`. Used for files stored inside Ren'Py archives and Android assets.
+
+    The window opens and exclusively owns its own handle on the underlying
+    file, so distinct IOSubFile objects over the same path are independent and
+    each read is a single SDL_ReadIO with no redundant seek.
+
+    `path`
+        The file to open, as a str, or os.PathLike[str]. An IOStream may
+        also be given, in which case its SDL stream is taken and this
+        object assumes exclusive ownership of it.
+
+    `base`
+        Non-negative offset into `path` where sub-file starts.
+
+    `length`
+        Non-negative length of the sub-file.
+
+    `name`
+        If given, a string with a file name this stream represents.
+    """
+
+    def __init__(IOSubFile self not None, object path, /, Sint64 base, Sint64 length, str name=None):
+        cdef SDL_IOStream *p
+        cdef bytes path_bytes
+        cdef const char* c_path
+
+        if base < 0:
+            raise ValueError(f"base must be non-negative, not {base}")
+
+        if length < 0:
+            raise ValueError(f"length must be non-negative, not {length}")
+
+        if isinstance(path, IOStream):
+            p = (<IOStream> path).take()
+            if name is None:
+                name = path.name
+
+            if path.name is None:
+                path = "<file-like>"
+            else:
+                path = path.name
+
+        else:
+            path_bytes = os.fsencode(path)
+            c_path = path_bytes
+            path = os.fsdecode(path)
+            with nogil:
+                p = SDL_IOFromFile(c_path, b"rb")
+
+            if p == NULL:
+                raise IOError(f"Could not open {path!r}: {get_error()}")
+
+        cdef Sint64 rv
+        with nogil:
+            rv = SDL_SeekIO(p, base, SDL_IO_SEEK_SET)
+
+        if rv < 0:
+            SDL_CloseIO(p)
+            raise IOError(f"Could not seek to {base} in {path!r}: {get_error()}")
+
+        cdef SubFileData *userdata = <SubFileData *>SDL_malloc(sizeof(SubFileData))
+        if userdata == NULL:
+            SDL_CloseIO(p)
+            raise MemoryError("Could not allocate SubFileData.")
+
+        userdata.parent = p
+        userdata.base = base
+        userdata.length = length
+        userdata.pos = 0
+        cdef SDL_IOStream *s = SDL_OpenIO(&sub_interface, userdata)
+        if s == NULL:
+            SDL_CloseIO(p)
+            SDL_free(userdata)
+            raise MemoryError(f"Could not create SDL_IOStream: {get_error()}")
+
+        self._stream = s
+        self.path = path
+        self.base = base
+        self.length = length
+        self.mode = "rb"
+        self.name = name
+
+    def __repr__(IOSubFile self not None, /):
+        class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+        name = "" if self.name is None else f", name={self.name!r}"
+        return f"{class_name}({self.path!r}, base={self.base}, length={self.length}{name})"
+
+    def readable(IOSubFile self not None, /):
+        self._checkClosed()
+        return True
+
+    def seekable(IOSubFile self not None, /):
+        self._checkClosed()
+        return True
+
+
+# IOBuffer - an object supporting the buffer protocol.
+cdef struct BufferData:
+    Py_buffer view
+    Sint64 pos
+
+
+cdef Sint64 buf_size(void *userdata) noexcept nogil:
+    return (<BufferData *> userdata).view.len
+
+
+cdef Sint64 buf_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil:
+    cdef BufferData *d = <BufferData *> userdata
+    cdef Sint64 length = d.view.len
+    cdef Sint64 target
+
+    if whence == SDL_IO_SEEK_SET:
+        target = offset
+    elif whence == SDL_IO_SEEK_CUR:
+        target = d.pos + offset
+    elif whence == SDL_IO_SEEK_END:
+        target = length + offset
+    else:
+        return -1
+
+    if target < 0:
+        target = 0
+    elif target > length:
+        target = length
+
+    d.pos = target
+    return target
+
+
+cdef size_t buf_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
+    cdef BufferData *d = <BufferData *> userdata
+    cdef size_t available = <size_t> (d.view.len - d.pos)
+
+    if size > available:
+        size = available
+
+    if size == 0:
+        status[0] = SDL_IO_STATUS_EOF
+        return 0
+
+    memcpy(ptr, <char *>d.view.buf + d.pos, size)
+    d.pos += size
+    return size
+
+
+cdef size_t buf_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
+    cdef BufferData *d = <BufferData *> userdata
+
+    if d.view.readonly:
+        status[0] = SDL_IO_STATUS_READONLY
+        return 0
+
+    cdef size_t available = <size_t> (d.view.len - d.pos)
+
+    if size > available:
+        size = available
+
+    if size == 0:
+        status[0] = SDL_IO_STATUS_ERROR
+        SDL_SetError("%s", <const char *> b"Buffer is full.")
+        return 0
+
+    memcpy(<char *>d.view.buf + d.pos, ptr, size)
+    d.pos += size
+    return size
+
+
+cdef cbool buf_flush(void *userdata, SDL_IOStatus *status) noexcept nogil:
+    return True
+
+
+cdef cbool buf_close(void *userdata) noexcept nogil:
+    cdef BufferData *d = <BufferData *> userdata
+
+    with gil:
+        PyBuffer_Release(&d.view)
+
+    SDL_free(d)
+    return True
+
+
+cdef SDL_IOStreamInterface buf_interface
+buf_interface.version = <Uint32> sizeof(SDL_IOStreamInterface)
+buf_interface.size = buf_size
+buf_interface.seek = buf_seek
+buf_interface.read = buf_read
+buf_interface.write = buf_write
+buf_interface.flush = buf_flush
+buf_interface.close = buf_close
+
+
+cdef class IOBuffer(IOStream):
+    """
+    An IOStream over any object supporting the buffer protocol. The buffer is
+    kept mapped for the lifetime of this object, and its size is fixed.
+
+    `buffer`
+        Object that supports buffer protocol and provide contigous memory.
+
+    `writable`
+        If True, `buffer` must allow requesting `PyBUF_CONTIG`.
+
+    `name`
+        If given, a string with a file name this stream represents.
+    """
+
+    def __init__(IOBuffer self not None, object buffer, /, bint writable=False, str name=None):
+        if not PyObject_CheckBuffer(buffer):
+            raise TypeError(f"{type(buffer).__qualname__} does not support the buffer protocol.")
+
+        cdef Py_buffer view
+        cdef int flags = PyBUF_CONTIG if writable else PyBUF_CONTIG_RO
+        PyObject_GetBuffer(buffer, &view, flags)
+
+        cdef BufferData *userdata = <BufferData *>SDL_malloc(sizeof(BufferData))
+        if userdata == NULL:
+            PyBuffer_Release(&view)
+            raise MemoryError("Could not allocate BufferData.")
+
+        userdata.view = view
+        userdata.pos = 0
+        cdef SDL_IOStream *s = SDL_OpenIO(&buf_interface, userdata)
+        if s == NULL:
+            PyBuffer_Release(&view)
+            SDL_free(userdata)
+            raise MemoryError(f"Could not create SDL_IOStream: {get_error()}")
+
+        self._stream = s
+        self.buffer = buffer
+        self.mode = "rb" if view.readonly else "rb+"
+        self.name = name
+
+    def __repr__(IOBuffer self not None, /):
+        class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+        name = "" if self.name is None else f", name={self.name!r}"
+        return f"{class_name}({self.buffer!r}, writable={self.writable()}{name})"
+
+    def readable(IOBuffer self not None, /):
+        self._checkClosed()
+        return True
+
+    def writable(IOBuffer self not None, /):
+        self._checkClosed()
+        return self.mode == "rb+"
+
+    def seekable(IOBuffer self not None, /):
+        self._checkClosed()
+        return True
+
+
+# IOFileLike - an arbitrary Python file-like object.
+cdef struct FileLikeData:
+    PyObject *filelike
+    bint close_filelike
+    bint has_readinto
+    bint readable
+    bint writable
+    bint seekable
+
+
+cdef Sint64 py_size(void *userdata) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
+
+    if not d.seekable:
+        set_error(f"{f} is not seekable.")
+        return -1
 
     try:
         cur = f.tell()
-        f.seek(0, 2)
-        rv = f.tell()
-        f.seek(cur, 0)
-    except Exception as e:
-        return -1
 
-    return rv
+        try:
+            f.seek(0, io.SEEK_END)
+            return f.tell()
+        finally:
+            try:
+                f.seek(cur, io.SEEK_SET)
+            except Exception:
+                pass
 
-cdef Sint64 python_seek(void *userdata, Sint64 seek, SDL_IOWhence whence) noexcept with gil:
-    f = <object> userdata
-
-    try:
-        f.seek(seek, whence)
-        rv = f.tell()
     except Exception as e:
         set_error(e)
         return -1
 
-    return rv
 
-cdef size_t python_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept with gil:
-    f = <object> userdata
+cdef Sint64 py_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
+    cdef int w
+
+    if not d.seekable:
+        set_error(f"{f} is not seekable.")
+        return -1
 
     try:
-        data = f.read(size)
+        if whence == SDL_IO_SEEK_SET:
+            w = io.SEEK_SET
+        elif whence == SDL_IO_SEEK_CUR:
+            w = io.SEEK_CUR
+        elif whence == SDL_IO_SEEK_END:
+            w = io.SEEK_END
+        else:
+            raise ValueError(f"Invalid whence: {whence!r}")
+
+        return <Sint64> f.seek(offset, w)
+
+    except Exception as e:
+        set_error(e)
+        return -1
+
+
+cdef size_t py_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
+
+    cdef char[:] cv = None
+    cdef object mv = None
+    cdef Py_buffer view
+    cdef Py_ssize_t n
+
+    if size == 0:
+        return 0
+
+    if not d.readable:
+        status[0] = SDL_IO_STATUS_WRITEONLY
+        return 0
+
+    try:
+        if d.has_readinto:
+            # Zero-copy: let the object fill SDL's buffer directly.
+            cv = <char[:<Py_ssize_t> size]><char *> ptr
+            mv = memoryview(cv)
+
+            try:
+                got = f.readinto(mv)
+            finally:
+                mv.release()
+
+            if got is None:
+                status[0] = SDL_IO_STATUS_NOT_READY
+                return 0
+
+            n = <Py_ssize_t> got
+
+            if n < 0 or n > <Py_ssize_t> size:
+                raise ValueError(f"readinto() reported {n} bytes for a {size}-byte buffer.")
+
+        else:
+            data = f.read(size)
+
+            if data is None:
+                status[0] = SDL_IO_STATUS_NOT_READY
+                return 0
+
+            PyObject_GetBuffer(data, &view, PyBUF_CONTIG_RO)
+            try:
+                n = view.len
+                if n > <Py_ssize_t> size:
+                    raise ValueError(f"read({size}) returned {n} bytes.")
+
+                if n:
+                    memcpy(ptr, <char *>view.buf, n)
+
+            finally:
+                PyBuffer_Release(&view)
+
+        if n == 0:
+            status[0] = SDL_IO_STATUS_EOF
+
+        return <size_t> n
+
     except Exception as e:
         status[0] = SDL_IO_STATUS_ERROR
         set_error(e)
-        return -1
+        return 0
 
-    memcpy(ptr, <void *><char *> data, len(data))
-    return len(data)
 
-cdef size_t python_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept with gil:
-    f = <object> userdata
-    data = (<char *> ptr)[:size]
+cdef size_t py_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
+
+    cdef const char[:] cv = None
+    cdef object mv = None
+    cdef object got
+    cdef Py_ssize_t n
+
+    if size == 0:
+        return 0
+
+    if not d.writable:
+        status[0] = SDL_IO_STATUS_READONLY
+        return 0
 
     try:
-        f.write(data)
+        cv = <char[:<Py_ssize_t> size]><char *> ptr
+        mv = memoryview(cv)
+
+        try:
+            got = f.write(mv)
+        finally:
+            mv.release()
+
+        if got is None:
+            status[0] = SDL_IO_STATUS_NOT_READY
+            return 0
+
+        n = <Py_ssize_t> got
+        if n < 0 or n > <Py_ssize_t> size:
+            raise ValueError(f"write() reported {n} bytes for a {size}-byte buffer.")
+
+        if n == 0:
+            raise ValueError(f"write() accepted 0 of {size} bytes without returning None.")
+
+        return <size_t> n
+
     except Exception as e:
         status[0] = SDL_IO_STATUS_ERROR
         set_error(e)
-        return -1
+        return 0
 
-    return len(data)
 
-cdef bool python_flush(void *userdata, SDL_IOStatus *status) noexcept with gil:
-    f = <object> userdata
+cdef cbool py_flush(void *userdata, SDL_IOStatus *status) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
 
     try:
-        f.flush()
+        flush = getattr(f, "flush", None)
+        if flush is not None:
+            flush()
+
+        return True
+
     except Exception as e:
         status[0] = SDL_IO_STATUS_ERROR
         set_error(e)
         return False
 
-    return True
 
-cdef bool python_close(void *userdata) noexcept with gil:
-    if userdata != NULL:
-        f = <object> userdata
+cdef cbool py_close(void *userdata) noexcept with gil:
+    cdef FileLikeData *d = <FileLikeData *>userdata
+    cdef object f = <object>d.filelike
 
-        Py_DECREF(f)
-
-        userdata = NULL
-    return True
-
-cdef SDL_IOStreamInterface python_iointerface
-python_iointerface.version = sizeof(SDL_IOStreamInterface)
-python_iointerface.size = python_size
-python_iointerface.seek = python_seek
-python_iointerface.read = python_read
-python_iointerface.write = python_write
-python_iointerface.flush = python_flush
-python_iointerface.close = python_close
-
-
-cdef struct SubFile:
-    SDL_IOStream *rw
-    Sint64 base
-    Sint64 length
-    Sint64 tell
-
-
-cdef Sint64 subfile_size(void *userdata) noexcept nogil:
-    cdef SubFile *sf = <SubFile *> userdata
-    return sf.length
-
-cdef Sint64 subfile_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil:
-    cdef SubFile *sf = <SubFile *> userdata
-
-    if whence == SDL_IO_SEEK_SET:
-        sf.tell = SDL_SeekIO(sf.rw, offset + sf.base, SDL_IO_SEEK_SET) - sf.base
-    elif whence == SDL_IO_SEEK_CUR:
-        sf.tell = SDL_SeekIO(sf.rw, offset, SDL_IO_SEEK_CUR) - sf.base
-    elif whence == SDL_IO_SEEK_END:
-        sf.tell = SDL_SeekIO(sf.rw, sf.base + sf.length + offset, SDL_IO_SEEK_SET) - sf.base
-
-    return sf.tell
-
-cdef size_t subfile_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    cdef SubFile *sf = <SubFile *> userdata
-
-    cdef size_t left = <size_t> (sf.length - sf.tell)
-    cdef size_t rv
-
-    if size > left:
-        size = left
-
-    if size == 0:
-        status[0] = SDL_IO_STATUS_EOF
-        return 0
-
-    rv = SDL_ReadIO(sf.rw, ptr, size)
-
-    if rv > 0:
-        sf.tell += rv
-        status[0] = SDL_IO_STATUS_READY
-    else:
-        status[0] = SDL_IO_STATUS_ERROR
-
-    return rv
-
-cdef size_t subfile_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    status[0] = SDL_IO_STATUS_READONLY
-    return 0
-
-cdef bool subfile_flush(void *userdata, SDL_IOStatus *status) noexcept nogil:
-    status[0] = SDL_IO_STATUS_READY
-    return True
-
-cdef bool subfile_close(void *userdata) noexcept nogil:
-    cdef SubFile *sf = <SubFile *> userdata
-
-    if sf != NULL:
-        if sf.rw != NULL:
-            SDL_CloseIO(sf.rw)
-        free(sf)
-
-    return True
-
-cdef SDL_IOStreamInterface subfile_iointerface
-subfile_iointerface.version = sizeof(SDL_IOStreamInterface)
-subfile_iointerface.size = subfile_size
-subfile_iointerface.seek = subfile_seek
-subfile_iointerface.read = subfile_read
-subfile_iointerface.write = subfile_write
-subfile_iointerface.flush = subfile_flush
-subfile_iointerface.close = subfile_close
-
-
-cdef struct SplitFile:
-    SDL_IOStream *a
-    SDL_IOStream *b
-    Sint64 split
-    Sint64 tell
-
-cdef Sint64 splitfile_size(void *userdata) noexcept nogil:
-    cdef SplitFile *sf = <SplitFile *> userdata
-    cdef Sint64 rv
-
-    return SDL_GetIOSize(sf.a) + SDL_GetIOSize(sf.b)
-
-cdef Sint64 splitfile_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil:
-    cdef SplitFile *sf = <SplitFile *> userdata
-    cdef Sint64 rv
-
-    if whence == SDL_IO_SEEK_SET:
-        sf.tell = offset
-    elif whence == SDL_IO_SEEK_CUR:
-        sf.tell += offset
-    elif whence == SDL_IO_SEEK_END:
-        sf.tell = splitfile_size(userdata) + offset
-
-    if sf.tell < sf.split:
-        rv = SDL_SeekIO(sf.a, sf.tell, SDL_IO_SEEK_SET)
-        SDL_SeekIO(sf.b, 0, SDL_IO_SEEK_SET)
-    else:
-        SDL_SeekIO(sf.a, sf.split, SDL_IO_SEEK_SET)
-        rv = SDL_SeekIO(sf.b, sf.tell - sf.split, SDL_IO_SEEK_SET)
-
-    if rv < 0:
-        return rv
-    else:
-        return sf.tell
-
-cdef size_t splitfile_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    cdef SplitFile *sf = <SplitFile *> userdata
-    cdef size_t left = <size_t> (splitfile_size(userdata) - sf.tell)
-    cdef size_t rv
-
-    cdef size_t total_read
-    cdef size_t left_read
-    cdef size_t right_read
-
-    if size > left:
-        size = left
-
-    if size == 0:
-        status[0] = SDL_IO_STATUS_EOF
-        return 0
-
-    left_read = min(size, <size_t> (sf.split - sf.tell))
-    left_read = max(left_read, <size_t> 0)
-
-    if left_read > 0:
-        left_read = SDL_ReadIO(sf.a, ptr, left_read)
-        if left_read < 0:
-            status[0] = SDL_IO_STATUS_ERROR
-            return 0
-
-    right_read = size - left_read
-
-    if right_read > 0:
-        right_read = SDL_ReadIO(sf.b, <char *> ptr + left_read, right_read)
-        if right_read < 0:
-            status[0] = SDL_IO_STATUS_ERROR
-            return 0
-
-    sf.tell += left_read + right_read
-
-    status[0] = SDL_IO_STATUS_READY
-    return left_read + right_read
-
-cdef size_t splitfile_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    status[0] = SDL_IO_STATUS_READONLY
-    return 0
-
-cdef bool splitfile_flush(void *userdata, SDL_IOStatus *status) noexcept nogil:
-    status[0] = SDL_IO_STATUS_READY
-    return True
-
-cdef bool splitfile_close(void *userdata) noexcept nogil:
-    cdef SplitFile *sf = <SplitFile *> userdata
-
-    if sf != NULL:
-        if sf.a != NULL:
-            SDL_CloseIO(sf.a)
-        if sf.b != NULL:
-            SDL_CloseIO(sf.b)
-        free(sf)
-
-    return True
-
-cdef SDL_IOStreamInterface splitfile_iointerface
-splitfile_iointerface.version = sizeof(SDL_IOStreamInterface)
-splitfile_iointerface.size = splitfile_size
-splitfile_iointerface.seek = splitfile_seek
-splitfile_iointerface.read = splitfile_read
-splitfile_iointerface.write = splitfile_write
-splitfile_iointerface.flush = splitfile_flush
-splitfile_iointerface.close = splitfile_close
-
-
-cdef struct BufFile:
-    Py_buffer view
-    Uint8 *base
-    Uint8 *here
-    Uint8 *stop
-
-cdef Sint64 buffile_size(void *userdata) noexcept nogil:
-    cdef BufFile *bf = <BufFile *> userdata
-
-    return bf.stop - bf.base
-
-cdef Sint64 buffile_seek(void *userdata, Sint64 offset, SDL_IOWhence whence) noexcept nogil:
-    cdef BufFile *bf = <BufFile *> userdata
-
-    cdef Uint8 *newpos
-
-    if whence == SDL_IO_SEEK_SET:
-        newpos = bf.base + offset
-    elif whence == SDL_IO_SEEK_CUR:
-        newpos = bf.here + offset
-    elif whence == SDL_IO_SEEK_END:
-        newpos = bf.stop + offset
-    else:
-        return -1
-    if newpos < bf.base:
-        newpos = bf.base
-    if newpos > bf.stop:
-        newpos = bf.stop
-    bf.here = newpos
-
-    return bf.here - bf.base
-
-cdef size_t buffile_read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    cdef BufFile *bf = <BufFile *> userdata
-    cdef size_t mem_available = 0
-
-    mem_available = bf.stop - bf.here
-    if size > mem_available:
-        size = mem_available
-
-    if size == 0:
-        status[0] = SDL_IO_STATUS_EOF
-        return 0
-
-    memcpy(ptr, bf.here, size)
-    bf.here += size
-
-    status[0] = SDL_IO_STATUS_READY
-    return size
-
-cdef size_t buffile_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status) noexcept nogil:
-    cdef BufFile *bf = <BufFile *> userdata
-
-    if bf.view.readonly != 0:
-        status[0] = SDL_IO_STATUS_READONLY
-        return 0
-
-    if (bf.here + size) > bf.stop:
-        size = bf.stop - bf.here
-
-    memcpy(bf.here, ptr, size)
-    bf.here += size
-
-    status[0] = SDL_IO_STATUS_READY
-    return size
-
-cdef bool buffile_flush(void *userdata, SDL_IOStatus *status) noexcept nogil:
-    status[0] = SDL_IO_STATUS_READY
-    return True
-
-cdef bool buffile_close(void *userdata) noexcept with gil:
-    cdef BufFile *bf = <BufFile *> userdata
-
-    if bf != NULL:
-        PyBuffer_Release(&bf.view)
-        free(bf)
-
-    return True
-
-cdef SDL_IOStreamInterface buffile_iointerface
-buffile_iointerface.version = sizeof(SDL_IOStreamInterface)
-buffile_iointerface.size = buffile_size
-buffile_iointerface.seek = buffile_seek
-buffile_iointerface.read = buffile_read
-buffile_iointerface.write = buffile_write
-buffile_iointerface.flush = buffile_flush
-buffile_iointerface.close = buffile_close
-
-
-cdef SDL_IOStream *to_sdl_iostream(filelike, mode="rb", base=None, length=None) except NULL:
-    """
-    This accepts, in order:
-
-    * An io.BufferedIOBase object, which is unwrapped to get the
-      underlying file object. (Which is then processed as below.)
-
-    * An IOStream object, which is closed and the underlying SDL_IOStream
-      object is returned.
-
-    * A filename, which is opened.
-
-    * An object with the name, base, and length attributes. The name is
-      interpreted as a filename, and the base and length are used to
-      create a subfile.
-
-    * An object with a name fileld. The name is interpreted as a filename.
-      and opened. The object will be closed.
-
-    * An object that supports the buffer protocol.
-
-    * A file-like object, which is wrapped in a Python file-like object
-
-    It returns an SDL_IOStream object, or NULL on error.
-    """
-
-    cdef FILE *f
-    cdef SubFile *sf
-    cdef SDL_IOStream *rv
-    cdef SDL_IOStream *rw
-    cdef char *cname
-    cdef char *cmode
-
-    cdef IOStreamImpl iostream
-
-    if not isinstance(mode, bytes):
-        mode = mode.encode("ascii")
-
-    name = filelike
-
-    # Handle turning BufferedIOBase and IOStream objects into their underlying
-    # objects.
     try:
-        while True:
-            filelike = filelike.raw
-    except AttributeError:
-        pass
+        if d.close_filelike:
+            f.close()
+    except BaseException:
+        PyErr_WriteUnraisable(f)
 
-    if isinstance(filelike, IOStreamImpl):
-        iostream = <IOStreamImpl> filelike
-        if not iostream.ops:
-            raise ValueError("I/O on closed file.")
-
-        rv = iostream.ops
-        iostream.ops = NULL
-        return rv
-
-    if isinstance(filelike, (io.FileIO, io.IOBase)) and mode == "rb":
-        name = getattr(filelike, "name", None)
-
-    # Try to open as a file.
-    if isinstance(name, bytes):
-        name = name.decode(fsencoding)
-    elif isinstance(name, str):
-        pass
-    else:
-        name = None
-
-    if (mode == b"rb") and (name is not None):
-
-        dname = name.encode("utf-8")
-        cname = dname
-        cmode = mode
-
-        with nogil:
-            rv = SDL_IOFromFile(cname, cmode)
-
-        if rv == NULL:
-            raise IOError("Could not open {!r}: {}".format(name, SDL_GetError()))
-
-        if base is None and length is None:
-            try:
-                base = filelike.base
-                length = filelike.length
-            except AttributeError:
-                pass
-
-        if base is not None and length is not None:
-
-            # If we have these properties, we're either an APK asset or a Ren'Py-style
-            # subfile, so use an optimized path.
-
-            rw = rv
-
-            SDL_SeekIO(rw, base, SDL_IO_SEEK_SET)
-
-            sf = <SubFile *> calloc(sizeof(SubFile), 1)
-            sf.rw = rw
-            sf.base = base
-            sf.length = length
-            sf.tell = 0
-
-            rv = SDL_OpenIO(&subfile_iointerface, <void *> sf)
-
-        try:
-            filelike.close()
-        except:
-            pass
-
-        return rv
-
-    if not (hasattr(filelike, "read") or hasattr(filelike, "write")):
-        raise IOError("{!r} is not a filename or file-like object.".format(filelike))
-
-    Py_INCREF(filelike)
-
-    rv = SDL_OpenIO(&python_iointerface, <void *> filelike)
-
-    return rv
+    Py_DECREF(f)
+    SDL_free(d)
+    return True
 
 
-whence_mapping = {
-    io.SEEK_SET : SDL_IO_SEEK_SET,
-    io.SEEK_CUR : SDL_IO_SEEK_CUR,
-    io.SEEK_END : SDL_IO_SEEK_END,
-}
+cdef SDL_IOStreamInterface py_interface
+py_interface.version = <Uint32> sizeof(SDL_IOStreamInterface)
+py_interface.size = py_size
+py_interface.seek = py_seek
+py_interface.read = py_read
+py_interface.write = py_write
+py_interface.flush = py_flush
+py_interface.close = py_close
 
-cdef class IOStreamImpl:
+
+cdef class IOFileLike(IOStream):
     """
-    This wraps an SDL_IOStream object in a Python file-like object.
+    An IOStream wrapping an arbitrary Python file-like object. Every operation
+    reacquires the GIL, prefer IOPath, IOSubFile, or IOBuffer when the data is
+    available another way.
+
+    If the wrapped object implements readinto(), reads are zero-copy.
+
+    `filelike`
+        A Python file-like object.
+
+    `close`
+        If true, closing this object also closes the wrapped object.
+
+    `name`
+        If given, a string with a file name this stream represents.
     """
 
-    cdef SDL_IOStream *ops
-    cdef public object name
-    cdef public object base
-    cdef public object length
-
-    def __dealloc__(self):
-        if self.ops != NULL:
-            SDL_CloseIO(self.ops)
-            self.ops = NULL
-
-    def __init__(self, filelike, mode="rb", base=None, length=None, name=None):
-        """
-        Creates a new IOStreamImpl object. All parameter are passed to to_sdl_iostream
-        to create the SDL_IOstream object.
-        """
-
-        if name is not None:
-            self.name = name
-        elif isinstance(filelike, str):
-            self.name = filelike
-        else:
-            self.name = getattr(filelike, "name", name)
-
-        self.base = base
-        self.length = length
-
-        if filelike is not None:
-            self.ops = to_sdl_iostream(filelike, mode, base, length)
-        else:
-            self.ops = NULL
-
-    def close(self):
-
-        # A closed file may be closed again.
-
-        if self.ops:
-            SDL_CloseIO(self.ops)
-            self.ops = NULL
-
-    def is_closed(self):
-        return not self.ops
-
-    def seek(self, long long offset, whence=0):
-        cdef SDL_IOWhence whence_io
-        cdef long long rv
-
-        if not self.ops:
-            raise ValueError("I/O operation on closed file.")
-
-        whence_io = whence_mapping.get(whence, SDL_IO_SEEK_SET)
-
-        with nogil:
-            rv = SDL_SeekIO(self.ops, offset, whence_io)
-
-        if rv < 0:
-            raise IOError("Could not seek: {}".format(SDL_GetError()))
-
-        return rv
-
-    def tell(self):
-        cdef long long rv
-
-        with nogil:
-            rv = SDL_TellIO(self.ops)
-
-        return rv
-
-    def readinto(self, b):
-        cdef Py_buffer view
-        cdef long long rv = 0
-
-        if not self.ops:
-            raise ValueError("I/O operation on closed file.")
-
-        if not PyObject_CheckBuffer(b):
-            raise ValueError("Passed in object does not support buffer protocol")
+    def __init__(IOFileLike self not None, object filelike, /, bint close=False, str name=None):
+        try:
+            readable = bool(filelike.readable())
+        except AttributeError:
+            readable = hasattr(filelike, "read")
 
         try:
-            PyObject_GetBuffer(b, &view, PyBUF_CONTIG)
-
-            with nogil:
-                rv = SDL_ReadIO(self.ops, view.buf, view.len)
-        finally:
-            PyBuffer_Release(&view)
-
-        if rv < 0:
-            raise IOError("Could not read: {}".format(SDL_GetError()))
-
-        return rv
-
-    def write(self, b):
-        cdef Py_buffer view
-        cdef long long rv = 0
-
-        if not self.ops:
-            raise ValueError("I/O operation on closed file.")
-
-        if not PyObject_CheckBuffer(b):
-            raise ValueError("Passed in object does not support buffer protocol")
+            writable = bool(filelike.writable())
+        except AttributeError:
+            writable = hasattr(filelike, "write")
 
         try:
-            PyObject_GetBuffer(b, &view, PyBUF_CONTIG_RO)
-            with nogil:
-                rv = SDL_WriteIO(self.ops, view.buf, view.len)
-        finally:
-            PyBuffer_Release(&view)
+            seekable = bool(filelike.seekable())
+        except AttributeError:
+            seekable = hasattr(filelike, "seek")
 
-        if rv < 0:
-            raise IOError("Could not write: {}".format(SDL_GetError()))
+        if not (readable or writable):
+            raise TypeError(f"{filelike!r} is not a file-like object.")
 
-        return rv
+        if name is None:
+            filelike_name = getattr(filelike, "name", None)
+            if isinstance(filelike_name, bytes):
+                filelike_name = os.fsdecode(filelike_name)
+            elif filelike_name is not None:
+                filelike_name = str(filelike_name)
+            name = filelike_name
 
+        has_readinto = hasattr(filelike, "readinto")
 
-cdef SDL_IOStream *SDLIOStreamFromPython(filelike) except NULL:
-    return to_sdl_iostream(filelike, "rb", None, None)
+        cdef FileLikeData *userdata = <FileLikeData *>SDL_malloc(sizeof(FileLikeData))
+        if userdata == NULL:
+            raise MemoryError("Could not allocate FileLikeData.")
 
+        Py_INCREF(filelike)
+        userdata.filelike = <PyObject *> filelike
+        userdata.close_filelike = close
+        userdata.has_readinto = has_readinto
+        userdata.readable = readable
+        userdata.writable = writable
+        userdata.seekable = seekable
 
-class IOStream(io.RawIOBase):
+        cdef SDL_IOStream *s = SDL_OpenIO(&py_interface, userdata)
+        if s == NULL:
+            Py_DECREF(filelike)
+            SDL_free(userdata)
+            raise MemoryError(f"Could not create SDL_IOStream: {get_error()}")
 
-    def __init__(self, filelike, mode='rb', base=None, length=None, name=None):
-        """
-        Creates a new IOStream object.
-        """
-
-        io.RawIOBase.__init__(self)
-
-        self.raw = IOStreamImpl(filelike, mode=mode, base=base, length=length, name=name)
-
-        self.close = self.raw.close
-        self.seek = self.raw.seek
-        self.tell = self.raw.tell
-        self.write = self.raw.write
-        self.readinto = self.raw.readinto
-
-    def __repr__(self):
-        if self.raw.base is not None:
-            return "<SDLIOStreamIO {!r} base={!r} length={!r}>".format(self.raw.name, self.raw.base, self.raw.length)
+        self._stream = s
+        self._readable = readable
+        self._writable = writable
+        self._seekable = seekable
+        self._close_filelike = close
+        self.filelike = filelike
+        if readable and writable:
+            self.mode = "rb+"
+        elif readable:
+            self.mode = "rb"
         else:
-            return "<SDLIOStreamIO {!r}>".format(self.raw.name)
+            self.mode = "wb"
+        self.name = name
 
-    # Implemented class: io.IOBase
+    def __repr__(IOFileLike self not None, /):
+        class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+        name = "" if self.name is None else f", name={self.name!r}"
+        return f"{class_name}({self.filelike!r}, close={self._close_filelike}{name})"
 
-    # close is taken from RWopsIOImpl.
+    def readable(IOFileLike self not None, /):
+        self._checkClosed()
+        return self._readable
 
-    @property
-    def closed(self):
-        return self.raw.is_closed()
+    def writable(IOFileLike self not None, /):
+        self._checkClosed()
+        return self._writable
 
-    def fileno(self):
-        raise OSError()
+    def seekable(IOFileLike self not None, /):
+        self._checkClosed()
+        return self._seekable
 
-    # inherited flush is used
+    # Reimplement some function to not drop and reacquire GIL for no reason.
+    def read(IOFileLike self not None, Py_ssize_t size=-1, /):
+        self._checkClosed()
+        self._checkReadable()
 
-    # inherited isatty is used
+        if size < 0:
+            return self.readall()
 
-    def readable(self):
-        return True
+        return self.filelike.read(size)
 
-    # inherited readline is used
+    def readinto(IOFileLike self not None, object b, /):
+        self._checkClosed()
+        self._checkReadable()
 
-    # inherited readlines is used
+        return self.filelike.readinto(b)
 
-    # seek is taken from RWopsIOImpl.
+    def write(IOFileLike self not None, object b, /):
+        self._checkClosed()
+        self._checkWritable()
 
-    def seekable(self):
-        return True
-
-    # tell is taken from RWopsIOImpl.
-
-    def truncate(self, size=None):
-        raise OSError()
-
-    def writable(self):
-        return True
-
-    # inherited writelines is used
-
-    # inherited __del__ is used
-
-    # Implemented class: io.RawIOBase
-
-    # inherited read is used
-
-    # inherited readall is used
-
-    # readinto is taken from RWopsIOImpl.
-
-    # write is taken from RWopsIOImpl.
-
-    @staticmethod
-    def from_buffer(buffer, mode="rb", name=None):
-        """
-        Creates a new RWopsIO object from a buffer.
-        """
-
-        cdef BufFile *bf
-        cdef SDL_IOStream *stream
-
-        if not PyObject_CheckBuffer(buffer):
-            raise ValueError("Passed in object does not support buffer protocol")
-
-        bf = <BufFile *> calloc(sizeof(BufFile), 1)
-        if bf == NULL:
-            raise MemoryError()
-
-        if PyObject_GetBuffer(buffer, &bf.view, PyBUF_CONTIG_RO) < 0:
-            free(bf)
-            raise ValueError("Could not get buffer.")
-
-        bf.base = <Uint8 *> bf.view.buf
-        bf.here = bf.base
-        bf.stop = bf.base + bf.view.len
-
-        stream = SDL_OpenIO(&buffile_iointerface, <void *> bf)
-
-        rv = IOStream(None, name=name)
-        (<IOStreamImpl> rv.raw).ops = stream
-        return rv
-
-    @staticmethod
-    def from_split(a, b, name=None):
-        """
-        Creates a new RWopsIO object from two other RWopsIO objects,
-        representing the concatenation of the two.
-        """
-
-        cdef SplitFile *sf
-        cdef SDL_IOStream *rw
-
-        sf = <SplitFile *> calloc(sizeof(SplitFile), 1)
-        if sf == NULL:
-            raise MemoryError()
-
-        sf.a = to_sdl_iostream(a)
-        sf.b = to_sdl_iostream(b)
-        sf.split = SDL_GetIOSize(sf.a)
-        sf.tell = 0
-
-        rw = SDL_OpenIO(&splitfile_iointerface, <void *> sf)
-
-        rv = IOStream(None, name=name)
-        (<IOStreamImpl> rv.raw).ops = rw
-        return rv
+        return self.filelike.write(b)

--- a/renpy/pygame/iostream.pyx
+++ b/renpy/pygame/iostream.pyx
@@ -35,7 +35,7 @@ reacquires the GIL for every operation, so prefer the others when the data
 is reachable another way:
 
 * A path on disk                                         IOPath
-* A file as a region in other IOStream, e.g. archive     IOSubFile
+* A region inside another IOStream, e.g. an archive      IOSubFile
 * bytes, bytearray, memoryview, mmap, array              IOBuffer
 * A BytesIO you own and will not resize                  IOBuffer(b.getbuffer())
 * Anything computed: gzip, zipfile, network              IOFileLike
@@ -46,8 +46,8 @@ Thread safety
 It is unsafe to read or write the same IOStream from different threads at the
 same time.
 
-SDL_Quit must be called before interpreter shutdown, or program may hung, unable
-to deallocate Python objects owned in Stream userdata.
+SDL_Quit must be called before interpreter shutdown, or the program may hang,
+unable to deallocate Python objects owned by stream userdata.
 """
 
 from .sdl cimport *
@@ -99,27 +99,31 @@ cdef class IOStream:
 
     def __cinit__(IOStream self not None, *args, **kwargs):
         self._stream = NULL
+        self._closed = False
 
     def __init__(IOStream self not None):
         if type(self) is IOStream:
             raise TypeError("IOStream is abstract, use one of its subclasses.")
 
     def __del__(IOStream self not None, /):
-        # Let subclasses overwrite IOStream.close.
-        if self._stream != NULL:
+        # Subclasses can overwrite IOStream.close and using __del__ guards
+        # against resurrection.
+        if not self.closed:
             try:
                 self.close()
             except Exception:
                 pass
 
     def __dealloc__(IOStream self not None, /):
-        if self._stream != NULL:
-            SDL_CloseIO(self._stream)
+        # Guard against close that didn't closed SDL stream.
+        cdef SDL_IOStream *stream = self._stream
+        if stream != NULL:
             self._stream = NULL
+            SDL_CloseIO(stream)
 
     # IOBase implements them and others use it, ugly.
     def _checkClosed(IOStream self not None, /):
-        if self._stream == NULL:
+        if self.closed:
             raise ValueError("I/O operation on closed file.")
 
     def _checkReadable(IOStream self not None, /):
@@ -143,7 +147,21 @@ cdef class IOStream:
         """
 
         self._checkClosed()
+
+        # Protection against improper subclass overrides.
+        if self._stream == NULL:
+            raise RuntimeError("SDL stream was closed unexpectedly.")
+
         return self._stream
+
+    def on_take(IOStream self not None, /):
+        """
+        Called before SDL stream is detached from the object, including when
+        the stream is about to be closed.
+
+        This function should clean any references to the objects that
+        will be owned by it.
+        """
 
     cdef SDL_IOStream *take(self) except NULL:
         """
@@ -153,10 +171,16 @@ cdef class IOStream:
         This object is closed from Python's point of view after the call.
         """
 
-        cdef SDL_IOStream *rv = self.borrow()
+        self._checkClosed()
+
+        self.on_take()
+
+        # Protection against improper subclass overrides.
+        cdef SDL_IOStream *stream = self.borrow()
 
         self._stream = NULL
-        return rv
+        self._closed = True
+        return stream
 
     # io.IOBase interface.
     def __iter__(IOStream self not None, /):
@@ -184,26 +208,25 @@ cdef class IOStream:
 
     def close(IOStream self not None, /):
         # A closed file may be closed again.
-        if self._stream == NULL:
+        if self.closed:
             return
 
-        # Mimic io.IOBase behavior.
+        # Mimic io.IOBase.close behavior.
         cdef cbool rv
+        cdef SDL_IOStream *stream
         try:
             self.flush()
         finally:
-            try:
-                with nogil:
-                    rv = SDL_CloseIO(self._stream)
-            finally:
-                self._stream = NULL
+            stream = self.take()
+            with nogil:
+                rv = SDL_CloseIO(stream)
 
             if not rv:
                 raise IOError(f"Could not close: {get_error()}")
 
     @property
     def closed(IOStream self not None, /):
-        return self._stream == NULL
+        return self._closed
 
     def fileno(IOStream self not None, /):
         raise io.UnsupportedOperation("This stream is not backed by a file descriptor.")
@@ -214,8 +237,9 @@ cdef class IOStream:
         if not self.writable():
             return
 
+        cdef SDL_IOStream *stream = self.borrow()
         with nogil:
-            rv = SDL_FlushIO(self._stream)
+            rv = SDL_FlushIO(stream)
 
         if not rv:
             raise IOError(f"Could not flush: {get_error()}")
@@ -781,14 +805,17 @@ buf_interface.close = buf_close
 
 cdef class IOBuffer(IOStream):
     """
-    An IOStream over any object supporting the buffer protocol. The buffer is
-    kept mapped for the lifetime of this object, and its size is fixed.
+    An IOStream over any object supporting the buffer protocol. The buffer view
+    is held for as long as the underlying SDL_IOStream is open, independent of
+    this Python object's lifetime. The view is released, and the source object's
+    reference dropped, only when the underlying stream is closed.
 
     `buffer`
-        Object that supports buffer protocol and provide contigous memory.
+        An object supporting the buffer protocol that provides contiguous memory.
+        Set to None when this stream is closed.
 
     `writable`
-        If True, `buffer` must allow requesting `PyBUF_CONTIG`.
+        If True, `buffer` must allow requesting writable buffer.
 
     `name`
         If given, a string with a file name this stream represents.
@@ -824,6 +851,9 @@ cdef class IOBuffer(IOStream):
         class_name = f"{type(self).__module__}.{type(self).__qualname__}"
         name = "" if self.name is None else f", name={self.name!r}"
         return f"{class_name}({self.buffer!r}, writable={self.writable()}{name})"
+
+    def on_take(IOBuffer self not None, /):
+        self.buffer = None
 
     def readable(IOBuffer self not None, /):
         self._checkClosed()
@@ -1148,6 +1178,22 @@ cdef class IOFileLike(IOStream):
         return self._seekable
 
     # Reimplement some function to not drop and reacquire GIL for no reason.
+    def seek(IOFileLike self not None, Sint64 offset, int whence=io.SEEK_SET, /):
+        self._checkClosed()
+        self._checkSeekable()
+
+        return self.filelike.seek(offset, whence)
+
+    def flush(IOFileLike self not None, /):
+        self._checkClosed()
+
+        if not self.writable():
+            return
+
+        flush = getattr(self.filelike, "flush", None)
+        if flush is not None:
+            flush()
+
     def read(IOFileLike self not None, Py_ssize_t size=-1, /):
         self._checkClosed()
         self._checkReadable()

--- a/renpy/pygame/iostream.pyx
+++ b/renpy/pygame/iostream.pyx
@@ -807,8 +807,7 @@ cdef class IOBuffer(IOStream):
     """
     An IOStream over any object supporting the buffer protocol. The buffer view
     is held for as long as the underlying SDL_IOStream is open, independent of
-    this Python object's lifetime. The view is released, and the source object's
-    reference dropped, only when the underlying stream is closed.
+    this Python object's lifetime.
 
     `buffer`
         An object supporting the buffer protocol that provides contiguous memory.

--- a/src/_renpy.pyx
+++ b/src/_renpy.pyx
@@ -27,7 +27,7 @@ def version():
 
 from renpy.pygame.sdl cimport *
 
-from renpy.pygame.iostream cimport SDLIOStreamFromPython
+from renpy.pygame.iostream cimport SDL_IOStreamFromPython
 
 import renpy
 
@@ -106,7 +106,7 @@ def save_png(surf, file, compress=-1):
     if not isinstance(surf, renpy.pygame.Surface):
         raise Exception("save_png requires a pygame Surface as its first argument.")
 
-    save_png_core(surf, SDLIOStreamFromPython(file), compress)
+    save_png_core(surf, SDL_IOStreamFromPython(file), compress)
 
 
 def pixellate(pysrc, pydst, avgwidth, avgheight, outwidth, outheight):


### PR DESCRIPTION
This PR refactors `renpy.pygame.iostream` so it has more clean semantic in both Python and C sides. This also fixes several crashes that unusual but valid, or slightly innacurate file-like implementations could cause, e.g. buffer overflow if `filelike.read` returns more bytes than requested.

I think it would simplify passing border between Python and SDL, makes fixing #7094 trivial, and if I read docs correctly should simplify/make faster IO on mobile and web.

New interface looks like
```py
class IOStream(io.RawIOBase):
    def __init__(self):
        raise TypeError("IOStream is abstract, use one of its subclasses.")

    cdef SDL_IOStream *borrow(self) except NULL:
        """
        Borrow the reference to the underlying SDL_IOStream.

        Caller must make sure this object is kept alive while the stream
        is used by SDL. To transfer ownership use IOStream.take().
        """

    cdef SDL_IOStream *take(self) except NULL:
        """
        Transfers ownership of the underlying SDL_IOStream to the caller, and
        caller is responsible to call SDL_CloseIO on it.

        This object is closed from Python's point of view after the call.
        """

class IOPath(IOStream):
    """
    An IOStream backed by a file on disk, opened by SDL. All operations are
    GIL-free.

    `path`
        The file to open, as a str or os.PathLike[str].

    `mode`
        A string, "rb" to open file for reading, "wb" to open file for writing.

    `name`
        If given, a string with a file name this stream represents.
    """

    def __init__(IOPath self not None, object path, /, str mode="rb", str name=None):
        ...

class IOSubFile(IOStream):
    """
    A read-only window into a file on disk, of `length` bytes starting at
    `base`. Used for files stored inside Ren'Py archives and Android assets.

    The window opens and exclusively owns its own handle on the underlying
    file, so distinct IOSubFile objects over the same path are independent and
    each read is a single SDL_ReadIO with no redundant seek.

    `path`
        The file to open, as a str, or os.PathLike[str]. An IOStream may
        also be given, in which case its SDL stream is taken and this
        object assumes exclusive ownership of it.

    `base`
        Non-negative offset into `path` where sub-file starts.

    `length`
        Non-negative length of the sub-file.

    `name`
        If given, a string with a file name this stream represents.
    """

    def __init__(IOSubFile self not None, object path, /, Sint64 base, Sint64 length, str name=None):
        ...

cdef class IOBuffer(IOStream):
    """
    An IOStream over any object supporting the buffer protocol. The buffer view
    is held for as long as the underlying SDL_IOStream is open, independent of
    this Python object's lifetime.

    `buffer`
        An object supporting the buffer protocol that provides contiguous memory.
        Set to None when this stream is closed.

    `writable`
        If True, `buffer` must allow requesting writable buffer.

    `name`
        If given, a string with a file name this stream represents.
    """

    def __init__(IOBuffer self not None, object buffer, /, bint writable=False, str name=None):
        ...

class IOFileLike(IOStream):
    """
    An IOStream wrapping an arbitrary Python file-like object. Every operation
    reacquires the GIL, prefer IOPath, IOSubFile, or IOBuffer when the data is
    available another way.

    If the wrapped object implements readinto(), reads are zero-copy.

    `filelike`
        A Python file-like object.

    `close`
        If true, closing this object also closes the wrapped object.

    `name`
        If given, a string with a file name this stream represents.
    """

    def __init__(IOFileLike self not None, object filelike, /, bint close=False, str name=None):
        ...

cdef inline SDL_IOStream *SDL_IOStreamFromPython(object obj, str name=None) except NULL:
    """
    This accepts, in order:

    * An IOStream object, which is closed and the underlying SDL_IOStream
      object is returned.

    * A str or path-like filename, which is opened.

    * An object with a name field. The name is interpreted as a filename.
      and opened. The object will be closed.

    * An object that supports the buffer protocol.

    * A file-like object.

    It returns an SDL_IOStream object, or NULL on error.

    Calling this function transfers exclusive ownership of `obj` to the returned
    stream, including responsibility for closing it.
    """
```
