### PR TITLE
fix: `draw.get_window_position` invalid pos

### DIFF
--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -410,7 +410,7 @@ cdef class GL2Draw:
 
             if physical_size is not None:
                 pwidth, pheight = physical_size
-                if pos[0] + pwidth > rect[2] and pos[1] + pheight > rect[3]:
+                if pos[0] + pwidth > rect[0] + rect[2] or pos[1] + pheight > rect[1] + rect[3]:
                     continue
 
             return pos


### PR DESCRIPTION
## Description

`get_display_bounds` returns areas according to `(x, y, w, h)`
`x` and `y` were not taken on calculating of boundaries.
Which led to the position being calculated incorrectly.

Old:
<img width="1893" height="216" alt="Screenshot from 2026-09-07 23-47-11" src="https://github.com/user-attachments/assets/ddc4d62e-30ab-4809-9929-ddb9200dd649" />

New:
<img width="1893" height="216" alt="Screenshot from 2026-09-07 23-48-46" src="https://github.com/user-attachments/assets/45a76b6c-6867-4f5d-b9bb-bebeb13e7cbc" />

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.
