### PR TITLE
Fix py_compile crash when source is not a string (None)

### DIFF
--- a/renpy/python.py
+++ b/renpy/python.py
@@ -1109,6 +1109,12 @@ def py_compile(
     elif hashcode is None:
         hashcode = hash32(source)
 
+    # Callers such as the screen language analyzer may pass a non-string
+    # value (for example None). Convert early so the checks below, which use
+    # string methods like startswith and "in", don't raise on them. This
+    # restores the behavior before quote_eval was reworked.
+    source = str(source)
+
     flags = file_compiler_flags.get(filename, 0)
 
     if renpy.config.future_annotations:


### PR DESCRIPTION
Fixes #7331.

After #7329 reworked `quote_eval`, `py_compile` stopped turning `source` into a string before the indentation and line-joining checks. Those checks use string methods (`startswith`, `"\n" in source`), so a caller that passes a non-string value raises `TypeError: argument of type 'NoneType' is not a container or iterable`.

That happens with the screen language analyzer, which calls `is_constant_expr` on things like `self.warp_function` — `py_compile` then gets `None` as the source.

The fix converts `source` to `str` right after the type dispatch (same place it used to happen before #7329), so the later checks see a string and behave as they did before.

I checked the two crash points in isolation: with `source=None` they raised the exact error from the issue, and after the early `str(source)` they pass. `fix` already does this via its short-circuit `source and (source[0] == " ")`, so this just brings `master` back in line.
