### PR TITLE
fix(audio): model channel lifecycle states

### DIFF
--- a/renpy/audio/audio.py
+++ b/renpy/audio/audio.py
@@ -45,6 +45,19 @@ import renpy.audio.renpysound as renpysound
 # This is True if we were able to successfully enable the pcm audio.
 pcm_ok = None
 
+# Backend channel lifecycle states. The numeric values are part of the
+# private Cython/backend contract; callers should use these names.
+CHANNEL_STATE_IDLE = "idle"
+CHANNEL_STATE_PLAYING = "playing"
+CHANNEL_STATE_PAUSED = "paused"
+CHANNEL_STATE_ENDED = "ended"
+CHANNEL_STATES = {
+    0: CHANNEL_STATE_IDLE,
+    1: CHANNEL_STATE_PLAYING,
+    2: CHANNEL_STATE_PAUSED,
+    3: CHANNEL_STATE_ENDED,
+}
+
 unique = time.time()
 serial = 0
 
@@ -826,7 +839,8 @@ class Channel(object):
 
         with lock:
             if self._number is not None:
-                rv = renpysound.playing_name(self.number)
+                if self.get_state() != CHANNEL_STATE_ENDED:
+                    rv = renpysound.playing_name(self.number)
 
             if rv is None and self.queue:
                 rv = self.queue[0].filename
@@ -835,6 +849,13 @@ class Channel(object):
                 rv = self.loop[0]
 
         return rv
+
+    def get_state(self):
+        """Returns the backend lifecycle state of this channel."""
+        if not pcm_ok or self._number is None:
+            return CHANNEL_STATE_IDLE
+
+        return CHANNEL_STATES.get(renpysound.get_state(self.number), CHANNEL_STATE_IDLE)
 
     def set_volume(self, volume):
         self.chan_volume = volume

--- a/renpy/audio/music.py
+++ b/renpy/audio/music.py
@@ -474,6 +474,24 @@ def get_playing(channel="music"):
         return None
 
 
+def get_state(channel="music"):
+    """
+    :doc: audio
+
+    Returns the lifecycle state of the channel as one of ``idle``,
+    ``playing``, ``paused``, or ``ended``. ``ended`` means natural EOF was
+    reached while the backend may retain the decoder for an explicit seek.
+    """
+
+    try:
+        return renpy.audio.audio.get_channel(channel).get_state()
+    except Exception:
+        if renpy.config.debug_sound:
+            raise
+
+        return renpy.audio.audio.CHANNEL_STATE_IDLE
+
+
 def is_playing(channel="music"):
     """
     :doc: audio

--- a/renpy/audio/renpysound.pyx
+++ b/renpy/audio/renpysound.pyx
@@ -62,6 +62,7 @@ cdef extern from "renpysound_core.h":
     void RPS_stop(int channel)
     void RPS_dequeue(int channel, int even_tight)
     int RPS_queue_depth(int channel)
+    int RPS_get_state(int channel)
     object RPS_playing_name(int channel)
     void RPS_fadeout(int channel, int ms)
     void RPS_pause(int channel, int pause)
@@ -222,6 +223,14 @@ def queue_depth(channel):
     """
 
     return RPS_queue_depth(channel)
+
+
+def get_state(channel):
+    """Returns the backend lifecycle state for `channel` as an integer."""
+
+    rv = RPS_get_state(channel)
+    check_error()
+    return rv
 
 
 def playing_name(channel):

--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -268,6 +268,19 @@ def queue_depth(channel):
 
 
 @proxy_with_channel
