### PR TITLE
Fix doubled words in the documentation

### DIFF
--- a/sphinx/source/audio.rst
+++ b/sphinx/source/audio.rst
@@ -174,7 +174,7 @@ When synchro start is enabled and multiple play statements are run at the same t
 will start synchronized. Specifically, the audio will start:
 
 * When the audio files on every channel have been loaded and audio samples are available.
-* When all all channels have been faded out.
+* When all channels have been faded out.
 
 New audio will start playing when both conditions are met.
 

--- a/sphinx/source/bubble.rst
+++ b/sphinx/source/bubble.rst
@@ -23,7 +23,7 @@ in it.
 
 Pressing the area button will launch the speech bubble editor. This editor
 lets you drag to select the area where the speech bubble will be placed,
-on a grid. When you complete the drag, the speech bubble will will change
+on a grid. When you complete the drag, the speech bubble will change
 locations.
 
 Pressing the properties buttons will select between sets of properties

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -503,7 +503,7 @@ Images
 
 .. var:: config.image_extensions =  [ ".jpg", ".jpeg", ".png", ".webp", ".avif", ".svg" ]
 
-    A list of of file extensions that Ren'Py will use when searching for images, as described in the :ref:`images-directory` section.
+    A list of file extensions that Ren'Py will use when searching for images, as described in the :ref:`images-directory` section.
 
 
 Input, Focus, and Events
@@ -847,7 +847,7 @@ Media (Music, Sound, and Video)
 .. var:: config.web_video_base = "./game"
 
     When playing a movie in the web browser, this is a URL that
-    is appended to to the movie filename to get the full URL
+    is appended to the movie filename to get the full URL
     to play the movie from. It can include directories in it, so
     "https://share.renpy.org/movies-for-mygame" would also be fine.
 
@@ -2278,7 +2278,7 @@ Debugging
 
 .. var:: config.debug_prediction = False
 
-    If True, Ren'Py will will write information about and errors that
+    If True, Ren'Py will write information about and errors that
     occur during prediction (of execution flow, images, and screens) to
     log.txt and the console.
 

--- a/sphinx/source/director.rst
+++ b/sphinx/source/director.rst
@@ -3,8 +3,8 @@ Interactive Director
 
 The Interactive Director is a tool that allows you to edit the script of
 your game from inside Ren'Py itself, with a live preview of the results
-of your editing. The director is not not meant as a complete
-replacement for the use of  a text editor, which is still required for
+of your editing. The director is not meant as a complete
+replacement for the use of a text editor, which is still required for
 writing the dialogue, choices, and logic of the visual novel.
 
 Rather, it's intended to help you direct your game's script, by adding:

--- a/sphinx/source/downloader.rst
+++ b/sphinx/source/downloader.rst
@@ -70,7 +70,7 @@ scene, play music, etc. You will need to make it separately, and build
 it for Android or iOS using the usual techniques.
 
 At the same time, it should ask the player if they want to download, mention
-that this can cost money if they're not on WiFi, and then download the the
+that this can cost money if they're not on WiFi, and then download the
 game.
 
 For the highest security, the ``public_key.pem`` file produced by building

--- a/sphinx/source/gui.rst
+++ b/sphinx/source/gui.rst
@@ -1016,7 +1016,7 @@ has a name (an empty name, like " ", counts).
     The horizontal alignment of the character's name. This can be 0.0 for left-
     aligned, 0.5 for centered, and 1.0 for right-aligned. (It's almost always
     0.0 or 0.5.) This is used for both the position of the namebox relative
-    to gui.name_xpos, and to select the side of of the namebox that is aligned
+    to gui.name_xpos, and to select the side of the namebox that is aligned
     with xpos.
 
 .. var:: gui.namebox_width = None

--- a/sphinx/source/lifecycle.rst
+++ b/sphinx/source/lifecycle.rst
@@ -20,7 +20,7 @@ Script Parsing Phase
 To read the game's code, Ren'Py reads each of the game's ``.rpy`` (and ``_ren.py``) files one by
 one. That's the "parsing" phase, or "early" phase. The order that files are read in is:
 
-1. Files inside :file:`renpy/common` are loaded using  using the full path, in unicode order. This is only for use by
+1. Files inside :file:`renpy/common` are loaded using the full path, in unicode order. This is only for use by
    Ren'Py.
 
 2. Only if :file:`game/libs/libs.txt` exists, files in :file:`game/libs` have the first directory removed, if any and

--- a/sphinx/source/matrixcolor.rst
+++ b/sphinx/source/matrixcolor.rst
@@ -87,7 +87,7 @@ useful for animating color changes. It's also useful to have a way of
 taking common matrices and encapsulating them in a way that allows the
 matrix to be parameterized.
 
-The ColorMatrix is a base class that is is extended by a number of
+The ColorMatrix is a base class that is extended by a number of
 Matrix-creating classes. Instances of ColorMatrix are called by Ren'Py,
 and return Matrixes. ColorMatrix is well integrated with ATL, allowing
 for matrixcolor animations. ::

--- a/sphinx/source/model.rst
+++ b/sphinx/source/model.rst
@@ -5,7 +5,7 @@ Model-Based Rendering
 
 While Ren'Py is primarily used with two dimensional rectangular images that
 are common in visual novels, underneath the hood it has a model-based renderer
