### PR TITLE
Fix comment and docstring typos

### DIFF
--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -2139,7 +2139,7 @@ def parse_atl(l):
             animation = True
 
         else:
-            # If we can't assign it it a statement more specifically,
+            # If we can't assign it to a statement more specifically,
             # we try to parse it into a RawMultipurpose. That will
             # then be turned into another statement, as appropriate.
 

--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -323,7 +323,7 @@ def busy(channel):
 def get_pos(channel):
     """
     Returns the position of the audio file playing in `channel`. Returns None
-    if not file is is playing or it is not known.
+    if no file is playing or it is not known.
     """
 
     rv = call_int("get_pos", channel)

--- a/renpy/compat/pickle.py
+++ b/renpy/compat/pickle.py
@@ -538,7 +538,7 @@ class ModuleWrapper(ast.Module):
         self.body = state["body"]
         self.type_ignores = []
 
-        # this is the root node, so now is a good moment do do some transforms we couldn't
+        # this is the root node, so now is a good moment to do some transforms we couldn't
         # do earlier because we weren't sure of the node type to be created.
 
         transformer = AstFixupTransformer()

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -705,7 +705,7 @@ always_shown_screens = []
 # A map from tag to the default layer that tag should be displayed on.
 tag_layer = {}
 
-# The default layer for tags not in in tag_layer.
+# The default layer for tags not in tag_layer.
 default_tag_layer = "master"
 
 # A map from tag to the default transform that's used for that tag.

--- a/renpy/display/scenelists.py
+++ b/renpy/display/scenelists.py
@@ -457,7 +457,7 @@ class SceneLists(renpy.object.Object):
             l.insert(add_index, sle)
 
         # By walking the tree of displayables we allow the displayables to
-        # capture the current state. In older code, we allow this to to fail.
+        # capture the current state. In older code, we allow this to fail.
         # Errors might exist in older games, which are ignored when not in
         # developer mode.
         try:

--- a/renpy/display/video.py
+++ b/renpy/display/video.py
@@ -478,8 +478,8 @@ class Movie(renpy.display.displayable.Displayable):
         an movie file is 1280x720 and oversample is 2, then the image will
         be treated as a 640x360 movie for the purpose of layout.
 
-        If None, Ren'Py will automatically determine oversamping. If an @ followed
-        by a number is found in the filename, that number will be used as the the
+        If None, Ren'Py will automatically determine oversampling. If an @ followed
+        by a number is found in the filename, that number will be used as the
         oversampling factor. Otherwise, Ren'Py will search for files and use those.
 
         Specifically, if :file`launch.webm` is used, Ren'Py will search for :file:`launch@2.webm`

--- a/renpy/exports/debugexports.py
+++ b/renpy/exports/debugexports.py
@@ -163,7 +163,7 @@ def error(msg):
     """
     :doc: lint
 
-    Reports `msg`, a string, as as error for the user. This is logged as a
+    Reports `msg`, a string, as an error for the user. This is logged as a
     parse or lint error when approprate, and otherwise it is raised as an
     exception.
     """

--- a/renpy/sl2/slast.py
+++ b/renpy/sl2/slast.py
@@ -464,7 +464,7 @@ class SLBlock(SLNode):
             self.has_keyword = True
 
             # We use screen analysis object, since it
-            # have all knowlege about our constants
+            # have all knowledge about our constants
             self.atl_transform.mark_constant(analysis)
 
             # We can only be a constant if we do not rely

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -188,7 +188,7 @@ def register(
         that would run after this statement.
 
         This should be called to predict the statements that can run after
-        this one. It's expected to return a list of of labels or SubParse
+        this one. It's expected to return a list of labels or SubParse
         objects. This is not called if `predict_all` is true.
 
     `execute_default`

--- a/renpy/ui.py
+++ b/renpy/ui.py
@@ -814,7 +814,7 @@ class Choice(object):
     :name: renpy.Choice
     :args: (value, /, *args, **kwargs)
 
-    This encapsulates a menu choice with with arguments. The first positional argument is is the value
+    This encapsulates a menu choice with arguments. The first positional argument is the value
     that will be returned, and the other arguments are the arguments that will be passed to the choice
     screen.
 


### PR DESCRIPTION
Second typo sweep, this time over comments and docstrings in the Python sources (the previous PR covered the Sphinx docs). 11 fixes across 10 files:

**Doubled words**
- `renpy/ui.py`: "a menu choice with with arguments" → "with arguments"; "The first positional argument is is the value" → "is the value" (this one is a public docstring rendered in the docs via `:doc:` se_menu`)
- `renpy/config.py`: "tags not in in tag_layer" → "not in tag_layer"
- `renpy/atl.py`: "can't assign it it a statement" → "assign it to a statement"
- `renpy/statements.py`: "a list of of labels" → "a list of labels"
- `renpy/compat/pickle.py`: "a good moment do do some transforms" → "moment to do"
- `renpy/exports/debugexports.py`: "Reports `msg`, a string, as as error" → "as an error"
- `renpy/audio/webaudio.py`: "if not file is is playing" → "if no file is playing"
- `renpy/display/video.py`: "used as the the oversampling factor" → "as the oversampling factor"
- `renpy/display/scenelists.py`: "we allow this to to fail" → "to fail"

**Misspellings**
- `renpy/sl2/slast.py`: knowlege → knowledge
- `renpy/display/video.py`: oversamping → oversampling

Intentional repeats were left alone (`Bork bork bork` example strings, the `WARNING WARNING` banner, "max max time" meaning maximum of maxima, and the Doki Doki easter egg). All touched files still compile.