### PR TITLE
Preserve compiled ATL blocks when copying transforms

### DIFF
--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -913,6 +913,11 @@ class Transform(Container):
         d = self()
         d.kwargs = {}
         d.take_state(self)
+
+        if isinstance(self, ATLTransform):
+            assert isinstance(d, ATLTransform)
+            d.block = self.block
+
         d.take_execution_state(self)
         d.st = self.st
         d.at = self.at

--- a/testcases/game/tests/test_atl.rpy
+++ b/testcases/game/tests/test_atl.rpy
@@ -1,0 +1,45 @@
+# This file tests ATL transforms and replacement behavior.
+
+# ==============
+# == Fixtures ==
+# ==============
+
+image atl__inline_parameter_scope__solid = Solid("#fff")
+
+label atl__inline_parameter_scope__start:
+    call .show(_alpha=0.0)
+
+    show atl__inline_parameter_scope__solid
+
+    "The image was replaced without re-evaluating the previous ATL block."
+    return
+
+label .show(_alpha):
+    show atl__inline_parameter_scope__solid:
+        alpha _alpha
+    return
+
+
+# ==============
+# === Tests ====
+# ==============
+
+testsuite atl:
+    after testcase:
+        if not screen "main_menu":
+            run MainMenu(confirm=False, save=False)
+
+    testcase inline_parameter_scope:
+        description "Does not re-evaluate replaced inline ATL outside its parameter scope"
+        # GH-7283: Replacing an image after returning from a parameterized label must not
+        # evaluate the old inline ATL block after the label parameter has left scope.
+        # https://github.com/renpy/renpy/issues/7283
+        run Start("atl__inline_parameter_scope__start")
+        pause 0.1
+
+        python:
+            entry = renpy.game.context().scene_lists.get_displayable_by_tag(
+                "master", "atl__inline_parameter_scope__solid"
+            )
+            assert entry is not None
+            assert entry.state.alpha == 0.0


### PR DESCRIPTION
Fixes #7283

## Summary

- preserve the compiled ATL block when making an exact transform copy
- avoid re-evaluating inline ATL after its label-local parameters leave scope
- add regression coverage that checks both successful replacement and preserved transform state

## Testing

- `renpy.py testcases test 'atl::inline_parameter_scope' --hide-execution all`
- `renpy.py testcases test camera_transform --hide-execution all`
- `renpy.py testcases test menus_and_branching --hide-execution all`
- `renpy.py testcases test menus_and_branching_variables --hide-execution all`
- `renpy.py testcases test label_control_flow --hide-execution all`
- `renpy.py testcases test textshaders --hide-execution all`
- `renpy.py testcases lint` (completed with existing testcase-project warnings)