### PR TITLE
Fix semantic of `python hide`

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -753,26 +753,6 @@ class WrapNode(ast.NodeTransformer):
 
 wrap_node = WrapNode()
 
-
-def wrap_hide(tree):
-    """
-    Wraps code inside a python hide or python early hide block inside a
-    function, so it gets its own scope that works the way Python expects
-    it to.
-    """
-
-    hide = ast.parse("""\
-def _execute_python_hide(): pass;
-_execute_python_hide()
-""")
-
-    for i in ast.walk(hide):
-        ast.copy_location(i, hide.body[0])
-
-    hide.body[0].body = tree.body  # type: ignore
-    tree.body = hide.body
-
-
 # A list of warnings that were issued during compilation.
 compile_warnings = []
 
@@ -1277,9 +1257,6 @@ def py_compile(source, mode, filename="<none>", lineno=1, ast_node=False, cache=
             tree.body = tree.body[0].body
 
         tree = wrap_node.visit(tree)
-
-        if mode == "hide":
-            wrap_hide(tree)
 
         LocationFixer(tree, lineno - 1, first_line_column_delta, rest_line_column_delta)
 


### PR DESCRIPTION
## Description
This PR removes `wrap_hide` that was initially added to address #1397, which is now handled by more correct `wrap_generator`, but removing it adds a benefit that `python` and `python hide` has matching semantic, i.e.
1. `return` in python block does not get recognized as early exit from it and now errors regardles of hide with `'return' outside function`
2. Same for `'yield' outside function`
3. There is no longer spurious frame in traceback

## Human Oversight

- [x] A human fully understood this pull request and the affected portions of Ren'Py.
- [ ] This pull request was created without a human fully understanding the changes and their impact.
- [ ] Other: <!-- explain -->
