### PR TITLE
Fix RPA loading

### DIFF
--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -175,7 +175,7 @@ def play(
 
     try:
         if not isinstance(file, str):
-            file = file.raw.name
+            file = getattr(file, "raw", file).name
     except Exception:
         if renpy.config.debug_sound:
             raise
@@ -212,7 +212,7 @@ def queue(
 
     try:
         if not isinstance(file, str):
-            file = file.raw.name
+            file = getattr(file, "raw", file).name
     except Exception:
         if renpy.config.debug_sound:
             raise

--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -175,7 +175,7 @@ def play(
 
     try:
         if not isinstance(file, str):
-            file = getattr(file, "raw", file).name
+            file = file.name
     except Exception:
         if renpy.config.debug_sound:
             raise
@@ -212,7 +212,7 @@ def queue(
 
     try:
         if not isinstance(file, str):
-            file = getattr(file, "raw", file).name
+            file = file.name
     except Exception:
         if renpy.config.debug_sound:
             raise

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -560,7 +560,8 @@ def load_from_archive(name):
         if len(index[name]) == 1 and len(index[name][0]) == 2:
             offset, dlen = index[name][0]
 
-            return IOSubFile(afn, base=offset, length=dlen, name=name)
+            stream = IOSubFile(afn, base=offset, length=dlen, name=name)
+            return io.BufferedReader(stream)
 
         # Compatibility path.
         parts: list[bytes] = []
@@ -573,7 +574,7 @@ def load_from_archive(name):
                     f.seek(offset)
                     parts.append(f.read(dlen))
 
-            return IOBuffer(b"".join(parts), name=name)
+            return io.BufferedReader(IOBuffer(b"".join(parts), name=name))
 
     return None
 

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -560,8 +560,7 @@ def load_from_archive(name):
         if len(index[name]) == 1 and len(index[name][0]) == 2:
             offset, dlen = index[name][0]
 
-            stream = IOSubFile(afn, base=offset, length=dlen)
-            return io.BufferedReader(stream)
+            return IOSubFile(afn, base=offset, length=dlen, name=name)
 
         # Compatibility path.
         parts: list[bytes] = []
@@ -574,7 +573,7 @@ def load_from_archive(name):
                     f.seek(offset)
                     parts.append(f.read(dlen))
 
-            return io.BufferedReader(IOBuffer(b"".join(parts)))
+            return IOBuffer(b"".join(parts), name=name)
 
     return None
 

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -162,15 +162,18 @@ class RPAv3ArchiveHandler(object):
             if len(index[k][0]) == 2:
                 index[k] = [(offset ^ key, dlen ^ key) for offset, dlen in index[k]]
             else:
-                index[k] = index_list = []
+                index_list = []
+
                 for offset, dlen, start in index[k]:
                     if start:
                         if not isinstance(start, bytes):
                             start = start.encode("latin-1")
 
-                        index_list.append(start)
+                        index_list.append((start,))
 
                     index_list.append((offset ^ key, dlen ^ key))
+
+                index[k] = index_list
 
         return index
 
@@ -557,7 +560,7 @@ def load_from_archive(name):
         if len(index[name]) == 1 and len(index[name][0]) == 2:
             offset, dlen = index[name][0]
 
-            stream = IOSubFile(afn, base=offset, length=dlen, name=name)
+            stream = IOSubFile(afn, base=offset, length=dlen)
             return io.BufferedReader(stream)
 
         # Compatibility path.
@@ -571,7 +574,7 @@ def load_from_archive(name):
                     f.seek(offset)
                     parts.append(f.read(dlen))
 
-            return io.BufferedReader(IOBuffer(b"".join(parts), name=name))
+            return io.BufferedReader(IOBuffer(b"".join(parts)))
 
     return None
 

--- a/renpy/pygame/iostream.pxd
+++ b/renpy/pygame/iostream.pxd
@@ -76,6 +76,9 @@ cdef inline SDL_IOStream *SDL_IOStreamFromPython(object obj, str name=None) exce
     """
 
     import os
+    
+    while hasattr(obj, "raw"):
+        obj = obj.raw
 
     cdef IOStream stream
     if isinstance(obj, IOStream):


### PR DESCRIPTION
Fixes an issue loading RPAs introduced by https://github.com/renpy/renpy/pull/7234. I tried to infer the intent of the original PR, but the first commit here solves the problem just by reverting to the old behavior.

`webaudio` is touched to prevent a silent sound drop if handed a raw stream directly.