### PR TITLE
Add shaders to prediction engine

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -458,6 +458,9 @@ expensive_predict_callbacks = []
 # Should screens be predicted?
 predict_screens = True
 
+# Should shaders be predicted?
+predict_shaders = True
+
 # Should we use the new choice screen format?
 choice_screen_chosen = True
 

--- a/renpy/defaultstore.py
+++ b/renpy/defaultstore.py
@@ -446,6 +446,9 @@ _cache_pin_set = set()
 # Used to store displayables that should be predicted.
 _predict_set = set()
 
+# Used to store shader combinations that should be predicted.
+_predict_shader = set()
+
 # A map from a screen name to an (args, kwargs) tuple. The arguments and
 # keyword arguments can be
 _predict_screen = dict()

--- a/renpy/display/anim.py
+++ b/renpy/display/anim.py
@@ -462,6 +462,9 @@ class Blink(renpy.display.displayable.Displayable):
     def visit(self):
         return [self.image]
 
+    def predict_shaders(self, shaders):
+        return [(self.image, shaders + ("renpy.alpha",))]
+
     def render(self, height, width, st, at):
         delay = 0
 

--- a/renpy/display/displayable.py
+++ b/renpy/display/displayable.py
@@ -486,6 +486,20 @@ class Displayable(renpy.object.Object):
 
         return
 
+    def predict_shaders(self, shaders):
+        """
+        Called to predict shader combinations used by this displayable.
+        """
+
+        children = [d for d in self.visit() if d is not None]
+
+        if children:
+            return [(d, shaders) for d in children]
+
+        renpy.gl2.gl2shadercache.predict_shader(shaders + ("renpy.texture",))
+
+        return []
+
     def predict_one_action(self):
         """
         Called to ask this displayable to cause image prediction

--- a/renpy/display/layout.py
+++ b/renpy/display/layout.py
@@ -2095,6 +2095,9 @@ class Alpha(renpy.display.displayable.Displayable):
     def visit(self):
         return [self.child]
 
+    def predict_shaders(self, shaders):
+        return [(self.child, shaders + ("renpy.alpha",))]
+
     def render(self, height, width, st, at):
         if self.anim_timebase:
             t = at
@@ -2315,6 +2318,11 @@ class Flatten(Container):
     def get_placement(self):
         return self.child.get_placement()
 
+    def predict_shaders(self, shaders):
+        renpy.gl2.gl2shadercache.predict_shader(shaders + ("renpy.texture",))
+
+        return [(self.child, ())]
+
 
 class AlphaMask(Container):
     """
@@ -2362,6 +2370,11 @@ class AlphaMask(Container):
 
     def visit(self):
         return [self.mask, self.child]
+
+    def predict_shaders(self, shaders):
+        renpy.gl2.gl2shadercache.predict_shader(shaders + ("renpy.mask",))
+
+        return [(self.mask, ()), (self.child, ())]
 
     def render(self, width, height, st, at):
         cr = renpy.display.render.render(self.child, width, height, st, at)

--- a/renpy/display/model.py
+++ b/renpy/display/model.py
@@ -159,6 +159,11 @@ class Model(renpy.display.displayable.Displayable):
         self.shaders.append(shader)
         return self
 
