### PR TITLE
Add an add_ids command that adds id clauses to say statements

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -444,6 +444,7 @@ def import_all():
     import renpy.translation.dialogue
     import renpy.translation.extract
     import renpy.translation.merge
+    import renpy.translation.addids
 
     import renpy.display
 

--- a/renpy/arguments.py
+++ b/renpy/arguments.py
@@ -47,7 +47,7 @@ commands = {}
 display = {}
 
 # Commands that force compile to be set.
-compile_commands = {"compile", "add_from", "merge_strings"}
+compile_commands = {"compile", "add_from", "add_ids", "merge_strings"}
 
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/renpy/translation/__init__.py
+++ b/renpy/translation/__init__.py
@@ -1306,6 +1306,7 @@ def detect_user_locale():
 import typing
 
 if typing.TYPE_CHECKING:
+    from . import addids as addids
     from . import dialogue as dialogue
     from . import extract as extract
     from . import generation as generation

--- a/renpy/translation/addids.py
+++ b/renpy/translation/addids.py
@@ -1,0 +1,218 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# This file contains the add_ids command, which adds an id clause to each
+# say statement that doesn't have one, using the translation identifier
+# Ren'Py generated for it. Once a say statement has an explicit identifier,
+# changing its text no longer changes the identifier, so translations, voice
+# files, and speech bubbles keep matching it.
+
+import collections
+import os
+
+import renpy
+
+
+def in_game_directory(filename):
+    """
+    Returns true if the elided `filename` is in the game directory, but not
+    in the translation (tl) directory under it.
+    """
+
+    gamedir = os.path.abspath(renpy.config.gamedir)
+    tldir = os.path.join(gamedir, "tl")
+
+    fn = os.path.abspath(renpy.lexer.unelide_filename(filename))
+
+    if not fn.startswith(gamedir + os.sep):
+        return False
+
+    return not fn.startswith(tldir + os.sep)
+
+
+def find_edits():
+    """
+    Finds the say statements that need an id clause.
+
+    Returns a tuple of (edits, skipped). `edits` is a map from elided filename
+    to a list of (linenumber, identifier) pairs. `skipped` is a list of
+    (filename, linenumber, reason) tuples for say statements that were
+    found, but that can't be given an id clause.
+    """
+
+    translator = renpy.game.script.translator
+
+    # A map from (filename, linenumber) to the identifiers of the say
+    # statements on that line. A logical line normally has one say statement,
+    # but monologue mode produces several from a single statement.
+    by_line = collections.defaultdict(list)
+
+    for identifier, node in translator.default_translates.items():
+        if isinstance(node, renpy.ast.TranslateSay):
+            says = [node]
+        else:
+            says = [i for i in node.block if isinstance(i, renpy.ast.Say)]
+
+        if not says:
+            continue
+
+        say = says[-1]
+
+        if say.explicit_identifier:
+            continue
+
+        if not in_game_directory(say.filename):
+            continue
+
+        by_line[(say.filename, say.linenumber)].append(identifier)
+
+    edits = collections.defaultdict(list)
+    skipped = []
+
+    for (filename, linenumber), identifiers in by_line.items():
+        if len(identifiers) > 1:
+            skipped.append((
+                filename,
+                linenumber,
+                "monologue mode say statements can't take an id clause. Split the statement up, or add ids by hand.",
+            ))
+            continue
+
+        edits[filename].append((linenumber, identifiers[0]))
+
+    return edits, skipped
+
+
+def process_file(filename, edits, dry_run):
+    """
+    Adds id clauses to the say statements in `filename`, an elided filename.
+
+    `edits`
+        A list of (linenumber, identifier) pairs.
+
+    `dry_run`
+        If true, the changes are reported but not made.
+
+    Returns the number of id clauses added, and a list of
+    (filename, linenumber, reason) tuples for lines that were skipped.
+    """
+
+    renpy.scriptedit.ensure_loaded(filename)
+
+    fullfn = renpy.lexer.unelide_filename(filename)
+
+    # The line positions in renpy.scriptedit are computed on the file as
+    # read in text mode, with newlines translated to \n. Read the file the
+    # same way, but remember what the line endings were so they can be
+    # written back unchanged.
+    with open(fullfn, "rb") as f:
+        newline = "\r\n" if b"\r\n" in f.read() else "\n"
+
+    with open(fullfn, "r", encoding="utf-8") as f:
+        data = f.read()
+
+    # How much of the input has been consumed.
+    consumed = 0
+
+    # The output.
+    output = ""
+
+    count = 0
+    skipped = []
+
+    for linenumber, identifier in sorted(edits):
+        line = renpy.scriptedit.lines.get((filename, linenumber), None)
+
+        if line is None:
+            skipped.append((filename, linenumber, "couldn't find the line in the file."))
+            continue
+
+        end = line.end
+
+        if end < consumed:
+            skipped.append((filename, linenumber, "couldn't find the end of the statement."))
+            continue
+
+        if dry_run:
+            print(f"{filename}:{linenumber}: would add id {identifier}")
+        else:
+            output += data[consumed:end]
+            output += " id " + identifier
+            consumed = end
+
+        count += 1
+
+    if dry_run or not count:
+        return count, skipped
+
+    output += data[consumed:]
+
+    with open(fullfn + ".new", "w", encoding="utf-8", newline=newline) as f:
+        f.write(output)
+
+    try:
+        os.unlink(fullfn + ".bak")
+    except OSError:
+        pass
+
+    os.rename(fullfn, fullfn + ".bak")
+    os.rename(fullfn + ".new", fullfn)
+
+    return count, skipped
+
+
+def add_ids_command():
+    ap = renpy.arguments.ArgumentParser(
+        description="Adds an id clause to each say statement that doesn't have one, so that the translation identifier stays the same when the dialogue is changed."
+    )
+
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Reports the id clauses that would be added, without changing any files.",
+    )
+
+    args = ap.parse_args()
+
+    edits, skipped = find_edits()
+
+    total = 0
+
+    for filename in sorted(edits):
+        count, file_skipped = process_file(filename, edits[filename], args.dry_run)
+        skipped.extend(file_skipped)
+        total += count
+
+        if not args.dry_run and count:
+            print(f"{filename}: added {count} id clause{'' if count == 1 else 's'}.")
+
+    for filename, linenumber, reason in sorted(skipped):
+        print(f"{filename}:{linenumber}: skipped, {reason}")
+
+    if args.dry_run:
+        print(f"{total} id clause{'' if total == 1 else 's'} would be added.")
+    elif not total:
+        print("Every say statement already has an id clause.")
+
+    return False
+
+
+renpy.arguments.register_command("add_ids", add_ids_command)

