### PR TITLE
Fix ECDSA signature encoding and EC private key structure in save token signing

### DIFF
--- a/src/ec_sign_core.c
+++ b/src/ec_sign_core.c
@@ -40,6 +40,7 @@
 
 static EVP_PKEY *GetKeyFromDer(int public, const unsigned char *key_der, size_t key_len);
 static int AddNumberToDER(char *der, int offset, const char *number);
+static int GetNumberFromDER(const unsigned char *der, size_t der_len, size_t *offset, char *number);
 static int Sign(EVP_PKEY *priv_key, const void *data, size_t data_len, void **sign, size_t *sign_len);
 static int Verify(EVP_PKEY *pub_key, const void *data, size_t data_len, const void *sign, size_t sign_len);
 
@@ -72,14 +73,25 @@ int ECSign(const unsigned char *priv_key_der, size_t key_len, const char *data, 
         // fprintf(stdout, "Calculated signature as DER:\n");
         // BIO_dump_indent_fp(stdout, sign, sign_len, 2);
 
-        // Copy R and S from DER sign to raw signature output
-        // Check if it has a extra leading 0 to skip (added to keep value positive in DER format)
-        int offset = sign[3] == 0x21 ? 5 : 4;
-        memcpy(signature, sign + offset, 32); // Copy R
+        // The signature is a DER SEQUENCE of two INTEGERs, R and S. DER uses
+        // the shortest possible encoding, so each of them is anywhere from 1
+        // to 33 bytes long - it gains a leading 0 when the top bit is set, and
+        // loses leading bytes when the value is small. Copy them out into the
+        // fixed-width raw signature.
 
-        // Get last 32 bytes which is S
-        offset = sign_len - 32;
-        memcpy(signature + 32, sign + offset, 32); // Copy S
+        size_t offset = 2;
+
+        if (sign_len < 2 || ((unsigned char *)sign)[0] != 0x30)
+        {
+            fprintf(stderr, "Signature is not a DER SEQUENCE.\n");
+            ret = 0;
+        }
+        else if (!GetNumberFromDER((unsigned char *)sign, sign_len, &offset, signature)      // R
+                 || !GetNumberFromDER((unsigned char *)sign, sign_len, &offset, signature + 32)) // S
+        {
+            fprintf(stderr, "Could not parse the DER signature.\n");
+            ret = 0;
+        }
     }
 
 cleanup:
@@ -180,8 +192,10 @@ void ECGeneratePrivateKey(unsigned char **priv_key_der, size_t *priv_len)
     //     fprintf(stdout, "Curve name: %s\n", out_curvename);
     // }
 