+def get_state(channel):
+    """Returns the best-effort lifecycle state of a web audio channel."""
+
+    # The web backend currently exposes queue depth but not a distinct EOF
+    # state. Keep the API compatible and add the richer state when the JS
+    # backend grows an explicit state query.
+    if queue_depth(channel):
+        return "playing"
+
+    return "idle"
+
+
+@proxy_with_channel
 def playing_name(channel):
     """
     Returns the `name`  argument of the playing sound. This was passed into

--- a/src/renpysound_core.c
+++ b/src/renpysound_core.c
@@ -203,6 +203,15 @@ static inline float log_power(float power) {
  */
 struct Channel {
 
+    /* Lifecycle state of the active stream. ENDED retains the decoder for an
+     * explicit seek, but is not considered actively playing. */
+    enum {
+        CHANNEL_IDLE = 0,
+        CHANNEL_PLAYING = 1,
+        CHANNEL_PAUSED = 2,
+        CHANNEL_ENDED = 3,
+    } state;
+
     /* The currently playing stream, NULL if this sample isn't playing
        anything. */
     struct MediaState *playing;
@@ -339,6 +348,7 @@ static void start_stream(struct Channel* c, int reset_fade) {
     if (!c) return;
 
     c->pos = 0;
+    c->state = c->paused ? CHANNEL_PAUSED : CHANNEL_PLAYING;
     if (!c->queued) {
         c->playing_pad = audio_spec.freq * 2;
     }
@@ -446,7 +456,7 @@ static void callback(void *userdata, SDL_AudioStream *stream, int additional_amo
 
         struct Channel *c = &channels[channel];
 
-        if (! c->playing || c->paused) {
+        if (! c->playing || c->paused || c->state == CHANNEL_ENDED) {
             c->last_playing = 0;
             continue;
         }
@@ -480,6 +490,15 @@ static void callback(void *userdata, SDL_AudioStream *stream, int additional_amo
 
                     c->playing_pad -= read_length;
                     memset(stream_buffer, 0, read_length * 2 * sizeof(short));
+
+                } else if (read_length == 0 && c->stop_samples != 0 && !c->queued) {
+                    /* Natural EOF with no queued stream. Retain the media
+                     * object for explicit seek, but stop treating the
+                     * channel as actively playing. */
+                    post_event(c);
+                    c->state = CHANNEL_ENDED;
+                    c->last_playing = 0;
+                    break;
 
                 } else {
 
@@ -530,7 +549,11 @@ static void callback(void *userdata, SDL_AudioStream *stream, int additional_amo
 
                     UNLOCK_NAME()
 
-                    start_stream(c, !old_tight);
+                    if (c->playing) {
+                        start_stream(c, !old_tight);
+                    } else {
+                        c->state = CHANNEL_IDLE;
+                    }
 
                     continue;
                 }
@@ -560,7 +583,7 @@ static void callback(void *userdata, SDL_AudioStream *stream, int additional_amo
 
         }
 
-        c->last_playing = 1;
+        c->last_playing = (c->state == CHANNEL_ENDED) ? 0 : 1;
     }
 
     if (channel_count == 1) {
@@ -712,6 +735,8 @@ void RPS_play(int channel, SDL_IOStream *rw, const char *ext, const char *name, 
         }
     }
 
+    c->state = CHANNEL_IDLE;
+
     /* Allocate playing sample. */
 
     c->playing = load_stream(rw, ext, start, end, c->video);
@@ -755,7 +780,7 @@ void RPS_queue(int channel, SDL_IOStream *rw, const char *ext, const char *name,
     c = &channels[channel];
 
     /* If we're not playing, then we should play instead of queue. */
-    if (!c->playing) {
+    if (!c->playing || c->state == CHANNEL_ENDED) {
         RPS_play(channel, rw, ext, name, synchro_start, fadein, tight, start, end, relative_volume, audio_filter);
         return;
     }
@@ -830,6 +855,8 @@ void RPS_stop(int channel) {
     if (c->playing) {
         post_event(c);
     }
+
+    c->state = CHANNEL_IDLE;
 
     /* Free playing and queued samples. */
     if (c->playing) {
@@ -928,7 +955,7 @@ int RPS_queue_depth(int channel) {
 
     LOCK_NAME();
 
-    if (c->playing) rv++;
+    if (c->playing && c->state != CHANNEL_ENDED) rv++;
     if (c->queued) rv++;
 
     UNLOCK_NAME();
@@ -936,6 +963,32 @@ int RPS_queue_depth(int channel) {
     error(SUCCESS);
 
     return rv;
+}
+
+/*
+ * Returns the lifecycle state of the active stream. ENDED means natural EOF
+ * was reached while the decoder is retained for an explicit seek.
+ */
+int RPS_get_state(int channel) {
+    int state;
+    struct Channel *c;
+
+    if (check_channel(channel)) {
+        return CHANNEL_IDLE;
+    }
+
+    if (!initialized) {
+        return CHANNEL_IDLE;
+    }
+
+    c = &channels[channel];
+
+    LOCK_AUDIO();
+    state = c->state;
+    UNLOCK_AUDIO();
+
+    error(SUCCESS);
+    return state;
 }
 
 PyObject *RPS_playing_name(int channel) {
@@ -1046,11 +1099,19 @@ void RPS_pause(int channel, int pause) {
 
     c = &channels[channel];
 
+    LOCK_AUDIO();
+
     c->paused = pause;
+
+    if (c->playing && c->state != CHANNEL_ENDED) {
+        c->state = pause ? CHANNEL_PAUSED : CHANNEL_PLAYING;
+    }
 
     if (c->playing) {
         media_pause(c->playing, pause);
     }
+
+    UNLOCK_AUDIO();
 
     error(SUCCESS);
 
@@ -1066,13 +1127,24 @@ void RPS_global_pause(int pause) {
     if (pause) {
         SDL_PauseAudioStreamDevice(audio_stream);
     } else {
-        SDL_ResumeAudioStreamDevice(audio_stream);
+        /* Keep the callback stopped while the channel states are updated. */
     }
+
+    LOCK_AUDIO();
 
     for (i = 0; i < num_channels; i++) {
         if (channels[i].playing) {
             media_pause(channels[i].playing, pause);
+            if (channels[i].state != CHANNEL_ENDED) {
+                channels[i].state = pause ? CHANNEL_PAUSED : CHANNEL_PLAYING;
+            }
         }
+    }
+
+    UNLOCK_AUDIO();
+
+    if (!pause) {
+        SDL_ResumeAudioStreamDevice(audio_stream);
     }
 }
 
@@ -1102,6 +1174,10 @@ void RPS_seek(int channel, double position) {
         }
 
         media_seek(c->playing, position);
+
+        if (c->state == CHANNEL_ENDED && !c->paused) {
+            c->state = CHANNEL_PLAYING;
+        }
     }
 
     UNLOCK_AUDIO();

--- a/src/renpysound_core.h
+++ b/src/renpysound_core.h
@@ -32,6 +32,7 @@ void RPS_queue(int channel, SDL_IOStream *rw, const char *ext, const char *name,
 void RPS_stop(int channel);
 void RPS_dequeue(int channel, int even_tight);
 int RPS_queue_depth(int channel);
+int RPS_get_state(int channel);
 PyObject *RPS_playing_name(int channel);
 void RPS_fadeout(int channel, int ms);
 void RPS_pause(int channel, int pause);


### PR DESCRIPTION
Natural EOF previously had to be inferred from the presence of a playing name, which conflated an active decoder with active playback and made seek-after-end behavior difficult to express.

This track idle, playing, paused, and ended states in the backend, retain ended decoders for explicit seek, and preserve the existing get_playing() contract for callers, and expose the state through the native and web audio APIs while synchronizing pause, stop, queue, and EOF transitions.