### PR TITLE
Only copy/render uniforms a transform actually sets

### DIFF
--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -967,7 +967,7 @@ cdef class RenderTransform:
 
         state_dict = state.__dict__
 
-        for name in renpy.display.transform.uniforms.intersection(state_dict):
+        for name in state_dict.keys() & renpy.display.transform.uniforms:
             value = state_dict[name]
 
             if isinstance(value, Displayable):

--- a/renpy/display/accelerator.pyx
+++ b/renpy/display/accelerator.pyx
@@ -965,8 +965,10 @@ cdef class RenderTransform:
                 for name in state.shader:
                     rv.add_shader(name)
 
-        for name in renpy.display.transform.uniforms:
-            value = getattr(state, name, None)
+        state_dict = state.__dict__
+
+        for name in renpy.display.transform.uniforms.intersection(state_dict):
+            value = state_dict[name]
 
             if isinstance(value, Displayable):
                 value = value.render(rv.width, rv.height, st, at)

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -149,9 +149,18 @@ class TransformState(renpy.object.Object):
 
     def take_state(self, ts):
         d = self.__dict__
+        src = ts.__dict__
 
-        for k in all_properties:
+        for k in non_uniform_properties:
             d[k] = getattr(ts, k)
+
+        # Uniforms only live in __dict__ when explicitly set.
+        for k in uniforms.intersection(d):
+            if k not in src:
+                del d[k]
+
+        for k in uniforms.intersection(src):
+            d[k] = src[k]
 
         self.last_angle = ts.last_angle
         self.radius_sign = ts.radius_sign
@@ -1297,6 +1306,9 @@ diff4_properties = set()
 uniforms = set()
 gl_properties = set()
 
+# Properties copied unconditionally by TransformState.take_state.
+non_uniform_properties = set()
+
 
 def add_property(name, atl=any_object, default=None, diff=2):  # type: (str, Any, Any, int|None) -> None
     """
@@ -1307,6 +1319,7 @@ def add_property(name, atl=any_object, default=None, diff=2):  # type: (str, Any
         return
 
     all_properties.add(name)
+    non_uniform_properties.add(name)
     setattr(TransformState, name, default)
     setattr(Transform, name, Proxy(name))
     renpy.atl.PROPERTIES[name] = atl
@@ -1334,6 +1347,7 @@ def add_uniform(name, uniform_type):
         setattr(TransformState, name, TextureUniform(name))
 
     uniforms.add(name)
+    non_uniform_properties.discard(name)
 
 
 def add_gl_property(name):

--- a/renpy/display/transform.py
+++ b/renpy/display/transform.py
@@ -155,11 +155,11 @@ class TransformState(renpy.object.Object):
             d[k] = getattr(ts, k)
 
         # Uniforms only live in __dict__ when explicitly set.
-        for k in uniforms.intersection(d):
+        for k in d.keys() & uniforms:
             if k not in src:
                 del d[k]
 
-        for k in uniforms.intersection(src):
+        for k in src.keys() & uniforms:
             d[k] = src[k]
 
         self.last_angle = ts.last_angle

--- a/testcases/game/tests/test_shaders.rpy
+++ b/testcases/game/tests/test_shaders.rpy
@@ -209,6 +209,27 @@ testsuite shaders:
                 assert len(helper.uniform_setters) == len(baseline.uniform_setters) + 1, \
                     "A uniform shared by both stages should have one setter"
 
+    testcase sparse_transform_uniforms:
+        description "Transform state copies only uniforms explicitly set on the source"
+
+        python:
+            from renpy.display.transform import TransformState
+
+            uniform_name = "u_test_shaders_modern_amount"
+            source = TransformState()
+            copied = TransformState()
+
+            assert uniform_name not in source.__dict__
+
+            setattr(source, uniform_name, 0.5)
+            copied.take_state(source)
+
+            assert copied.__dict__[uniform_name] == 0.5
+
+            copied.take_state(TransformState())
+
+            assert uniform_name not in copied.__dict__
+
     testcase generated_fragment_output:
         description "Modern fragment output has an explicit location"
 


### PR DESCRIPTION
## Description

Avoids scanning all registered uniforms for every transform, such that states don't get populated with unused defaults.

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.