### PR TITLE
Add language mappings for resource path translations

### DIFF
--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -431,6 +431,32 @@ init -1500 python:
             return self.language in renpy.known_languages()
 
 
+    @renpy.pure
+    class ChangeResourcePathTranslation(Action, DictEquality):
+        """
+        :doc: language_action
+
+        Changes the translated path used for resources beneath `path`.
+        Passing None as `translation` removes the mapping.
+        """
+
+        def __init__(self, path, translation):
+            self.path = path
+            self.translation = translation
+
+        def __call__(self):
+            if self.translation is None:
+                _preferences.resource_path_translations.pop(self.path, None)
+            else:
+                _preferences.resource_path_translations[self.path] = self.translation
+
+            renpy.free_memory()
+            renpy.restart_interaction()
+
+        def get_selected(self):
+            return _preferences.resource_path_translations.get(self.path) == self.translation
+
+
     #########################################################################
 
     # Transitions used when entering and leaving replays.

--- a/renpy/common/00action_other.rpy
+++ b/renpy/common/00action_other.rpy
@@ -437,7 +437,15 @@ init -1500 python:
         :doc: language_action
 
         Changes the translated path used for resources beneath `path`.
-        Passing None as `translation` removes the mapping.
+
+        `path`
+            A resource path prefix, including any directory supplied when the
+            resource is loaded. For example, audio loaded from
+            :func:`renpy.music.play` uses an ``audio/`` prefix.
+
+        `translation`
+            The translated path prefix to use. If None, the mapping is removed
+            and the normal global-language lookup is restored.
         """
 
         def __init__(self, path, translation):

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -634,6 +634,44 @@ def check_name(name):
             raise Exception("Filenames may not contain relative directories like '.' and '..': %r" % name)
 
 
+def get_translate_path(name):
+    """
+    Returns the translated path mapped from `name`, or None if `name` is not
+    covered by a translation path mapping.
+    """
+
+    paths = getattr(renpy.game.preferences, "translate_paths", {})
+
+    if not isinstance(paths, dict):
+        return None
+
+    match = None
+
+    for source, destination in paths.items():
+        if not isinstance(source, str) or not isinstance(destination, str):
+            continue
+
+        source = source.strip("/")
+        destination = destination.strip("/")
+
+        if not source or not destination:
+            continue
+
+        if ((name == source) or name.startswith(source + "/")) and ((match is None) or (len(source) > len(match[0]))):
+            match = (source, destination)
+
+    if match is None:
+        return None
+
+    source, destination = match
+    suffix = name[len(source) :].lstrip("/")
+
+    if suffix:
+        return destination + "/" + suffix
+    else:
+        return destination
+
+
 def get_prefixes(tl=True, directory=None):
     """
     Returns a list of prefixes to search for files.
@@ -674,6 +712,14 @@ def load(name, directory=None, tl=True):
     while "//" in name:
         name = name.replace("//", "/")
     name = name.lstrip("/")
+
+    if tl:
+        translated_name = get_translate_path(name)
+
+        if translated_name is not None:
+            rv = load_core(translated_name)
+            if rv is not None:
+                return rv
 
     for p in get_prefixes(directory=directory, tl=tl):
         rv = load_core(p + name)
@@ -729,6 +775,12 @@ def loadable(name, tl=True, directory=None):
 
     if (renpy.config.loadable_callback is not None) and renpy.config.loadable_callback(name):
         return True
+
+    if tl:
+        translated_name = get_translate_path(name)
+
+        if (translated_name is not None) and loadable_core(translated_name):
+            return True
 
     for p in get_prefixes(tl=tl, directory=directory):
         if loadable_core(p + name):

