### PR TITLE
Handful of fixes from GLSL migration

### DIFF
--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -1637,6 +1637,9 @@ cdef class GL2DrawingContext:
         halfwidth = self.width / 2.0
         halfheight = self.height / 2.0
 
+        if halfwidth == 0.0 or halfheight == 0.0:
+            return
+
         sx = self.model_matrix.xdw
         sy = self.model_matrix.ydw
         sz = self.model_matrix.zdw

--- a/renpy/gl2/gl2shader.pyx
+++ b/renpy/gl2/gl2shader.pyx
@@ -412,9 +412,13 @@ cdef class Program:
             v = Variable(shader_name, l, fragment)
 
             if v.storage == "uniform":
+                if v.name in seen_uniforms:
+                    continue
+
                 location = glGetUniformLocation(self.program, v.name.encode("utf-8"))
 
                 if location >= 0:
+                    seen_uniforms.add(v.name)
                     setter, samplers = generate_uniform_setter(shader_name, location, v.name, v.type, v.array, samplers)
                     self.uniform_setters.append(setter)
 
@@ -477,6 +481,7 @@ cdef class Program:
         cdef GLuint vertex
         cdef GLuint program
         cdef GLint status
+        cdef GLint max_samplers = 0
 
         cdef char[1024] error
 
@@ -519,7 +524,14 @@ cdef class Program:
         self.uniform_setters = [ ]
 
         samplers = self.find_variables(self.vertex, seen_uniforms, samplers, False)
-        self.find_variables(self.fragment, seen_uniforms, samplers, True)
+        samplers = self.find_variables(self.fragment, seen_uniforms, samplers, True)
+
+        glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &max_samplers)
+
+        if max_samplers > 0 and samplers > max_samplers:
+            raise ShaderError(
+                "Shader %s needs %d texture units, but this system provides %d." % (
+                    "+".join(self.name), samplers, max_samplers))
 
     cpdef void draw(self, GL2DrawingContext context, GL2Model model, Mesh mesh):
 

--- a/renpy/gl2/gl2shadercache.py
+++ b/renpy/gl2/gl2shadercache.py
@@ -397,8 +397,8 @@ class ShaderPart(object):
         # any.
         self.legacy_storage = None
 
-        self.vertex_functions = vertex_functions
-        self.fragment_functions = fragment_functions
+        self.vertex_functions = self.substitute_name(vertex_functions)
+        self.fragment_functions = self.substitute_name(fragment_functions)
 
         # A list of priority, text pairs for each section of the vertex and fragment shaders.
         self.vertex_parts = []
@@ -414,6 +414,12 @@ class ShaderPart(object):
         # A sets of variable names used in the vertex and fragments shader.
         vertex_used = set()
         fragment_used = set()
+
+        for m in re.finditer(r"\b\w+\b", self.vertex_functions):
+            vertex_used.add(m.group(0))
+
+        for m in re.finditer(r"\b\w+\b", self.fragment_functions):
+            fragment_used.add(m.group(0))
 
         self.uniforms = []
 

--- a/testcases/game/tests/test_shaders.rpy
+++ b/testcases/game/tests/test_shaders.rpy
@@ -61,6 +61,24 @@ init python:
         fragment_600="gl_FragColor.rgb *= u__amount;\n",
     )
 
+    # A shader-local uniform that is only referenced inside helper functions.
+    renpy.register_shader(
+        "test_shaders.helper", glsl=300,
+        variables="uniform float u__amount;",
+        vertex_functions="""
+            vec4 test_shaders_helper_scale_vertex(vec4 position) {
+                return position * u__amount;
+            }
+        """,
+        fragment_functions="""
+            vec4 test_shaders_helper_scale(vec4 color) {
+                return color * u__amount;
+            }
+        """,
+        vertex_600="gl_Position = test_shaders_helper_scale_vertex(gl_Position);\n",
+        fragment_600="fragment_color = test_shaders_helper_scale(fragment_color);\n",
+    )
+
 
 transform test_shaders__both:
     shader [ "test_shaders.modern", "test_shaders.legacy" ]
@@ -176,6 +194,20 @@ testsuite shaders:
                     f"The error should suggest glsl=100, got: {error}"
             else:
                 assert error is None, f"Legacy part did not compile: {error}"
+
+    testcase helper_function_variables:
+        description "A shader-local variable used by both stages' functions is declared once"
+
+        python:
+            cache = test_shaders__cache()
+            error = test_shaders__compile("renpy.texture", "test_shaders.helper")
+            assert error is None, f"Helper-function shader did not compile: {error}"
+
+            if cache is not None:
+                baseline = cache.get(("renpy.texture",))
+                helper = cache.get(("renpy.texture", "test_shaders.helper"))
+                assert len(helper.uniform_setters) == len(baseline.uniform_setters) + 1, \
+                    "A uniform shared by both stages should have one setter"
 
     testcase generated_fragment_output:
         description "Modern fragment output has an explicit location"

--- a/testcases/game/tests/test_shaders.rpy
+++ b/testcases/game/tests/test_shaders.rpy
@@ -257,7 +257,7 @@ testsuite shaders:
             old_write = renpy.display.log.write
             messages = []
 
-            def write(message, *args):
+            def write(message, *args, messages=messages):
                 messages.append(message % args if args else message)
 
             renpy.display.log.write = write
@@ -333,7 +333,9 @@ testsuite shaders:
                     pass
 
                 def load(self):
-                    raise shader.ShaderError("test shader failure")
+                    from renpy.gl2.gl2shader import ShaderError
+
+                    raise ShaderError("test shader failure")
 
             shadercache.ShaderPart(name, glsl=100)
             shader.Program = FailingProgram


### PR DESCRIPTION
## Description

Some fixes from playing around with https://github.com/renpy/renpy/pull/7246.

1. Added a protection in `correct_pixel_perfect` if a drawable size ever returns 0, which seems to happen with some minimized windows and sometimes during resize.
2. Added a ShaderError if any shader asks for more samplers than `GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS`.
3. Fixed an issue where uniforms referenced only inside `vertex_functions`/`fragment_functions` never got declared and lead to compilation failures.
4. Two catches for failures on some of the new testcases.

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.