### PR TITLE
feat(audio): allow runtime seeking on channels

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -857,6 +857,14 @@ class Channel(object):
 
         return renpysound.get_duration(self.number)
 
+    def seek(self, position):
+        """Seeks this channel without reopening its media stream."""
+
+        if not pcm_ok or self._number is None:
+            return
+
+        renpysound.seek(self.number, position)
+
     def set_pan(self, pan, delay):
         with lock:
             now = get_serial()

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -383,6 +383,22 @@ def get_delay(time, channel="music"):
         return None
 
 
+def seek(position, channel="music"):
+    """
+    :doc: audio
+
+    Seeks the media currently playing on `channel` to `position` seconds.
+    This preserves the active decoder and queued tracks, unlike restarting
+    playback with an audio ``<from ...>`` specifier.
+    """
+
+    try:
+        get_channel(channel).seek(position)
+    except Exception:
+        if renpy.config.debug_sound:
+            raise
+
+
 def get_pos(channel="music"):
     """
     :doc: audio

--- a/renpy/audio/renpysound.pyx
+++ b/renpy/audio/renpysound.pyx
@@ -67,6 +67,7 @@ cdef extern from "renpysound_core.h":
     void RPS_pause(int channel, int pause)
     void RPS_unpause_all_at_start()
     void RPS_global_pause(int pause)
+    void RPS_seek(int channel, double position)
     int RPS_get_pos(int channel)
     double RPS_get_duration(int channel)
     void RPS_set_endevent(int channel, int event)
@@ -261,6 +262,13 @@ def global_pause(pause):
     """
 
     RPS_global_pause(pause)
+
+
+def seek(channel, position):
+    """Seeks the playing media on `channel` to `position` seconds."""
+
+    RPS_seek(channel, position)
+    check_error()
 
 
 def fadeout(channel, delay):

--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -237,6 +237,13 @@ def stop(channel):
 
 
 @proxy_with_channel
+def seek(channel, position):
+    """Seeks the playing media on `channel` to `position` seconds."""
+
+    call("seek", channel, position)
+
+
+@proxy_with_channel
 def dequeue(channel, even_tight=False):
     """
     Dequeues the queued sound file.

--- a/renpy/common/00barvalues.rpy
+++ b/renpy/common/00barvalues.rpy
@@ -601,13 +601,20 @@ init -1500 python:
 
         `update_interval`
             How often the value updates, in seconds.
+
+        `adjustable`
+            If true, the player can seek by dragging the bar.
         """
 
-        def __init__(self, channel='music', update_interval=0.1):
+        def __init__(self, channel='music', update_interval=0.1, adjustable=False):
             self.channel = channel
             self.update_interval = update_interval
+            self.adjustable = adjustable
 
             self.adjustment = None
+
+        def changed(self, position):
+            renpy.music.seek(position, self.channel)
 
         def get_pos_duration(self):
             pos = renpy.music.get_pos(self.channel) or 0.0
@@ -617,7 +624,12 @@ init -1500 python:
 
         def get_adjustment(self):
             pos, duration = self.get_pos_duration()
-            self.adjustment = ui.adjustment(value=pos, range=duration, adjustable=False)
+            self.adjustment = ui.adjustment(
+                value=pos,
+                range=duration,
+                changed=self.changed if self.adjustable else None,
+                adjustable=self.adjustable,
+            )
             return self.adjustment
 
         def periodic(self, st):

--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -714,6 +714,50 @@ renpyAudio.get_pos = (channel) => {
 };
 
 