+    def predict_shaders(self, shaders):
+        renpy.gl2.gl2shadercache.predict_shader(shaders + tuple(self.shaders))
+
+        return [(texture.displayable, ()) for texture in self.textures]
+
     def uniform(self, name, value):
         """
         :doc: model_displayable method

--- a/renpy/display/predict.py
+++ b/renpy/display/predict.py
@@ -60,6 +60,28 @@ def displayable(d):
     if d not in predicted:
         predicted.add(d)
         d.visit_all(lambda i: i.predict_one())
+        predict_displayable_shaders(d)
+
+
+def predict_displayable_shaders(d):
+    stack = [(d, ())]
+    seen = set()
+
+    while stack:
+        d, shaders = stack.pop()
+        key = (id(d), shaders)
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+        children = d.predict_shaders(shaders)
+        stack.extend(reversed(children))
+
+
+def predict_registered_shaders():
+    for shaders in renpy.store._predict_shader:
+        renpy.gl2.gl2shadercache.predict_shader(shaders)
 
 
 def screen(_screen_name, *args, **kwargs):
@@ -209,6 +231,19 @@ def prediction_coroutine(root_widget):
         predicting = True
 
         renpy.display.screen.predict_screen(name, *args, **kwargs)
+
+        predicting = False
+
+    predict_registered_shaders()
+
+    # Pre-build shader combinations exposed by prediction.
+    while renpy.gl2.gl2shadercache.has_predicted_shaders():
+        while not (yield False):
+            continue
+
+        predicting = True
+
+        renpy.gl2.gl2shadercache.preload_predicted_shader()
 
         predicting = False
 

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -652,6 +652,56 @@ class Proxy(object):
         return setattr(instance.state, self.name, value)
 
 
+def _predict_transform_shaders(transform, state, shaders):
+    local_shaders = []
+
+    if state.matrixcolor:
+        local_shaders.append("renpy.matrixcolor")
+
+    alpha = state.alpha
+
+    if alpha < 0.0:
+        alpha = 0.0
+    elif alpha > 1.0:
+        alpha = 1.0
+
+    if alpha != 1.0 or state.additive != 0.0:
+        local_shaders.append("renpy.alpha")
+
+    if state.shader is not None:
+        if isinstance(state.shader, str):
+            local_shaders.append(state.shader)
+        else:
+            local_shaders.extend(state.shader)
+
+    shaders = shaders + tuple(local_shaders)
+    mesh = state.mesh or (True if state.blur else None)
+
+    if mesh:
+        if state.blur is not None and state.blur > 0:
+            shaders += ("renpy.blur",)
+        else:
+            shaders += ("renpy.texture",)
+
+        renpy.gl2.gl2shadercache.predict_shader(shaders)
+
+    elif transform.child is None:
+        renpy.gl2.gl2shadercache.predict_shader(shaders + ("renpy.texture",))
+
+    children = []
+
+    if transform.child is not None:
+        children.append((transform.child, () if mesh else shaders))
+
+    for name in sorted(state.texture_uniforms or ()):
+        value = getattr(state, name, None)
+
+        if isinstance(value, Displayable):
+            children.append((value, ()))
+
+    return children
+
+
 class Transform(Container):
     """
     Documented in sphinx, because we can't scan this object.
@@ -822,6 +872,9 @@ class Transform(Container):
             return []
         else:
             return [self.child]
+
+    def predict_shaders(self, shaders):
+        return _predict_transform_shaders(self, self.state, shaders)
 
     # The default function chooses entries from self.arguments that match
     # the style prefix, and applies them to the state.
@@ -1279,6 +1332,21 @@ class ATLTransform(renpy.atl.ATLTransformBase, Transform):
             if self.state.events and renpy.game.interface is not None:
                 renpy.game.interface.timeout(0)
             self.state.last_events = self.state.events
+
+    def predict_shaders(self, shaders):
+        if self.get_block() is None:
+            self.compile()
+
+        if self.properties is None:
+            return Transform.predict_shaders(self, shaders)
+
+        state = TransformState()
+        state.take_state(self.state)
+
+        for name, value in self.properties:
+            setattr(state, name, value)
+
+        return _predict_transform_shaders(self, state, shaders)
 
     def _repr_info(self):
         return repr((self.child, self.atl.loc))

--- a/renpy/display/transition.py
+++ b/renpy/display/transition.py
@@ -72,6 +72,12 @@ def null_render(d, width, height, st, at):
     return rv
 
 
