### PR TITLE
Report invalid PyExpr

### DIFF
--- a/renpy/astsupport.pyx
+++ b/renpy/astsupport.pyx
@@ -80,29 +80,6 @@ cdef class PyExpr(str):
     def __reduce__(self):
         return (PyExpr, (str(self), self.filename, self.linenumber, self.py, self.hashcode, self.column))
 
-    @staticmethod
-    def checkpoint() -> Any:
-        """
-        Checkpoints the pyexpr list. Returns an opaque object that can be used
-        to revert the list.
-        """
-
-        if renpy.game.script.all_pyexpr is None:
-            return None
-
-        return len(renpy.game.script.all_pyexpr)
-
-    @staticmethod
-    def revert(opaque: Any):
-
-        if renpy.game.script.all_pyexpr is None:
-            return
-
-        if opaque is None:
-            return
-
-        renpy.game.script.all_pyexpr[opaque:] = []
-
 
 # cdef classes can't have a new method, so we have to modify the type to add our own.
 
@@ -152,12 +129,6 @@ cdef object PyExpr_new(type cls, PyObject *args, PyObject *kwargs):
             rv.hashcode = hashcode
         else:
             rv.hashcode = hash32(s)
-
-        all_pyexpr = renpy.game.script.all_pyexpr
-
-        # Queue the string for precompilation.
-        if all_pyexpr is not None:
-            all_pyexpr.append(rv)
 
     return rv
 

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -1310,7 +1310,7 @@ class Lexer:
             end = end - (len(s) - len(s.rstrip()))
 
         expr = make_pyexpr(
-            s,
+            self.text[start:end],
             self.filename,
             self.number,
             self.column,

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -1301,16 +1301,16 @@ class Lexer:
         context: ExpressionContext = "unknown",
     ) -> PyExpr:
 
+        s = self.text[start:end]
+
         # Only eval expressions need to strip its leading whitespace,
         # trailing whitespace is to simulate `strip`.
         if context == "eval":
