### PR TITLE
Include the label flow graph in the --json-dump output

### DIFF
--- a/renpy/dump.py
+++ b/renpy/dump.py
@@ -27,9 +27,9 @@ from __future__ import division, absolute_import, with_statement, print_function
 from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, round, str, tobytes, unicode  # *
 
 
+import ast as python_ast
 import inspect
 import json
-import re
 import sys
 import os
 
@@ -57,12 +57,13 @@ def file_exists(fn):
     return rv
 
 
-# Matches renpy.jump("label") and renpy.call("label") in Python code, so the
-# targets can be reported as static edges.
-python_flow_re = re.compile(r"""renpy\.(jump|call)\(\s*(["'])([^"'\n]+)\2""")
-
-# Matches uses of the flow functions that couldn't be resolved statically.
-python_dynamic_re = re.compile(r"renpy\.(jump|call|jump_out_of_context|call_in_new_context|invoke_in_new_context)\b")
+python_flow_functions = {
+    "jump",
+    "call",
+    "jump_out_of_context",
+    "call_in_new_context",
+    "invoke_in_new_context",
+}
 
 
 def new_flow():
@@ -83,14 +84,52 @@ def flow_python(source, into):
     Records the flow found in the Python `source` in `into`.
     """
 
-    for kind, _quote, target in python_flow_re.findall(source):
-        if kind == "jump":
-            add_target(into["jumps"], target)
-        else:
-            add_target(into["calls"], target)
-
-    if python_dynamic_re.search(python_flow_re.sub("", source)):
+    try:
+        tree = python_ast.parse(source)
+    except SyntaxError:
         into["dynamic"] = True
+        return
+
+    class FlowVisitor(python_ast.NodeVisitor):
+        def visit_Call(self, node):
+            function = node.func
+
+            if not (
+                isinstance(function, python_ast.Attribute)
+                and isinstance(function.value, python_ast.Name)
+                and function.value.id == "renpy"
+                and function.attr in python_flow_functions
+            ):
+                self.generic_visit(node)
+                return
+
+            if function.attr in ("jump", "call") and node.args:
+                target = node.args[0]
+
+                if isinstance(target, python_ast.Constant) and isinstance(target.value, str):
+                    if function.attr == "jump":
+                        add_target(into["jumps"], target.value)
+                    else:
+                        add_target(into["calls"], target.value)
+
+                    self.generic_visit(node)
+                    return
+
+            into["dynamic"] = True
+            self.generic_visit(node)
+
+        # Calls inside a function declared by this block do not transfer
+        # control when the label itself runs.
+        def visit_FunctionDef(self, node):
+            return
+
+        def visit_AsyncFunctionDef(self, node):
+            return
+
+        def visit_Lambda(self, node):
+            return
+
+    FlowVisitor().visit(tree)
 
 
 def flow_block(block, into):

--- a/renpy/dump.py
+++ b/renpy/dump.py
@@ -29,6 +29,7 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 
 import inspect
 import json
+import re
 import sys
 import os
 
@@ -52,6 +53,134 @@ def file_exists(fn):
 
         rv = os.path.exists(fullfn)
         file_exists_cache[fn] = rv
+
+    return rv
+
+
+# Matches renpy.jump("label") and renpy.call("label") in Python code, so the
+# targets can be reported as static edges.
+python_flow_re = re.compile(r"""renpy\.(jump|call)\(\s*(["'])([^"'\n]+)\2""")
+
+# Matches uses of the flow functions that couldn't be resolved statically.
+python_dynamic_re = re.compile(r"renpy\.(jump|call|jump_out_of_context|call_in_new_context|invoke_in_new_context)\b")
+
+
+def new_flow():
+    """
+    Returns a new, empty, flow record.
+    """
+
+    return {"jumps": [], "calls": [], "menus": [], "dynamic": False}
+
+
+def add_target(targets, name):
+    if name not in targets:
+        targets.append(name)
+
+
+def flow_python(source, into):
+    """
+    Records the flow found in the Python `source` in `into`.
+    """
+
+    for kind, _quote, target in python_flow_re.findall(source):
+        if kind == "jump":
+            add_target(into["jumps"], target)
+        else:
+            add_target(into["calls"], target)
+
+    if python_dynamic_re.search(python_flow_re.sub("", source)):
+        into["dynamic"] = True
+
+
+def flow_block(block, into):
+    """
+    Walks `block`, a list of nodes, and records the jumps, calls, and menus
+    found in it (and in the blocks nested inside it) in `into`, a flow record
+    created by new_flow. Labels nested inside the block are skipped, as they
+    get their own records.
+    """
+
+    for n in block:
+        if isinstance(n, renpy.ast.Label):
+            continue
+
+        if isinstance(n, renpy.ast.Jump):
+            if n.expression:
+                into["dynamic"] = True
+            else:
+                add_target(into["jumps"], n.target)
+
+        elif isinstance(n, renpy.ast.Call):
+            if n.expression:
+                into["dynamic"] = True
+            else:
+                add_target(into["calls"], n.label)
+
+        elif isinstance(n, renpy.ast.Menu):
+            choices = []
+
+            for label, condition, choice_block in n.items:
+                # Captions have no block.
+                if choice_block is None:
+                    continue
+
+                choice = new_flow()
+                choice["label"] = label
+
+                if condition != "True":
+                    choice["condition"] = condition
+
+                flow_block(choice_block, choice)
+                choices.append(choice)
+
+            into["menus"].append({"line": n.linenumber, "choices": choices})
+
+        elif isinstance(n, renpy.ast.If):
+            for _condition, entry_block in n.entries:
+                flow_block(entry_block, into)
+
+        elif isinstance(n, (renpy.ast.While, renpy.ast.Translate, renpy.ast.TranslateBlock)):
+            flow_block(n.block, into)
+
+        elif isinstance(n, renpy.ast.Python):
+            flow_python(n.code.source, into)
+
+        elif isinstance(n, renpy.ast.UserStatement):
+            # Creator-defined statements can declare the labels they transfer
+            # control to. Their sub-blocks are walked like any other block.
+            try:
+                reachable = n.reachable(True)
+            except Exception:
+                reachable = set()
+
+            for i in reachable:
+                if isinstance(i, str):
+                    add_target(into["jumps"], i)
+
+            for i in n.subparses:
+                flow_block(i.block, into)
+
+
+def label_flow(label):
+    """
+    Returns the flow record for `label`, a Label node.
+    """
+
+    rv = new_flow()
+
+    flow_block(label.block, rv)
+
+    # The statement control reaches when it runs off the end of the block.
+    if label.block:
+        after = label.block[-1].next
+    else:
+        after = label.next
+
+    if isinstance(after, renpy.ast.Label) and isinstance(after.name, str):
+        rv["falls_through"] = after.name
+    else:
+        rv["falls_through"] = None
 
     return rv
 
@@ -137,6 +266,28 @@ def dump(error):
             continue
 
         label[name] = [filename, line]
+
+    # Flow - the jumps, calls, and menus in each label, and the label control
+    # falls through to at the end of it.
+    flow = result["flow"] = {}
+
+    for n in renpy.game.script.namemap.values():
+        if not isinstance(n, renpy.ast.Label):
+            continue
+
+        name = n.name
+
+        if not isinstance(name, str):
+            continue
+
+        if not name_filter(name, n.filename):
+            continue
+
+        record = label_flow(n)
+        record["file"] = n.filename
+        record["line"] = n.linenumber
+
+        flow[name] = record
 
     # Definitions.
     define = location["define"] = {}

--- a/sphinx/source/cli.rst
+++ b/sphinx/source/cli.rst
@@ -182,6 +182,39 @@ These options let you select the file, and choose what is dumped.
 
     Includes names defined in the common directory in the dump.
 
+Among other things, the dump contains a ``location`` object giving the file
+and line of each label, define, screen, transform, and callable, and a
+``flow`` object describing how control moves between labels. ``flow`` has
+one entry per label, keyed by the label's name::
+
+    "flow": {
+      "start": {
+        "file": "game/script.rpy",
+        "line": 10,
+        "jumps": ["chapter_1"],
+        "calls": ["intro"],
+        "menus": [
+          {"line": 14, "choices": [
+            {"label": "Go left", "condition": "has_key", "jumps": ["left"], "calls": [], "menus": [], "dynamic": false}
+          ]}
+        ],
+        "falls_through": "chapter_1",
+        "dynamic": false
+      }
+    }
+
+``jumps`` and ``calls`` list the labels the label's statements jump to and
+call, including those found in ``if`` and ``while`` blocks, in
+``renpy.jump("label")`` and ``renpy.call("label")`` with a literal label,
+and those a creator-defined statement declares through its ``reachable``
+function. ``menus`` lists each menu statement, and for each choice, the
+flow found inside that choice (``condition`` is only present when the
+choice has an ``if`` clause). ``falls_through`` is the label control
+reaches when it runs off the end of this one, or null. ``dynamic`` is true
+when the label contains ``jump expression``, ``call expression``, or Python
+code that jumps or calls somewhere that can't be determined without running
+the game, so the static edges are known to be incomplete.
+
 .. note::
 
     The CLI may change between different releases. To see the latest commands


### PR DESCRIPTION
Fixes #7312. The editor-tooling background is in #6676.

This adds a `flow` section to `--json-dump`, keyed by label name. Each record contains the label location, static jump and call targets, menu choices, the next label reached by fall-through, and a `dynamic` flag when the destination cannot be resolved without running the game.

The collector follows Ren'Py's parsed statements through `if`, `while`, translation blocks, menus, and creator-defined statement sub-blocks. Python blocks are parsed with Python's AST. Literal `renpy.jump("label")` and `renpy.call("label")` calls become static edges; comments, strings, and calls inside a function declared by the block do not. Non-literal targets and context-changing flow calls set `dynamic=true`.

The existing `--json-dump-private` and `--json-dump-common` filters also apply to flow records.

Validation with the 8.6 nightly:

- `the_question`, `testcases`, nested menus, local labels, conditional choices, dynamic jumps, Python calls, and creator-defined statements were exercised
- a focused probe confirmed that a real literal jump is exported while the same text in a comment, string, or nested function is ignored
- non-literal Python targets set `dynamic=true`
- the generated dump remains valid JSON
- Ruff and formatting checks passed for the changed code, excluding the file's existing compatibility-import warnings

Draft while I review the output semantics and final diff.