+renpyAudio.seek = (channel, position) => {
+    let c = get_channel(channel);
+    let p = c.playing;
+
+    if (p === null) {
+        return;
+    }
+
+    position = Math.max(0, position);
+    if (p.end > 0) {
+        position = Math.min(position, p.end);
+    }
+
+    if (c.video && c.video_el) {
+        c.video_el.currentTime = position;
+        p.start = position;
+        p.started = c.paused ? null : c.video_el.currentTime;
+        return;
+    }
+
+    if (!p.buffer) {
+        return;
+    }
+
+    position = Math.min(position, p.buffer.duration);
+
+    if (p.source !== null && p.started !== null) {
+        renpyAudio.disconnectFilter(p.filter, p.source, c.destination);
+        try {
+            p.source.stop();
+        } catch (e) {
+        }
+    }
+
+    p.source = create_source(c, p.buffer);
+    p.start = position;
+    p.started = null;
+
+    if (!c.paused) {
+        start_playing(c);
+    }
+};
+
+
 renpyAudio.get_duration = (channel) => {
     let c = get_channel(channel);
     let p = c.playing;

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -60,6 +60,8 @@ The :var:`config.tts_voice` variable is no longer used.
 Features
 --------
 
+The new :func:`renpy.music.seek` function seeks the audio or video currently playing on a channel, while :class:`AudioPositionValue` now accepts an `adjustable` argument that allows a bar to seek when dragged.
+
 A new :ref:`renpy.red_to_alpha <shader-renpy.red_to_alpha>` shader part has been added, which creates a new image that is white with the alpha taken from
 the red channel of the original data being drawn. This is intended for use to replace: :class:`im.AlphaMask` with :class:`AlphaMask`.
 

--- a/src/ffmedia.c
+++ b/src/ffmedia.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "ffmedia.h"
 
@@ -211,6 +212,10 @@ typedef struct MediaState {
 	/* The number of seconds to skip at the start. */
 	double skip;
 
+	/* A seek requested by the audio callback thread. Protected by lock. */
+	int seek_requested;
+	double seek_target;
+
 	/* These become true when the audio and video finish. */
 	int audio_finished;
 	int video_finished;
@@ -232,6 +237,9 @@ typedef struct MediaState {
 
 	/* The total duration of the video. Only used for information purposes. */
 	double total_duration;
+
+	/* The end time requested by media_start_end(), or -1 for natural EOF. */
+	double end_time;
 
 	/* Audio Stuff ***********************************************************/
 
@@ -311,6 +319,49 @@ static void free_surface_entry(SurfaceQueueEntry *sqe) {
 	av_free(sqe->yuv_y);
 	av_free(sqe->yuv_uv);
 	av_free(sqe);
+}
+
+static void clear_decoded_data(MediaState *ms) {
+	AVFrame *frame;
+	SurfaceQueueEntry *surface;
+
+	free_packet_queue(&ms->audio_packet_queue);
+	free_packet_queue(&ms->video_packet_queue);
+
+	if (ms->audio_out_frame) {
+		av_frame_free(&ms->audio_out_frame);
+	}
+	ms->audio_out_index = 0;
+	ms->audio_queue_samples = 0;
+	ms->audio_queue_target_samples = 0;
+
+	while ((frame = dequeue_frame(&ms->audio_queue))) {
+		av_frame_free(&frame);
+	}
+
+	while ((surface = dequeue_surface(&ms->surface_queue))) {
+		free_surface_entry(surface);
+	}
+	ms->surface_queue_size = 0;
+}
+
+static void reset_after_seek(MediaState *ms, double position) {
+	clear_decoded_data(ms);
+
+	ms->skip = position;
+	ms->audio_finished = 0;
+	ms->video_finished = 0;
+	ms->audio_read_samples = 0;
+	ms->video_pts_offset = 0.0;
+	ms->video_read_time = 0.0;
+
+	if (ms->end_time >= 0.0) {
+		ms->audio_duration = (int) (fmax(0.0, ms->end_time - position) * audio_sample_rate);
+	} else if (ms->total_duration > 0.0) {
+		ms->audio_duration = (int) (fmax(0.0, ms->total_duration - position) * audio_sample_rate);
+	} else {
+		ms->audio_duration = -1;
+	}
 }
 
 
@@ -1462,6 +1513,40 @@ static int decode_thread(void *arg) {
 	}
 
 	while (!ms->quit) {
+		double seek_target = -1.0;
+
+		SDL_LockMutex(ms->lock);
+		if (ms->seek_requested) {
+			seek_target = ms->seek_target;
+			ms->seek_requested = 0;
+		}
+		SDL_UnlockMutex(ms->lock);
+
+		if (seek_target >= 0.0) {
+			double maximum = ms->end_time >= 0.0 ? ms->end_time : ms->total_duration;
+			if (maximum > 0.0 && seek_target > maximum) {
+				seek_target = maximum;
+			}
+
+			if (av_seek_frame(ctx, -1, (int64_t) (seek_target * AV_TIME_BASE), AVSEEK_FLAG_BACKWARD) >= 0) {
+				avformat_flush(ctx);
+				if (ms->audio_context) {
+					avcodec_flush_buffers(ms->audio_context);
+				}
+				if (ms->video_context) {
+					avcodec_flush_buffers(ms->video_context);
+				}
+				if (ms->swr) {
+					swr_close(ms->swr);
+					swr_init(ms->swr);
+				}
+
+				SDL_LockMutex(ms->lock);
+				reset_after_seek(ms, seek_target);
+				ms->needs_decode = 1;
+				SDL_UnlockMutex(ms->lock);
+			}
+		}
 
 		if (! ms->audio_finished) {
 			decode_audio(ms);
@@ -1822,6 +1907,7 @@ MediaState *media_open(SDL_IOStream *rwops, const char *filename) {
  */
 void media_start_end(MediaState *ms, double start, double end) {
 	ms->skip = start;
+	ms->end_time = end;
 
 	if (end >= 0) {
 		if (end < start) {
@@ -1847,6 +1933,39 @@ void media_pause(MediaState *ms, int pause) {
         ms->time_offset += current_time - ms->pause_time;
         ms->pause_time = 0;
     }
+}
+
+void media_seek(MediaState *ms, double position) {
+#ifdef __EMSCRIPTEN__
+    if (position < 0.0 || !ms->ctx) {
+        return;
+    }
+
+    if (av_seek_frame(ms->ctx, -1, (int64_t) (position * AV_TIME_BASE), AVSEEK_FLAG_BACKWARD) < 0) {
+        return;
+    }
+
+    avformat_flush(ms->ctx);
+    if (ms->audio_context) {
+        avcodec_flush_buffers(ms->audio_context);
+    }
+    if (ms->video_context) {
+        avcodec_flush_buffers(ms->video_context);
+    }
+    if (ms->swr) {
+        swr_close(ms->swr);
+        swr_init(ms->swr);
+    }
+
+    reset_after_seek(ms, position);
+#else
+    SDL_LockMutex(ms->lock);
+    ms->seek_target = position;
+    ms->seek_requested = 1;
+    ms->needs_decode = 1;
+    SDL_BroadcastCondition(ms->cond);
+    SDL_UnlockMutex(ms->lock);
+#endif
 }
 
 void media_close(MediaState *ms) {

--- a/src/renpysound_core.c
+++ b/src/renpysound_core.c
@@ -70,6 +70,7 @@ MediaState *media_open(SDL_IOStream *, const char *);
 void media_want_video(MediaState *, int);
 void media_start_end(MediaState *, double, double);
 void media_start(MediaState *);
+void media_seek(MediaState *, double);
 void media_pause(MediaState *, int);
 void media_close(MediaState *);
 
@@ -1073,6 +1074,39 @@ void RPS_global_pause(int pause) {
             media_pause(channels[i].playing, pause);
         }
     }
+}
+
+/*
+ * Requests that the decoder for a channel seek to an absolute position in the
+ * source media. The actual FFmpeg calls run on the decoder thread.
+ */
+void RPS_seek(int channel, double position) {
+    struct Channel *c;
+
+    if (check_channel(channel)) {
+        return;
+    }
+
+    if (position < 0.0) {
+        position = 0.0;
+    }
+
+    c = &channels[channel];
+
+    LOCK_AUDIO();
+
+    if (c->playing) {
+        c->pos = (int) (position * audio_spec.freq) - ms_to_samples(c->playing_start_ms);
+        if (c->pos < 0) {
+            c->pos = 0;
+        }
+
+        media_seek(c->playing, position);
+    }
+
+    UNLOCK_AUDIO();
+
+    error(SUCCESS);
 }
 
 

--- a/src/renpysound_core.h
+++ b/src/renpysound_core.h
@@ -36,6 +36,7 @@ PyObject *RPS_playing_name(int channel);
 void RPS_fadeout(int channel, int ms);
 void RPS_pause(int channel, int pause);
 void RPS_global_pause(int pause);
+void RPS_seek(int channel, double position);
 void RPS_set_endevent(int channel, int event);
 int RPS_get_pos(int channel);
 double RPS_get_duration(int channel);


### PR DESCRIPTION
Inspiration from [this commit](https://github.com/potato-flower-alt/renpy/commit/6354f6a600872463eca45d870ec9ad6e7ae25697).

This adds a public `renpy.music.seek(position, channel="music")` API for seeking the media currently playing on an audio channel, while `AudioPositionValue` can opt into an adjustable progress bar:

```renpy
bar value AudioPositionValue("music", adjustable=True)
```

The existing default remains read-only, so existing uses retain their current behavior. Seeking is routed through the channel API to native and web audio backends. The native FFmpeg backend processes requests on its decoder thread, flushes its decoder and resampler state, and clears queued decoded audio and video data. The WebAudio backend seeks buffered audio and video sources while preserving the current stream and channel queue, rather than restarting playback with an audio `<from ...>` specifier.