-            while start < end and self.text[start].isspace():
-                start += 1
-            while end > start and self.text[end - 1].isspace():
-                end -= 1
+            start = start + (len(s) - len(s.lstrip()))
+            end = end - (len(s) - len(s.rstrip()))
 
         expr = make_pyexpr(
-            self.text[start:end],
+            s,
             self.filename,
             self.number,
             self.column,

--- a/renpy/lexer.py
+++ b/renpy/lexer.py
@@ -27,15 +27,18 @@ import os
 import re
 import sys
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import renpy
 
 try:
-    from renpy.astsupport import make_pyexpr
+    from renpy.astsupport import PyExpr, make_pyexpr
     from renpy.lexersupport import match_logical_word, match_operator, match_string, match_whitespace
 except ImportError:
     pass
+
+
+type ExpressionContext = Literal["eval", "exec", "hide", "unknown"]
 
 
 class ParseError(SyntaxError):
@@ -1278,21 +1281,48 @@ class Lexer:
 
         return rv
 
-    def expr(self, s, expr):
+    def expr(self, s: str, expr: bool) -> str:
 
         if not expr:
             return s
 
-        pos = self.pos - len(s)
+        rv = PyExpr(s, self.filename, self.number)
 
-        return make_pyexpr(
-            s,
+        # Empty expression can't be compiled.
+        if rv:
+            renpy.parser.parsed_expressions.append((rv, "unknown"))
+
+        return rv
+
+    def _expr_from_range(
+        self,
+        start: int,
+        end: int,
+        context: ExpressionContext = "unknown",
+    ) -> PyExpr:
+
+        # Only eval expressions need to strip its leading whitespace,
+        # trailing whitespace is to simulate `strip`.
+        if context == "eval":
+            while start < end and self.text[start].isspace():
+                start += 1
+            while end > start and self.text[end - 1].isspace():
+                end -= 1
+
+        expr = make_pyexpr(
+            self.text[start:end],
             self.filename,
             self.number,
             self.column,
             self.text,
-            pos,
+            start,
         )
+
+        # Empty expression can't be compiled.
+        if expr:
+            renpy.parser.parsed_expressions.append((expr, context))
+
+        return expr
 
     def delimited_python(self, delim, expr=True):
         """
@@ -1308,7 +1338,10 @@ class Lexer:
             c = self.text[self.pos]
 
             if c in delim:
-                return self.expr(self.text[start : self.pos], expr)
+                if not expr:
+                    return self.text[start : self.pos]
+
+                return self._expr_from_range(start, self.pos, "eval")
 
             if self.python_string():
                 continue
@@ -1326,14 +1359,16 @@ class Lexer:
         extending to a colon.
         """
 
+        start = self.pos
         pe = self.delimited_python(":", False)
 
         if not pe:
             self.error("expected python_expression")
 
-        rv = self.expr(pe.strip(), expr)
+        if not expr:
+            return pe
 
-        return rv
+        return self._expr_from_range(start, self.pos, "eval")
 
     def parenthesised_python(self):
         """
@@ -1364,7 +1399,7 @@ class Lexer:
 
         return False
 
-    def simple_expression(self, comma=False, operator=True, image=False):
+    def simple_expression(self, comma=False, operator=True, image=False) -> PyExpr | None:
         """
         Tries to parse a simple_expression. Returns the text if it can, or
         None if it cannot.
@@ -1437,12 +1472,12 @@ class Lexer:
 
             break
 
-        text = self.text[start : self.pos].strip()
+        expr = self._expr_from_range(start, self.pos, "eval")
 
-        if not text:
+        if not expr:
             return None
 
-        return self.expr(text, True)
+        return expr
 
     def comma_expression(self):
         """
@@ -1458,7 +1493,10 @@ class Lexer:
         """
         return self.simple_expression(operator=False)
 
-    def checkpoint(self):
+    type LexerCheckpoint = Any
+    "Opaque representation of the lexer state."
+
+    def checkpoint(self) -> LexerCheckpoint:
         """
         Returns an opaque representation of the lexer state. This can be
         passed to revert to back the lexer up.
@@ -1472,10 +1510,10 @@ class Lexer:
             self.subblock,
             self.pos,
             self.column,
-            renpy.ast.PyExpr.checkpoint(),
+            len(renpy.parser.parsed_expressions),
         )
 
-    def revert(self, state):
+    def revert(self, state: LexerCheckpoint):
         """
         Reverts the lexer to the given state. State must have been returned
         by a previous checkpoint operation on this lexer.
@@ -1492,7 +1530,7 @@ class Lexer:
             pyexpr_checkpoint,
         ) = state
 
-        renpy.ast.PyExpr.revert(pyexpr_checkpoint)
+        renpy.parser.parsed_expressions[pyexpr_checkpoint:] = []
 
         self.word_cache_pos = -1
         if self.line < len(self.block):
@@ -1543,7 +1581,7 @@ class Lexer:
 
         pos = self.pos
         self.pos = len(self.text)
-        return self.expr(self.text[pos:].strip(), True)
+        return self._expr_from_range(pos, self.pos, "exec")
 
     rest_statement = rest
 

--- a/renpy/parser.py
+++ b/renpy/parser.py
@@ -27,7 +27,9 @@ import time
 
 import renpy
 from renpy import ast
+from renpy.astsupport import PyExpr
 from renpy.lexer import (
+    ExpressionContext,
     Lexer,
     ParseError,
     group_logical_lines,
@@ -45,6 +47,13 @@ parse_errors: list[str] = []
 # A list of deferred parser error. These are potential parse errors that
 # can be released or not when parse errors are reported.
 deferred_parse_errors: collections.defaultdict[str, list[str]] = collections.defaultdict(list)
+
+type ExpressionsList = list[tuple[PyExpr, ExpressionContext]]
+parsed_expressions: ExpressionsList = []
+"""
+A list of tuples containing a PyExpr object and the context in which it appears.
+The context is one of "eval", "exec", "hide", or "unknown".
+"""
 
 ################################################################################
 # Parsing of structures that are less than a full statement.

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -134,7 +134,6 @@ class Script:
         self.namemap = {}
         self.all_stmts = []
         self.all_pycode = []
-        self.all_pyexpr = []
 
         # A list of statements that haven't been analyzed.
         self.need_analysis = []
@@ -561,6 +560,9 @@ class Script:
 
         stmts = renpy.parser.parse(filename, filedata, linenumber=linenumber)
 
+        expressions = renpy.parser.parsed_expressions
+        renpy.parser.parsed_expressions = []
+
         if stmts is None:
             return None, None
 
@@ -573,7 +575,7 @@ class Script:
 
         initcode = []
 
-        stmts = self.finish_load(stmts, initcode, False)
+        stmts = self.finish_load(stmts, initcode, False, expressions=expressions)
 
         initcode.sort(key=lambda i: i[0])
 
@@ -585,6 +587,7 @@ class Script:
         initcode: list,
         check_names=True,
         filename=None,
+        expressions: renpy.parser.ExpressionsList | None = None,
     ):
         """
         Given `stmts`, a list of AST nodes comprising the root block,
@@ -685,7 +688,7 @@ class Script:
                         )
                     )
 
-        self.update_bytecode()
+        self.update_bytecode(expressions or [])
 
         for node in all_stmts:
             if isinstance(node, renpy.ast.Testcase):
@@ -826,6 +829,7 @@ class Script:
                 data["version"] = script_version
                 data["key"] = self.key or "unlocked"
                 data["deferred_parse_errors"] = renpy.parser.deferred_parse_errors
+                data["expressions"] = renpy.parser.parsed_expressions
 
                 if stmts is None:
                     return data, []
@@ -833,9 +837,7 @@ class Script:
                 used_names = set()
 
                 for mergefn in [oldrpycfn, rpycfn]:
-                    old_all_pyexpr = self.all_pyexpr
                     self.record_pycode = False
-                    self.all_pyexpr = None
 
                     # See if we have a corresponding .rpyc file. If so, then
                     # we want to try to upgrade our .rpy file with it.
@@ -853,7 +855,6 @@ class Script:
                         pass
                     finally:
                         self.record_pycode = True
-                        self.all_pyexpr = old_all_pyexpr
 
                 self.assign_names(stmts, renpy.lexer.elide_filename(fullfn))
 
@@ -944,6 +945,7 @@ class Script:
                 old_deferred_parse_errors[k].extend(v)
 
             renpy.parser.deferred_parse_errors = old_deferred_parse_errors
+            renpy.parser.parsed_expressions = []
 
     def load_appropriate_file(self, compiled, source_extensions, dir, fn, initcode):
         data = None
@@ -1062,23 +1064,41 @@ class Script:
                 f"{fn} does not share a key with at least one .rpyc file. To fix, delete all .rpyc files, or rerun Ren'Py with the --lock option."
             )
 
-        self.finish_load(stmts, initcode, filename=lastfn)
+        self.finish_load(stmts, initcode, filename=lastfn, expressions=data.get("expressions"))
 
         self.digest.update(digest)  # type: ignore
 
-    def update_bytecode(self):
+    def update_bytecode(self, expressions: renpy.parser.ExpressionsList):
         """
         Compiles the PyCode objects in self.all_pycode, updating the
         cache. Clears out self.all_pycode.
         """
 
-        for i in self.all_pyexpr:
-            try:
-                renpy.python.py_compile(i, "eval")
-            except Exception:
-                pass
+        for expr, context in expressions:
+            if context == "unknown":
+                mode = "eval"
+            else:
+                mode = context
 
-        self.all_pyexpr = []
+            try:
+                renpy.python.py_compile(expr, mode)
+            except SyntaxError as e:
+                if context == "unknown":
+                    continue
+
+                assert e.filename is not None
+                assert e.lineno is not None
+                pem = renpy.parser.ParseError(
+                    e.msg,
+                    e.filename,
+                    e.lineno,
+                    e.offset,
+                    e.text,
+                    e.end_lineno,
+                    e.end_offset,
+                )
+
+                renpy.parser.parse_errors.append(pem.message)
 
         # Update all of the PyCode objects in the system with the loaded
         # bytecode.

--- a/renpy/script.py
+++ b/renpy/script.py
@@ -558,16 +558,17 @@ class Script:
         list of init statements that need to be run.
         """
 
-        stmts = renpy.parser.parse(filename, filedata, linenumber=linenumber)
-
         expressions = renpy.parser.parsed_expressions
-        renpy.parser.parsed_expressions = []
 
-        if stmts is None:
-            return None, None
+        try:
+            stmts = renpy.parser.parse(filename, filedata, linenumber=linenumber)
+            if stmts is None:
+                return None, None
 
-        renpy.parser.release_deferred_errors()
-        if renpy.parser.parse_errors:
+        finally:
+            renpy.parser.parsed_expressions = []
+
+        if renpy.parser.get_parse_errors():
             return None, None
 
         self.assign_names(stmts, filename)


### PR DESCRIPTION
## Description
This PR makes Ren'Py emit syntax error for python expressions that can't be compiled e.g.
```
label start:
    return if persistent.completed_already

    if while True:
        pass

    menu:
        "Caption" if bad expr:
            pass
```
instead of being runtime errors.

This is achieved by moving tracking a list of created PyExpr from Script to parser and adding compilation mode to the list. After file is parsed, the list of parsed expressions is put into rpyc data. Manually created expressions with `Lexer.expr` are kept with `"unknown"` context so existing CDS should work as before.

This fixes #6940

## Human Oversight

<!-- Please delete the lines that do not apply. -->

- A human fully understood this pull request and the affected portions of Ren'Py.

