### PR TITLE
Use repository-bound paths in tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "run.sh --build",
             "type": "shell",
-            "command": "/home/tom/ab/renpy/run.sh --build",
+            "command": "${workspaceFolder}/run.sh --build",
         }
     ]
 }


### PR DESCRIPTION
## Description

Improve genericity by not relying on tom's pc setup for the vscode build task

## Human Oversight

- A human fully understood this pull request and the affected portions of Ren'Py.
