### PR TITLE
Test: Expressions allowed in all statements

### DIFF
--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -1141,7 +1141,7 @@ class RepeatCounter(Condition):
 
     def ready(self):
         self.value -= 1
-        return self.value == 0
+        return self.value < 0
 
 
 class Pass(Node):
@@ -1431,8 +1431,7 @@ class Repeat(Until):
         if not isinstance(count, int):
             raise TypeError(f"Expected a number for repeat count, got {count!r}.")
 
-        ## Multiplied by 2 to account for Until.execute() calling ready twice per iteration.
-        self.right = RepeatCounter((self.filename, self.linenumber), count * 2)
+        self.right = RepeatCounter((self.filename, self.linenumber), count)
 
         return super().start()
 

--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -1107,7 +1107,22 @@ class Label(Condition):
         self.name = name
 
     def ready(self):
-        return self.name in renpy.test.testexecution.reached_labels
+        # Match the evaluated value or the raw expression text.
+        # This lets `label chapter_1` and `label "chapter_1"` both work,
+        # while also allowing `label label_name` to use a variable.
+
+        names = [self.name]
+
+        try:
+            eval_name = scoped_eval(self.name)
+            if not isinstance(eval_name, str):
+                raise TypeError(f"Expected a string, got {eval_name!r}.")
+
+            names.append(eval_name.strip())
+        except (NameError, TypeError):
+            pass
+
+        return any(name in renpy.test.testexecution.reached_labels for name in names)
 
     def get_repr_params(self):
         return f"{self.name}"

--- a/renpy/test/testast.py
+++ b/renpy/test/testast.py
@@ -877,11 +877,20 @@ class SelectorDrivenNode(Node):
 
 
 class Click(SelectorDrivenNode):
-    # The number of the button to click.
-    button: int = 1
+    __slots__ = ("button_expr",)
+
+    def __init__(self, loc: NodeLocation, button_expr: str = "1", **kwargs):
+        super().__init__(loc, **kwargs)
+        self.button_expr = button_expr
+
+    def start(self):
+        button = scoped_eval(self.button_expr)
+        if not isinstance(button, int):
+            raise TypeError(f"Expected an integer for click button, got {button!r}.")
+        return button
 
     def perform(self, x, y, state, t):
-        click_mouse(self.button, x, y)
+        click_mouse(state, x, y)
 
 
 class Move(SelectorDrivenNode):
@@ -890,9 +899,21 @@ class Move(SelectorDrivenNode):
 
 
 class Scroll(SelectorDrivenNode):
-    amount: int = 1
+    __slots__ = ("amount_expr",)
+
+    def __init__(self, loc: NodeLocation, amount_expr: str = "1", **kwargs):
+        super().__init__(loc, **kwargs)
+        self.amount_expr = amount_expr
+
+    def start(self):
+        amount = scoped_eval(self.amount_expr)
+        if not isinstance(amount, int):
+            raise TypeError(f"Expected an integer for scroll amount, got {amount!r}.")
+        return amount
 
     def perform(self, x, y, state, t):
+        amount = state
+
         if self.selector is not None:
             element = self.selector.element
 
@@ -905,31 +926,31 @@ class Scroll(SelectorDrivenNode):
                 if adj.value == adj.range:
                     new = 0
                 else:
-                    new = adj.value + (adj.page * self.amount)
+                    new = adj.value + (adj.page * amount)
 
                 new = max(0, min(new, adj.range))
                 adj.change(new)
                 return
 
-        scroll_mouse(-self.amount, x, y)
+        scroll_mouse(-amount, x, y)
 
 
 class Drag(Node):
-    __slots__ = ("button", "end_point", "start_point", "steps")
+    __slots__ = ("button_expr", "end_point", "start_point", "steps_expr")
 
     def __init__(
         self,
         loc: NodeLocation,
         start_point: SelectorDrivenNode,
         end_point: SelectorDrivenNode,
-        button: int = 1,
-        steps: int = 10,
+        button_expr: str = "1",
+        steps_expr: str = "10",
     ):
         super().__init__(loc)
         self.start_point = start_point
         self.end_point = end_point
-        self.button = button
-        self.steps = steps
+        self.button_expr = button_expr
+        self.steps_expr = steps_expr
 
     def ready(self):
         return self.start_point.ready() and self.end_point.ready()
