### PR TITLE
Fix typos and doubled words in comments and docstrings

### DIFF
--- a/launcher/Atom.edit.py
+++ b/launcher/Atom.edit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # The path to a copy of Atom that's been installed globally, if one exists.
-# This is overidden by RENPY_ATOM, if set. If either is given, that is used
+# This is overridden by RENPY_ATOM, if set. If either is given, that is used
 # and no special handing of the .atom directory is performed.
 ATOM = None
 

--- a/launcher/game/change_icon.py
+++ b/launcher/game/change_icon.py
@@ -311,7 +311,7 @@ def change_icons(oldexe, icofn):
     data = f.read(physize)
 
     # Symbol table, I could not understand so well
-    #  Some analysis and the little I could find on how the symbol tables were layed out show that the PE table is in two sections. One is
+    #  Some analysis and the little I could find on how the symbol tables were laid out show that the PE table is in two sections. One is
     # a list of NumberOfSymbols*(18 bytes) symbol entries, followed immediately by a string table who's length is specified in the 4 bytes following the symbol structure list
     # Again, the information *seems* to indicate that this will always follow the entire block of all sections (so be at the end of the file)
 
@@ -357,7 +357,7 @@ def change_icons(oldexe, icofn):
     # FileAlignment = 512
     #
     #  Section, SizeOfRawData = multiple of FileAlignment   (On Disk size)
-    #  Scetion, VirtualSize   is  NOT aligned to any specific number, and rwdata may be > than this due to its alignment requirement  (In memory size)
+    #  Section, VirtualSize   is  NOT aligned to any specific number, and rwdata may be > than this due to its alignment requirement  (In memory size)
     #
     #  the resource section should be padded out to meet the alignment requirement of  SizeOfRawData = multiple of FileAlignment  (So, in the file, since on disk)
     #

--- a/launcher/game/distribute.rpy
+++ b/launcher/game/distribute.rpy
@@ -475,7 +475,7 @@ fix_dlc("renios", "renios")
         def split_by_prefix(self, prefix):
             """
             Returns two filelists, one that contains all the files starting with prefix,
-            and one tht contains all other files.
+            and one that contains all other files.
             """
 
             yes = FileList()

--- a/launcher/game/installer.py
+++ b/launcher/game/installer.py
@@ -452,7 +452,7 @@ def manifest(url, renpy=False, insecure=False):
         to the current project.
 
     `insecure`
-        If true, verificaiton is disabled.
+        If true, verification is disabled.
     """
 
     import renpy.ecsign

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -553,7 +553,7 @@ init python in project:
             # Normal projects, in alphabetical order by lowercase name.
             self.projects = [ ]
 
-            # Controls wether the folder is collapsed or shown.
+            # Controls whether the folder is collapsed or shown.
             self.hidden = True
 
         # NOTE
@@ -714,7 +714,7 @@ init python in project:
                 if not pf.hidden and not pf.projects:
                     pf.hidden = True
 
-                # Return None if the project folder is emtpy.
+                # Return None if the project folder is empty.
                 if not pf.projects:
                     return None
 

--- a/renpy/atl.py
+++ b/renpy/atl.py
@@ -2164,7 +2164,7 @@ def parse_atl(l):
             animation = True
 
         else:
-            # If we can't assign it it a statement more specifically,
+            # If we can't assign it to a statement more specifically,
             # we try to parse it into a RawMultipurpose. That will
             # then be turned into another statement, as appropriate.
 

--- a/renpy/statements.py
+++ b/renpy/statements.py
@@ -188,7 +188,7 @@ def register(
         that would run after this statement.
 
         This should be called to predict the statements that can run after
-        this one. It's expected to return a list of of labels or SubParse
+        this one. It's expected to return a list of labels or SubParse
         objects. This is not called if `predict_all` is true.
 
     `execute_default`

--- a/renpy/ui.py
+++ b/renpy/ui.py
@@ -814,7 +814,7 @@ class Choice(object):
     :name: renpy.Choice
     :args: (value, /, *args, **kwargs)
 
-    This encapsulates a menu choice with with arguments. The first positional argument is is the value
+    This encapsulates a menu choice with arguments. The first positional argument is the value
     that will be returned, and the other arguments are the arguments that will be passed to the choice
     screen.
 


### PR DESCRIPTION
Came across these while reading through the launcher code and a few core docstrings. Everything here is in comments/docstrings only, no functional changes.

- launcher/Atom.edit.py: overidden -> overridden
- launcher/game/change_icon.py: layed -> laid, Scetion -> Section
- launcher/game/distribute.rpy: tht -> that
- launcher/game/installer.py: verificaiton -> verification
- launcher/game/project.rpy: wether -> whether, emtpy -> empty
- renpy/ui.py: doubled "with with" and "is is"
- renpy/atl.py: "assign it it a statement" -> "assign it to a statement"
- renpy/statements.py: doubled "of of"