### PR TITLE
Explain the error when flow falls through into a label with parameters

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1172,7 +1172,13 @@ class Label(Node):
 
         renpy.game.context().mark_seen()
 
-        values = apply_arguments(self.parameters, renpy.store._args, renpy.store._kwargs)
+        try:
+            values = apply_arguments(self.parameters, renpy.store._args, renpy.store._kwargs)
+        except TypeError as e:
+            if self.reached_by_fall_through():
+                raise TypeError(self.fall_through_message(e)) from None
+
+            raise
 
         renpy.exports.dynamic(**values)
 
@@ -1181,6 +1187,64 @@ class Label(Node):
 
         renpy.easy.run_callbacks(renpy.config.label_callback, self.name, renpy.game.context().last_abnormal)
         renpy.easy.run_callbacks(renpy.config.label_callbacks, self.name, renpy.game.context().last_abnormal)
+
+    def reached_by_fall_through(self):
+        """
+        Returns true if this label was reached by control flowing into it from
+        the statement before it, rather than by a call or jump.
+        """
+
+        if renpy.store._args is not None or renpy.store._kwargs is not None:
+            return False
+
+        return not renpy.game.context().last_abnormal
+
+    def fall_through_message(self, e):
+        """
+        Given the TypeError `e` raised when applying arguments to this label,
+        returns a message that explains that this label was reached by falling
+        through from the statement before it, which is usually a missing
+        return or jump at the end of the label above this one.
+        """
+
+        msg = (
+            f"{e} - label {self.name!r} takes parameters, but was reached by falling through "
+            "from the statement before it, not by a call or jump."
+        )
+
+        previous = self.previous_label()
+
+        if previous is not None:
+            msg += f" Check that label {previous.name!r}, above it, ends with a return or jump."
+        else:
+            msg += " Check that the statements above it end with a return or jump."
+
+        return msg
+
+    def previous_label(self):
+        """
+        Returns the closest label that precedes this one in the same file, or
+        None if there isn't one.
+        """
+
+        all_stmts = renpy.game.script.all_stmts
+
+        if not all_stmts:
+            return None
+
+        rv = None
+
+        for node in all_stmts:
+            if not isinstance(node, Label):
+                continue
+
+            if node.filename != self.filename or node.linenumber >= self.linenumber:
+                continue
+
+            if rv is None or node.linenumber > rv.linenumber:
+                rv = node
+
+        return rv
 
     def restructure(self, callback):
         callback(self.block)


### PR DESCRIPTION
Fixes #5166.

When a label with required parameters is reached by falling off the end of the label above it, the only error you got was:

```
TypeError: missing a required argument: 'duration'
```

pointing at the label that was entered. The label that's actually wrong is the one above it, which is missing a `return` or `jump`, and nothing in the traceback says so. hsandt's example in the issue is the typical case: a few utility labels in a row, one of them without a `return`, and the error lands on the next one.

With this change, that case now reads:

```
TypeError: missing a required argument: 'duration' - label 'ft_helper' takes parameters, but was reached by falling through from the statement before it, not by a call or jump. Check that label 'ft_start', above it, ends with a return or jump.
```

How it decides: in `Label.execute`, if applying the arguments raises `TypeError`, and `_args`/`_kwargs` are both `None`, and `context.last_abnormal` is false (nothing jumped or called into this label), it's a fall-through. `jump`, `call`, and `renpy.call()` all set `abnormal`, so a `jump` to a parameterised label without arguments keeps the original message. It's still a `TypeError`, so anything catching that is unaffected.

"The label above it" is the closest `Label` node earlier in the same file, found from `script.all_stmts` only on the error path. That's a heuristic, but since every file ends in an implicit `return`, fall-through can't cross files, so it's right in practice. It handles local labels (`ft_local.part_two`). If no label precedes it, the message just says to check the statements above.

Tested by running a small project with `RENPY_SIMPLE_EXCEPTIONS=1` through five scenarios: fall-through (new message), fall-through from a local label (new message naming `outer.local`), `jump` with no args (old message), `renpy.call()` with no args (old message), and a normal `call` with args (works). Nothing changes when `config.developer` is off, since argument errors are ignored there anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiCybf967CQTuP88Uzr8vz