@@ -938,64 +959,83 @@ class Drag(Node):
         start_pos = self.start_point.get_position()
         end_pos = self.end_point.get_position()
 
-        return (start_pos, end_pos, 0)  # (x, y, step)
+        button = scoped_eval(self.button_expr)
+        steps = scoped_eval(self.steps_expr)
 
-    def execute(self, state, t):
+        if not isinstance(button, int):
+            raise TypeError(f"Expected an integer for drag button, got {button!r}.")
+
+        if not isinstance(steps, int):
+            raise TypeError(f"Expected an integer for drag steps, got {steps!r}.")
+
+        return (start_pos, end_pos, button, steps, 0)  # (x, y, button, steps, step)
+
+    def execute(self, state: tuple[tuple[int, int], tuple[int, int], int, int, int], t):
         if renpy.display.interface.trans_pause:
             return state
 
-        (start_pos, end_pos, step) = state
-        x = int(start_pos[0] + (end_pos[0] - start_pos[0]) * step / self.steps)
-        y = int(start_pos[1] + (end_pos[1] - start_pos[1]) * step / self.steps)
+        start_pos, end_pos, button, steps, step = state
+        x = int(start_pos[0] + (end_pos[0] - start_pos[0]) * step / steps)
+        y = int(start_pos[1] + (end_pos[1] - start_pos[1]) * step / steps)
 
         renpy.test.testmouse.move_mouse(x, y)
 
         if step == 0:
-            renpy.test.testmouse.press_mouse(self.button)
+            renpy.test.testmouse.press_mouse(button)
 
-        elif step >= self.steps:
-            renpy.test.testmouse.release_mouse(self.button)
+        elif step >= steps:
+            renpy.test.testmouse.release_mouse(button)
             next_node(self.next)
             return None
 
-        return (start_pos, end_pos, step + 1)
+        return (start_pos, end_pos, button, steps, step + 1)
 
 
 class Type(SelectorDrivenNode):
-    __slots__ = ("text",)
-    # interval = .01 # unused
+    __slots__ = ("text_expr",)
 
-    def __init__(self, loc: NodeLocation, text: str, **kwargs):
+    def __init__(self, loc: NodeLocation, text_expr: str, **kwargs):
         super().__init__(loc, **kwargs)
-        self.text = text
+        self.text_expr = text_expr
 
     def start(self):
-        return 0
+        text = scoped_eval(self.text_expr)
+        if not isinstance(text, str):
+            raise TypeError(f"Expected a string, got {text!r}.")
+        return (text, 0)
 
-    def perform(self, x, y, state, t):
-        if state >= len(self.text):
+    def perform(self, x, y, state: tuple[str, int], t):
+        text, idx = state
+        if idx >= len(text):
             next_node(self.next)
             return None
 
         move_mouse(x, y)
 
-        key = self.text[state]
+        key = text[idx]
         renpy.test.testkey.down(key)
         renpy.test.testkey.up(key)
 
-        return state + 1
+        return (text, idx + 1)
 
 
 class Keysym(SelectorDrivenNode):
-    __slots__ = ("keysym",)
+    __slots__ = ("keysym_expr",)
 
-    def __init__(self, loc: NodeLocation, keysym: str, **kwargs):
+    def __init__(self, loc: NodeLocation, keysym_expr: str, **kwargs):
         super().__init__(loc, **kwargs)
-        self.keysym = keysym
+        self.keysym_expr = keysym_expr
 
-    def perform(self, x, y, state, t):
+    def start(self):
+        keysym = scoped_eval(self.keysym_expr)
+        if not isinstance(keysym, str):
+            raise TypeError(f"Expected a string, got {keysym!r}.")
+
+        return keysym
+
+    def perform(self, x, y, state: str, t):
         move_mouse(x, y)
-        renpy.test.testkey.queue_keysym(self.keysym)
+        renpy.test.testkey.queue_keysym(state)
 
 
 class Action(Node):
@@ -1091,6 +1131,9 @@ class RepeatCounter(Condition):
         super().__init__(loc)
         self.initial_value = value
         self.restart()
+
+    def get_repr_params(self) -> str:
+        return f"{self.initial_value}"
 
     def restart(self) -> None:
         self.value = self.initial_value
