### PR TITLE
Title: Add resource-specific language overrides

### DIFF
--- a/renpy/common/00gui.rpy
+++ b/renpy/common/00gui.rpy
@@ -134,7 +134,7 @@ init -1150 python in gui:
         Note: This is a very slow function.
         """
 
-        renpy.translation.change_language(_preferences.language, force=True, rebuild=True)
+        renpy.translation.change_text_language(_preferences.text_language, force=True, rebuild=True)
         renpy.exports.restart_interaction()
 
     not_set = object()

--- a/renpy/common/00nvl_mode.rpy
+++ b/renpy/common/00nvl_mode.rpy
@@ -379,9 +379,9 @@ init -1500 python:
             if store.nvl_list is None:
                 store.nvl_list = [ ]
 
-            if store._nvl_language != _preferences.language:
+            if store._nvl_language != renpy.translation.get_text_language():
                 store.nvl_list = [ ]
-                store._nvl_language = _preferences.language
+                store._nvl_language = renpy.translation.get_text_language()
 
             while config.nvl_list_length and (len(nvl_list) + 1 > config.nvl_list_length):
                 nvl_list.pop(0)

--- a/renpy/common/00translation.rpy
+++ b/renpy/common/00translation.rpy
@@ -80,7 +80,7 @@ screen _translation_info():
 
                     action EditFile(filename, line)
 
-                if tl and preferences.language:
+                if tl and renpy.translation.get_text_language():
                     textbutton _(" translates [tl.filename]:[tl.linenumber]"):
                         padding (0, 0)
                         text_color "#fff"
@@ -89,7 +89,7 @@ screen _translation_info():
 
                         action EditFile(tl.filename, tl.linenumber)
 
-            if tl and preferences.language and tl.source:
+            if tl and renpy.translation.get_text_language() and tl.source:
                 null height gui._scale(7)
 
                 for s in tl.source:

--- a/renpy/execution.py
+++ b/renpy/execution.py
@@ -371,7 +371,7 @@ class Context(renpy.object.Object):
         self.use_modes = True
 
         # The language we started with.
-        self.translate_language = renpy.game.preferences.language  # type: ignore
+        self.translate_language = renpy.translation.get_text_language()
 
         # The identifier of the current translate block.
         self.translate_identifier = None

--- a/renpy/exports/__init__.py
+++ b/renpy/exports/__init__.py
@@ -281,9 +281,16 @@ from renpy.text.textsupport import (
 )
 
 from renpy.translation import (
+    GLOBAL_LANGUAGE as GLOBAL_LANGUAGE,
+    change_image_language as change_image_language,
     change_language as change_language,
+    change_text_language as change_text_language,
+    change_voice_language as change_voice_language,
+    get_image_language as get_image_language,
+    get_text_language as get_text_language,
     get_translation_identifier as get_translation_identifier,
     get_translation_info as get_translation_info,
+    get_voice_language as get_voice_language,
     known_languages as known_languages,
     translate_string as translate_string,
 )

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -642,7 +642,7 @@ def get_prefixes(tl=True, directory=None):
     rv = []
 
     if tl:
-        language = renpy.game.preferences.language  # type: ignore
+        language = renpy.translation.get_language_for_directory(directory)
     else:
         language = None
 

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -157,6 +157,16 @@ Preference("performance_test", True)
 # The language we use for translations.
 Preference("language", None, (str, type(None)))
 
+# Selects the global language for a category-specific language override.
+GLOBAL_LANGUAGE = renpy.object.Sentinel("global_language")
+
+# Optional language overrides for individual resource categories. The
+# GLOBAL_LANGUAGE marker makes a category follow `language` for backwards
+# compatibility.
+Preference("text_language", GLOBAL_LANGUAGE, (str, type(None), type(GLOBAL_LANGUAGE)))
+Preference("image_language", GLOBAL_LANGUAGE, (str, type(None), type(GLOBAL_LANGUAGE)))
+Preference("voice_language", GLOBAL_LANGUAGE, (str, type(None), type(GLOBAL_LANGUAGE)))
+
 # Should we self-voice?
 Preference("self_voicing", False, (bool, str, type(None)))
 
@@ -267,6 +277,9 @@ class Preferences(renpy.object.Object):
     renderer: str
     performance_test: bool
     language: str | None
+    text_language: str | None | renpy.object.Sentinel
+    image_language: str | None | renpy.object.Sentinel
+    voice_language: str | None | renpy.object.Sentinel
     self_voicing: bool | str | None
     self_voicing_volume_drop: float
     emphasize_audio: bool

--- a/renpy/text/text.py
+++ b/renpy/text/text.py
@@ -2336,7 +2336,7 @@ class Text(renpy.display.displayable.Displayable):
         if renpy.game.context().init_phase:
             self.language = None
         else:
-            self.language = renpy.game.preferences.language
+            self.language = renpy.translation.get_text_language()
 
         if self.tokenized:
             if update and self.text != text:
@@ -2386,7 +2386,7 @@ class Text(renpy.display.displayable.Displayable):
         return True
 
     def per_interact(self):
-        if (self.language != renpy.game.preferences.language) and not self._uses_scope:
+        if (self.language != renpy.translation.get_text_language()) and not self._uses_scope:
             self.set_text(self.text_parameter, substitute=self.substitute, update=True)
 
         if self.style.slow_abortable:

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -209,7 +209,7 @@ class ScriptTranslator(object):
 
     def lookup_translate(self, identifier, alternate=None) -> tuple[renpy.ast.Node, bool]:
         identifier = identifier.replace(".", "_")
-        language = renpy.game.preferences.language
+        language = get_text_language()
 
         if language is not None:
             tl = self.language_translates.get((identifier, language), None)
@@ -594,6 +594,67 @@ def add_string_translation(language, old, new, newloc):
 
 
 Default = renpy.object.Sentinel("default")
+GLOBAL_LANGUAGE = renpy.preferences.GLOBAL_LANGUAGE
+
+
+def _get_category_language(override) -> str | None:
+    """Resolves a category preference to its effective language."""
+
+    if override is GLOBAL_LANGUAGE:
+        return renpy.game.preferences.language
+
+    return override
+
+
+def get_text_language() -> str | None:
+    """
+    :doc: translation_functions
+
+    Returns the effective language used for text translation. This is the text
+    language override when one is set, or the language selected by
+    :func:`renpy.change_language` when it is :var:`renpy.GLOBAL_LANGUAGE`.
+    It returns None when Ren'Py's original, untranslated text is being used.
+    """
+
+    return _get_category_language(renpy.game.preferences.text_language)
+
+
+def get_image_language() -> str | None:
+    """
+    :doc: translation_functions
+
+    Returns the effective language used for translated images. This is the
+    image language override when one is set, or the language selected by
+    :func:`renpy.change_language` when it is :var:`renpy.GLOBAL_LANGUAGE`.
+    It returns None when untranslated images are being used.
+    """
+
+    return _get_category_language(renpy.game.preferences.image_language)
+
+
+def get_voice_language() -> str | None:
+    """
+    :doc: translation_functions
+
+    Returns the effective language used for translated audio. This is the
+    voice language override when one is set, or the language selected by
+    :func:`renpy.change_language` when it is :var:`renpy.GLOBAL_LANGUAGE`.
+    It returns None when untranslated audio is being used.
+    """
+
+    return _get_category_language(renpy.game.preferences.voice_language)
+
+
+def get_language_for_directory(directory: str | None) -> str | None:
+    """Returns the effective language for a loader resource directory."""
+
+    if directory == "images":
+        return get_image_language()
+
+    if directory == "audio":
+        return get_voice_language()
+
+    return get_text_language()
 
 
 def translate_string(s, language=Default):  # type (str, str|renpy.object.Sentinel|None) -> str
@@ -602,7 +663,7 @@ def translate_string(s, language=Default):  # type (str, str|renpy.object.Sentin
     :name: renpy.translate_string
 
     Returns `s` immediately translated into `language`. If `language`
-    is Default, uses the language set in the preferences.
+    is Default, uses the effective text language.
     Strings enclosed in this function will **not** be added
     to the list of translatable strings. Note that the string may be
     double-translated, if it matches a string translation when it
@@ -610,15 +671,16 @@ def translate_string(s, language=Default):  # type (str, str|renpy.object.Sentin
     """
 
     if language is Default:
