### PR TITLE
Add a text event stream for external tools (TTS, live translation)

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -495,6 +495,7 @@ def import_all():
     import renpy.display.predict
     import renpy.display.emulator
     import renpy.display.tts
+    import renpy.display.textevents
     import renpy.display.gesture
     import renpy.display.model
     import renpy.display.quaternion

--- a/renpy/config.py
+++ b/renpy/config.py
@@ -1402,6 +1402,31 @@ extra_savedirs = []
 # The text-to-speech dictionary. A list of [ (RegEx|String, String) ] pairs.
 tts_substitutions = []
 
+# If not None, the port on 127.0.0.1 that the text events server listens on.
+# The RENPY_TEXT_EVENTS_PORT environment variable overrides this.
+text_events_port = None
+
+# A map from style name to the role reported for text using that style (or a
+# style descended from it) in the text event stream.
+text_events_roles = {
+    "say_label": "who",
+    "say_dialogue": "what",
+    "nvl_label": "who",
+    "nvl_dialogue": "what",
+    "nvl_thought": "what",
+    "bubble_who": "who",
+    "bubble_what": "what",
+    "choice_button": "choice",
+    "choice_button_text": "choice",
+    "quick_button": "quick_menu",
+    "quick_button_text": "quick_menu",
+    "navigation_button": "navigation",
+    "navigation_button_text": "navigation",
+    "input": "input",
+    "input_prompt": "input_prompt",
+    "notify_text": "notify",
+}
+
 # The base URL where unpacked web videos can be found.
 web_video_base = "./game"
 

--- a/renpy/display/__init__.py
+++ b/renpy/display/__init__.py
@@ -103,6 +103,7 @@ if typing.TYPE_CHECKING:
     from . import swdraw as swdraw
     from . import transform as transform
     from . import transition as transition
+    from . import textevents as textevents
     from . import tts as tts
     from . import video as video
     from . import viewport as viewport

--- a/renpy/display/focus.py
+++ b/renpy/display/focus.py
@@ -261,6 +261,7 @@ def set_focused(widget, arg, screen):
     sls.focused = widget
 
     renpy.display.tts.displayable(widget)
+    renpy.display.textevents.focus_changed(widget)
 
     # Figure out the tooltip.
 