-intended to to take advantage of features found in modern GPUs. This allows
+intended to take advantage of features found in modern GPUs. This allows
 for a number of visual effects that would not otherwise be possible.
 
 As a warning, this is one of the most advanced features available in Ren'Py.

--- a/sphinx/source/persistent.rst
+++ b/sphinx/source/persistent.rst
@@ -119,7 +119,7 @@ storing instances of user-defined types in the object.
     and it returns a new ``MultiPersistent`` with the given name.
 
     `name`
-        The name used to to access the multipersistent data. Games using the
+        The name used to access the multipersistent data. Games using the
         same name will access the same multipersistent data.
 
     `save_on_quit`

--- a/sphinx/source/quickstart.rst
+++ b/sphinx/source/quickstart.rst
@@ -204,7 +204,7 @@ character, and to change the color of the character's name.
         m "Sure!"
 
 
-The first and and second lines define characters. The first line
+The first and second lines define characters. The first line
 defines a character with the short name of "s", the long name
 "Sylvie", with a name that is shown in a greenish color. (The colors
 are red-green-blue hex triples, as used in web pages.)

--- a/sphinx/source/screen_python.rst
+++ b/sphinx/source/screen_python.rst
@@ -244,7 +244,7 @@ becomes::
         text "This is a test."
 
 Creator-defined screen language statements must be registered in a ``python early`` block.
-What's more, the filename containing the creator-defined statement must be be loaded earlier
+What's more, the filename containing the creator-defined statement must be loaded earlier
 than any file that uses it. Since Ren'Py loads files in the Unicode sort order of their paths,
 it generally makes sense to prefix the name of any file registering a user-defined
 statement with 01, or some other small number.

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -943,7 +943,7 @@ The input statement takes no parameters, and the following properties:
     input is active. This overrides the default action of returning
     the input value.
 
-    Generally, this is is used with a `value` that stores the input into
+    Generally, this is used with a `value` that stores the input into
     a variable, so the action can access it.
 
 .. screen-property:: arrowkeys

--- a/sphinx/source/store_variables.rst
+++ b/sphinx/source/store_variables.rst
@@ -3,7 +3,7 @@ Store Variables
 
 Ren'Py has a number of store variables that control its function. Store
 variables may be changed at any time. If a store variable is changed after
-the game has started, it will be be saved and loaded by the save system,
+the game has started, it will be saved and loaded by the save system,
 and rolled-back when rollback occurs.
 
 .. var:: adv = Character(...)

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -1001,7 +1001,7 @@ Button Style Properties
     focus.
 
     This can be useful when buttons overlap. The keyboard focus algorithm
-    doesn't work with overlapping buttons, and so this can be used to to
+    doesn't work with overlapping buttons, and so this can be used to
     shrink the size of the buttons internally, allowing focus to work.
 
 .. style-property:: key_events boolean

--- a/sphinx/source/template_projects.rst
+++ b/sphinx/source/template_projects.rst
@@ -1,7 +1,7 @@
 Template Projects
 =================
 
-It's possible to to create a template project that can be used to create
+It's possible to create a template project that can be used to create
 new projects. This can be used to make it easy for creators to begin
 making a game with, for example, a gui you develop, rather than the
 default gui that comes with Ren'Py.

--- a/sphinx/source/text.rst
+++ b/sphinx/source/text.rst
@@ -69,7 +69,7 @@ ensure that their writing is not accidentally misinterpreted by the engine.
     brace in your text, double it – write ``{{``.
 
 【 (left lenticular bracket)
-    The left lenticular bracket is used to to introduce ruby/furigana
+    The left lenticular bracket is used to introduce ruby/furigana
     text. To include a left lenticular bracket in your text, double it
     – write ``【【``.
 

--- a/sphinx/source/transforms.rst
+++ b/sphinx/source/transforms.rst
@@ -1582,7 +1582,7 @@ When the displayable is shown without a tag, ``st`` and ``at`` are the same.
 Transform Class
 ===============
 
-One equivalent to to the simplest ATL transforms is the Transform class.
+One equivalent to the simplest ATL transforms is the Transform class.
 
 .. class:: Transform(child=None, *, function=None, reset=False, **properties)
 
@@ -1653,7 +1653,7 @@ One equivalent to to the simplest ATL transforms is the Transform class.
     .. method:: unique():
 
         This should be called on a newly created transform to mark it as unique. Usually, transforms are
-        copied when when added to a displayable, resetting transform state. Calling this prevents thart
+        copied when added to a displayable, resetting transform state. Calling this prevents that
         behavior, and is useful when you want to create a transform that maintains state across multiple
         uses, or that needs to be accessed from outside its `function` argument.
 

--- a/sphinx/source/web.rst
+++ b/sphinx/source/web.rst
@@ -205,7 +205,7 @@ Playing back video is also supported. There are two variables that control
 it:
 
 :var:`config.web_video_base`
-    This is a URL that's appended to to the movie filename to get the full URL
+    This is a URL that's appended to the movie filename to get the full URL
     to play the movie from. It can include directories in it, so
     "https://share.renpy.org/movies-for-mygame/" would also be fine.
 


### PR DESCRIPTION
Fixes 23 doubled-word typos across 19 files in `sphinx/source/`, found with a mechanical scan and confirmed by hand in context. Code samples (e.g. `size size`, `pos pos`, `delay delay`) and changelog entries were deliberately left untouched.

Includes one adjacent typo on the same line: "prevents thart behavior" → "prevents that behavior" (`transforms.rst`, `unique()` method docs).