### PR TITLE
Explain label parameter errors caused by fall-through

### DIFF
--- a/renpy/ast.py
+++ b/renpy/ast.py
@@ -1141,7 +1141,13 @@ class Label(Node):
 
         renpy.game.context().mark_seen()
 
-        values = apply_arguments(self.parameters, renpy.store._args, renpy.store._kwargs)
+        try:
+            values = apply_arguments(self.parameters, renpy.store._args, renpy.store._kwargs)
+        except TypeError as e:
+            if self.missing_required_parameters_after_fall_through():
+                raise TypeError(self.fall_through_message(e)) from None
+
+            raise
 
         renpy.exports.dynamic(**values)
 
@@ -1150,6 +1156,66 @@ class Label(Node):
 
         renpy.easy.run_callbacks(renpy.config.label_callback, self.name, renpy.game.context().last_abnormal)
         renpy.easy.run_callbacks(renpy.config.label_callbacks, self.name, renpy.game.context().last_abnormal)
+
+    def missing_required_parameters_after_fall_through(self):
+        """
+        Returns true if this label was reached by falling through from the
+        statement before it and has required parameters that were not passed.
+        """
+
+        if renpy.store._args is not None or renpy.store._kwargs is not None:
+            return False
+
+        if renpy.game.context().last_abnormal or self.parameters is None:
+            return False
+
+        for parameter in self.parameters.parameters.values():
+            if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+                continue
+
+            if parameter.default is parameter.empty:
+                return True
+
+        return False
+
+    def fall_through_message(self, e):
+        """
+        Explains the likely missing return or jump after a label falls
+        through into this parameterized label.
+        """
+
+        msg = (
+            f"{e} - label {self.name!r} takes parameters, but was reached by falling through "
+            "from the statement before it, not by a call or jump."
+        )
+
+        previous = self.previous_label()
+
+        if previous is not None:
+            msg += f" Check that label {previous.name!r}, above it, ends with a return or jump."
+        else:
+            msg += " Check that the statements above it end with a return or jump."
+
+        return msg
+
+    def previous_label(self):
+        """
+        Returns the closest label that precedes this one in the same file.
+        """
+
+        rv = None
+
+        for node in renpy.game.script.all_stmts:
+            if not isinstance(node, Label):
+                continue
+
+            if node.filename != self.filename or node.linenumber >= self.linenumber:
+                continue
+
+            if rv is None or node.linenumber > rv.linenumber:
+                rv = node
+
+        return rv
 
     def restructure(self, callback):
         callback(self.block)


### PR DESCRIPTION
Fixes #5166.

When execution falls through into a label with required parameters, the existing error points at the second label even though the usual mistake is a missing `return` or `jump` in the label above it. This adds that context to the `TypeError` and names the preceding label when one can be identified.

The extra message is deliberately limited to the fall-through case:

- no call arguments are present
- the previous transfer was not a call or jump
- the target label has at least one required parameter

Errors raised while evaluating optional default values are left unchanged, as are missing-argument errors after an explicit jump.

Validation with the 8.5.4 fix nightly:

- fall-through into `label needs_argument(value)` includes the preceding label and missing `return`/`jump` guidance
- an explicit jump with no argument keeps the original missing-argument error
- a `TypeError` inside an optional default expression keeps the original exception

This replaces #7315, which was based on `master`. Bug fixes target `fix` in this repository.

Draft while I review the final diff against the fix branch.
