### PR TITLE
fix: missing `renpy.update` modules during `renpy.reload_all`

### DIFF
--- a/renpy/__init__.py
+++ b/renpy/__init__.py
@@ -561,7 +561,9 @@ def import_all():
     import renpy.test.testcli
 
     import renpy.update
+    import renpy.update.common
     import renpy.update.deferred
+    import renpy.update.update
 
     try:
         import renpy.tfd

--- a/renpy/update/download.py
+++ b/renpy/update/download.py
@@ -24,7 +24,12 @@ from renpy.compat import PY2, basestring, bchr, bord, chr, open, pystr, range, r
 
 import renpy
 
-import requests
+# requests not available on emscripten
+try:
+    import requests
+except ImportError:
+    requests = None
+
 import re
 import os
 

--- a/renpy/update/update.py
+++ b/renpy/update/update.py
@@ -27,8 +27,6 @@ import os
 import time
 import zlib
 
-import requests
-
 from . import download
 from . import common
 from . import deferred
@@ -634,6 +632,8 @@ class Update(object):
 
 
 def main():
+    import requests
+
     ap = argparse.ArgumentParser()
     ap.add_argument("url")
     ap.add_argument("targetdir")


### PR DESCRIPTION
## Description

Since modules are not imported during `import_all`, after `reload_all`
there may be an exception about the absence of, for example, `Update`

## Human Oversight

- [x] A human fully understood this pull request and the affected portions of Ren'Py.
- [ ] This pull request was created without a human fully understanding the changes and their impact.
- [ ] Other: <!-- explain -->
