### PR TITLE
Remove MOUSEMOTION from redraw-blocking events

### DIFF
--- a/renpy/display/core.py
+++ b/renpy/display/core.py
@@ -60,6 +60,7 @@ EVENTNAME = pygame.event.register("EVENTNAME")
 
 # All events except for TIMEEVENT and REDRAW
 ALL_EVENTS: set[int] = set(pygame.event.get_standard_events())
+ALL_EVENTS.discard(pygame.MOUSEMOTION)
 ALL_EVENTS.add(PERIODIC)
 ALL_EVENTS.add(EVENTNAME)
 


### PR DESCRIPTION
## Description

Discards mouse motion from the set of pygame events that blocks redraw. This gets rid of the classic dramatic framerate drop that accompanies player mouse motion. I am unable to see a downside to this other than some imperceptible input -> display latency.

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.