### PR TITLE
Fix typo in config.translate_ignore_who

### DIFF
--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -2153,7 +2153,7 @@ Translation
 
 .. var:: config.translate_ignore_who = [ ]
 
-    A list of strings giving characters that will not have tanslations generated. This is useful
+    A list of strings giving characters that will not have translations generated. This is useful
     for characters that are used for debugging or note purposes. This compares against string value
     of the expression in the statement. (So "e" will match ``e`` but not ``l``, even if e and l are
     the same object.)


### PR DESCRIPTION
Fix typo in config.translate_ignore_who

tanslations > translations