--- a/renpy/loader.py
+++ b/renpy/loader.py
@@ -640,7 +640,7 @@ def get_translate_path(name):
     covered by a translation path mapping.
     """
 
-    paths = getattr(renpy.game.preferences, "translate_paths", {})
+    paths = getattr(renpy.game.preferences, "resource_path_translations", {})
 
     if not isinstance(paths, dict):
         return None
@@ -713,16 +713,18 @@ def load(name, directory=None, tl=True):
         name = name.replace("//", "/")
     name = name.lstrip("/")
 
+    paths = [p + name for p in get_prefixes(directory=directory, tl=tl)]
+
     if tl:
-        translated_name = get_translate_path(name)
+        for path in paths:
+            translated_name = get_translate_path(path)
+            if translated_name is not None:
+                rv = load_core(translated_name)
+                if rv is not None:
+                    return rv
 
-        if translated_name is not None:
-            rv = load_core(translated_name)
-            if rv is not None:
-                return rv
-
-    for p in get_prefixes(directory=directory, tl=tl):
-        rv = load_core(p + name)
+    for path in paths:
+        rv = load_core(path)
         if rv is not None:
             return rv
 
@@ -776,14 +778,16 @@ def loadable(name, tl=True, directory=None):
     if (renpy.config.loadable_callback is not None) and renpy.config.loadable_callback(name):
         return True
 
+    paths = [p + name for p in get_prefixes(tl=tl, directory=directory)]
+
     if tl:
-        translated_name = get_translate_path(name)
+        for path in paths:
+            translated_name = get_translate_path(path)
+            if (translated_name is not None) and loadable_core(translated_name):
+                return True
 
-        if (translated_name is not None) and loadable_core(translated_name):
-            return True
-
-    for p in get_prefixes(tl=tl, directory=directory):
-        if loadable_core(p + name):
+    for path in paths:
+        if loadable_core(path):
             return True
 
     return False

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -157,6 +157,10 @@ Preference("performance_test", True)
 # The language we use for translations.
 Preference("language", None, (str, type(None)))
 
+# Paths to translated resource directories. Each key is a resource path prefix,
+# and its value is the corresponding translated path prefix.
+Preference("translate_paths", {}, dict)
+
 # Should we self-voice?
 Preference("self_voicing", False, (bool, str, type(None)))
 
@@ -267,6 +271,7 @@ class Preferences(renpy.object.Object):
     renderer: str
     performance_test: bool
     language: str | None
+    translate_paths: dict[str, str]
     self_voicing: bool | str | None
     self_voicing_volume_drop: float
     emphasize_audio: bool

--- a/renpy/preferences.py
+++ b/renpy/preferences.py
@@ -157,9 +157,9 @@ Preference("performance_test", True)
 # The language we use for translations.
 Preference("language", None, (str, type(None)))
 
-# Paths to translated resource directories. Each key is a resource path prefix,
-# and its value is the corresponding translated path prefix.
-Preference("translate_paths", {}, dict)
+# Paths to translated resources. Each key is a resource path prefix, and its
+# value is the corresponding translated path prefix.
+Preference("resource_path_translations", {}, dict)
 
 # Should we self-voice?
 Preference("self_voicing", False, (bool, str, type(None)))
@@ -271,7 +271,7 @@ class Preferences(renpy.object.Object):
     renderer: str
     performance_test: bool
     language: str | None
-    translate_paths: dict[str, str]
+    resource_path_translations: dict[str, str]
     self_voicing: bool | str | None
     self_voicing_volume_drop: float
     emphasize_audio: bool

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -63,6 +63,9 @@ Features
 When :var:`build.wavedash_id` is configured, building a web distribution now
 creates a :file:`wavedash.toml` file for uploading the build to Wavedash.
 
+Resource path translations can now be overridden independently of the global language with
+:var:`_preferences.resource_path_translations` and :class:`ChangeResourcePathTranslation`.
+
 The new :func:`renpy.music.seek` function seeks the audio or video currently playing on a channel, while :class:`AudioPositionValue` now accepts an `adjustable` argument that allows a bar to seek when dragged.
 
 A new :ref:`renpy.red_to_alpha <shader-renpy.red_to_alpha>` shader part has been added, which creates a new image that is white with the alpha taken from

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -373,6 +373,54 @@ If the file is in a directory under game, that directory should be
 included underneath the language. For example, the file :file:`game/gui/main_menu.png`
 can be translated by creating the file :file:`game/tl/piglatin/gui/main_menu.png`.
 
+Resource Path Translations
+--------------------------
+
+By default, translated resources are looked up beneath the active global language,
+as described above. A game can override that location for selected resource path
+prefixes with :var:`_preferences.translate_paths`. This is a dictionary whose keys
+are source path prefixes and whose values are the translated path prefixes to use::
+
+    init python:
+        _preferences.translate_paths = {
+            "backgrounds": "tl/english/background",
+            "voice/eileen": "tl/chinese/voice/eileen",
+            "voice/lucy": "tl/japanese/voice/lucy",
+            "gui": "tl/klingon/gui",
+        }
+
+When Ren'Py loads a resource beneath a mapped prefix, it first tries the mapped
+path with the unmatched suffix appended. For example, loading
+:file:`voice/eileen/greeting.ogg` first tries
+:file:`tl/chinese/voice/eileen/greeting.ogg`. If more than one prefix matches,
+the longest matching prefix is used. Prefixes match complete path components, so
+``gui`` matches :file:`gui/button.png` but not :file:`guide.png`.
+
+If the mapped resource does not exist, or no prefix matches, Ren'Py continues with
+the usual global-language and original-resource search. This mapping affects files
+loaded through Ren'Py's loader; dialogue, string translations, translate blocks,
+and translated styles continue to use the global language selected with
+:func:`renpy.change_language`.
+
+Games can change the destination when a player makes a selection. For example, a
+settings screen can use code like this to change Eileen's voice without changing
+the language used by the rest of the game::
+
+    init python:
+        def set_eileen_voice_language(language):
+            _preferences.translate_paths["voice/eileen"] = "tl/{}/voice/eileen".format(language)
+            renpy.free_memory()
+            renpy.restart_interaction()
+
+The mapping is a preference, so changes made by the game can be saved through the
+normal preferences mechanism. The cache-clearing and interaction restart ensure
+that already-created displayables are rebuilt using the new path; currently playing
+audio is not implicitly stopped by changing the mapping.
+
+The mapping is based only on the requested resource path. Ren'Py does not infer a
+resource type from a file extension. Passing ``tl=False`` to loader functions also
+skips path mappings, just as it skips the normal translated-resource search.
+
 Style Translations
 ==================
 
@@ -549,6 +597,11 @@ translation template that contains all of the strings in it.
 If a game doesn't include support for changing the language, it may be
 appropriate to use an ``init python`` block to set :var:`config.language`
 to the target language.
+
+.. var:: _preferences.translate_paths = {}
+
+    A mapping from resource path prefixes to translated path prefixes. The
+    mapping is applied by the loader before the normal global-language search.
 
 .. var:: config.language = None
 

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -417,10 +417,6 @@ normal preferences mechanism. The cache-clearing and interaction restart ensure
 that already-created displayables are rebuilt using the new path; currently playing
 audio is not implicitly stopped by changing the mapping.
 
-The mapping is based only on the requested resource path. Ren'Py does not infer a
-resource type from a file extension. Passing ``tl=False`` to loader functions also
-skips path mappings, just as it skips the normal translated-resource search.
-
 Style Translations
 ==================
 

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -378,20 +378,21 @@ Resource Path Translations
 
 By default, translated resources are looked up beneath the active global language,
 as described above. A game can override that location for selected resource path
-prefixes with :var:`_preferences.translate_paths`. This is a dictionary whose keys
+prefixes with :var:`_preferences.resource_path_translations`. This is a dictionary whose keys
 are source path prefixes and whose values are the translated path prefixes to use::
 
     init python:
-        _preferences.translate_paths = {
-            "backgrounds": "tl/english/background",
-            "voice/eileen": "tl/chinese/voice/eileen",
-            "voice/lucy": "tl/japanese/voice/lucy",
+        _preferences.resource_path_translations = {
+            "images/backgrounds": "tl/english/background",
+            "audio/voice/eileen": "tl/chinese/voice/eileen",
+            "audio/voice/lucy": "tl/japanese/voice/lucy",
             "gui": "tl/klingon/gui",
         }
 
 When Ren'Py loads a resource beneath a mapped prefix, it first tries the mapped
-path with the unmatched suffix appended. For example, loading
-:file:`voice/eileen/greeting.ogg` first tries
+path with the unmatched suffix appended. The optional ``directory`` argument is
+prepended before matching, so an audio load of
+:file:`voice/eileen/greeting.ogg` matches ``audio/voice/eileen`` and first tries
 :file:`tl/chinese/voice/eileen/greeting.ogg`. If more than one prefix matches,
 the longest matching prefix is used. Prefixes match complete path components, so
 ``gui`` matches :file:`gui/button.png` but not :file:`guide.png`.
@@ -408,9 +409,9 @@ the language used by the rest of the game::
 
     init python:
         def set_eileen_voice_language(language):
-            _preferences.translate_paths["voice/eileen"] = "tl/{}/voice/eileen".format(language)
-            renpy.free_memory()
-            renpy.restart_interaction()
+            ChangeResourcePathTranslation(
+                "audio/voice/eileen", "tl/{}/voice/eileen".format(language)
+            )()
 
 The mapping is a preference, so changes made by the game can be saved through the
 normal preferences mechanism. The cache-clearing and interaction restart ensure
@@ -594,7 +595,7 @@ If a game doesn't include support for changing the language, it may be
 appropriate to use an ``init python`` block to set :var:`config.language`
 to the target language.
 
-.. var:: _preferences.translate_paths = {}
+.. var:: _preferences.resource_path_translations = {}
 
     A mapping from resource path prefixes to translated path prefixes. The
     mapping is applied by the loader before the normal global-language search.


### PR DESCRIPTION
Reimplements #7267, according to the idea of @renpytom (https://github.com/renpy/renpy/issues/7267#issuecomment-5295943190).