### PR TITLE
feature: support `AudioData` & `iostream` inside `emscripten`

### DIFF
--- a/renpy/audio/webaudio.py
+++ b/renpy/audio/webaudio.py
@@ -24,10 +24,11 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 
 import renpy
 import emscripten  # type: ignore
-import pygame
+from io import BufferedIOBase, BufferedReader
 from json import dumps
 
 import renpy.audio.renpysound as renpysound
+import renpy.pygame.iostream as iostream
 
 # True if the browser only supports video decoding (not audio)
 video_only = False
@@ -173,9 +174,20 @@ def play(
         The audio filter to apply when the file is being played.
     """
 
+    array = None
+
     try:
-        # Assume it is some file-like with name attribute meaning the filename.
-        if not isinstance(file, str):
+        # renpy.loader.open_file
+        if isinstance(file, iostream.IOPath):
+            file = file.path
+        # renpy.exports.loaderexports.open_file
+        elif isinstance(file, BufferedReader) and isinstance(file.raw, iostream.IOPath):
+            file = file.raw.path
+        # renpy.audio.audio.AudioData | renpy.loader.load
+        elif isinstance(file, (BufferedIOBase, iostream.IOStream)):
+            file, array = name, list(file.read())
+        # something else, but probably it unreachable
+        elif not isinstance(file, str) and hasattr(file, "name"):
             file = file.name
     except Exception:
         if renpy.config.debug_sound:
@@ -188,7 +200,7 @@ def play(
     afid = load_audio_filter(audio_filter)
 
     call("stop", channel)
-    call("queue", channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid)
+    call("queue", channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid, array)
 
 
 @proxy_with_channel
@@ -211,8 +223,20 @@ def queue(
     The other arguments are as for play.
     """
 
+    array = None
+
     try:
-        if not isinstance(file, str):
+        # renpy.loader.open_file
+        if isinstance(file, iostream.IOPath):
+            file = file.path
+        # renpy.exports.loaderexports.open_file
+        elif isinstance(file, BufferedReader) and isinstance(file.raw, iostream.IOPath):
+            file = file.raw.path
+        # renpy.audio.audio.AudioData | renpy.loader.load
+        elif isinstance(file, (BufferedIOBase, iostream.IOStream)):
+            file, array = name, list(file.read())
+        # something else, but probably it unreachable
+        elif not isinstance(file, str) and hasattr(file, "name"):
             file = file.name
     except Exception:
         if renpy.config.debug_sound:
@@ -224,7 +248,7 @@ def queue(
 
     afid = load_audio_filter(audio_filter)
 
-    call("queue", channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid)
+    call("queue", channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid, array)
 
 
 @proxy_with_channel

--- a/renpy/common/_audio.js
+++ b/renpy/common/_audio.js
@@ -1,4 +1,4 @@
-﻿/* Copyright 2004-2025 Tom Rothamel <pytom@bishoujo.us>
+﻿/* Copyright 2004-2026 Tom Rothamel <pytom@bishoujo.us>
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation files
@@ -421,7 +421,7 @@ renpyAudio.set_channel_count = (count) => {
 }
 
 
-renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid) => {
+renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, end, relative_volume, afid, array) => {
 
     const c = get_channel(channel);
 
@@ -525,7 +525,7 @@ renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, en
         fadein: fadein,
         fadeout: null,
         tight: tight,
-        file: file,
+        name: name,
         filter: renpyAudio.getFilter(afid),
         synchro_start: synchro_start,
     };
@@ -543,7 +543,7 @@ renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, en
         c.paused = false;
     } else {
         c.queued = q;
-        if (c.playing.file === file) {
+        if (c.playing.name === name) {
             // Same file, re-use the data to reduce memory and CPU footprint
             if (c.playing.buffer !== null) {
                 reuseBuffer(c);
@@ -555,7 +555,12 @@ renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, en
         }
     }
 
-    const array = FS.readFile(file);
+    if (array === null) {
+        array = FS.readFile(file);
+    } else {
+        array = new Uint8Array(array);
+    }
+
     context.decodeAudioData(array.buffer, (buffer) => {
 
         q.source = create_source(c, buffer);
@@ -563,7 +568,7 @@ renpyAudio.queue = (channel, file, name, synchro_start, fadein, tight, start, en
 
         start_playing(c);
 
-        if (c.playing === q && c.queued !== null && c.queued.file === q.file) {
+        if (c.playing === q && c.queued !== null && c.queued.name === q.name) {
             // Same file, re-use the data to reduce memory and CPU footprint
             reuseBuffer(c);
         }
@@ -911,8 +916,6 @@ renpyAudio.can_play_types = (l) => {
 
     return 1;
 }
-
-
 
 renpyAudio.set_video = (channel, video, loop, web_video_prompt) => {
     const c = get_channel(channel);


### PR DESCRIPTION
## Description

This change allow use `renpy.audio.audio.AudioData` & `iostream` from `archives` on `emscripten` for `audio`.

## Human Oversight

- [x] A human fully understood this pull request and the affected portions of Ren'Py.
- [ ] This pull request was created without a human fully understanding the changes and their impact.
- [ ] Other: <!-- explain -->
