### PR TITLE
Use glScissor to avoid clearing buffer on every RTT

### DIFF
--- a/renpy/gl2/gl2draw.pxd
+++ b/renpy/gl2/gl2draw.pxd
@@ -28,6 +28,8 @@ from renpy.display.render cimport Render
 
 from renpy.uguu.gl cimport *
 
+cdef void clear_color_buffer(int x, int y, int width, int height) noexcept nogil
+
 cdef class GL2Draw:
 
 

--- a/renpy/gl2/gl2draw.pyx
+++ b/renpy/gl2/gl2draw.pyx
@@ -130,6 +130,13 @@ cdef set get_gl_extensions_list():
     return extensions
 
 
+cdef void clear_color_buffer(int x, int y, int width, int height) noexcept nogil:
+    glEnable(GL_SCISSOR_TEST)
+    glScissor(x, y, width, height)
+    glClear(GL_COLOR_BUFFER_BIT)
+    glDisable(GL_SCISSOR_TEST)
+
+
 cdef class GL2Draw:
 
     def __init__(self, name):
@@ -1232,7 +1239,10 @@ cdef class GL2Draw:
         # Clear the screen.
         clear_r, clear_g, clear_b = renpy.color.Color(renpy.config.gl_clear_color).rgb
         glClearColor(clear_r, clear_g, clear_b, 0.0 if screenshot else 1.0)
-        glClear(GL_COLOR_BUFFER_BIT)
+        if screenshot:
+            clear_color_buffer(0, 0, <int> w, <int> h)
+        else:
+            glClear(GL_COLOR_BUFFER_BIT)
 
         # Project the child from virtual space to the screen space.
         cdef Matrix transform

--- a/renpy/gl2/gl2functions.py
+++ b/renpy/gl2/gl2functions.py
@@ -61,6 +61,7 @@ required_functions = [
     "glPixelStorei",
     "glReadPixels",
     "glRenderbufferStorage",
+    "glScissor",
     "glShaderSource",
     "glTexImage2D",
     "glTexParameterf",

--- a/renpy/gl2/gl2texture.pyx
+++ b/renpy/gl2/gl2texture.pyx
@@ -41,7 +41,7 @@ import math
 
 import renpy
 from renpy.uguu.gl cimport *
-from renpy.gl2.gl2draw cimport GL2Draw
+from renpy.gl2.gl2draw cimport GL2Draw, clear_color_buffer
 
 from renpy.gl2.gl2mesh cimport Mesh
 from renpy.gl2.gl2mesh2 cimport Mesh2
@@ -481,7 +481,7 @@ cdef class GLTexture(GL2Model):
 
         # Clear the screen.
         glClearColor(0.0, 0.0, 0.0, 0.0)
-        glClear(GL_COLOR_BUFFER_BIT)
+        clear_color_buffer(0, 0, tw, th)
 
         # Set up the default modes.
         glEnable(GL_BLEND)


### PR DESCRIPTION
## Description

This was a tough performance hit to track down, and it may very well only hit in niche cases. I stumbled onto it because of a modeling framework I'm using depends on a lot of RTTs.

Instead of allowing even tiny RTTs to clear the entire backing buffer, uses glScissor for more surgical clearing. E.g. window clears still affect the whole buffer as they should.

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.