@@ -1373,10 +1416,29 @@ class Repeat(Until):
     Executes `left` for `count` times.
     """
 
-    def __init__(self, loc: NodeLocation, left: Node, count: int, timeout: str = "None"):
-        ## Multiplied by 2 to account for Until.execute() calling ready twice per iteration.
-        right = RepeatCounter(loc, count * 2)
+    __slots__ = ("count_expr",)
+
+    def __init__(self, loc: NodeLocation, left: Node, count_expr: str, timeout: str = "None"):
+        self.count_expr = count_expr
+        # A placeholder counter, replaced with a real one in start() when the
+        # count expression is evaluated at runtime.
+        right = RepeatCounter(loc, 0)
         super().__init__(loc, left, right, timeout)
+
+    def start(self):
+        count = scoped_eval(self.count_expr)
+
+        if not isinstance(count, int):
+            raise TypeError(f"Expected a number for repeat count, got {count!r}.")
+
+        ## Multiplied by 2 to account for Until.execute() calling ready twice per iteration.
+        self.right = RepeatCounter((self.filename, self.linenumber), count * 2)
+
+        return super().start()
+
+    def restart(self):
+        self.right = RepeatCounter((self.filename, self.linenumber), 0)
+        super().restart()
 
     def ready(self):
         return self.left.ready()
@@ -1678,7 +1740,7 @@ class Screenshot(Node):
     def start(self):
         filename = scoped_eval(self.filename_expr)
         if not isinstance(filename, str):
-            raise ValueError("Filename must be a string.")
+            raise TypeError("Filename must be a string.")
 
         filename = filename.replace("\\", "/")
         filename = filename.lstrip("/")

--- a/renpy/test/testparser.py
+++ b/renpy/test/testparser.py
@@ -181,7 +181,7 @@ def click_statement(l: Lexer, loc: NodeLocation) -> testast.Click | testast.Unti
 
     while True:
         if l.keyword("button"):
-            rv.button = int(l.require(l.integer))
+            rv.button_expr = l.require(l.simple_expression)
 
         elif l.keyword("pos"):
             rv.position = l.require(l.simple_expression)
@@ -214,10 +214,10 @@ def drag_statement(l: Lexer, loc: NodeLocation) -> testast.Drag:
 
     while True:
         if l.keyword("button"):
-            rv.button = int(l.require(l.integer))
+            rv.button_expr = l.require(l.simple_expression)
 
         elif l.keyword("steps"):
-            rv.steps = int(l.require(l.integer))
+            rv.steps_expr = l.require(l.simple_expression)
 
         elif l.keyword("pos"):
             start_point.position = l.require(l.simple_expression)
@@ -233,10 +233,10 @@ def drag_statement(l: Lexer, loc: NodeLocation) -> testast.Drag:
 
     while True:
         if l.keyword("button"):
-            rv.button = int(l.require(l.integer))
+            rv.button_expr = l.require(l.simple_expression)
 
         elif l.keyword("steps"):
-            rv.steps = int(l.require(l.integer))
+            rv.steps_expr = l.require(l.simple_expression)
 
         elif l.keyword("pos"):
             end_point.position = l.require(l.simple_expression)
@@ -257,7 +257,7 @@ def drag_statement(l: Lexer, loc: NodeLocation) -> testast.Drag:
 def keysym_statement(l: Lexer, loc: NodeLocation) -> testast.Keysym | testast.Until:
     l.expect_noblock("keysym statement")
 
-    text = l.require(l.string)
+    text = l.require(l.simple_expression)
     rv = testast.Keysym(loc, text)
 
     while True:
@@ -349,7 +349,7 @@ def scroll_statement(l: Lexer, loc: NodeLocation) -> testast.Scroll | testast.Un
 
     while True:
         if l.keyword("amount"):
-            rv.amount = int(l.require(l.integer))
+            rv.amount_expr = l.require(l.simple_expression)
 
         elif l.keyword("pos"):
             rv.position = l.require(l.simple_expression)
@@ -391,7 +391,7 @@ def skip_statement(l: Lexer, loc: NodeLocation) -> testast.Skip | testast.Until:
 def type_statement(l: Lexer, loc: NodeLocation) -> testast.Type | testast.Until:
     l.expect_noblock("type statement")
 
-    text = l.require(l.string)
+    text = l.require(l.simple_expression)
     rv = testast.Type(loc, text)
 
     while True:
@@ -895,15 +895,12 @@ def parse_until(l: Lexer, loc: NodeLocation, left: testast.Node) -> testast.Unti
             return testast.Until(loc, left, right)
 
     elif l.keyword("repeat"):
-        right = l.require(l.simple_expression)
-        right = renpy.python.py_eval(right)
-        if not isinstance(right, int):
-            l.error("Expected a number for repeat count.")
+        count_expr = l.require(l.simple_expression)
 
         if l.keyword("timeout"):
             timeout = l.require(l.simple_expression)
-            return testast.Repeat(loc, left, right, timeout)
+            return testast.Repeat(loc, left, count_expr, timeout)
         else:
-            return testast.Repeat(loc, left, right)
+            return testast.Repeat(loc, left, count_expr)
 
     return None

--- a/renpy/test/testparser.py
+++ b/renpy/test/testparser.py
@@ -791,7 +791,7 @@ def parse_selector(l: Lexer, loc: NodeLocation) -> testast.Selector | None:
         elif l.keyword("focused"):
             focused = True
 
-        elif l.keyword("expression"):
+        elif l.keyword("text"):
             expression = True
             if pattern is not None:
                 l.error("Only one text pattern may be specified in a selector.")

--- a/renpy/test/testparser.py
+++ b/renpy/test/testparser.py
@@ -859,7 +859,7 @@ def parse_condition(l: Lexer, loc: NodeLocation, left: testast.Condition | None 
             rv = testast.Eval(loc, source)
 
         elif l.keyword("label"):
-            name = l.require(l.label_name)
+            name = l.simple_expression(operator=False) or l.require(l.label_name)
             rv = testast.Label(loc, name)
 
         elif rv := parse_selector(l, loc):

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -117,8 +117,8 @@ see :var:`config.image_directories` and :var:`config.audio_directories`.
 The new :var:`config.audio_directories` variable is a list of directories that are searched for audio Files
 and used to populate the :ref:`audio-namespace <audio-namespace>`.
 
-Tests
------
+Automated Testing
+-----------------
 
 Tests can now be filtered using the ``*`` wildcard (e.g. ``suite.sub*``),
 by parameter (e.g. ``math.addition(a=1, b=2)``), and any combination of the two.
@@ -131,7 +131,20 @@ A testcase and testsuite can no longer have the same name at the same level in t
 
 User mouse movements are ignored during tests.
 
-Variables and expressions may now be used in all test statements.
+The following test statements now accept expressions:
+
+- ``click button <expr>`` (e.g. ``click button 2``, ``click button button_num``)
+- ``drag ... button <expr> steps <expr>``
+- ``scroll amount <expr>``
+- ``type <expr>``
+- ``keysym <expr>``
+- ``label <expr>`` matches naked strings (e.g. ``label chapter1``) and
+  expressions (e.g. ``label "chapter1"``, ``label label_name``)
+
+Text can now be selected with ``text <expr>`` (e.g. ``assert text "Hello"``, ``assert text dialogue_text``)
+
+Fixed a counting bug with the ``repeat <num>`` statement.
+
 
 Other Changes
 -------------

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -131,6 +131,8 @@ A testcase and testsuite can no longer have the same name at the same level in t
 
 User mouse movements are ignored during tests.
 
+Variables and expressions may now be used in all test statements.
+
 Other Changes
 -------------
 

--- a/sphinx/source/testcases.rst
+++ b/sphinx/source/testcases.rst
@@ -696,7 +696,7 @@ for each value in the list. For example::
 
     testcase click_buttons:
         parameter button_name = ["Load", "Save"]
-        click expression button_name
+        click text button_name
 
 This runs twice: first clicking "Load", then clicking "Save".
 
@@ -770,14 +770,6 @@ depending on the value of ``choice_text``::
         run ShowMenu(screen_name)
         pause until screen screen_name
         run Return()
-
-Parameters can be used, preceded by ``expression``, to select a button by
-parameter name.
-
-    testcase click_buttons:
-        parameter button_name = ["Load", "Save"]
-
-        click expression button_name
 
 Parameters can also be used inside Python code blocks.
 For example, this test prints the current values of ``x`` and ``y``,
@@ -1134,9 +1126,9 @@ Executes a simulated click on the screen.
     # Click a button with specific text
     click "Start"
 
-    # Click a button using an expression.
+    # Click a button using a variable.
     $ button_name = "Load"
-    click expression button_name
+    click text button_name
 
     # Right-click on a specific target.
     click id "inventory_button" button 2
@@ -1370,7 +1362,7 @@ Selectors are a special kind of condition.
 
 In command signatures, ``<selector>`` represents any selector form documented
 in this section, including ``screen <name: str>``, ``id <name: str>``,
-a quoted text selector, or ``expression <expression>``.
+a quoted text selector, or ``text <expression>``.
 
 Displayable Selector
 ^^^^^^^^^^^^^^^^^^^^
@@ -1411,8 +1403,8 @@ Text Selector
 
     Type: :dfn:`Condition, Selector`
 
+    .. describe:: text <expression> [raw]
     .. describe:: "<text>" [raw]
-    .. describe:: expression <expression> [raw]
 
 The ``text`` selector takes a string which resolves to a target
 found on the screen. The search is performed by going through all focusable
@@ -1428,8 +1420,6 @@ If ``raw`` is given, the search is performed on the text as given in the
 script, before translation and :ref:`interpolation <text-interpolation>`.
 If not given, the search is performed on the text as it appears on screen,
 after translation and interpolation.
-
-If ``expression`` is given, the string to search for is determined by evaluating the provided expression.
 
 ::
 
@@ -1520,16 +1510,16 @@ Example::
     for choice in ["Talk", "Trade", "Leave"]:
         if eval (choice == "Trade" and not persistent.shop_unlocked):
             continue
-        click expression choice
+        click text choice
         if screen "shop":
             break
 
     # Click each of the tabs in the stats screen, skipping "Quests" if quests are not enabled
     for stat_tab in ["Stats", "Skills", "Quests"]:
-        click expression stat_tab
+        click text stat_tab
         if eval (stat_tab == "Quests" and not persistent.quests_enabled):
             continue
-        assert expression stat_tab timeout 2.0
+        assert text stat_tab timeout 2.0
 
 If
 ^^^^^^^^^

--- a/sphinx/source/testcases.rst
+++ b/sphinx/source/testcases.rst
@@ -1441,6 +1441,10 @@ after translation and interpolation.
     assert "スタート"
     assert "Start" raw
 
+    # Look for variable text
+    $ string_to_find = "Hello!"
+    assert text string_to_find
+
 .. note ::
 
     Prefer `id` selectors for stable UI tests.

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -21,6 +21,13 @@ screen teleporting_button(x=0, y=0, remaining=20):
         else:
             action Hide("teleporting_button")
 
+screen test_expressions__input__screen():
+    default input_value = ""
+
+    input:
+        id "test_expressions__input"
+        value ScreenVariableInputValue("input_value")
+
 testsuite flow:
     testcase skip:
         enabled False
@@ -160,7 +167,7 @@ testsuite boolean_conditions:
 testsuite message_if:
     setup:
         run Start("three_messages")
-        pause until screen "say"
+        assert screen "say"
 
     testcase test_if:
         if "Message 1":
@@ -187,12 +194,12 @@ testsuite message_if:
 testsuite selectors:
     testcase teleporting_button_test:
         run Show("teleporting_button")
-        pause until screen "teleporting_button"
+        assert screen "teleporting_button"
         click id "teleporting_button" until not screen "teleporting_button"
 
     testcase drag_and_drop:
         run Show("drag_and_drop")
-        pause until screen "drag_and_drop"
+        assert screen "drag_and_drop"
         drag id "peg" pos (0, 0) to id "hole" pos (0, 0)
         assert id "success"
         drag id "peg" pos (0.5, 0.5) to id "hole" pos (0, 0)
@@ -207,7 +214,7 @@ testsuite selectors:
 
     testcase scroll_test:
         run Show("scroll_screen")
-        pause until screen "scroll_screen"
+        assert screen "scroll_screen"
         scroll id "scroll_vp" amount 50
         click id "close_screen_button"
         assert not screen "scroll_screen"
@@ -215,7 +222,7 @@ testsuite selectors:
 testsuite timeout:
     setup:
         run Jump("hard_pause")
-        pause until screen "say"
+        assert screen "say"
 
     testcase hard_pause_fail_timeout:
         xfail True
@@ -438,7 +445,7 @@ testsuite for_loops:
         description "Clicks menu choices on loop"
 
         run Start("branching.variable_test")
-        pause until screen "choice"
+        assert screen "choice"
 
         for option in ["Increment", "Increment", "Decrement", "Increment", "Increment"]:
             click text option
@@ -530,7 +537,7 @@ testsuite while_loops:
         description "Clicks menu choices on loop"
 
         run Start("branching.variable_test")
-        pause until screen "choice"
+        assert screen "choice"
 
         $ clicks = 0
         while eval (menu_var < 3):
@@ -542,3 +549,116 @@ testsuite while_loops:
         assert eval (clicks == 3)
         assert "Value: 3" timeout 2.0
         click "Done"
+
+
+testsuite test_expressions:
+    description "Tests that test statements accept Python expressions."
+
+    after testcase:
+        run Return()
+        run Hide()
+        if not screen "main_menu":
+            run MainMenu(confirm=False, save=False)
+
+    testcase keysym:
+        description "Keysym accepts a variable for the keysym name."
+
+        run Show("test_expressions__input__screen")
+        assert screen "test_expressions__input__screen"
+        click id "test_expressions__input"
+
+        $ keyval = "K_a"
+        keysym keyval
+
+        $ value = renpy.exports.get_screen("test_expressions__input__screen").scope.get("input_value", "NOT DEFINED")
+        $ assert value == "a", f"Expected 'a', got '{value}'"
+
+        run Hide("test_expressions__input__screen")
+
+    testcase type:
+        description "Type accepts a variable for the text to type."
+
+        run Show("test_expressions__input__screen")
+        assert screen "test_expressions__input__screen"
+        click id "test_expressions__input"
+
+        $ textval = "Hello"
+        type textval
+
+        $ value = renpy.exports.get_screen("test_expressions__input__screen").scope.get("input_value", "NOT DEFINED")
+        $ assert value == "Hello", f"Expected 'Hello', got '{value}'"
+
+        run Hide("test_expressions__input__screen")
+
+    testcase drag_button_steps_before_to:
+        description "Drag accepts expressions for button and steps."
+
+        run Show("drag_and_drop")
+        assert screen "drag_and_drop"
+
+        $ btn = 1
+        $ step_count = 10
+        drag id "peg" pos (0, 0) button btn steps step_count to id "hole" pos (0, 0)
+        assert id "success"
+
+        run Hide("drag_and_drop")
+
+    testcase drag_button_steps_after_to:
+        description "Drag accepts expressions for button and steps (after to)."
+
+        run Show("drag_and_drop")
+        assert screen "drag_and_drop"
+
+        $ btn = 1
+        $ step_count = 10
+        drag id "peg" pos (0, 0) to id "hole" pos (0, 0) button btn steps step_count
+        assert id "success"
+
+        run Hide("drag_and_drop")
+
+    testcase click_button:
+        description "Click button accepts a variable for the button number."
+
+        run Show("teleporting_button")
+        assert screen "teleporting_button"
+
+        $ btn = 1
+        $ element_id = "teleporting_button"
+        $ screen_name = "teleporting_button"
+        click button btn id element_id until not screen screen_name
+
+    testcase scroll_amount:
+        description "Scroll amount accepts a variable for the scroll amount."
+
+        run Show("scroll_screen")
+        assert screen "scroll_screen"
+
+        $ scroll_amount = 50
+        scroll amount scroll_amount id "scroll_vp"
+        click id "close_screen_button"
+        assert not screen "scroll_screen"
+
+    testcase repeat:
+        description "Repeat accepts an expression for the count."
+
+        run Show("test_expressions__input__screen")
+        assert screen "test_expressions__input__screen"
+        click id "test_expressions__input"
+
+        $ num = 4
+        keysym "K_a" repeat num
+
+        $ value = renpy.exports.get_screen("test_expressions__input__screen").scope.get("input_value", "NOT DEFINED")
+        $ assert value == "aaaa", f"Expected 'aaaa', got '{value}'"
+
+        run Hide("test_expressions__input__screen")
+
+    testcase skip_fast:
+        description "Skip fast works."
+
+        run Start("three_messages")
+        assert screen "say"
+
+        skip fast
+        $ assert renpy.config.skipping == "fast", f"Expected 'fast', got {renpy.config.skipping!r}"
+        $ renpy.config.skipping = None

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -441,7 +441,7 @@ testsuite for_loops:
         pause until screen "choice"
 
         for option in ["Increment", "Increment", "Decrement", "Increment", "Increment"]:
-            click expression option
+            click text option
 
         assert "Value: 3" timeout 2.0
         click "Done"

--- a/testcases/game/tests/test_testcase.rpy
+++ b/testcases/game/tests/test_testcase.rpy
@@ -662,3 +662,33 @@ testsuite test_expressions:
         skip fast
         $ assert renpy.config.skipping == "fast", f"Expected 'fast', got {renpy.config.skipping!r}"
         $ renpy.config.skipping = None
+
+
+    testsuite label:
+        description "Tests the label selector with quoted strings, naked names, and variables."
+
+        testcase naked_name:
+            description "Label selector matches a naked label name."
+
+            run Start("three_messages")
+            assert label three_messages timeout 0.2
+
+        testcase quoted_string:
+            description "Label selector matches a quoted string literal."
+
+            run Start("three_messages")
+            assert label "three_messages" timeout 0.2
+
+        testcase variable:
+            description "Label selector matches a variable."
+
+            $ label_name = "three_messages"
+            run Start("three_messages")
+            assert label label_name timeout 0.2
+
+        testcase negative:
+            description "Label selector does not match an unreached label."
+
+            run Start("three_messages")
+            assert screen "say"
+            assert not label "hard_pause"

--- a/tutorial/game/testcases.rpy
+++ b/tutorial/game/testcases.rpy
@@ -2,7 +2,7 @@
     import time
 
 testsuite global:
-    before testsuite:
+    after testsuite:
         if not screen "main_menu":
             run MainMenu(confirm=False)
 
@@ -10,7 +10,7 @@ testsuite global:
         exit
 
 
-testsuite default:
+testsuite play_game:
     description "Default project testsuite"
     parameter language = ["french", None]
 
@@ -35,15 +35,6 @@ testsuite default:
         click "That's enough for now." raw
         advance until screen "main_menu"
         # click "Quit" raw
-
-
-    testsuite blank:
-        testcase do_nothing:
-            pass
-
-    testsuite blank2:
-        testcase do_nothing2:
-            pass
 
 
     ## Run the testcases
@@ -85,29 +76,28 @@ testsuite default:
         click "No." raw
         advance until screen "tutorials"
 
-    testcase new_game:
-        scroll "Bar" until "Creating a New Game" raw
-        click "Creating a New Game" raw
-        advance until screen "tutorials"
+    testcase advance_till_end_simple:
+        parameter choice_text = [
+            "Creating a New Game", # new_game
+            "Writing Dialogue", # dialogue
+            "Adding Images", # images
+            "Transitions", # transitions
+            "Music and Sound Effects", # music
+            "Positioning Images", # positioning_images
+            "Video Playback", # video
+            "Tools and the Interactive Director", # tools
+            "Building Distributions", # building
+            "Text Tags, Escapes, and Interpolation", # text_tags
+            "Character Objects", # character_objects
+            "Simple Displayables", # simple_displayables
+            "Transforms and Animation", # transforms
+            "Transform Properties",
+            "GUI Customization", # gui_customization
+            "Translations", # translations
+        ]
 
-    testcase dialogue:
-        scroll "Bar" until "Writing Dialogue" raw
-        click "Writing Dialogue" raw
-        advance until screen "tutorials"
-
-    testcase images:
-        scroll "Bar" until "Adding Images" raw
-        click "Adding Images" raw
-        advance until screen "tutorials"
-
-    testcase transitions:
-        scroll "Bar" until "Transitions" raw
-        click "Transitions" raw
-        advance until screen "tutorials"
-
-    testcase music:
-        scroll "Bar" until "Music and Sound Effects" raw
-        click "Music and Sound Effects" raw
+        scroll "Bar" until text choice_text raw
+        click text choice_text raw
         advance until screen "tutorials"
 
     testcase choices:
@@ -131,49 +121,11 @@ testsuite default:
         keysym "K_RETURN"
         advance until screen "tutorials"
 
-    testcase positioning_images:
-        scroll "Bar" until "Positioning Images" raw
-        click "Positioning Images" raw
-        advance until screen "tutorials"
-
-    testcase video:
-        scroll "Bar" until "Video Playback" raw
-        click "Video Playback" raw
-        advance until screen "tutorials"
-
-
     testcase nvl_mode:
         scroll "Bar" until "NVL Mode" raw
         click "NVL Mode" raw
         advance until eval ("nvl_menu" in renpy.game.context().modes) # screen "nvl_choice"
         click "Yes." raw
-        advance until screen "tutorials"
-
-    testcase tools:
-        scroll "Bar" until "Tools and the Interactive Director" raw
-        click "Tools and the Interactive Director" raw
-        advance until screen "tutorials"
-
-        # Not actually testing the various tools yet.
-
-    testcase building:
-        scroll "Bar" until "Building Distributions" raw
-        click "Building Distributions" raw
-        advance until screen "tutorials"
-
-    testcase text_tags:
-        scroll "Bar" until "Text Tags, Escapes, and Interpolation" raw
-        click "Text Tags, Escapes, and Interpolation" raw
-        advance until screen "tutorials"
-
-    testcase character_objects:
-        scroll "Bar" until "Character Objects" raw
-        click "Character Objects" raw
-        advance until screen "tutorials"
-
-    testcase simple_displayables:
-        scroll "Bar" until "Simple Displayables" raw
-        click "Simple Displayables" raw
         advance until screen "tutorials"
 
     testcase transition_gallery:
@@ -211,11 +163,6 @@ testsuite default:
 
         scroll "Bar" until "Transform Properties" raw
         click "Transform Properties" raw
-        advance until screen "tutorials"
-
-    testcase gui_customization:
-        scroll "Bar" until "GUI Customization" raw
-        click "GUI Customization" raw
         advance until screen "tutorials"
 
     testcase styles:
@@ -303,62 +250,51 @@ testsuite default:
 
         advance until screen "tutorials"
 
-    testcase translations:
-        scroll "Bar" until "Translations" raw
-        click "Translations" raw
-        advance until screen "tutorials"
+testcase out_of_game:
+    run Start()
 
+    $ _preferences.self_voicing = False
+    $ _preferences.afm_time = 1
 
-    testcase out_of_game:
-        click "Back" raw
-        click "Back" raw
+    click "Auto" raw
+    scroll "Bar" until "Player Experience" raw
+    click "Player Experience" raw
+    click "Auto" raw
+    click "History" raw
 
-        click "Skip" raw
+    pause .5
 
-        click "Back" raw
+    click "Save" raw
+    pause .5
 
-        $ _preferences.self_voicing = False
-        $ _preferences.afm_time = 1
-
-        click "Auto" raw
-        scroll "Bar" until "Player Experience" raw
-        click "Player Experience" raw
-        click "Auto" raw
-        click "History" raw
-
-        pause .5
-
-        click "Save" raw
-        pause .5
-
-        click id "save_slot_1"
-        pause 0.2
-        if screen "confirm":
-            click id "confirm_yes_button" until not screen "confirm"
-
-        click "Load" raw
-        pause .5
-
-        click id "save_slot_1"
+    click id "save_slot_1"
+    pause 0.2
+    if screen "confirm":
         click id "confirm_yes_button" until not screen "confirm"
 
-        click "Prefs" raw
-        pause .5
+    click "Load" raw
+    pause .5
 
-        click "About" raw
-        pause .5
+    click id "save_slot_1"
+    click id "confirm_yes_button" until not screen "confirm"
 
-        click "Help" raw
-        pause .5
+    click "Prefs" raw
+    pause .5
 
-        click "Main Menu" raw
-        click id "confirm_yes_button" until not screen "confirm"
+    click "About" raw
+    pause .5
 
-        click "Load" raw
-        pause .5
+    click "Help" raw
+    pause .5
 
-        click id "save_slot_1"
+    click "Main Menu" raw
+    click id "confirm_yes_button" until not screen "confirm"
 
-        advance until screen "choice"
-        click "Yes." raw
-        advance until screen "tutorials"
+    click "Load" raw
+    pause .5
+
+    click id "save_slot_1"
+
+    advance until screen "choice"
+    click "Yes." raw
+    advance until screen "tutorials"


### PR DESCRIPTION
Addresses #7057

- All numeric/string properties in test statements accept expressions now. These are evaluated when the statement is first executed in the given test.
- Renamed `expression` to `text` as per discussion (e.g. `click expression button_name` is now `click text button_name`)
- Label selector accepts expressions with backwards compatibility (valid: `label chapter1`, `label "chapter1"`, `label label_name`)
- Added test coverage for the above
- Slight reorganization of Tutorial tests