### PR TITLE
pygame: Fix inverted mouse wheel scrolling under SDL3

### DIFF
--- a/renpy/pygame/event.pyx
+++ b/renpy/pygame/event.pyx
@@ -275,9 +275,6 @@ cdef make_mousewheel_event(SDL_MouseWheelEvent *e):
 
     cdef float y = e.y
 
-    if e.direction == SDL_MOUSEWHEEL_FLIPPED:
-        y = -y
-
     if y > 0:
         btn = 4
     elif y < 0:


### PR DESCRIPTION
Mouse wheel scrolling is inverted on macOS with SDL3: with natural scrolling on, two fingers up scrolls the content down, opposite to every other app. This regressed in ae42ae1f8, which implemented an SDL2-era TODO sign flip during the SDL3 port. That flip made sense with SDL2, whose Cocoa backend negated the vertical delta, but SDL3's Cocoa backend passes AppKit's delta through unchanged, so `e.y` already has the documented sign (positive = away from the user) and `SDL_MOUSEWHEEL_FLIPPED` is informational only — flipping a second time is what inverts scrolling.

This drops the flip in `make_mousewheel_event()`. 