+def _predict_mesh_shaders(displayable, shaders, shader):
+    renpy.gl2.gl2shadercache.predict_shader(shaders + (shader,))
+
+    return [(child, ()) for child in displayable.visit() if child is not None]
+
+
 class NoTransition(Transition):
     """
     :doc: transition function
@@ -281,6 +287,9 @@ class Pixellate(Transition):
 
         self.quantum = time / (2 * steps)
 
+    def predict_shaders(self, shaders):
+        return _predict_mesh_shaders(self, shaders, "renpy.texture")
+
     def render(self, width, height, st, at):
         if renpy.game.less_updates:
             return null_render(self, width, height, st, at)
@@ -357,6 +366,9 @@ class Dissolve(Transition):
         self.events = False
         self.alpha = alpha
         self.time_warp = time_warp
+
+    def predict_shaders(self, shaders):
+        return _predict_mesh_shaders(self, shaders, "renpy.dissolve")
 
     def render(self, width, height, st, at):
         if renpy.game.less_updates:
@@ -551,6 +563,9 @@ class ImageDissolve(Transition):
     def visit(self):
         return super(ImageDissolve, self).visit() + [self.image]
 
+    def predict_shaders(self, shaders):
+        return _predict_mesh_shaders(self, shaders, "renpy.imagedissolve")
+
     def render(self, width, height, st, at):
         if renpy.game.less_updates or renpy.display.less_imagedissolve:
             return null_render(self, width, height, st, at)
@@ -673,6 +688,9 @@ class AlphaDissolve(Transition):
 
     def visit(self):
         return super(AlphaDissolve, self).visit() + [self.control]
+
+    def predict_shaders(self, shaders):
+        return _predict_mesh_shaders(self, shaders, "renpy.imagedissolve")
 
     def render(self, width, height, st, at):
         if renpy.game.less_updates or renpy.display.less_imagedissolve:

--- a/renpy/exports/__init__.py
+++ b/renpy/exports/__init__.py
@@ -533,8 +533,10 @@ from renpy.exports.predictexports import (
     expand_predict as expand_predict,
     predicting as predicting,
     start_predict_screen as start_predict_screen,
+    start_predict_shader as start_predict_shader,
     start_predict as start_predict,
     stop_predict_screen as stop_predict_screen,
+    stop_predict_shader as stop_predict_shader,
     stop_predict as stop_predict,
 )
 

--- a/renpy/exports/predictexports.py
+++ b/renpy/exports/predictexports.py
@@ -146,6 +146,48 @@ def stop_predict_screen(name):
     renpy.store._predict_screen = new_predict
 
 
+def _shader_tuple(shaders):
+    if len(shaders) == 1 and not isinstance(shaders[0], str):
+        return tuple(shaders[0])
+
+    return tuple(shaders)
+
+
+def start_predict_shader(*shaders):
+    """
+    :doc: model
+
+    Causes Ren'Py to predict the specified combination of shaders during every
+    interaction until it is removed by :func:`renpy.stop_predict_shader`.
+
+    This accepts shader part names as separate arguments, or one iterable of
+    shader part names.
+
+    Prediction will occur during normal gameplay. To wait for prediction to
+    complete, use the `predict` argument to :func:`renpy.pause`.
+    """
+
+    new_predict = renpy.revertable.RevertableSet(renpy.store._predict_shader)
+    new_predict.add(_shader_tuple(shaders))
+    renpy.store._predict_shader = new_predict
+
+
+def stop_predict_shader(*shaders):
+    """
+    :doc: model
+
+    Causes Ren'Py to stop predicting the specified combination of shaders during
+    every interaction.
+
+    Shader parts can be supplied as described in
+    :func:`renpy.start_predict_shader`.
+    """
+
+    new_predict = renpy.revertable.RevertableSet(renpy.store._predict_shader)
+    new_predict.discard(_shader_tuple(shaders))
+    renpy.store._predict_shader = new_predict
+
+
 def predicting():
     """
     :doc: other

--- a/renpy/gl2/gl2shadercache.py
+++ b/renpy/gl2/gl2shadercache.py
@@ -19,13 +19,71 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import re
+import collections
 import os
+import re
 
 import renpy
 
 # A map from shader part name to ShaderPart
 shader_part = {}
+
+def _get_shader_cache():
+    draw = renpy.display.draw
+
+    if draw is None:
+        return None
+
+    return getattr(draw, "shader_cache", None)
+
+
+def predict_shader(partnames, cache=None):
+    if not renpy.config.predict_shaders:
+        return
+
+    if isinstance(partnames, str):
+        partnames = (partnames,)
+    else:
+        partnames = tuple(partnames)
+
+    if cache is None:
+        cache = _get_shader_cache()
+
+    if cache is None:
+        return
+
+    cache.predict(partnames)
+
+
+def has_predicted_shaders(cache=None):
+    if cache is None:
+        cache = _get_shader_cache()
+
+    if cache is None:
+        return False
+
+    if not renpy.config.predict_shaders:
+        cache.predicted.clear()
+
+        return False
+
+    return bool(cache.predicted)
+
+
+def preload_predicted_shader(cache=None):
+    if cache is None:
+        cache = _get_shader_cache()
+
+    if cache is None:
+        return False
+
+    if not renpy.config.predict_shaders:
+        cache.predicted.clear()
+
+        return False
+
+    return cache.preload_predicted()
+
 
 # The name of the variable a fragment shader writes its color to, when the
 # modern dialect is being emitted (for legacy support, as GLSL ES 3.00 removed
@@ -806,27 +864,22 @@ class ShaderCache(object):
         # True if this is dirty, and should be saved to the cache.
         self.dirty = False
 
