### PR TITLE
Pass text_input to mesh renders

### DIFF
--- a/renpy/display/render.pyx
+++ b/renpy/display/render.pyx
@@ -797,6 +797,9 @@ cdef class Render:
             self.depends_on_list.append(source)
             source.parents.add(self)
 
+            if source.text_input:
+                self.text_input = True
+
         return 0
 
     cpdef int subpixel_blit(Render self, source, tuple pos, object focus=True, object main=True, object index=None):
@@ -831,6 +834,9 @@ cdef class Render:
             self.depends_on_list.append(source)
             source.parents.add(self)
 
+            if source.text_input:
+                self.text_input = True
+
         return 0
 
     cpdef int absolute_blit(Render self, source, tuple pos, object focus=True, object main=True, object index=None):
@@ -864,6 +870,9 @@ cdef class Render:
         if isinstance(source, Render):
             self.depends_on_list.append(source)
             source.parents.add(self)
+
+            if source.text_input:
+                self.text_input = True
 
         return 0
 

--- a/testcases/game/tests/test_input.rpy
+++ b/testcases/game/tests/test_input.rpy
@@ -1,0 +1,48 @@
+# Tests for interacting with input fields in various scenarios
+
+# ==============
+# == Fixtures ==
+# ==============
+
+screen input__mesh_property__screen():
+    default show = False
+    default input_value = ""
+
+    button:
+        at transform:
+            mesh True
+
+        action ToggleScreenVariable('show')
+
+        if show:
+            input:
+                id "transform_input"
+                value ScreenVariableInputValue('input_value')
+
+        else:
+            text "Click to input":
+                id "transform_input_click"
+
+
+# ==============
+# === Tests ====
+# ==============
+
+testsuite input:
+    testcase input_accepts_text_inside_mesh:
+        description "Input inside mesh True transform accepts typed text."
+        # GH-7177: Input field does not work stably when a parent displayable has `mesh True`.
+        # https://github.com/renpy/renpy/issues/7177
+
+        run Show("input__mesh_property__screen")
+        assert screen "input__mesh_property__screen"
+
+        click id "transform_input_click"
+        assert id "transform_input"
+
+        type "Hello"
+
+        $ value = renpy.exports.get_screen("input__mesh_property__screen").scope.get("input_value", "NOT DEFINED")
+        $ assert value == "Hello", f"Expected 'Hello', got '{value}'"
+
+        run Hide("input__mesh_property__screen")


### PR DESCRIPTION
Fixes #7177

The `text_input` flag was not being propagated correctly to the mesh render. The mesh render made by `make_mesh()` has `operation = FLATTEN`, so the draw function doesn't traverse its children and `text_input` was never set.

The end result is that `pygame.key.start_text_input()` was never called. When SDL processes keyboard events, it would create KEYDOWN events with unicode="" which gets ignored by `Input.event()` and no TEXTINPUT events would be created.