### PR TITLE
Let the launcher add and remove projects outside the projects directory

### DIFF
--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -59,17 +59,7 @@ init python:
         """
 
         def __call__(self):
-            fn = os.path.join(project.manager.projects_directory, "projects.txt")
-
-            if os.path.exists(fn):
-                return
-
-            with open(fn, "w") as f:
-                f.write("""\
-# This file can be used to add projects not in the projects directory
-# by listing the full path to each project, one per line.
-
-""")
+            project.manager.ensure_projects_txt()
 
 
 default persistent.force_new_tutorial = False
@@ -166,6 +156,39 @@ screen preferences():
                                     textbutton _("Not Set"):
                                         action Jump("projects_directory_preference")
                                         alt _("Projects directory: [text]")
+
+                        add SPACER
+
+                        add SEPARATOR2
+
+                        frame:
+                            style "l_indent"
+
+                            has vbox
+
+                            text _("Additional Projects:")
+
+                            add HALF_SPACER
+
+                            frame style "l_indent":
+
+                                has vbox
+
+                                for p in project.manager.extra_projects():
+                                    hbox:
+                                        spacing 10
+
+                                        text "[p!q]" style "l_small_text" yalign 0.5
+
+                                        textbutton _("Remove"):
+                                            style "l_small_button"
+                                            action project.RemoveExtraProject(p)
+                                            alt _("Remove this project from the launcher.")
+
+                                textbutton _("Add a project from another directory"):
+                                    style "l_nonbox"
+                                    action Jump("add_extra_project")
+                                    alt _("Add a project from another directory to the launcher.")
 
                         add SPACER
 
@@ -397,6 +420,28 @@ label clean_tmp:
 
 label projects_directory_preference:
     call choose_projects_directory
+    jump preferences
+
+label add_extra_project:
+
+    python:
+        path = None
+
+        if tfd:
+            path = tfd.selectFolderDialog(__("Select Project Directory"), project.manager.projects_directory)
+        else:
+            interface.error(_("A directory chooser isn't available on this platform. Add the project's full path to projects.txt instead."), label="preferences")
+
+        if path:
+            result = project.manager.add_extra_project(path)
+
+            if result == "not_a_project":
+                interface.error(_("[path!q] doesn't contain a Ren'Py project. Choose the directory that has the game directory in it."), path=path, label="preferences")
+            elif result == "exists":
+                interface.info(_("[path!q] is already listed."), path=path)
+            elif result == "no_projects_directory":
+                interface.error(_("Set the projects directory before adding a project from another directory."), label="preferences")
+
     jump preferences
 
 

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -761,7 +761,7 @@ init python in project:
 
             if os.path.exists(extra_projects_fn):
 
-                with open(extra_projects_fn, "r") as f:
+                with open(extra_projects_fn, "r", encoding="utf-8") as f:
 
                     for path in f:
                         path = path.strip()
@@ -774,6 +774,139 @@ init python in project:
                         if len(path) > 0:
                             self.scan_directory_direct(path)
 
+
+        def projects_txt(self):
+            """
+            Returns the path to the projects.txt file in the projects
+            directory, or None if there is no projects directory.
+            """
+
+            if not self.projects_directory:
+                return None
+
+            return os.path.join(self.projects_directory, "projects.txt")
+
+        def ensure_projects_txt(self):
+            """
+            Creates projects.txt, with a comment explaining it, if it
+            doesn't exist. Returns its path, or None if there is no
+            projects directory.
+            """
+
+            fn = self.projects_txt()
+
+            if fn is None or os.path.exists(fn):
+                return fn
+
+            with open(fn, "w", encoding="utf-8") as f:
+                f.write("""\
+# This file can be used to add projects not in the projects directory
+# by listing the full path to each project, one per line.
+
+""")
+
+            return fn
+
+        def extra_projects(self):
+            """
+            Returns the paths listed in projects.txt, in the order they
+            appear there.
+            """
+
+            fn = self.projects_txt()
+
+            if fn is None or not os.path.exists(fn):
+                return [ ]
+
+            rv = [ ]
+
+            with open(fn, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+
+                    if line and not line.startswith("#"):
+                        rv.append(line)
+
+            return rv
+
+        @staticmethod
+        def normalize_extra_project(path):
+            return os.path.normpath(os.path.abspath(path)).replace("\\", "/")
+
+        def add_extra_project(self, path):
+            """
+            Adds the project at `path` to projects.txt, and rescans.
+
+            Returns "added" if it was added, "exists" if it was already
+            listed, "not_a_project" if the directory doesn't contain a
+            project, or "no_projects_directory" if there's nowhere to put
+            projects.txt.
+            """
+
+            fn = self.ensure_projects_txt()
+
+            if fn is None:
+                return "no_projects_directory"
+
+            path = self.normalize_extra_project(path)
+
+            if not self.find_basedir(path):
+                return "not_a_project"
+
+            if path in [ self.normalize_extra_project(i) for i in self.extra_projects() ]:
+                return "exists"
+
+            with open(fn, "r", encoding="utf-8") as f:
+                contents = f.read()
+
+            with open(fn, "a", encoding="utf-8") as f:
+                if contents and not contents.endswith("\n"):
+                    f.write("\n")
+
+                f.write(path + "\n")
+
+            self.scan()
+
+            return "added"
+
+        def remove_extra_project(self, path):
+            """
+            Removes the project at `path` from projects.txt, keeping every
+            other line (including comments) as it is, and rescans. Returns
+            true if it was listed.
+            """
+
+            fn = self.projects_txt()
+
+            if fn is None or not os.path.exists(fn):
+                return False
+
+            path = self.normalize_extra_project(path)
+
+            with open(fn, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+
+            kept = [ ]
+            removed = False
+
+            for line in lines:
+                stripped = line.strip()
+
+                if stripped and not stripped.startswith("#") and self.normalize_extra_project(stripped) == path:
+                    removed = True
+                    continue
+
+                kept.append(line)
+
+            if not removed:
+                return False
+
+            with open(fn, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+
+            self.scan()
+
+            return True
 
         def scan_directory_direct(self, ppath, name=None):
             """