-    def get(self, partnames):
-        """
-        Gets a shader, creating it if necessary.
+        # Shader combinations waiting to be compiled in prediction order.
+        self.predicted = collections.OrderedDict()
 
-        `partnames`
-            A tuple of strings, giving the names of the shader parts to include in
-            the cache.
-        """
+    def _filter_partnames(self, partnames):
+        if renpy.config.shader_part_filter is None:
+            return partnames
 
-        if renpy.config.shader_part_filter is not None:
-            new_partnames = shader_part_filter_cache.get(partnames, None)
-            if new_partnames is None:
-                new_partnames = renpy.config.shader_part_filter(partnames)
-                shader_part_filter_cache[partnames] = new_partnames
+        new_partnames = shader_part_filter_cache.get(partnames, None)
+        
+        if new_partnames is None:
+            new_partnames = renpy.config.shader_part_filter(partnames)
+            shader_part_filter_cache[partnames] = new_partnames
 
-            partnames = new_partnames
+        return new_partnames
 
-        rv = self.cache.get(partnames, None)
-        if rv is not None:
-            return rv
-
+    def _normalize_partnames(self, partnames):
         partnameset = set()
         partnamenotset = set()
 
@@ -841,7 +894,58 @@ class ShaderCache(object):
         if "renpy.ftl" not in partnameset:
             partnameset.add(renpy.config.default_shader)
 
-        sortedpartnames = tuple(sorted(partnameset))
+        return tuple(sorted(partnameset))
+
+    def predict(self, partnames):
+        partnames = self._filter_partnames(partnames)
+
+        if partnames in self.cache:
+            return
+
+        normalized = self._normalize_partnames(partnames)
+
+        if normalized in self.cache:
+            return
+
+        self.predicted.setdefault(normalized, partnames)
+
+    def preload_predicted(self):
+        while self.predicted:
+            normalized, partnames = self.predicted.popitem(last=False)
+
+            if normalized in self.cache:
+                continue
+
+            try:
+                self._get_filtered(partnames)
+            except Exception:
+                if renpy.config.debug_prediction:
+                    raise
+
+            return True
+
+        return False
+
+    def get(self, partnames):
+        """
+        Gets a shader, creating it if necessary.
+
+        `partnames`
+            A tuple of strings, giving the names of the shader parts to include in
+            the cache.
+        """
+
+        partnames = self._filter_partnames(partnames)
+
+        return self._get_filtered(partnames)
+
+    def _get_filtered(self, partnames):
+        rv = self.cache.get(partnames, None)
+        
+        if rv is not None:
+            return rv
+
+        sortedpartnames = self._normalize_partnames(partnames)
 
         rv = self.cache.get(sortedpartnames, None)
         if rv is not None:
@@ -1028,6 +1132,7 @@ class ShaderCache(object):
 
         self.cache.clear()
         self.missing.clear()