--- a/renpy/translation/addids.py
+++ b/renpy/translation/addids.py
@@ -37,15 +37,19 @@ def in_game_directory(filename):
     in the translation (tl) directory under it.
     """
 
-    gamedir = os.path.abspath(renpy.config.gamedir)
+    gamedir = os.path.normcase(os.path.abspath(renpy.config.gamedir))
     tldir = os.path.join(gamedir, "tl")
 
-    fn = os.path.abspath(renpy.lexer.unelide_filename(filename))
+    fn = os.path.normcase(os.path.abspath(renpy.lexer.unelide_filename(filename)))
 
-    if not fn.startswith(gamedir + os.sep):
+    try:
+        if os.path.commonpath((gamedir, fn)) != gamedir:
+            return False
+    except ValueError:
+        # On Windows, paths on different drives have no common path.
         return False
 
-    return not fn.startswith(tldir + os.sep)
+    return os.path.commonpath((tldir, fn)) != tldir
 
 
 def find_edits():
@@ -132,8 +136,8 @@ def process_file(filename, edits, dry_run):
     # How much of the input has been consumed.
     consumed = 0
 
-    # The output.
-    output = ""
+    # The output fragments.
+    output = []
 
     count = 0
     skipped = []
@@ -154,8 +158,8 @@ def process_file(filename, edits, dry_run):
         if dry_run:
             print(f"{filename}:{linenumber}: would add id {identifier}")
         else:
-            output += data[consumed:end]
-            output += " id " + identifier
+            output.append(data[consumed:end])
+            output.append(" id " + identifier)
             consumed = end
 
         count += 1
@@ -163,10 +167,10 @@ def process_file(filename, edits, dry_run):
     if dry_run or not count:
         return count, skipped
 
-    output += data[consumed:]
+    output.append(data[consumed:])
 
     with open(fullfn + ".new", "w", encoding="utf-8", newline=newline) as f:
-        f.write(output)
+        f.write("".join(output))
 
     try:
         os.unlink(fullfn + ".bak")
@@ -209,8 +213,10 @@ def add_ids_command():
 
     if args.dry_run:
         print(f"{total} id clause{'' if total == 1 else 's'} would be added.")
-    elif not total:
+    elif not total and not skipped:
         print("Every say statement already has an id clause.")
+    elif not total:
+        print("No id clauses were added.")
 
     return False
 

--- a/renpy/translation/addids.py
+++ b/renpy/translation/addids.py
@@ -34,11 +34,11 @@ import renpy
 def in_game_directory(filename):
     """
     Returns true if the elided `filename` is in the game directory, but not
