### PR TITLE
Fix config.raise_image_load_exceptions not taking the value of developer

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1755,5 +1755,5 @@ def post_init():
     if renpy.config.raise_image_exceptions is None:
         renpy.config.raise_image_exceptions = renpy.config.developer
 
-    if renpy.config.raise_image_load_exceptions:
+    if renpy.config.raise_image_load_exceptions is None:
         renpy.config.raise_image_load_exceptions = renpy.config.developer


### PR DESCRIPTION
Fixes the code side of #7235.

`config.raise_image_load_exceptions` is documented as: "If None, this takes on the value of config.developer." But `config.post_init()` checks it with a truthiness test:

```python
if renpy.config.raise_image_load_exceptions:
    renpy.config.raise_image_load_exceptions = renpy.config.developer
```

With the default of `None` that check is falsy, so the value stays `None` and image load errors are never raised, even in development. That's why the focus_mask repro in #7235 fails silently — `im.ImageBase.render()` catches the load error and renders the "Couldn't find file ..." text as the mask.

The fix is one line, using the same `is None` pattern that `raise_image_exceptions` uses two lines above:

```python
if renpy.config.raise_image_load_exceptions is None:
    renpy.config.raise_image_load_exceptions = renpy.config.developer
```

This matches what Tom suggested in the issue (treat missing files as errors rather than placeholders) and Andykl's analysis, with `config.developer` as the gate, so release builds are unaffected.

I verified it against the stock 8.5.3 SDK using the exact script from the issue (`imagebutton` + `focus_mask "gui/button/choice_focus_mask.png"` pointing at a nonexistent file). Before, the game runs without an exception and silently uses the text placeholder as the mask. With `config.developer = True` it raises `FileNotFoundError: Couldn't find file 'gui/button/choice_focus_mask.png'`. With `config.developer = False` the placeholder behaviour is unchanged. The affected code paths (`im.py`, `behavior.py`, `config.py`) are identical between 8.5.3 and current master, so the repro is representative.