+        self.predicted.clear()
 
     def log_shader(self, kind, partnames, text):
         """

--- a/sphinx/source/changelog.rst
+++ b/sphinx/source/changelog.rst
@@ -31,6 +31,11 @@ Ren'Py 8.5 or earlier. A single part can override it by passing `glsl` to
 Existing shader parts do not require changes. Ren'Py translates between the two
 versions, so parts written in either can be combined in the same shader.
 
+Shader combinations used by predicted displayables are now compiled during
+idle prediction, reducing stalls when they are first shown. The new
+:func:`renpy.start_predict_shader` and
+:func:`renpy.stop_predict_shader` functions support explicit prediction.
+
 Graphics
 --------
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -1683,6 +1683,11 @@ Showing Images
     When True, Ren'Py will scan images to find the bounding box of the
     non-transparent pixels, and only load those pixels into a texture.
 
+.. var:: config.predict_shaders = True
+
+    If True, shader combinations used by predicted displayables are
+    compiled during expensive idle prediction.
+
 .. var:: config.predict_statements = 32
 
     This is the number of statements, including the current one, to

--- a/sphinx/source/model.rst
+++ b/sphinx/source/model.rst
@@ -151,6 +151,13 @@ used in game/cache/shaders.txt, and loads them at startup. If major changes
 in shader use occur, this file should be edited or deleted so it can be
 re-created with valid data.
 
+When :var:`config.predict_shaders` is true, shader combinations exposed by
+predicted displayables are compiled during expensive idle prediction.
+
+Dynamic systems that know the shader combination they will use can register it
+with :func:`renpy.start_predict_shader`, and remove it with
+:func:`renpy.stop_predict_shader`.
+
 
 .. _custom-shaders:
 

--- a/testcases/game/tests/test_shaders.rpy
+++ b/testcases/game/tests/test_shaders.rpy
@@ -149,6 +149,34 @@ testsuite shaders:
                 assert list(cache.predicted) == expected, \
                     f"Unexpected shader prediction graph: {list(cache.predicted)}"
 
+    testcase prediction_api:
+        description "Shader prediction can be started and stopped explicitly"
+
+        python:
+            old_predict_shader = renpy.store._predict_shader
+            old_draw = renpy.display.draw
+            renpy.store._predict_shader = renpy.revertable.RevertableSet()
+            renpy.display.draw = None
+
+            try:
+                legacy = ("renpy.texture", "test_shaders.legacy")
+                modern = ("renpy.texture", "test_shaders.modern")
+
+                renpy.start_predict_shader(*legacy)
+                renpy.start_predict_shader(modern)
+                assert renpy.store._predict_shader == {legacy, modern}
+
+                renpy.stop_predict_shader(legacy)
+                assert renpy.store._predict_shader == {modern}
+
+                with test_shaders__prediction_cache() as cache:
+                    renpy.display.predict.predict_registered_shaders()
+                    expected = test_shaders__prediction_key(*modern)
+                    assert list(cache.predicted) == [expected]
+            finally:
+                renpy.store._predict_shader = old_predict_shader
+                renpy.display.draw = old_draw
+
     testcase builtin_parts:
         description "Ren'Py's own shader parts compile at the emitted version"
 

--- a/testcases/game/tests/test_shaders.rpy
+++ b/testcases/game/tests/test_shaders.rpy
@@ -7,6 +7,8 @@
 
 init python:
 
+    import contextlib
+
     def test_shaders__cache():
         return getattr(renpy.display.draw, "shader_cache", None)
 
@@ -26,6 +28,22 @@ init python:
             return str(e)
 
         return None
+
+    @contextlib.contextmanager
+    def test_shaders__prediction_cache():
+        import renpy.gl2.gl2shadercache as shadercache
+
+        cache = shadercache.ShaderCache("test-shader-prediction.txt", True, 300)
+        old_draw = renpy.display.draw
+        renpy.display.draw = type("PredictionDraw", (), {"shader_cache": cache})()
+
+        try:
+            yield cache
+        finally:
+            renpy.display.draw = old_draw
+
+    def test_shaders__prediction_key(*parts):
+        return tuple(sorted((renpy.config.default_shader,) + parts))
 
     renpy.register_shader(
         "test_shaders.modern", glsl=300,
@@ -100,6 +118,36 @@ testsuite shaders:
     after testcase:
         if not screen "main_menu":
             run MainMenu(confirm=False, save=False)
+
+    testcase prediction_displayables:
+        description "Displayable prediction composes shaders across render boundaries"
+
+        python:
+            with test_shaders__prediction_cache() as cache:
+                texture = renpy.display.imagelike.Solid("#fff")
+                model = renpy.display.model.Model()
+                model.texture(texture)
+                model.shader("renpy.texture")
+                model.shader("test_shaders.legacy")
+
+                mask = renpy.display.imagelike.Solid("#000")
+                masked = renpy.display.layout.AlphaMask(model, mask)
+                transform = renpy.display.transform.Transform(masked, alpha=0.5, shader="test_shaders.modern")
+                renpy.display.predict.predict_displayable_shaders(transform)
+
+                expected_mask = test_shaders__prediction_key(
+                    "renpy.alpha",
+                    "renpy.mask",
+                    "test_shaders.modern",
+                )
+                expected_texture = test_shaders__prediction_key("renpy.texture")
+                expected_model = test_shaders__prediction_key(
+                    "renpy.texture",
+                    "test_shaders.legacy",
+                )
+                expected = [expected_mask, expected_texture, expected_model]
+                assert list(cache.predicted) == expected, \
+                    f"Unexpected shader prediction graph: {list(cache.predicted)}"
 
     testcase builtin_parts:
         description "Ren'Py's own shader parts compile at the emitted version"


### PR DESCRIPTION
## Description

Migrating shaders has raised discussion about ways to mitigate hitching from first-time shader compilation. The current shader cache system records possible shaders based on developer activity and rebuilds these at startup, which is a) not always a good proxy for what players will actually experience and b) can negatively impact startup time. It also has some maintenance burden since it does not self-clean.

This introduces an independent system to address shader-associated hitching that piggybacks off of the well-established prediction machinery to predict and pre-compile shaders before they are first shown.

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.