-    in the translation (tl) directory under it.
+    in the configured translation directory under it.
     """
 
     gamedir = os.path.normcase(os.path.abspath(renpy.config.gamedir))
-    tldir = os.path.join(gamedir, "tl")
+    tldir = os.path.normcase(os.path.abspath(os.path.join(gamedir, renpy.config.tl_directory)))
 
     fn = os.path.normcase(os.path.abspath(renpy.lexer.unelide_filename(filename)))
 

--- a/sphinx/source/cli.rst
+++ b/sphinx/source/cli.rst
@@ -539,6 +539,47 @@ Implies :option:`--compile`.
     This will modify your game's script files.
 
 
+.. _cli-add-ids:
+
+Add Translation IDs To Dialogue
+-------------------------------
+
+Adds an ``id`` clause to each say statement that doesn't have one, using the
+:ref:`translation identifier <translation>` Ren'Py currently generates for
+that statement. Once a say statement has an explicit identifier, fixing a
+typo or rewording the line no longer changes its identifier, so existing
+translations, automatic voice files, and speech bubble placements keep
+matching it.
+
+Say statements in monologue mode (using triple-quoted strings) can't take an
+``id`` clause. They are reported and left alone, as are files under
+``game/tl``.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh <basedir> add_ids [--dry-run]
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py <basedir> add_ids [--dry-run]
+
+.. option:: --dry-run
+
+    Reports the ``id`` clauses that would be added, without changing any
+    files.
+
+.. warning::
+
+    This will modify your game's script files. Commit them to version
+    control, or make a backup, before running it.
+
+
 .. _cli-distribute:
 
 Distribute

--- a/sphinx/source/translation.rst
+++ b/sphinx/source/translation.rst
@@ -228,6 +228,10 @@ statement. For example::
     label start:
         e "This used to have a typo." id start_61b861a2
 
+The :ref:`add_ids <cli-add-ids>` command line tool adds an ``id`` clause to
+every say statement that doesn't have one, using the identifier Ren'Py
+generated for it, so this can be done for a whole game at once.
+
 Adding labels can also confuse the translation process. To prevent
 this, labels that are given the ``hide`` clause are ignored when generating
 translations. ::


### PR DESCRIPTION
Addresses #6918 and the earlier discussion in #4156.

This adds a command for projects that need stable dialogue identifiers for translations, auto-voice files, or speech-bubble data:

```
./renpy.sh <project> add_ids [--dry-run]
```

The command uses `translator.default_translates`, so each explicit `id` is the identifier Ren'Py already assigned to that translation unit. It does not reimplement the hash. Files under `game/tl` and statements that already have an ID are skipped. Monologue-mode statements are reported because the parser does not allow one `id` clause to represent several generated say statements.

File-handling boundaries:

- the project is compiled first, so IDs come from the current `.rpy` files rather than stale bytecode
- `--dry-run` reports every proposed edit without writing
- each changed file gets a `.bak`
- LF and CRLF files keep their newline style
- edits use `renpy.scriptedit` positions, so multiline statements and trailing comments are preserved
- project and translation-directory checks use normalized path boundaries, including Windows drive handling

Validation with the 8.6 nightly:

- a line added after cached bytecode was created was included, confirming the command recompiles first
- simple, character, multiline, menu-caption, clause, comment, LF, CRLF, existing-ID, and monologue cases were exercised
- generated translation identifiers were unchanged before and after the edit
- a second run made no changes
- lint passed after rewriting the project
- Ruff and formatting checks passed for the changed files

Draft while I review the file-rewriting behavior and final diff.
