### PR TITLE
Preserve source order in translated dialogue exports

### DIFF
--- a/renpy/translation/dialogue.py
+++ b/renpy/translation/dialogue.py
@@ -273,17 +273,20 @@ class DialogueFile(object):
                         what = what.replace("\n", "\\n")
 
                     if self.tdf:
-                        lines.append([t.identifier, who, what, n.filename, str(n.linenumber), n.get_code(what_filter)])
+                        line = [t.identifier, who, what, n.filename, str(n.linenumber), n.get_code(what_filter)]
 
                     else:
-                        lines.append([what])
+                        line = [what]
+
+                    lines.append((t.linenumber, line))
 
         for m in self.menu_statements:
             for label, _condition, block in m.items:
                 if block is not None:
                     continue
 
-                lines.append(["<menu caption>", "", label, m.filename, str(m.linenumber), what_filter(label)])
+                line = ["<menu caption>", "", label, m.filename, str(m.linenumber), what_filter(label)]
+                lines.append((m.linenumber, line))
 
         if self.strings:
             lines.extend(self.get_strings())
@@ -291,9 +294,9 @@ class DialogueFile(object):
             # If we're tab-delimited, we have line number info, which means we
             # can sort the list so everything's in order, for menus and stuff.
             if self.tdf:
-                lines.sort(key=lambda x: int(x[4]))
+                lines.sort(key=lambda x: x[0])
 
-        for line in lines:
+        for _source_line, line in lines:
             self.f.write("\t".join(line) + "\n")
 
     def get_strings(self):
@@ -334,10 +337,10 @@ class DialogueFile(object):
                 s = s.replace("\n", "\\n")
 
             if self.tdf:
-                lines.append(["", "", s, filename, str(line)])
+                lines.append((line, ["", "", s, filename, str(line)]))
 
             else:
-                lines.append([s])
+                lines.append((line, [s]))
 
         return lines
 


### PR DESCRIPTION
## Summary

- Preserve original script order when exporting translated dialogue with all translatable strings.
- Keep translated filenames and line numbers in the exported rows.
- Leave the existing spreadsheet and plain-text output formats unchanged.

## Why

When all translatable strings were included, dialogue rows were sorted using line numbers from the translation file. If translation blocks appeared in a different order from the original script, separately exported languages no longer lined up.

The export now sorts by each entry's source-script line while retaining the translated entry's metadata in the output.

## Validation

- Reproduced with Spanish translation blocks ordered third, first, second.
- Verified `dialogue spanish --strings` exports first, second, third.
- Verified `dialogue spanish` remains in source order.
- Verified `dialogue spanish --text --strings` remains in source order.
- Ran `git diff --check`.

Addresses #4265.