### PR TITLE
fix: `renpy.display.tts.last`

### DIFF
--- a/renpy/display/tts.py
+++ b/renpy/display/tts.py
@@ -814,5 +814,5 @@ def displayable(d):
     if s != last_raw:
         last_raw = s
         s = apply_substitutions(s)
-        last = s
+        last = get_voice(s)[1]
         tts(prefix + s)


### PR DESCRIPTION
## Description

`renpy.display.tts.last` is used inside `_self_voicing`
But the `alt` setted inside the `Preference` is not deleted.
Which causes `voice=` to be used as an tag.

## Human Oversight

- [x] A human fully understood this pull request and the affected portions of Ren'Py.
- [ ] This pull request was created without a human fully understanding the changes and their impact.
- [ ] Other: <!-- explain -->