-        language = renpy.game.preferences.language
+        language = get_text_language()
 
     stl = renpy.game.script.translator.strings[language]
     return stl.translate(s)
 
 
 def write_updated_strings():
-    stl = renpy.game.script.translator.strings[renpy.game.preferences.language]
-    stl.write_updated_strings(renpy.game.preferences.language)
+    language = get_text_language()
+    stl = renpy.game.script.translator.strings[language]
+    stl.write_updated_strings(language)
 
 
 ################################################################################
@@ -701,7 +763,7 @@ def init_translation():
     load_all_rpts()
 
 
-old_language = "language never set"
+old_text_language = "language never set"
 
 # A list of styles that have beend deferred to right before translate
 # styles are run.
@@ -768,19 +830,24 @@ def clean_data():
     renpy.game.log.forward = []
 
 
-def change_language(language, force: bool = False, rebuild: bool = False):
+def _change_text_language(language, force: bool = False, rebuild: bool = False):
     """
-    :doc: translation_functions
+    Applies an effective text language, including translation blocks and
+    styles.
 
-    Changes the current language to `language`, which can be a string or
-    None to use the default language.
+    `language`
+        The effective text language to apply, or None to use Ren'Py's original,
+        untranslated text.
 
     `force`
-        If true, ensure the Python code is re-executed even if the language
-        hasn't changed.
+        If True, re-execute translation Python when required even if `language`
+        has not changed.
 
     `rebuild`
-        This forces the styles to be rebuilt even if the language hasn't changed.
+        If True, rebuild styles even if `language` has not changed.
+
+    Returns True if changing the effective text language cleared the resource
+    caches, or False otherwise.
     """
 
     def run_blocks():