@@ -925,6 +1058,19 @@ init python in project:
 
             if self.label is not None:
                 renpy.jump(self.label)
+
+    class RemoveExtraProject(Action):
+        """
+        Removes a project listed in projects.txt from the launcher. The
+        project itself is left alone.
+        """
+
+        def __init__(self, path):
+            self.path = path
+
+        def __call__(self):
+            manager.remove_extra_project(self.path)
+            renpy.restart_interaction()
 
     class SelectTutorial(Action):
         """
@@ -1125,3 +1271,44 @@ init python:
         return False
 
     renpy.arguments.register_command("set_project", set_project_command)
+
+    def add_project_command():
+        ap = renpy.arguments.ArgumentParser(
+            description="Adds a project that isn't in the projects directory to the launcher, by listing it in projects.txt.")
+        ap.add_argument("project", help="The full path to the project's directory.")
+
+        args = ap.parse_args()
+
+        result = project.manager.add_extra_project(args.project)
+
+        if result == "added":
+            print("Added {} to {}.".format(project.manager.normalize_extra_project(args.project), project.manager.projects_txt()))
+        elif result == "exists":
+            print("{} is already listed in {}.".format(project.manager.normalize_extra_project(args.project), project.manager.projects_txt()))
+        elif result == "not_a_project":
+            print("{} does not contain a Ren'Py project.".format(args.project))
+            renpy.quit(status=1)
+        else:
+            print("The launcher has no projects directory yet, so there is nowhere to put projects.txt. Run the launcher, or use set_projects_directory, first.")
+            renpy.quit(status=1)
+
+        return False
+
+    renpy.arguments.register_command("add_project", add_project_command)
+
+    def remove_project_command():
+        ap = renpy.arguments.ArgumentParser(
+            description="Removes a project that was added with add_project (or listed in projects.txt) from the launcher. The project's files are not touched.")
+        ap.add_argument("project", help="The full path to the project's directory.")
+
+        args = ap.parse_args()
+
+        if project.manager.remove_extra_project(args.project):
+            print("Removed {} from {}.".format(project.manager.normalize_extra_project(args.project), project.manager.projects_txt()))
+        else:
+            print("{} is not listed in projects.txt.".format(args.project))
+            renpy.quit(status=1)
+
+        return False
+
+    renpy.arguments.register_command("remove_project", remove_project_command)

--- a/sphinx/source/cli.rst
+++ b/sphinx/source/cli.rst
@@ -1143,6 +1143,70 @@ This can only be done when the launcher is not running.
     Specifies the full path to the project to select.
 
 
+.. _cli-add-project:
+
+Add Project
+-----------
+
+Adds a project that isn't in the projects directory to the launcher, by
+listing its path in the ``projects.txt`` file in the projects directory.
+The project's files aren't touched. This is the same as the "Add a project
+from another directory" button in the launcher's preferences.
+
+This can only be done when the launcher is not running, and requires that the
+launcher's projects directory has been set.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher add_project <project>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher add_project <project>
+
+.. describe:: <project>
+
+    Specifies the full path to the project's directory - the one that
+    contains the ``game`` directory.
+
+
+.. _cli-remove-project:
+
+Remove Project
+--------------
+
+Removes a project that was added with ``add_project`` (or listed in
+``projects.txt`` by hand) from the launcher. The project's files aren't
+touched.
+
+This can only be done when the launcher is not running.
+
+.. tabs::
+
+    .. tab:: Linux / macOS
+
+        .. code-block:: bash
+
+            ./renpy.sh launcher remove_project <project>
+
+    .. tab:: Windows
+
+        .. code-block:: bat
+
+            .\lib\py3-windows-x86_64\python.exe renpy.py launcher remove_project <project>
+
+.. describe:: <project>
+
+    Specifies the full path to the project's directory, as it was given to
+    ``add_project``.
+
+
 .. _cli-update-old-game:
 
 Update Old Game

--- a/sphinx/source/launcher.rst
+++ b/sphinx/source/launcher.rst
@@ -28,6 +28,14 @@ to contain a list of full paths, one per line. These paths are treated as if
 they were inside the projects directory, and projects they contain show
 up in the launcher.
 
+The file can be edited by hand (lines starting with ``#`` are comments), but
+it doesn't have to be. The General tab of the launcher's preferences lists
+the projects it contains under "Additional Projects", with a button to remove
+each one and a button to add a project by choosing its directory. The
+:ref:`add_project <cli-add-project>` and
+:ref:`remove_project <cli-remove-project>` commands do the same from the
+command line.
+
 
 No Launcher Links
 -----------------


### PR DESCRIPTION
Fixes #3668.

`projects.txt` has done the job since 2022, but only for people who know it exists and are comfortable editing it, which is exactly the group that didn't need help. This puts it in the launcher.

**Preferences, General tab.** Under the projects directory there's now an "Additional Projects" list showing each path in `projects.txt`, a Remove button beside each, and an "Add a project from another directory" button that opens the usual directory chooser. Adding checks the chosen directory actually contains a project (same `find_basedir` check the scanner uses) and tells you if it doesn't, or if it's already listed. The list rescans immediately, so the project shows up on the front page without a restart.


**Command line.** `renpy.sh launcher add_project <path>` and `renpy.sh launcher remove_project <path>`, alongside the existing `set_projects_directory` / `set_project`. Both print what they did and exit non-zero on failure (not a project, not listed, no projects directory yet). This was the "teammate who isn't technical" case from the thread: one command in a setup script instead of instructions to edit a file.

**Keeping hand edits intact.** The thread had a long back-and-forth about whether the launcher should own the file. It doesn't have to. Adding appends one line (creating the file with its explanatory comment if needed), and removing rewrites the file keeping every other line, blank lines and comments included, in their original order. Manual edits survive either way. Duplicate detection normalises paths (`abspath`, forward slashes) so `C:\foo\` and `C:/foo` count as the same entry. The file is now read and written as UTF-8 explicitly, since paths aren't always ASCII.

**Implementation.** `ProjectManager` gains `projects_txt()`, `ensure_projects_txt()` (which the existing `EnsureProjectsTxt` action now calls instead of carrying its own copy of the header text), `extra_projects()`, `add_extra_project()`, and `remove_extra_project()`. A `RemoveExtraProject` action sits beside `Select`. The chooser flow is a label in `preferences.rpy` like `projects_directory_preference`. Docs: the projects.txt section of `launcher.rst`, and two new command sections in `cli.rst`.

**Tested** with a copy of the launcher pointed at a scratch projects directory: `add_project` (added, already listed, not a project), `remove_project` (removed, not listed), exit codes, and that the front page's project list picks the project up and drops it again. Then a testcase through the actual preferences screen: open General, assert the Remove button is there, click it, assert it's gone, and check `projects.txt` on disk only lost that one line. The directory chooser itself can't be driven from a testcase, so the add button was only tried by hand.

New launcher strings are untranslated for now, as usual.

Opened as a draft so it can be reviewed properly first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiCybf967CQTuP88Uzr8vz