--- a/renpy/display/textevents.py
+++ b/renpy/display/textevents.py
@@ -1,0 +1,343 @@
+# Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# This file contains the text events server. When enabled, Ren'Py listens on
+# a TCP port on 127.0.0.1 and streams the text it shows on the screen, with
+# the role each piece of text plays (who, what, choice, ...), as one JSON
+# object per line. This lets text-to-speech engines, live translators, and
+# similar tools react to what the game shows without scraping the screen.
+#
+# The text is gathered by a pass over the displayables that mirrors the one
+# self-voicing makes, so the two agree about what's on screen and in what
+# order.
+
+import json
+import os
+import queue
+import socket
+import threading
+import traceback
+
+import renpy
+
+# The TextEventServer, if one is running.
+server = None
+
+# The id of the next record.
+next_id = 0
+
+# The current interaction number. This goes up each time the set of text on
+# the screen changes.
+interaction = 0
+
+# The (text, role, style) tuples sent for the current interaction, used to
+# avoid sending the same text again when the interaction restarts.
+last_texts = None
+
+# The displayable the last focus record was sent for.
+last_focused = None
+
+
+class TextEventServer:
+    """
+    Listens for connections on a port, and sends records to every client
+    that has connected. Records are sent from a thread, so a slow client
+    never stalls the game.
+    """
+
+    def __init__(self, port):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", port))
+        self.sock.listen(5)
+
+        self.port = self.sock.getsockname()[1]
+
+        self.clients = []
+        self.lock = threading.Lock()
+        self.queue = queue.Queue()
+
+        threading.Thread(target=self.accept_loop, name="text events accept", daemon=True).start()
+        threading.Thread(target=self.send_loop, name="text events send", daemon=True).start()
+
+    def accept_loop(self):
+        while True:
+            try:
+                conn, _addr = self.sock.accept()
+            except OSError:
+                return
+
+            conn.settimeout(5.0)
+
+            with self.lock:
+                self.clients.append(conn)
+
+    def send_loop(self):
+        while True:
+            data = self.queue.get()
+
+            with self.lock:
+                clients = list(self.clients)
+
+            for c in clients:
+                try:
+                    c.sendall(data)
+                except OSError:
+                    self.drop(c)
+
+    def drop(self, c):
+        with self.lock:
+            if c in self.clients:
+                self.clients.remove(c)
+
+        try:
+            c.close()
+        except OSError:
+            pass
+
+    def send(self, record):
+        self.queue.put((json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8"))
+
+
+def init():
+    """
+    Starts the server, if config.text_events_port or the
+    RENPY_TEXT_EVENTS_PORT environment variable is set.
+    """
+
+    global server
+
+    if server is not None:
+        return
+
+    port = os.environ.get("RENPY_TEXT_EVENTS_PORT", None)
+
+    if port is None:
+        port = renpy.config.text_events_port
+
+    if port is None:
+        return
+
+    try:
+        server = TextEventServer(int(port))
+    except Exception as e:
+        renpy.display.log.write("Could not start the text events server on port %r: %r", port, e)
+        return
+
+    renpy.display.log.write("Text events server listening on 127.0.0.1:%d", server.port)
+
+
+def send(record):
+    global next_id
+
+    record["id"] = next_id
+    next_id += 1
+
+    record["interaction"] = interaction
+
+    server.send(record)
+
+
+def style_info(d):
+    """
+    Returns the (role, style name) of the displayable `d`, or (None, None)
+    if it can't be determined.
+
+    The role comes from config.text_events_roles, looked up by the name of
+    the displayable's style and then the names of its parents. If none of
+    them is in the map, the name of the first named style is the role.
+    """
+
+    style = getattr(d, "style", None)
+
+    first = None
+    seen = 0
+
+    while style is not None and seen < 32:
+        seen += 1
+
+        name = style.name
+
+        if name:
+            base = name[0]
+
+            if base in renpy.config.text_events_roles:
+                return renpy.config.text_events_roles[base], first or base
+
+            if first is None:
+                first = base
+
+        parent = style.parent
+
+        if not parent:
+            break
+
+        # Style names are tuples, and renpy.style.styles maps those to the
+        # style objects.
+        style = renpy.style.styles.get(parent, None)
+
+    return first, first
+
+
+def add(records, text, d):
+    """
+    Adds a record for `text`, shown by displayable `d`, to `records`.
+    """
+
+    text = text.strip()
+
+    if not text:
+        return
+
+    role, style = style_info(d)
+    records.append((text, role, style))
+
+
+def gather(d, records):
+    """
+    Walks the displayable `d` and its children, adding the text they show to
+    `records` in the order self-voicing would read it. Returns true if a
+    displayable asked for the traversal to stop (a modal screen, for
+    example), in which case the text before it is dropped, as self-voicing
+    does.
+    """
+
+    if d is None:
+        return False
+
+    # Screens that are on their way out say nothing. Modal screens are read,
+    # and then stop the traversal, so nothing behind them is read.
+    if isinstance(d, renpy.display.screen.ScreenDisplayable):
+        if d.phase in (renpy.display.screen.OLD, renpy.display.screen.HIDE):
+            return False
+
+        gather_children(d, records)
+        return bool(d.modal)
+
+    if isinstance(d, renpy.display.layout.NearRect) and d.parent_rect is None:
+        return False
+
+    if isinstance(d, renpy.display.behavior.DismissBehavior):
+        return False
+
+    # Buttons and bars are read as a whole, using their alt text or the text
+    # of their children. Self-voicing skips them when reading the screen and
+    # reads them when they're focused, but a tool wants to see choices and
+    # the like as part of the screen.
+    if isinstance(d, (renpy.display.behavior.Button, renpy.display.behavior.Bar)):
+        try:
+            text = d._tts_all(raw=False)
+        except renpy.display.tts.TTSRoot:
+            return False
+
+        add(records, text, d)
+        return isinstance(text, renpy.display.tts.TTSDone)
+
+    # A displayable with alt text speaks that instead of its children.
+    style = getattr(d, "style", None)
+
+    if style is not None and style.alt is not None:
+        text = d._tts_all(raw=False)
+        add(records, text, d)
+        return isinstance(text, renpy.display.tts.TTSDone)
+
+    children = [i for i in d.visit() if i is not None]
+
+    if not children:
+        text = d._tts(raw=False)
+        add(records, text, d)
+        return isinstance(text, renpy.display.tts.TTSDone)
+
+    return gather_children(d, records)
+
+
+def gather_children(d, records):
+    children = [i for i in d.visit() if i is not None]
+
+    if isinstance(d, renpy.display.layout.MultiBox) and (d.layers or d.scene_list) and renpy.config.tts_front_to_back:
+        children.reverse()
+
+    for i in children:
+        start = len(records)
+
+        if gather(i, records):
+            del records[:start]
+            return True
+
+    return False
+
+
+def focus_changed(widget):
+    """
+    Called when an interaction starts or the focus changes. Sends the text
+    on the screen, if it has changed, and then the text of the focused
+    displayable.
+    """
+
+    global interaction
+    global last_texts
+    global last_focused
+
+    if server is None:
+        return
+
+    root = renpy.display.tts.root
+
+    if root is None:
+        return
+
+    records = []
+
+    try:
+        gather(root, records)
+    except Exception as e:
+        renpy.display.log.write("Text events: could not gather text: %r\n%s", e, traceback.format_exc())
+        return
+
+    if records != last_texts:
+        last_texts = records
+        last_focused = None
+        interaction += 1
+
+        send({"kind": "interaction", "image_tag": renpy.exports.get_say_image_tag()})
+
+        for text, role, style in records:
+            send({"kind": "text", "role": role, "style": style, "text": text})
+
+    if widget is None or widget is last_focused:
+        return
+
+    last_focused = widget
+
+    try:
+        text = widget._tts_all(raw=False)
+    except renpy.display.tts.TTSRoot:
+        return
+    except Exception:
+        return
+
+    text = text.strip()
+
+    if not text:
+        return
+
+    role, style = style_info(widget)
+    send({"kind": "focus", "role": role, "style": style, "text": text})

--- a/renpy/main.py
+++ b/renpy/main.py
@@ -578,6 +578,8 @@ def main():
         renpy.translation.init_translation()
         log_clock("Init translation")
 
+        renpy.display.textevents.init()
+
         # Start things running.
         restart = None
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1582,6 +1582,24 @@ Self-Voicing / Text to Speech
 Showing Images
 --------------
 
+.. var:: config.text_events_port = None
+
+    If not None, Ren'Py listens on this TCP port on 127.0.0.1 and streams
+    the text it shows on screen, with the role each piece of text plays, to
+    any tool that connects. See :ref:`text-events` for the format. The
+    ``RENPY_TEXT_EVENTS_PORT`` environment variable overrides this, so a
+    player can turn the stream on for a game that doesn't set it.
+
+.. var:: config.text_events_roles = { ... }
+
+    A map from style names to roles. The role of a piece of text in the
+    :ref:`text event stream <text-events>` is found by looking up the name
+    of the style of the displayable showing it, and then the names of that
+    style's parents, in this map. If no name is found, the name of the first
+    named style is used as the role. The default maps the styles used by the
+    default screens, so that ``say_label`` becomes ``who``, ``say_dialogue``
+    becomes ``what``, ``choice_button`` becomes ``choice``, and so on.
+
 .. var:: config.adjust_attributes = { }
 
     If not None, this is a dictionary. When a statement or function that

--- a/sphinx/source/self_voicing.rst
+++ b/sphinx/source/self_voicing.rst
@@ -165,3 +165,49 @@ Python
 The following functions are provided by the self-voicing system:
 
 .. include:: inc/self_voicing
+
+.. _text-events:
+
+Text Events
+-----------
+
+Ren'Py can stream the text it shows on the screen to other programs, so that
+a text-to-speech engine, a live translator, or a streaming overlay can react
+to what the game is showing without having to read the screen. This is
+separate from self-voicing, and works whether or not self-voicing is on.
+
+The stream is off by default. It's turned on by setting
+:var:`config.text_events_port`, or by running the game with the
+``RENPY_TEXT_EVENTS_PORT`` environment variable set to a port number. Ren'Py
+then listens on that port on 127.0.0.1, and any number of programs can
+connect to it. Ren'Py only writes to the connection; it never reads from it,
+and a program that stops reading is disconnected rather than allowed to stall
+the game.
+
+Each line Ren'Py writes is one JSON object. When the text on the screen
+changes, Ren'Py writes an ``interaction`` record, followed by one ``text``
+record for each piece of text on the screen, in the order self-voicing would
+read them (front to back). When the focus changes, it writes a ``focus``
+record for the focused displayable. ::
+
+    {"kind": "interaction", "image_tag": "eileen", "id": 12, "interaction": 4}
+    {"kind": "text", "role": "who", "style": "say_label", "text": "Eileen", "id": 13, "interaction": 4}
+    {"kind": "text", "role": "what", "style": "say_dialogue", "text": "Hi! My name is Eileen.", "id": 14, "interaction": 4}
+    {"kind": "text", "role": "quick_menu", "style": "quick_button", "text": "Back", "id": 15, "interaction": 4}
+    {"kind": "focus", "role": "choice", "style": "choice_button", "text": "To ask her right away.", "id": 16, "interaction": 4}
+
+``id`` goes up with every record. ``interaction`` goes up each time the set
+of text on the screen changes, so a tool can tell which records belong
+together. ``image_tag`` is the image tag of the speaking character, if there
+is one.
+
+``role`` comes from :var:`config.text_events_roles`, which maps style names
+to roles; the default covers the styles the default screens use, giving
+``who``, ``what``, ``choice``, ``quick_menu``, ``navigation``, ``input``,
+and ``notify``. When no style in the chain is in the map, the role is the name
+of the style itself. ``style`` is always the name of the displayable's own
+style, for tools that need more detail than the role gives.
+
+The text is given as self-voicing would speak it: text tags are removed,
+``{alt}`` text is used where it's present, and a displayable with the
+:propref:`alt` style property contributes that text instead of its children.


### PR DESCRIPTION
This is a first pass at #6593, along the lines Tom sketched there: a TCP daemon streaming JSON, a gathering pass like the self-voicing one, and roles on the text. Two things differ from the sketch, explained below.

**Enabling it.** `define config.text_events_port = 4444` for a creator who wants it on, or `RENPY_TEXT_EVENTS_PORT=4444` in the environment for a player or tool author who wants it on for a game that doesn't set it. Off by default. Ren'Py listens on 127.0.0.1 only, and only writes; clients never send anything.

**What comes out.** One JSON object per line:

```
{"kind": "interaction", "image_tag": null, "id": 20, "interaction": 4}
{"kind": "text", "role": "quick_menu", "style": "quick_button", "text": "Back", "id": 21, "interaction": 4}
{"kind": "text", "role": "who", "style": "say_label", "text": "Sylvie", "id": 29, "interaction": 4}
{"kind": "text", "role": "what", "style": "say_dialogue", "text": "Hi there! How was class?", "id": 30, "interaction": 4}
{"kind": "text", "role": "choice", "style": "choice_button", "text": "To ask her right away.", "id": 127, "interaction": 14}
{"kind": "focus", "role": "choice", "style": "choice_button", "text": "To ask her later.", "id": 130, "interaction": 14}
```

`interaction` goes up when the set of text on the screen changes (interaction restarts that don't change the text send nothing). `focus` records go out when the focus moves. Text is what self-voicing would say: tags stripped, `{alt}` honoured, `alt` style property honoured.

**Where roles come from.** The sketch had a `role` style property. Adding a style property means touching `generate_styles.py` and rebuilding the Cython, which I can't verify in this environment, and it also means every screen has to be annotated before a tool sees anything. So for now the role is derived from the style: `config.text_events_roles` maps style names to roles, and the lookup walks up the style's parents. The default map covers the default screens (`say_label` -> `who`, `say_dialogue` -> `what`, `choice_button` -> `choice`, `quick_button` -> `quick_menu`, `navigation_button`, `input`, `notify`, and the nvl/bubble equivalents). Because it walks parents, `the_question`'s `say_thought` (which inherits `say_dialogue`) reports `what` with no configuration. The raw style name is sent alongside for tools that need more. A `role` property could be added later and take precedence; the map would then be the fallback.

**The pass.** `renpy/display/textevents.py` walks from `renpy.display.tts.root` mirroring `_tts_common`: front-to-back layer order (`config.tts_front_to_back`), screens in OLD/HIDE phase skipped, modal screens drop what's behind them, `NearRect` without a rect skipped, `alt` replaces children, `TTSDone` stops the walk. The one deliberate difference from self-voicing: buttons and bars are included in the screen pass (via `_tts_all`, so `alt` and "selected" work) rather than only when focused, because a TTS or translation tool needs to see the choices as part of the screen. It's hooked in `focus.py` right after `tts.displayable()`, so it runs whenever self-voicing would.

**Not blocking the game.** Records go on a queue and a thread does the `sendall`; sockets get a 5 s timeout and a client that stops reading is dropped.

Tested by running `the_question`'s `bad_end` and `good_end` testcases with a small client attached (708 records on `good_end`; main menu navigation, quick menu, narrator/`say_thought`, `Sylvie`/`Me` dialogue, both choices, and focus changes all come through with the expected roles; nothing logged to `log.txt`). Docs: a "Text Events" section at the end of `self_voicing.rst`, and the two config variables in `config.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiCybf967CQTuP88Uzr8vz
