### PR TITLE
fix: `fetch_emscripten` incorrect timeout of status

### DIFF
--- a/renpy/exports/fetchexports.py
+++ b/renpy/exports/fetchexports.py
@@ -252,12 +252,12 @@ def fetch_emscripten(url, method, data, content_type, timeout, headers):
         result = emscripten.run_script_string("""fetchFileResult({})""".format(fetch_id))
         status, _ignored, message = result.partition(" ")
 
-        if status != "PENDING":
-            break
-
-        if time.time() > start + timeout:
+        if status == "PENDING" and time.time() > start + timeout:
             status = "TIMEOUT"
             message = "Fetch timed out."
+
+        if status != "PENDING":
+            break
 
     try:
         if status == "OK":


### PR DESCRIPTION
## Description

`status = ...` and `message = ...` resets on next cycle

## Human Oversight

- [x] A human fully understood this pull request and the affected portions of Ren'Py.
- [ ] This pull request was created without a human fully understanding the changes and their impact.
- [ ] Other: <!-- explain -->
