### PR TITLE
textshader: Respect {cps} tags when preferences.text_cps = 0

### DIFF
--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -2952,7 +2952,7 @@ class Text(renpy.display.displayable.Displayable):
     def render_textshader(self, render, layout, st, at):
         slow_time = layout.max_time
 
-        if self.slow and layout.cps:
+        if self.slow and layout.max_time:
             slow_time = min(slow_time, st)
 
         render.add_uniform("u_text_slow_time", slow_time)

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -15,6 +15,10 @@ The interpretation of Bezier curves in Live2D has been changed to match the Card
 which is consistent with the Live2D SDK. This behavior can be changed with the `old_beziers` parameter to the :func:`Live2D`
 displayable, or with the :var:`config.live2d_old_beziers` variable,
 
+Fixes
+-----
+
+Textshaders now respect the :tt:`cps` text tag when the player's text speed is set to instant.
 
 .. _renpy-8.5.3:
 

--- a/testcases/game/tests/test_textshaders.rpy
+++ b/testcases/game/tests/test_textshaders.rpy
@@ -1,0 +1,42 @@
+# Tests for text shaders
+
+# ==============
+# == Fixtures ==
+# ==============
+
+label textshaders__cps__label:
+    "{cps=40}This appears one letter at a time at a speed of 40 characters per second{/cps}"
+
+# ==============
+# === Tests ====
+# ==============
+
+testsuite textshaders:
+    after testcase:
+        if not screen "main_menu":
+            run MainMenu(confirm=False, save=False)
+
+    testcase respect_cps_tag:
+        description "Typewriter shader follows {cps} when preferences.text_cps = 0"
+        # GH-7242: Text shaders should follow the line's {cps} value even if
+        # `preferences.text_cps` is set to instant text
+        # https://github.com/renpy/renpy/issues/7242
+
+        run Preference("text speed", 0)
+        $ renpy.game.style.default.textshader = None
+        $ renpy.game.style.rebuild()
+
+        run Start("textshaders__cps__label")
+        assert "This appears"
+        pause 0.5
+        screenshot "textshaders/cps.png" max_pixel_difference 200 crop (0, 440, 740, 80)
+        advance until screen "main_menu"
+
+        $ renpy.game.style.default.textshader = "typewriter"
+        $ renpy.game.style.rebuild()
+
+        run Start("textshaders__cps__label")
+        assert "This appears"
+        pause 0.5
+        screenshot "textshaders/cps.png" max_pixel_difference 200 crop (0, 440, 740, 80)
+        advance until screen "main_menu"


### PR DESCRIPTION
Fixes #7242

`layout.cps` is the default cps for the layout (zero in this case). I changed the condition check to `layout.max_time` instead, which reflects the actual per-segment timings. You can do `layout.max_time > 0` if you want to be extra safe. Test with the new `textshaders` suite.

This line was last modified in 376c520b7509db062af0ccafb8650d94282bde20

I'm still not comfortable doing direct commits to the main branches outside of the tests folder, so apologies if this feels minor.