-    // Convert private key to DER
-    ectx = OSSL_ENCODER_CTX_new_for_pkey(privkey, EVP_PKEY_KEYPAIR, "DER", NULL, NULL);
+    // Convert private key to DER. The output structure has to be named
+    // explicitly - the default for EC is the type-specific SEC1 ECPrivateKey,
+    // which crypto.subtle in the web build can't import.
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(privkey, EVP_PKEY_KEYPAIR, "DER", "PrivateKeyInfo", NULL);
     if (OSSL_ENCODER_to_data(ectx, priv_key_der, priv_len) <= 0)
     {
         fprintf(stderr, "Failed to get private key as DER\n");
@@ -204,8 +218,9 @@ void ECGetPublicKeyFromPrivate(const unsigned char *priv_key_der, size_t priv_le
     // Get private key from DER
     privkey = GetKeyFromDer(0, priv_key_der, priv_len);
 
-    // Create public key in DER
-    ectx = OSSL_ENCODER_CTX_new_for_pkey(privkey, EVP_PKEY_PUBLIC_KEY, "DER", NULL, NULL);
+    // Create public key in DER. This is the default for EC, but name it
+    // anyway, to match ECGeneratePrivateKey.
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(privkey, EVP_PKEY_PUBLIC_KEY, "DER", "SubjectPublicKeyInfo", NULL);
     if (OSSL_ENCODER_to_data(ectx, public_key_der, pub_len) <= 0)
     {
         fprintf(stderr, "Failed to get public key\n");
@@ -260,19 +275,72 @@ static EVP_PKEY *GetKeyFromDer(int public, const unsigned char *key_der, size_t 
 
 static int AddNumberToDER(char *der, int offset, const char *number)
 {
-    der[offset++] = 0x02;
-    if (((unsigned char *)number)[0] < 128)
+    const unsigned char *n = (const unsigned char *)number;
+
+    // DER requires the shortest possible encoding, so leading zero bytes have
+    // to go. Keep the last byte, so that a zero encodes as a single 0x00 - a
+    // zero R or S is not a valid signature, but it's OpenSSL's job to say so.
+    int start = 0;
+    while (start < 31 && n[start] == 0x00)
     {
-        der[offset++] = 0x20; // length R
+        start++;
+    }
+
+    int len = 32 - start;
+
+    der[offset++] = 0x02;
+
+    if (n[start] < 128)
+    {
+        der[offset++] = len;
     }
     else
     {
-        der[offset++] = 0x21; // length R
+        // Add a leading 0 to keep the value positive.
+        der[offset++] = len + 1;
         der[offset++] = 0x00;
     }
-    // Copy R value
-    memcpy(der + offset, number, 32);
-    return offset + 32;
+
+    memcpy(der + offset, number + start, len);
+    return offset + len;
+}
+
+static int GetNumberFromDER(const unsigned char *der, size_t der_len, size_t *offset, char *number)
+{
+    size_t i = *offset;
+
+    if (i + 2 > der_len || der[i] != 0x02)
+    {
+        return 0;
+    }
+
+    // R and S are at most 33 bytes, so the length is always in short form.
+    size_t len = der[i + 1];
+    if (len > 0x7f || len > der_len - (i + 2))
+    {
+        return 0;
+    }
+
+    i += 2;
+
+    // Drop the leading zeroes DER adds to keep the value positive.
+    while (len > 0 && der[i] == 0x00)
+    {
+        i++;
+        len--;
+    }
+
+    if (len > 32)
+    {
+        return 0;
+    }
+
+    // Right-align the value in the fixed-width output.
+    memset(number, 0, 32);
+    memcpy(number + (32 - len), der + i, len);
+
+    *offset = i + len;
+    return 1;
 }
 
 static int Sign(EVP_PKEY *priv_key, const void *data, size_t data_len, void **sign, size_t *sign_len)

--- a/src/ec_sign_core_web.c
+++ b/src/ec_sign_core_web.c
@@ -24,10 +24,236 @@
 #ifdef __EMSCRIPTEN__
 
 #include <stdlib.h>
+#include <string.h>
 #include <emscripten.h>
 #include <emscripten/console.h>
 
 #include "ec_sign_core.h"
+
+/*
+*******************************
+       Key conversion
+*******************************
+*/
+
+/*
+ * crypto.subtle only imports EC private keys as PKCS#8 PrivateKeyInfo, but
+ * Ren'Py releases before this one stored what OpenSSL produces by default,
+ * which is a bare SEC1 ECPrivateKey. Wrapping the latter keeps tokens created
+ * by an older desktop build usable in the web build.
+ */
+
+// SEQUENCE { OID id-ecPublicKey, OID prime256v1 }
+static const unsigned char EC_P256_ALGID[] = {
+    0x30, 0x13,
+    0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+    0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
+};
+
+static size_t PutDerLength(unsigned char *out, size_t len)
+{
+    if (len < 0x80)
+    {
+        out[0] = (unsigned char)len;
+        return 1;
+    }
+
+    if (len < 0x100)
+    {
+        out[0] = 0x81;
+        out[1] = (unsigned char)len;
+        return 2;
+    }
+
+    out[0] = 0x82;
+    out[1] = (unsigned char)(len >> 8);
+    out[2] = (unsigned char)len;
+    return 3;
+}
+
+/*
+ * Reads the DER element at *offset, advancing *offset past it. Returns the
+ * tag and the range of the contents, or 0 if the element is malformed.
+ */
+static int ReadDerHeader(const unsigned char *der, size_t der_len, size_t *offset, size_t *content, size_t *content_len)
+{
+    size_t i = *offset;
+
+    if (i + 2 > der_len)
+    {
+        return 0;
+    }
+
+    int tag = der[i++];
+    size_t len = der[i++];
+
+    if (len & 0x80)
+    {
+        size_t n = len & 0x7f;
+
+        if (n == 0 || n > 4 || i + n > der_len)
+        {
+            return 0;
+        }
+
+        len = 0;
+
+        while (n--)
+        {
+            len = (len << 8) | der[i++];
+        }
+    }
+
+    if (len > der_len - i)
+    {
+        return 0;
+    }
+
+    *content = i;
+    *content_len = len;
+    *offset = i + len;
+
+    return tag;
+}
+
+/*
+ * Returns a malloc'd PKCS#8 PrivateKeyInfo holding `der`, or NULL if `der`
+ * isn't a private key we recognize. A key that already is a PrivateKeyInfo is
+ * copied unchanged, so the caller always owns the result.
+ */
+static unsigned char *ToPkcs8(const unsigned char *der, size_t der_len, size_t *out_len)
+{
+    *out_len = 0;
+
+    size_t i = 0;
+    size_t seq, seq_len;
+
+    if (ReadDerHeader(der, der_len, &i, &seq, &seq_len) != 0x30)
+    {
+        return NULL;
+    }
+
+    // The version INTEGER tells the two apart: PrivateKeyInfo is version 0,
+    // SEC1 ECPrivateKey is version 1.
+    size_t ver, ver_len;
+    i = seq;
+
+    if (ReadDerHeader(der, der_len, &i, &ver, &ver_len) != 0x02 || ver_len != 1)
+    {
+        return NULL;
+    }
+
+    if (der[ver] == 0x00)
+    {
+        // Already what we want - hand back a copy, so the caller can free the
+        // result either way.
+        unsigned char *rv = (unsigned char *)malloc(der_len);
+
+        if (rv != NULL)
+        {
+            memcpy(rv, der, der_len);
+            *out_len = der_len;
+        }
+
+        return rv;
+    }
+
+    if (der[ver] != 0x01)
+    {
+        return NULL;
+    }
+
+    // Copy the ECPrivateKey, dropping its optional [0] parameters field. The
+    // curve is named by the PrivateKeyInfo's AlgorithmIdentifier instead, and
+    // RFC 5915 says the inner copy should go.
+    unsigned char *inner = (unsigned char *)malloc(seq_len);
+
+    if (inner == NULL)
+    {
+        return NULL;
+    }
+
+    size_t inner_len = 0;
+    size_t end = seq + seq_len;
+
+    i = seq;
+
+    while (i < end)
+    {
+        size_t start = i;
+        size_t content, content_len;
+
+        if (!ReadDerHeader(der, end, &i, &content, &content_len))
+        {
+            free(inner);
+            return NULL;
+        }
+
+        if (der[start] != 0xa0)
+        {
+            memcpy(inner + inner_len, der + start, i - start);
+            inner_len += i - start;
+        }
+    }
+
+    unsigned char inner_len_der[4];
+    size_t inner_len_der_size = PutDerLength(inner_len_der, inner_len);
+
+    // The ECPrivateKey SEQUENCE goes inside the privateKey OCTET STRING.
+    size_t key_len = 1 + inner_len_der_size + inner_len;
+
+    unsigned char key_len_der[4];
+    size_t key_len_der_size = PutDerLength(key_len_der, key_len);
+
+    size_t body_len = 3 + sizeof(EC_P256_ALGID) + 1 + key_len_der_size + key_len;
+
+    unsigned char body_len_der[4];
+    size_t body_len_der_size = PutDerLength(body_len_der, body_len);
+
+    unsigned char *rv = (unsigned char *)malloc(1 + body_len_der_size + body_len);
+
+    if (rv == NULL)
+    {
+        free(inner);
+        return NULL;
+    }
+
+    size_t o = 0;
+
+    rv[o++] = 0x30;
+    memcpy(rv + o, body_len_der, body_len_der_size);
+    o += body_len_der_size;
+
+    // version
+    rv[o++] = 0x02;
+    rv[o++] = 0x01;
+    rv[o++] = 0x00;
+
+    memcpy(rv + o, EC_P256_ALGID, sizeof(EC_P256_ALGID));
+    o += sizeof(EC_P256_ALGID);
+
+    // privateKey
+    rv[o++] = 0x04;
+    memcpy(rv + o, key_len_der, key_len_der_size);
+    o += key_len_der_size;
+
+    rv[o++] = 0x30;
+    memcpy(rv + o, inner_len_der, inner_len_der_size);
+    o += inner_len_der_size;
+    memcpy(rv + o, inner, inner_len);
+    o += inner_len;
+
+    free(inner);
+
+    *out_len = o;
+    return rv;
+}
+
+/*
+*******************************
+      Asynchronous JS
+*******************************
+*/
 
 EM_ASYNC_JS(int, ecsign_GenerateKey, (char **key, int *len), {
     try
@@ -64,7 +290,7 @@ EM_ASYNC_JS(int, ecsign_CheckPrivateKey, (const char *key, int len), {
     try
     {
         const binaryDer = new Uint8Array(HEAPU8.buffer, key, len);
-        pkey = await crypto.subtle.importKey(
+        const pkey = await crypto.subtle.importKey(
             "pkcs8",
             binaryDer,
             {
@@ -86,7 +312,7 @@ EM_ASYNC_JS(int, ecsign_CheckPublicKey, (const char *key, int len), {
     try
     {
         const binaryDer = new Uint8Array(HEAPU8.buffer, key, len);
-        pkey = await crypto.subtle.importKey(
+        const pkey = await crypto.subtle.importKey(
             "spki",
             binaryDer,
             {
@@ -108,7 +334,7 @@ EM_ASYNC_JS(int, ecsign_Sign, (const char *key, int len, const char *data, int d
     try
     {
         const binaryDer = new Uint8Array(HEAPU8.buffer, key, len);
-        pkey = await crypto.subtle.importKey(
+        const pkey = await crypto.subtle.importKey(
             "pkcs8",
             binaryDer,
             {
@@ -140,7 +366,7 @@ EM_ASYNC_JS(int, ecsign_Verify, (const char *key, int len, const char *data, int
     try
     {
         const binaryDer = new Uint8Array(HEAPU8.buffer, key, len);
-        pkey = await crypto.subtle.importKey(
+        const pkey = await crypto.subtle.importKey(
             "spki",
             binaryDer,
             {
@@ -152,7 +378,7 @@ EM_ASYNC_JS(int, ecsign_Verify, (const char *key, int len, const char *data, int
 
         const msg = new Uint8Array(HEAPU8.buffer, data, data_len);
         const signature = new Uint8Array(HEAPU8.buffer, sign, 64);
-        return await crypto.subtle.verify(
+        const ok = await crypto.subtle.verify(
             {
                 name : "ECDSA",
                 hash : {name : "SHA-1"},
@@ -160,6 +386,7 @@ EM_ASYNC_JS(int, ecsign_Verify, (const char *key, int len, const char *data, int
             pkey,
             signature,
             msg);
+        return ok ? 1 : 0;
     }
     catch(e)
     {
@@ -173,7 +400,7 @@ EM_ASYNC_JS(int, ecsign_GetPublicKey, (const char *key, int len, char **pub, int
     try
     {
         const binaryDer = new Uint8Array(HEAPU8.buffer, key, len);
-        privateKey = await crypto.subtle.importKey(
+        const privateKey = await crypto.subtle.importKey(
             "pkcs8",
             binaryDer,
             {
@@ -211,7 +438,17 @@ int ECSign(const unsigned char *priv_key_der, size_t key_len, const char *data, 
 {
     if (signature_len != 64)
         return 0;
-    return ecsign_Sign((char *)priv_key_der, (int)key_len, data, (int)data_len, signature);
+
+    size_t pkcs8_len;
+    unsigned char *pkcs8 = ToPkcs8(priv_key_der, key_len, &pkcs8_len);
+
+    if (pkcs8 == NULL)
+        return 0;
+
+    int rv = ecsign_Sign((char *)pkcs8, (int)pkcs8_len, data, (int)data_len, signature);
+
+    free(pkcs8);
+    return rv;
 }
 
 int ECVerify(const unsigned char *public_key_der, size_t key_len, const char *data, size_t data_len, char *signature, size_t signature_len)
@@ -241,7 +478,11 @@ void ECGeneratePrivateKey(unsigned char **priv_key_der, size_t *priv_len)
 void ECGetPublicKeyFromPrivate(const unsigned char *priv_key_der, size_t priv_len, unsigned char **public_key_der, size_t *pub_len)
 {
     int len;
-    if (ecsign_GetPublicKey((char *)priv_key_der, (int)priv_len, (char **)public_key_der, &len))
+
+    size_t pkcs8_len;
+    unsigned char *pkcs8 = ToPkcs8(priv_key_der, priv_len, &pkcs8_len);
+
+    if (pkcs8 != NULL && ecsign_GetPublicKey((char *)pkcs8, (int)pkcs8_len, (char **)public_key_der, &len))
     {
         *pub_len = len;
     }
@@ -250,6 +491,8 @@ void ECGetPublicKeyFromPrivate(const unsigned char *priv_key_der, size_t priv_le
         *pub_len = 0;
         *public_key_der = NULL;
     }
+
+    free(pkcs8);
 }
 
 int ECValidateKey(int public, const unsigned char *key_der, size_t key_len)
@@ -258,10 +501,17 @@ int ECValidateKey(int public, const unsigned char *key_der, size_t key_len)
     {
         return ecsign_CheckPublicKey((char *)key_der, (int)key_len);
     }
-    else
-    {
-        return ecsign_CheckPrivateKey((char *)key_der, (int)key_len);
-    }
+
+    size_t pkcs8_len;
+    unsigned char *pkcs8 = ToPkcs8(key_der, key_len, &pkcs8_len);
+
+    if (pkcs8 == NULL)
+        return 0;
+
+    int rv = ecsign_CheckPrivateKey((char *)pkcs8, (int)pkcs8_len);
+
+    free(pkcs8);
+    return rv;
 }
 
 #endif // __EMSCRIPTEN__


### PR DESCRIPTION
This PR fixes the spurious rejection of legitimate saves.
The exact fixes are:
1. In ECSign: non-canonical DER to raw conversion. Now it uses a real TLV walk (GetNumberFromDER)
2. Opposite non-minimal INTEGER encoding in AddNumberToDER. Now it correctly strips leading zeros.
3. EC private keys: SEC1 vs PKCS#8: `OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_KEYPAIR, "DER", NULL, NULL)` leaves the output structure unspecified, OpenSSL's default for EC is the type-specific SEC1 ECPrivateKey. `crypto.subtle.importKey` has no SEC1 format — the web build requests "pkcs8" and throws DataError with an empty message. The fix now names "PrivateKeyInfo" explicitly and ToPkcs8 converts old SEC1 to PKCS#8.

This leaves saves signed by the old ECSign incorrect, so ~0.43% of users have permanently unloadable saves. I don't know how to handle this correctly. Probably pass saves upgrade when that's the case.

The analysis and the fix were made by Claude. I see the bug is fixed, but have limited knowledge in cryptography so could miss something.
@renpytom @bkats.

Also less related question. Is there a special reason to keep this code C? It was hard to wrap my head around. I was thinking to embed it into `renpy/ecsign.pyx` and `renpy/common/_ecsign.js` so it is easer to read.