@@ -807,18 +874,17 @@ def change_language(language, force: bool = False, rebuild: bool = False):
         for i in renpy.config.translate_clean_stores:
             renpy.python.reset_store_changes(i)
 
-    global old_language
+    global old_text_language
 
     renpy.exports.load_language(language)
 
-    renpy.game.preferences.language = language
-    changed = language != old_language
+    changed = language != old_text_language
 
     if rebuild:
         changed = True
 
     if not changed and not force:
-        return
+        return False
 
     tl = renpy.game.script.translator
 
@@ -828,7 +894,7 @@ def change_language(language, force: bool = False, rebuild: bool = False):
     # restarted. Re-run Python if the language requires it, but avoid rebuilding styles.
     if not changed:
         if not tl.requires_init(language):
-            return
+            return False
 
         # Prevent memory leak by ignoring any style changes from translate
         # blocks when language hasn't changed.
@@ -840,7 +906,7 @@ def change_language(language, force: bool = False, rebuild: bool = False):
 
         # Restart the interaction.
         renpy.exports.restart_interaction()
-        return
+        return False
 
     renpy.style.restore(style_backup)
     renpy.style.rebuild(False)
@@ -855,10 +921,112 @@ def change_language(language, force: bool = False, rebuild: bool = False):
 
     renpy.display.tts.init()
 
-    if language != old_language:
+    if language != old_text_language:
         renpy.exports.block_rollback()
 
-    old_language = language
+    old_text_language = language
+    return True
+
+
+def change_language(language, force: bool = False, rebuild: bool = False):
+    """
+    :doc: translation_functions
+
+    Changes the language that text, images, and audio use when they do not have
+    a category-specific language override. Existing category-specific
+    overrides remain in effect.
+
+    `language`
+        A string giving the language to use, or None to use Ren'Py's original,
+        untranslated text and resources.
+
+    `force`
+        If True, ensure the Python code is re-executed even if the effective
+        text language hasn't changed.
+
+    `rebuild`
+        This forces the styles to be rebuilt even if the effective text
+        language hasn't changed.
+    """
+
+    old_image_language = get_image_language()
+    old_voice_language = get_voice_language()
+
+    renpy.game.preferences.language = language
+
+    text_cleared_memory = _change_text_language(get_text_language(), force=force, rebuild=rebuild)
+
+    if (old_image_language != get_image_language()) and not text_cleared_memory:
+        renpy.exports.free_memory()
+
+    if (old_image_language != get_image_language()) or (old_voice_language != get_voice_language()):
+        renpy.exports.restart_interaction()
+
+
+def change_text_language(language, force: bool = False, rebuild: bool = False):
+    """
+    :doc: translation_functions
+
+    Sets the language override used for text translation.
+
+    `language`
+        A string giving the language to use for text, or None to use the
+        original, untranslated text. Pass :var:`renpy.GLOBAL_LANGUAGE` to
+        follow the language selected by :func:`renpy.change_language`.
+
+    `force`
+        If True, ensure the Python code is re-executed even if the effective
+        text language hasn't changed.
+
+    `rebuild`
+        If True, force styles to be rebuilt even if the effective text language
+        hasn't changed.
+    """
+
+    renpy.game.preferences.text_language = language
+    _change_text_language(get_text_language(), force=force, rebuild=rebuild)
+
+
+def change_image_language(language):
+    """
+    :doc: translation_functions
+
+    Sets the language override used for translated images. Changing
+    the effective image language clears cached images.
+
+    `language`
+        A string giving the language to use for images, or None to use the
+        original images. Pass :var:`renpy.GLOBAL_LANGUAGE` to follow the
+        language selected by :func:`renpy.change_language`.
+    """
+
+    old_language = get_image_language()
+    renpy.game.preferences.image_language = language
+
+    if old_language != get_image_language():
+        renpy.exports.free_memory()
+        renpy.exports.restart_interaction()
+
+
+def change_voice_language(language):
+    """
+    :doc: translation_functions
+
+    Sets the language override used for translated audio. The new
+    language is used for subsequent audio loads; audio that is already playing
+    is not interrupted.
+
+    `language`
+        A string giving the language to use for audio, or None to use the
+        original audio. Pass :var:`renpy.GLOBAL_LANGUAGE` to follow the
+        language selected by :func:`renpy.change_language`.
+    """
+
+    old_language = get_voice_language()
+    renpy.game.preferences.voice_language = language
+
+    if old_language != get_voice_language():
+        renpy.exports.restart_interaction()
 
 
 def check_language():
@@ -868,13 +1036,13 @@ def check_language():
     """
 
     ctx = renpy.game.contexts[-1]
-    preferences = renpy.game.preferences
+    language = get_text_language()
 
     # Deal with a changed language.
-    if ctx.translate_language != preferences.language:
+    if ctx.translate_language != language:
         clean_data()
 
-        ctx.translate_language = preferences.language
+        ctx.translate_language = language
 
         tid = ctx.translate_identifier or ctx.deferred_translate_identifier
 

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -373,6 +373,25 @@ If the file is in a directory under game, that directory should be
 included underneath the language. For example, the file :file:`game/gui/main_menu.png`
 can be translated by creating the file :file:`game/tl/piglatin/gui/main_menu.png`.
 
+By default, translated text, images, and audio all use the language selected by
+:func:`renpy.change_language`. A game can select these independently by calling
+:func:`renpy.change_text_language`, :func:`renpy.change_image_language`, and
+:func:`renpy.change_voice_language`. For example::
+
+    $ renpy.change_language("english")
+    $ renpy.change_text_language("schinese")
+    $ renpy.change_image_language("schinese")
+    $ renpy.change_voice_language("japanese")
+
+Passing None to a category-specific function selects the original resources
+for that category. Passing :var:`renpy.GLOBAL_LANGUAGE` makes it follow the
+global language again.
+Ren'Py determines the category from the context in which a resource is loaded,
+such as an image or audio load. It does not infer the category from the filename
+extension. Loads without an image or audio directory use the text language.
+The :var:`config.default_language` and :var:`config.language` variables set only
+the global language; each category initially follows that language.
+
 Style Translations
 ==================
 
@@ -474,7 +493,7 @@ preferences screen::
         textbutton "English" action Language(None)
         textbutton "Igpay Atinlay" action Language("piglatin")
 
-There are two translation-related functions:
+The translation-related functions are:
 
 .. include:: inc/translation_functions
 
@@ -509,15 +528,31 @@ translation:
 
 .. include:: inc/translate_string
 
-There are two language-related variables. One is
-:var:`config.default_language`, which is used to change the default language
-of the game.
+The :var:`config.default_language` variable is used to change the default
+language of the game.
 
 .. var:: _preferences.language
 
     The name of the current language, or None if the default language is
     being used. This should be treated as a read-only variable. To
     change the language, call :func:`renpy.change_language`.
+
+.. var:: _preferences.text_language
+.. var:: _preferences.image_language
+.. var:: _preferences.voice_language
+
+    Optional category-specific language overrides. Each defaults to
+    :var:`renpy.GLOBAL_LANGUAGE`, which makes that category follow
+    :var:`_preferences.language`. A string selects a translated resource and
+    None selects the original resource. These should be treated as read-only
+    variables and changed using the corresponding ``renpy.change_*_language``
+    function.
+
+.. var:: renpy.GLOBAL_LANGUAGE
+
+    A value accepted by the category-specific language functions to make a
+    category follow the global language. This differs from None, which selects
+    the original, untranslated resources.
 
 
 Unsanctioned Translations

--- a/sphinx/source/voice.rst
+++ b/sphinx/source/voice.rst
@@ -104,6 +104,12 @@ It works just the same for automatic voice, as long as the filepath of the
 translation file starting from :file:`game/tl/{<language>}/` matches the filepath of
 the original file starting from :file:`game/`\ .
 
+Voice can use a different language from dialogue by calling
+:func:`renpy.change_voice_language`. The selected language applies to future
+audio loads and does not interrupt audio that is already playing. Passing None
+selects the original voice files; passing :var:`renpy.GLOBAL_LANGUAGE` makes
+voice follow the global language again.
+
 Voice Functions
 ---------------
 


### PR DESCRIPTION
Implements #7267.

This change adds persistent language overrides for text, image, and voice resources.

The global language remains the fallback, so existing games retain their current behavior. Each category can now be selected independently:

- `renpy.change_text_language(language)` controls text translation and translated strings.
- `renpy.change_image_language(language)` controls translated images loaded with `directory="images"`.
- `renpy.change_voice_language(language)` controls translated audio loaded with `directory="audio"`.

For each category, `None` selects the original resources, a language string selects a translation, and `renpy.GLOBAL_LANGUAGE` restores following the global language. The corresponding `renpy.get_*_language()` functions report the effective language.